### PR TITLE
#11 Make summary counts severity-aware

### DIFF
--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -31,9 +31,13 @@ vi.mock('../src/runRdy.ts', () => ({
   runRdy: mockRunRdy,
 }));
 
-vi.mock('../src/reportRdy.ts', () => ({
-  reportRdy: mockReportRdy,
-}));
+vi.mock('../src/reportRdy.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/reportRdy.ts')>('../src/reportRdy.ts');
+  return {
+    ...actual,
+    reportRdy: mockReportRdy,
+  };
+});
 
 vi.mock('../src/formatCombinedSummary.ts', () => ({
   formatCombinedSummary: mockFormatCombinedSummary,
@@ -697,8 +701,26 @@ describe(runCommand, () => {
 
     expect(mockFormatCombinedSummary).toHaveBeenCalledTimes(1);
     expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
-      expect.objectContaining({ name: 'deploy', passed: 1, failed: 0, skipped: 0, allPassed: true }),
-      expect.objectContaining({ name: 'infra', passed: 1, failed: 0, skipped: 0, allPassed: true }),
+      expect.objectContaining({
+        name: 'deploy',
+        passed: 1,
+        errors: 0,
+        warnings: 0,
+        recommendations: 0,
+        blocked: 0,
+        optional: 0,
+        worstSeverity: null,
+      }),
+      expect.objectContaining({
+        name: 'infra',
+        passed: 1,
+        errors: 0,
+        warnings: 0,
+        recommendations: 0,
+        blocked: 0,
+        optional: 0,
+        worstSeverity: null,
+      }),
     ]);
   });
 
@@ -774,8 +796,26 @@ describe(runCommand, () => {
     });
 
     expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
-      expect.objectContaining({ name: 'deploy', passed: 1, failed: 1, skipped: 0, allPassed: false }),
-      expect.objectContaining({ name: 'infra', passed: 0, failed: 0, skipped: 1, allPassed: false }),
+      expect.objectContaining({
+        name: 'deploy',
+        passed: 1,
+        errors: 1,
+        warnings: 0,
+        recommendations: 0,
+        blocked: 0,
+        optional: 0,
+        worstSeverity: 'error',
+      }),
+      expect.objectContaining({
+        name: 'infra',
+        passed: 0,
+        errors: 0,
+        warnings: 0,
+        recommendations: 0,
+        blocked: 1,
+        optional: 0,
+        worstSeverity: null,
+      }),
     ]);
   });
 
@@ -842,7 +882,7 @@ describe(runCommand, () => {
       const kit = makeKit();
       mockLoadRdyKit.mockResolvedValue(kit);
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
-      mockFormatJsonReport.mockReturnValue('{"allPassed":true}');
+      mockFormatJsonReport.mockReturnValue('{"worstSeverity":null}');
 
       await runCommand({
         names: ['deploy'],
@@ -860,7 +900,7 @@ describe(runCommand, () => {
 
   describe('JSON mode', () => {
     beforeEach(() => {
-      mockFormatJsonReport.mockReturnValue('{"allPassed":true}');
+      mockFormatJsonReport.mockReturnValue('{"worstSeverity":null}');
       mockFormatJsonError.mockReturnValue('{"error":"boom"}');
     });
 
@@ -878,7 +918,7 @@ describe(runCommand, () => {
       expect(mockFormatJsonReport).toHaveBeenCalledTimes(1);
       expect(mockReportRdy).not.toHaveBeenCalled();
       expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
-      expect(stdoutSpy).toHaveBeenCalledWith('{"allPassed":true}\n');
+      expect(stdoutSpy).toHaveBeenCalledWith('{"worstSeverity":null}\n');
       expect(exitCode).toBe(0);
     });
 

--- a/packages/readyup/__tests__/formatCombinedSummary.test.ts
+++ b/packages/readyup/__tests__/formatCombinedSummary.test.ts
@@ -7,9 +7,12 @@ function makeSummary(overrides?: Partial<ChecklistSummary>): ChecklistSummary {
   return {
     name: 'test-checklist',
     passed: 3,
-    failed: 0,
-    skipped: 0,
-    allPassed: true,
+    errors: 0,
+    warnings: 0,
+    recommendations: 0,
+    blocked: 0,
+    optional: 0,
+    worstSeverity: null,
     durationMs: 100,
     ...overrides,
   };
@@ -23,54 +26,74 @@ describe(formatCombinedSummary, () => {
     expect(output.split('\n').at(-2)).toMatch(/^─+$/);
   });
 
-  it('shows 🟢 prefix for a passing checklist', () => {
+  it('shows 🟢 prefix when worstSeverity is null', () => {
     const output = formatCombinedSummary([makeSummary({ name: 'deploy' })]);
 
     expect(output).toContain('🟢 deploy');
   });
 
-  it('shows 🔴 prefix for a failing checklist', () => {
-    const output = formatCombinedSummary([makeSummary({ name: 'deploy', failed: 1, allPassed: false })]);
+  it('shows 🔴 prefix when worstSeverity is error', () => {
+    const output = formatCombinedSummary([makeSummary({ name: 'deploy', errors: 1, worstSeverity: 'error' })]);
 
     expect(output).toContain('🔴 deploy');
   });
 
-  it('includes duration and non-zero counts in each row', () => {
-    const output = formatCombinedSummary([
-      makeSummary({ name: 'infra', passed: 2, failed: 1, skipped: 0, allPassed: false, durationMs: 45 }),
-    ]);
+  it('shows 🟠 prefix when worstSeverity is warn', () => {
+    const output = formatCombinedSummary([makeSummary({ name: 'deploy', warnings: 1, worstSeverity: 'warn' })]);
 
-    expect(output).toContain('🔴 infra  45ms  2 passed, 1 failed');
-    expect(output).not.toContain('skipped');
+    expect(output).toContain('🟠 deploy');
   });
 
-  it('omits zero counts from row', () => {
+  it('shows 🟡 prefix when worstSeverity is recommend', () => {
     const output = formatCombinedSummary([
-      makeSummary({ name: 'deploy', passed: 5, failed: 0, skipped: 0, durationMs: 200 }),
+      makeSummary({ name: 'deploy', recommendations: 1, worstSeverity: 'recommend' }),
     ]);
+
+    expect(output).toContain('🟡 deploy');
+  });
+
+  it('includes duration and grouped counts in each row', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ name: 'infra', passed: 2, errors: 1, worstSeverity: 'error', durationMs: 45 }),
+    ]);
+
+    expect(output).toContain('🔴 infra  45ms  2 passed. Failed: 1 error');
+    expect(output).not.toContain('Skipped:');
+  });
+
+  it('omits zero-count categories from row', () => {
+    const output = formatCombinedSummary([makeSummary({ name: 'deploy', passed: 5, durationMs: 200 })]);
 
     expect(output).toContain('🟢 deploy  200ms  5 passed');
-    expect(output).not.toContain('failed');
+    expect(output).not.toContain('Failed:');
+    expect(output).not.toContain('Skipped:');
   });
 
-  it('renders the Total line with icon-prefixed counts and total duration', () => {
+  it('renders the Total line with icon-prefixed grouped counts and total duration', () => {
     const output = formatCombinedSummary([
-      makeSummary({ passed: 10, failed: 0, skipped: 0, durationMs: 100 }),
-      makeSummary({ name: 'other', passed: 5, failed: 2, skipped: 1, allPassed: false, durationMs: 200 }),
+      makeSummary({ passed: 10, durationMs: 100 }),
+      makeSummary({
+        name: 'other',
+        passed: 5,
+        errors: 2,
+        blocked: 1,
+        worstSeverity: 'error',
+        durationMs: 200,
+      }),
     ]);
 
-    expect(output).toContain('Total: 🟢 15 passed, 🔴 2 failed, ⛔ 1 skipped (300ms)');
+    expect(output).toContain('Total: 🟢 15 passed. Failed: 🔴 2 errors. Skipped: ⛔ 1 blocked (300ms)');
   });
 
-  it('omits zero counts from the Total line', () => {
+  it('omits zero-count groups from the Total line', () => {
     const output = formatCombinedSummary([
-      makeSummary({ passed: 3, failed: 0, skipped: 0, durationMs: 50 }),
-      makeSummary({ name: 'other', passed: 7, failed: 0, skipped: 0, durationMs: 150 }),
+      makeSummary({ passed: 3, durationMs: 50 }),
+      makeSummary({ name: 'other', passed: 7, durationMs: 150 }),
     ]);
 
     expect(output).toContain('Total: 🟢 10 passed (200ms)');
-    expect(output).not.toContain('failed');
-    expect(output).not.toContain('skipped');
+    expect(output).not.toContain('Failed:');
+    expect(output).not.toContain('Skipped:');
   });
 
   it('right-aligns durations and left-aligns names across rows', () => {
@@ -85,11 +108,32 @@ describe(formatCombinedSummary, () => {
     expect(rows[1]).toContain('🟢 cdef  1200ms');
   });
 
-  it('includes skipped in row when non-zero', () => {
+  it('includes skip groups in row when counts are non-zero', () => {
     const output = formatCombinedSummary([
-      makeSummary({ name: 'checks', passed: 1, failed: 1, skipped: 2, allPassed: false, durationMs: 80 }),
+      makeSummary({
+        name: 'checks',
+        passed: 1,
+        errors: 1,
+        blocked: 2,
+        worstSeverity: 'error',
+        durationMs: 80,
+      }),
     ]);
 
-    expect(output).toContain('1 passed, 1 failed, 2 skipped');
+    expect(output).toContain('1 passed. Failed: 1 error. Skipped: 2 blocked');
+  });
+
+  it('uses worst severity across all summaries for the Total row', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ name: 'only-recommend', recommendations: 1, worstSeverity: 'recommend', durationMs: 10 }),
+      makeSummary({ name: 'has-warn', warnings: 1, worstSeverity: 'warn', durationMs: 10 }),
+    ]);
+
+    // The Total row uses the formatSummaryCounts which shows the icons per-category;
+    // the Total row is still prefixed with "Total:" not a worst-severity icon — only
+    // the per-checklist rows get worst-severity icons. Verify both per-row icons are
+    // rendered correctly.
+    expect(output).toContain('🟡 only-recommend');
+    expect(output).toContain('🟠 has-warn');
   });
 });

--- a/packages/readyup/__tests__/formatCombinedSummary.test.ts
+++ b/packages/readyup/__tests__/formatCombinedSummary.test.ts
@@ -123,17 +123,35 @@ describe(formatCombinedSummary, () => {
     expect(output).toContain('1 passed. Failed: 1 error. Skipped: 2 blocked');
   });
 
-  it('uses worst severity across all summaries for the Total row', () => {
+  it('renders per-row icons reflecting each checklist worst severity', () => {
     const output = formatCombinedSummary([
       makeSummary({ name: 'only-recommend', recommendations: 1, worstSeverity: 'recommend', durationMs: 10 }),
       makeSummary({ name: 'has-warn', warnings: 1, worstSeverity: 'warn', durationMs: 10 }),
     ]);
 
-    // The Total row uses the formatSummaryCounts which shows the icons per-category;
-    // the Total row is still prefixed with "Total:" not a worst-severity icon — only
-    // the per-checklist rows get worst-severity icons. Verify both per-row icons are
-    // rendered correctly.
+    // Per-checklist rows get worst-severity icons; the Total row itself is always
+    // prefixed with "Total:" and uses per-category icons from `formatSummaryCounts`.
     expect(output).toContain('🟡 only-recommend');
     expect(output).toContain('🟠 has-warn');
+  });
+
+  it('aggregates mixed-severity checklists into a single Total line with per-category icons', () => {
+    const output = formatCombinedSummary([
+      makeSummary({
+        name: 'only-recommend',
+        passed: 0,
+        recommendations: 1,
+        worstSeverity: 'recommend',
+        durationMs: 10,
+      }),
+      makeSummary({ name: 'has-warn', passed: 0, warnings: 1, worstSeverity: 'warn', durationMs: 10 }),
+    ]);
+
+    const totalLine = output.split('\n').find((l) => l.startsWith('Total:'));
+    expect(totalLine).toBeDefined();
+    // Both failure categories are summed with their own per-category icons.
+    expect(totalLine).toContain('Failed: 🟠 1 warning, 🟡 1 recommendation');
+    expect(totalLine).toContain('(20ms)');
+    expect(totalLine).not.toContain('passed');
   });
 });

--- a/packages/readyup/__tests__/formatJsonReport.test.ts
+++ b/packages/readyup/__tests__/formatJsonReport.test.ts
@@ -65,7 +65,7 @@ describe(formatJsonReport, () => {
     }).not.toThrow();
   });
 
-  it('returns correct summary counts for a single checklist', () => {
+  it('returns granular summary counts for a single checklist', () => {
     const report = makeReport({
       results: [makePassedResult({ name: 'a' }), makeFailedResult({ name: 'b' }), makeSkippedResult({ name: 'c' })],
       passed: false,
@@ -76,13 +76,16 @@ describe(formatJsonReport, () => {
 
     expect(parsed).toMatchObject({
       passed: 1,
-      failed: 1,
-      skipped: 1,
-      allPassed: false,
+      errors: 1,
+      warnings: 0,
+      recommendations: 0,
+      blocked: 1,
+      optional: 0,
+      worstSeverity: 'error',
     });
   });
 
-  it('aggregates counts across multiple checklists', () => {
+  it('aggregates granular counts across multiple checklists', () => {
     const report1 = makeReport({
       results: [makePassedResult({ name: 'a' }), makePassedResult({ name: 'b' })],
       passed: true,
@@ -103,14 +106,17 @@ describe(formatJsonReport, () => {
 
     expect(parsed).toMatchObject({
       passed: 2,
-      failed: 1,
-      skipped: 0,
-      allPassed: false,
+      errors: 1,
+      warnings: 0,
+      recommendations: 0,
+      blocked: 0,
+      optional: 0,
+      worstSeverity: 'error',
       checklists: expect.arrayContaining([expect.anything(), expect.anything()]),
     });
   });
 
-  it('includes checklist-level allPassed and counts', () => {
+  it('includes granular checklist-level counts and null worstSeverity when all passed', () => {
     const report = makeReport({
       results: [makePassedResult({ name: 'a' })],
       passed: true,
@@ -123,17 +129,20 @@ describe(formatJsonReport, () => {
       checklists: [
         {
           name: 'deploy',
-          allPassed: true,
           passed: 1,
-          failed: 0,
-          skipped: 0,
+          errors: 0,
+          warnings: 0,
+          recommendations: 0,
+          blocked: 0,
+          optional: 0,
+          worstSeverity: null,
           durationMs: 10,
         },
       ],
     });
   });
 
-  it('sets top-level allPassed to true when checks are skipped but none failed', () => {
+  it('sets worstSeverity to null when checks are skipped but none failed', () => {
     const report = makeReport({
       results: [makeSkippedResult({ name: 'a' }), makeSkippedResult({ name: 'b' })],
       passed: true,
@@ -143,14 +152,17 @@ describe(formatJsonReport, () => {
     const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
 
     expect(parsed).toMatchObject({
-      allPassed: true,
       passed: 0,
-      failed: 0,
-      skipped: 2,
+      errors: 0,
+      warnings: 0,
+      recommendations: 0,
+      blocked: 2,
+      optional: 0,
+      worstSeverity: null,
     });
   });
 
-  it('emits the expected top-level shape with no summary wrapper', () => {
+  it('emits the expected top-level shape with granular fields', () => {
     const report = makeReport({
       results: [makePassedResult({ name: 'a' })],
       passed: true,
@@ -162,7 +174,56 @@ describe(formatJsonReport, () => {
     // eslint-disable-next-line unicorn/no-array-sort -- toSorted requires Node 20+; engine target is >=18.17.0
     const topLevelKeys = Object.keys(parsed).sort();
 
-    expect(topLevelKeys).toStrictEqual(['allPassed', 'checklists', 'durationMs', 'failed', 'passed', 'skipped']);
+    expect(topLevelKeys).toStrictEqual([
+      'blocked',
+      'checklists',
+      'durationMs',
+      'errors',
+      'optional',
+      'passed',
+      'recommendations',
+      'warnings',
+      'worstSeverity',
+    ]);
+  });
+
+  it('selects the highest severity across multiple failure buckets for worstSeverity', () => {
+    const report = makeReport({
+      results: [
+        makeFailedResult({ name: 'e', severity: 'error' }),
+        makeFailedResult({ name: 'w', severity: 'warn' }),
+        makeFailedResult({ name: 'r', severity: 'recommend' }),
+      ],
+      passed: false,
+      durationMs: 0,
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+    expect(parsed).toMatchObject({
+      errors: 1,
+      warnings: 1,
+      recommendations: 1,
+      worstSeverity: 'error',
+    });
+  });
+
+  it('distinguishes blocked skips from optional skips', () => {
+    const report = makeReport({
+      results: [
+        makeSkippedResult({ name: 'pre', skipReason: 'precondition' }),
+        makeSkippedResult({ name: 'na', skipReason: 'n/a' }),
+      ],
+      passed: true,
+      durationMs: 0,
+    });
+
+    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+
+    expect(parsed).toMatchObject({
+      blocked: 1,
+      optional: 1,
+    });
   });
 
   it('serializes error as a string message', () => {
@@ -400,7 +461,7 @@ describe(formatJsonReport, () => {
       });
     });
 
-    it('counts all results across nesting levels in summary', () => {
+    it('counts all results across nesting levels in granular summary', () => {
       const report = makeReport({
         results: [
           makePassedResult({ name: 'parent', depth: 0 }),
@@ -416,9 +477,10 @@ describe(formatJsonReport, () => {
 
       expect(parsed).toMatchObject({
         passed: 2,
-        failed: 1,
-        skipped: 1,
-        checklists: [{ passed: 2, failed: 1, skipped: 1 }],
+        errors: 1,
+        blocked: 1,
+        worstSeverity: 'error',
+        checklists: [{ passed: 2, errors: 1, blocked: 1, worstSeverity: 'error' }],
       });
     });
 
@@ -473,7 +535,7 @@ describe(formatJsonReport, () => {
       });
     });
 
-    it('counts only visible results', () => {
+    it('counts only visible results in granular buckets', () => {
       const report = makeReport({
         results: [
           makePassedResult({ name: 'a', severity: 'error' }),
@@ -487,8 +549,12 @@ describe(formatJsonReport, () => {
 
       expect(parsed).toMatchObject({
         passed: 1,
-        failed: 0,
-        skipped: 0,
+        errors: 0,
+        warnings: 0,
+        recommendations: 0,
+        blocked: 0,
+        optional: 0,
+        worstSeverity: null,
       });
     });
   });

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatSummaryCounts, reportRdy } from '../src/reportRdy.ts';
+import { formatSummaryCounts, formatSummaryCountsPlain, reportRdy, tallyResult } from '../src/reportRdy.ts';
 import type { FailedResult, PassedResult, RdyReport, RdyResult, SkippedResult, SummaryCounts } from '../src/types.ts';
 
 function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
@@ -637,5 +637,228 @@ describe(formatSummaryCounts, () => {
 
   it('returns empty string when all counts are zero', () => {
     expect(formatSummaryCounts(makeCounts())).toBe('');
+  });
+});
+
+describe(formatSummaryCountsPlain, () => {
+  it('formats passed count without inline icons', () => {
+    expect(formatSummaryCountsPlain(makeCounts({ passed: 3 }))).toBe('3 passed');
+  });
+
+  it('formats Failed segment without per-count severity icons', () => {
+    const counts = makeCounts({
+      errors: 1,
+      warnings: 2,
+      recommendations: 3,
+      worstSeverity: 'error',
+    });
+
+    const output = formatSummaryCountsPlain(counts);
+
+    expect(output).toBe('Failed: 1 error, 2 warnings, 3 recommendations');
+    expect(output).not.toContain('\u{1F534}');
+    expect(output).not.toContain('\u{1F7E0}');
+    expect(output).not.toContain('\u{1F7E1}');
+  });
+
+  it('formats Skipped segment without per-count reason icons', () => {
+    const counts = makeCounts({ blocked: 2, optional: 3 });
+
+    const output = formatSummaryCountsPlain(counts);
+
+    expect(output).toBe('Skipped: 2 blocked, 3 optional');
+    expect(output).not.toContain('\u26D4');
+    expect(output).not.toContain('\u26AA');
+  });
+
+  it('joins all three groups with icon-free counts', () => {
+    const counts = makeCounts({
+      passed: 14,
+      errors: 1,
+      warnings: 1,
+      recommendations: 2,
+      blocked: 5,
+      optional: 2,
+      worstSeverity: 'error',
+    });
+
+    expect(formatSummaryCountsPlain(counts)).toBe(
+      '14 passed. Failed: 1 error, 1 warning, 2 recommendations. Skipped: 5 blocked, 2 optional',
+    );
+  });
+
+  it('omits the 🟢 prefix from the passed count', () => {
+    expect(formatSummaryCountsPlain(makeCounts({ passed: 5 }))).not.toContain('\u{1F7E2}');
+  });
+
+  it('returns empty string when all counts are zero', () => {
+    expect(formatSummaryCountsPlain(makeCounts())).toBe('');
+  });
+
+  it('matches formatSummaryCounts except for the absence of per-count icon prefixes', () => {
+    const counts = makeCounts({
+      passed: 2,
+      errors: 1,
+      warnings: 1,
+      recommendations: 1,
+      blocked: 1,
+      optional: 1,
+      worstSeverity: 'error',
+    });
+
+    // Strip every known severity/skip icon (and the trailing space) from the iconed output.
+    const iconStripped = formatSummaryCounts(counts)
+      .replace(/\u{1F7E2} /gu, '')
+      .replace(/\u{1F534} /gu, '')
+      .replace(/\u{1F7E0} /gu, '')
+      .replace(/\u{1F7E1} /gu, '')
+      .replace(/\u26D4 /gu, '')
+      .replace(/\u26AA /gu, '');
+
+    expect(formatSummaryCountsPlain(counts)).toBe(iconStripped);
+  });
+});
+
+describe(tallyResult, () => {
+  it('increments `passed` for a passed result', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makePassedResult());
+
+    expect(counts.passed).toBe(1);
+    expect(counts.worstSeverity).toBeNull();
+  });
+
+  it('leaves `worstSeverity` null after a passing result', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makePassedResult());
+    tallyResult(counts, makePassedResult());
+
+    expect(counts.worstSeverity).toBeNull();
+  });
+
+  it('increments `errors` and sets worstSeverity to error for a failed error result', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'error' }));
+
+    expect(counts.errors).toBe(1);
+    expect(counts.warnings).toBe(0);
+    expect(counts.recommendations).toBe(0);
+    expect(counts.worstSeverity).toBe('error');
+  });
+
+  it('increments `warnings` and sets worstSeverity to warn for a failed warn result', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
+
+    expect(counts.warnings).toBe(1);
+    expect(counts.errors).toBe(0);
+    expect(counts.recommendations).toBe(0);
+    expect(counts.worstSeverity).toBe('warn');
+  });
+
+  it('increments `recommendations` and sets worstSeverity to recommend for a failed recommend result', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
+
+    expect(counts.recommendations).toBe(1);
+    expect(counts.errors).toBe(0);
+    expect(counts.warnings).toBe(0);
+    expect(counts.worstSeverity).toBe('recommend');
+  });
+
+  it('increments `blocked` for a precondition-skipped result', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeSkippedResult({ skipReason: 'precondition' }));
+
+    expect(counts.blocked).toBe(1);
+    expect(counts.optional).toBe(0);
+    expect(counts.worstSeverity).toBeNull();
+  });
+
+  it('increments `optional` for an n/a-skipped result', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeSkippedResult({ skipReason: 'n/a' }));
+
+    expect(counts.optional).toBe(1);
+    expect(counts.blocked).toBe(0);
+    expect(counts.worstSeverity).toBeNull();
+  });
+
+  it('escalates worstSeverity from null to recommend on first recommend failure', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
+
+    expect(counts.worstSeverity).toBe('recommend');
+  });
+
+  it('escalates worstSeverity from recommend to warn', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
+    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
+
+    expect(counts.worstSeverity).toBe('warn');
+  });
+
+  it('escalates worstSeverity from warn to error', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
+    tallyResult(counts, makeFailedResult({ severity: 'error' }));
+
+    expect(counts.worstSeverity).toBe('error');
+  });
+
+  it('does not de-escalate worstSeverity when a lower-severity failure follows a higher one', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'error' }));
+    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
+
+    expect(counts.worstSeverity).toBe('error');
+
+    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
+
+    expect(counts.worstSeverity).toBe('error');
+  });
+
+  it('does not de-escalate worstSeverity from warn when a recommend failure follows', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
+    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
+
+    expect(counts.worstSeverity).toBe('warn');
+  });
+
+  it('does not change worstSeverity when a passed result follows a failure', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
+    tallyResult(counts, makePassedResult());
+
+    expect(counts.worstSeverity).toBe('warn');
+    expect(counts.passed).toBe(1);
+    expect(counts.warnings).toBe(1);
+  });
+
+  it('does not change worstSeverity when a skipped result follows a failure', () => {
+    const counts = makeCounts();
+
+    tallyResult(counts, makeFailedResult({ severity: 'error' }));
+    tallyResult(counts, makeSkippedResult({ skipReason: 'precondition' }));
+    tallyResult(counts, makeSkippedResult({ skipReason: 'n/a' }));
+
+    expect(counts.worstSeverity).toBe('error');
+    expect(counts.blocked).toBe(1);
+    expect(counts.optional).toBe(1);
   });
 });

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatSummaryCounts, reportRdy } from '../src/reportRdy.ts';
-import type { FailedResult, PassedResult, RdyReport, RdyResult, SkippedResult } from '../src/types.ts';
+import type { FailedResult, PassedResult, RdyReport, RdyResult, SkippedResult, SummaryCounts } from '../src/types.ts';
 
 function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
   return {
@@ -125,7 +125,7 @@ describe(reportRdy, () => {
     expect(output).toContain('\u26D4 check-pre (0ms)');
   });
 
-  it('renders the summary line', () => {
+  it('renders the summary line with granular failure and skip groups', () => {
     const report = makeReport({
       results: [
         makePassedResult({ name: 'a', durationMs: 10 }),
@@ -138,7 +138,7 @@ describe(reportRdy, () => {
 
     const output = reportRdy(report);
 
-    expect(output).toContain('\u{1F7E2} 1 passed, \u{1F534} 1 failed, \u26D4 1 skipped (142ms)');
+    expect(output).toContain('\u{1F7E2} 1 passed. Failed: \u{1F534} 1 error. Skipped: \u26D4 1 blocked (142ms)');
   });
 
   it('omits zero counts from the summary line', () => {
@@ -449,10 +449,10 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      expect(output).toContain('\u{1F7E2} 2 passed, \u{1F534} 1 failed');
+      expect(output).toContain('\u{1F7E2} 2 passed. Failed: \u{1F534} 1 error');
     });
 
-    it('counts n/a parent but excludes suppressed descendants from summary', () => {
+    it('counts n/a parent as optional skip and excludes suppressed descendants from summary', () => {
       const report = makeReport({
         results: [
           makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
@@ -464,9 +464,9 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      // na-parent counts as skipped; na-child is suppressed; sibling counts as passed.
+      // na-parent counts as optional skip; na-child is suppressed; sibling counts as passed.
       expect(output).toContain('\u{1F7E2} 1 passed');
-      expect(output).toContain('\u{26D4} 1 skipped');
+      expect(output).toContain('\u26AA 1 optional');
       expect(output).toContain('na-parent');
       expect(output).not.toContain('na-child');
     });
@@ -559,20 +559,83 @@ describe(reportRdy, () => {
   });
 });
 
+function makeCounts(overrides?: Partial<SummaryCounts>): SummaryCounts {
+  return {
+    passed: 0,
+    errors: 0,
+    warnings: 0,
+    recommendations: 0,
+    blocked: 0,
+    optional: 0,
+    worstSeverity: null,
+    ...overrides,
+  };
+}
+
 describe(formatSummaryCounts, () => {
-  it('includes all non-zero counts with icons', () => {
-    expect(formatSummaryCounts(3, 1, 2)).toBe('\u{1F7E2} 3 passed, \u{1F534} 1 failed, \u26D4 2 skipped');
+  it('includes all non-zero counts with icons across all three groups', () => {
+    const counts = makeCounts({
+      passed: 14,
+      errors: 1,
+      warnings: 1,
+      recommendations: 2,
+      blocked: 5,
+      optional: 2,
+      worstSeverity: 'error',
+    });
+
+    expect(formatSummaryCounts(counts)).toBe(
+      '\u{1F7E2} 14 passed. Failed: \u{1F534} 1 error, \u{1F7E0} 1 warning, \u{1F7E1} 2 recommendations. Skipped: \u26D4 5 blocked, \u26AA 2 optional',
+    );
   });
 
-  it('omits zero counts', () => {
-    expect(formatSummaryCounts(5, 0, 0)).toBe('\u{1F7E2} 5 passed');
+  it('pluralizes errors correctly for counts of 1 and 2', () => {
+    expect(formatSummaryCounts(makeCounts({ errors: 1, worstSeverity: 'error' }))).toBe('Failed: \u{1F534} 1 error');
+    expect(formatSummaryCounts(makeCounts({ errors: 2, worstSeverity: 'error' }))).toBe('Failed: \u{1F534} 2 errors');
   });
 
-  it('omits passed when zero', () => {
-    expect(formatSummaryCounts(0, 2, 1)).toBe('\u{1F534} 2 failed, \u26D4 1 skipped');
+  it('pluralizes warnings correctly for counts of 1 and 2', () => {
+    expect(formatSummaryCounts(makeCounts({ warnings: 1, worstSeverity: 'warn' }))).toBe('Failed: \u{1F7E0} 1 warning');
+    expect(formatSummaryCounts(makeCounts({ warnings: 2, worstSeverity: 'warn' }))).toBe(
+      'Failed: \u{1F7E0} 2 warnings',
+    );
+  });
+
+  it('pluralizes recommendations correctly for counts of 1 and 2', () => {
+    expect(formatSummaryCounts(makeCounts({ recommendations: 1, worstSeverity: 'recommend' }))).toBe(
+      'Failed: \u{1F7E1} 1 recommendation',
+    );
+    expect(formatSummaryCounts(makeCounts({ recommendations: 2, worstSeverity: 'recommend' }))).toBe(
+      'Failed: \u{1F7E1} 2 recommendations',
+    );
+  });
+
+  it('keeps `blocked` and `optional` labels unchanged for any count', () => {
+    expect(formatSummaryCounts(makeCounts({ blocked: 1, optional: 1 }))).toBe(
+      'Skipped: \u26D4 1 blocked, \u26AA 1 optional',
+    );
+    expect(formatSummaryCounts(makeCounts({ blocked: 3, optional: 4 }))).toBe(
+      'Skipped: \u26D4 3 blocked, \u26AA 4 optional',
+    );
+  });
+
+  it('omits the Failed group when no failure categories have counts', () => {
+    expect(formatSummaryCounts(makeCounts({ passed: 5 }))).toBe('\u{1F7E2} 5 passed');
+  });
+
+  it('omits the Skipped group when no skip categories have counts', () => {
+    expect(formatSummaryCounts(makeCounts({ passed: 5, errors: 1, worstSeverity: 'error' }))).toBe(
+      '\u{1F7E2} 5 passed. Failed: \u{1F534} 1 error',
+    );
+  });
+
+  it('omits zero-count categories within an otherwise non-empty group', () => {
+    expect(formatSummaryCounts(makeCounts({ errors: 2, recommendations: 1, worstSeverity: 'error' }))).toBe(
+      'Failed: \u{1F534} 2 errors, \u{1F7E1} 1 recommendation',
+    );
   });
 
   it('returns empty string when all counts are zero', () => {
-    expect(formatSummaryCounts(0, 0, 0)).toBe('');
+    expect(formatSummaryCounts(makeCounts())).toBe('');
   });
 });

--- a/packages/readyup/__tests__/utils/pluralize.test.ts
+++ b/packages/readyup/__tests__/utils/pluralize.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { pluralize, pluralizeWithCount } from '../../src/utils/pluralize.ts';
+
+describe(pluralize, () => {
+  it('returns the singular form for count 1', () => {
+    expect(pluralize(1, 'apple')).toBe('apple');
+  });
+
+  it('returns the plural form for count other than 1', () => {
+    expect(pluralize(1.1, 'apple')).toBe('apples');
+    expect(pluralize(0, 'apple')).toBe('apples');
+    expect(pluralize(-1, 'apple')).toBe('apple');
+  });
+
+  it('uses a custom plural form if given', () => {
+    expect(pluralize(2, 'child', 'children')).toBe('children');
+  });
+});
+
+describe(pluralizeWithCount, () => {
+  it('returns the singular form with count for count 1', () => {
+    expect(pluralizeWithCount(1, 'apple')).toBe('1 apple');
+  });
+
+  it('returns the plural form with count for count other than 1', () => {
+    expect(pluralizeWithCount(1.1, 'apple')).toBe('1.1 apples');
+    expect(pluralizeWithCount(0, 'apple')).toBe('0 apples');
+    expect(pluralizeWithCount(-1, 'apple')).toBe('-1 apple');
+  });
+
+  it('uses a custom plural form if given', () => {
+    expect(pluralizeWithCount(2, 'child', 'children')).toBe('2 children');
+  });
+});

--- a/packages/readyup/__tests__/utils/severity.test.ts
+++ b/packages/readyup/__tests__/utils/severity.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { worseSeverity } from '../../src/utils/severity.ts';
+
+describe(worseSeverity, () => {
+  it('returns null when both arguments are null', () => {
+    expect(worseSeverity(null, null)).toBe(null);
+  });
+
+  it('returns the non-null value when one argument is null', () => {
+    expect(worseSeverity(null, 'recommend')).toBe('recommend');
+    expect(worseSeverity('warn', null)).toBe('warn');
+    expect(worseSeverity(null, 'error')).toBe('error');
+  });
+
+  it('returns error when either argument is error', () => {
+    expect(worseSeverity('error', 'warn')).toBe('error');
+    expect(worseSeverity('warn', 'error')).toBe('error');
+    expect(worseSeverity('error', 'recommend')).toBe('error');
+    expect(worseSeverity('recommend', 'error')).toBe('error');
+    expect(worseSeverity('error', 'error')).toBe('error');
+  });
+
+  it('returns warn when either argument is warn and neither is error', () => {
+    expect(worseSeverity('warn', 'recommend')).toBe('warn');
+    expect(worseSeverity('recommend', 'warn')).toBe('warn');
+    expect(worseSeverity('warn', 'warn')).toBe('warn');
+  });
+
+  it('returns recommend when both arguments are recommend', () => {
+    expect(worseSeverity('recommend', 'recommend')).toBe('recommend');
+  });
+});

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -7,7 +7,7 @@ import { formatJsonError } from './formatJsonError.ts';
 import { formatJsonReport } from './formatJsonReport.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { parseArgs } from './parseArgs.ts';
-import { reportRdy } from './reportRdy.ts';
+import { reportRdy, tallyResult } from './reportRdy.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
 import { resolveRequestedNames } from './resolveRequestedNames.ts';
 import { meetsThreshold, runRdy } from './runRdy.ts';
@@ -19,6 +19,7 @@ import type {
   RdyReport,
   RdyStagedChecklist,
   Severity,
+  SummaryCounts,
 } from './types.ts';
 
 /** Valid severity values for CLI flag validation. */
@@ -217,16 +218,20 @@ function resolveFixLocation(checklist: RdyChecklist | RdyStagedChecklist, kitDef
 
 /** Build a checklist summary from a report, filtering results by reporting threshold. */
 function summarizeReport(name: string, report: RdyReport, reportOn: Severity): ChecklistSummary {
-  let passed = 0;
-  let failed = 0;
-  let skipped = 0;
+  const counts: SummaryCounts = {
+    passed: 0,
+    errors: 0,
+    warnings: 0,
+    recommendations: 0,
+    blocked: 0,
+    optional: 0,
+    worstSeverity: null,
+  };
   for (const r of report.results) {
     if (!meetsThreshold(r.severity, reportOn)) continue;
-    if (r.status === 'passed') passed++;
-    else if (r.status === 'failed') failed++;
-    else skipped++;
+    tallyResult(counts, r);
   }
-  return { name, passed, failed, skipped, allPassed: report.passed, durationMs: report.durationMs };
+  return { name, ...counts, durationMs: report.durationMs };
 }
 
 /** Resolve threshold values from the cascade: CLI flag > kit field > default. */

--- a/packages/readyup/src/formatCombinedSummary.ts
+++ b/packages/readyup/src/formatCombinedSummary.ts
@@ -1,34 +1,71 @@
-import { formatSummaryCounts } from './reportRdy.ts';
-import type { ChecklistSummary } from './types.ts';
+import { formatSummaryCounts, formatSummaryCountsPlain } from './reportRdy.ts';
+import type { ChecklistSummary, Severity, SummaryCounts } from './types.ts';
 
 const ICON_PASSED = '\u{1F7E2}';
-const ICON_FAILED = '\u{1F534}';
+const ICON_ERROR_FAILED = '\u{1F534}';
+const ICON_WARN_FAILED = '\u{1F7E0}';
+const ICON_RECOMMEND_FAILED = '\u{1F7E1}';
 
 /** Format a duration in milliseconds for display. */
 function formatDuration(ms: number): string {
   return `${Math.round(ms)}ms`;
 }
 
-/** Format a single row's non-zero counts without icons. */
+/** Format a single row's granular non-zero counts without inline icons. */
 function formatRowCounts(summary: ChecklistSummary): string {
-  const parts: string[] = [];
-  if (summary.passed > 0) parts.push(`${summary.passed} passed`);
-  if (summary.failed > 0) parts.push(`${summary.failed} failed`);
-  if (summary.skipped > 0) parts.push(`${summary.skipped} skipped`);
-  return parts.join(', ');
+  return formatSummaryCountsPlain(summary);
+}
+
+/** Return the row-level icon reflecting the worst failed severity in a summary. */
+function getRowIcon(worstSeverity: Severity | null): string {
+  if (worstSeverity === 'error') return ICON_ERROR_FAILED;
+  if (worstSeverity === 'warn') return ICON_WARN_FAILED;
+  if (worstSeverity === 'recommend') return ICON_RECOMMEND_FAILED;
+  return ICON_PASSED;
+}
+
+/** Return the more severe of two severity values. `error` > `warn` > `recommend` > `null`. */
+function worseSeverity(current: Severity | null, candidate: Severity | null): Severity | null {
+  if (current === 'error' || candidate === 'error') return 'error';
+  if (current === 'warn' || candidate === 'warn') return 'warn';
+  if (current === 'recommend' || candidate === 'recommend') return 'recommend';
+  return null;
+}
+
+/** Sum granular counts across multiple summaries, propagating the worst severity. */
+function aggregateCounts(summaries: ChecklistSummary[]): SummaryCounts {
+  const totals: SummaryCounts = {
+    passed: 0,
+    errors: 0,
+    warnings: 0,
+    recommendations: 0,
+    blocked: 0,
+    optional: 0,
+    worstSeverity: null,
+  };
+  for (const s of summaries) {
+    totals.passed += s.passed;
+    totals.errors += s.errors;
+    totals.warnings += s.warnings;
+    totals.recommendations += s.recommendations;
+    totals.blocked += s.blocked;
+    totals.optional += s.optional;
+    totals.worstSeverity = worseSeverity(totals.worstSeverity, s.worstSeverity);
+  }
+  return totals;
 }
 
 /** Format the combined summary table shown after multiple checklists run. */
 export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
   const HEADER =
-    '\u2500\u2500 Summary \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500';
+    '\u2500\u2500 Summary \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500';
   const lines: string[] = [HEADER];
 
   const maxNameLen = Math.max(...summaries.map((s) => s.name.length));
   const maxDurationLen = Math.max(...summaries.map((s) => formatDuration(s.durationMs).length));
 
   for (const summary of summaries) {
-    const icon = summary.allPassed ? ICON_PASSED : ICON_FAILED;
+    const icon = getRowIcon(summary.worstSeverity);
     const name = summary.name.padEnd(maxNameLen);
     const duration = formatDuration(summary.durationMs).padStart(maxDurationLen);
     const counts = formatRowCounts(summary);
@@ -39,14 +76,10 @@ export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
     '\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500',
   );
 
-  const totalPassed = summaries.reduce((sum, s) => sum + s.passed, 0);
-  const totalFailed = summaries.reduce((sum, s) => sum + s.failed, 0);
-  const totalSkipped = summaries.reduce((sum, s) => sum + s.skipped, 0);
+  const totals = aggregateCounts(summaries);
   const totalDuration = summaries.reduce((sum, s) => sum + s.durationMs, 0);
 
-  lines.push(
-    `Total: ${formatSummaryCounts(totalPassed, totalFailed, totalSkipped)} (${formatDuration(totalDuration)})`,
-  );
+  lines.push(`Total: ${formatSummaryCounts(totals)} (${formatDuration(totalDuration)})`);
 
   return lines.join('\n');
 }

--- a/packages/readyup/src/formatCombinedSummary.ts
+++ b/packages/readyup/src/formatCombinedSummary.ts
@@ -1,19 +1,17 @@
-import { formatSummaryCounts, formatSummaryCountsPlain } from './reportRdy.ts';
+import {
+  formatSummaryCounts,
+  formatSummaryCountsPlain,
+  ICON_ERROR_FAILED,
+  ICON_PASSED,
+  ICON_RECOMMEND_FAILED,
+  ICON_WARN_FAILED,
+} from './reportRdy.ts';
 import type { ChecklistSummary, Severity, SummaryCounts } from './types.ts';
-
-const ICON_PASSED = '\u{1F7E2}';
-const ICON_ERROR_FAILED = '\u{1F534}';
-const ICON_WARN_FAILED = '\u{1F7E0}';
-const ICON_RECOMMEND_FAILED = '\u{1F7E1}';
+import { worseSeverity } from './utils/severity.ts';
 
 /** Format a duration in milliseconds for display. */
 function formatDuration(ms: number): string {
   return `${Math.round(ms)}ms`;
-}
-
-/** Format a single row's granular non-zero counts without inline icons. */
-function formatRowCounts(summary: ChecklistSummary): string {
-  return formatSummaryCountsPlain(summary);
 }
 
 /** Return the row-level icon reflecting the worst failed severity in a summary. */
@@ -22,14 +20,6 @@ function getRowIcon(worstSeverity: Severity | null): string {
   if (worstSeverity === 'warn') return ICON_WARN_FAILED;
   if (worstSeverity === 'recommend') return ICON_RECOMMEND_FAILED;
   return ICON_PASSED;
-}
-
-/** Return the more severe of two severity values. `error` > `warn` > `recommend` > `null`. */
-function worseSeverity(current: Severity | null, candidate: Severity | null): Severity | null {
-  if (current === 'error' || candidate === 'error') return 'error';
-  if (current === 'warn' || candidate === 'warn') return 'warn';
-  if (current === 'recommend' || candidate === 'recommend') return 'recommend';
-  return null;
 }
 
 /** Sum granular counts across multiple summaries, propagating the worst severity. */
@@ -68,7 +58,7 @@ export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
     const icon = getRowIcon(summary.worstSeverity);
     const name = summary.name.padEnd(maxNameLen);
     const duration = formatDuration(summary.durationMs).padStart(maxDurationLen);
-    const counts = formatRowCounts(summary);
+    const counts = formatSummaryCountsPlain(summary);
     lines.push(`${icon} ${name}  ${duration}  ${counts}`);
   }
 

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -9,6 +9,7 @@ import type {
   Severity,
   SummaryCounts,
 } from './types.ts';
+import { worseSeverity } from './utils/severity.ts';
 
 interface ChecklistEntry {
   name: string;
@@ -31,14 +32,6 @@ function emptyCounts(): SummaryCounts {
     optional: 0,
     worstSeverity: null,
   };
-}
-
-/** Return the more severe of two severity values. `error` > `warn` > `recommend` > `null`. */
-function worseSeverity(current: Severity | null, candidate: Severity | null): Severity | null {
-  if (current === 'error' || candidate === 'error') return 'error';
-  if (current === 'warn' || candidate === 'warn') return 'warn';
-  if (current === 'recommend' || candidate === 'recommend') return 'recommend';
-  return null;
 }
 
 /** Transform an array of checklist results into a JSON-serializable report string. */
@@ -133,29 +126,14 @@ function buildCheckEntries(
  */
 function buildCheckEntry(result: RdyResult, children: JsonCheckEntry[] = []): JsonCheckEntry {
   const errorString = result.error !== null ? result.error.message : null;
-
-  if (result.status === 'skipped') {
-    return {
-      name: result.name,
-      status: result.status,
-      ok: result.ok,
-      severity: result.severity,
-      skipReason: result.skipReason,
-      detail: result.detail,
-      fix: result.fix,
-      error: errorString,
-      progress: result.progress,
-      durationMs: result.durationMs,
-      checks: children,
-    };
-  }
+  const skipReason = result.status === 'skipped' ? result.skipReason : null;
 
   return {
     name: result.name,
     status: result.status,
     ok: result.ok,
     severity: result.severity,
-    skipReason: null,
+    skipReason,
     detail: result.detail,
     fix: result.fix,
     error: errorString,

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -1,5 +1,14 @@
+import { tallyResult } from './reportRdy.ts';
 import { meetsThreshold } from './runRdy.ts';
-import type { JsonCheckEntry, JsonChecklistEntry, JsonReport, RdyReport, RdyResult, Severity } from './types.ts';
+import type {
+  JsonCheckEntry,
+  JsonChecklistEntry,
+  JsonReport,
+  RdyReport,
+  RdyResult,
+  Severity,
+  SummaryCounts,
+} from './types.ts';
 
 interface ChecklistEntry {
   name: string;
@@ -11,42 +20,58 @@ export interface FormatJsonReportOptions {
   reportOn?: Severity;
 }
 
+/** Create a zeroed `SummaryCounts` object. */
+function emptyCounts(): SummaryCounts {
+  return {
+    passed: 0,
+    errors: 0,
+    warnings: 0,
+    recommendations: 0,
+    blocked: 0,
+    optional: 0,
+    worstSeverity: null,
+  };
+}
+
+/** Return the more severe of two severity values. `error` > `warn` > `recommend` > `null`. */
+function worseSeverity(current: Severity | null, candidate: Severity | null): Severity | null {
+  if (current === 'error' || candidate === 'error') return 'error';
+  if (current === 'warn' || candidate === 'warn') return 'warn';
+  if (current === 'recommend' || candidate === 'recommend') return 'recommend';
+  return null;
+}
+
 /** Transform an array of checklist results into a JSON-serializable report string. */
 export function formatJsonReport(entries: ChecklistEntry[], options?: FormatJsonReportOptions): string {
   const reportOn = options?.reportOn ?? 'recommend';
-  let totalPassed = 0;
-  let totalFailed = 0;
-  let totalSkipped = 0;
+  const totals = emptyCounts();
 
   const checklists: JsonChecklistEntry[] = entries.map(({ name, report }) => {
-    let passed = 0;
-    let failed = 0;
-    let skipped = 0;
+    const counts = emptyCounts();
 
     // Filter results by reporting threshold.
     const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
 
     // Count all visible results (flat count across all nesting levels).
     for (const result of visibleResults) {
-      if (result.status === 'passed') passed++;
-      else if (result.status === 'failed') failed++;
-      else skipped++;
+      tallyResult(counts, result);
     }
 
     // Reconstruct tree from flat depth-first results.
     const { entries: checks } = buildCheckEntries(visibleResults, 0, 0);
 
-    totalPassed += passed;
-    totalFailed += failed;
-    totalSkipped += skipped;
+    totals.passed += counts.passed;
+    totals.errors += counts.errors;
+    totals.warnings += counts.warnings;
+    totals.recommendations += counts.recommendations;
+    totals.blocked += counts.blocked;
+    totals.optional += counts.optional;
+    totals.worstSeverity = worseSeverity(totals.worstSeverity, counts.worstSeverity);
 
     return {
       name,
-      allPassed: report.passed,
       durationMs: report.durationMs,
-      passed,
-      failed,
-      skipped,
+      ...counts,
       checks,
     };
   });
@@ -54,10 +79,7 @@ export function formatJsonReport(entries: ChecklistEntry[], options?: FormatJson
   const totalDurationMs = checklists.reduce((sum, c) => sum + c.durationMs, 0);
 
   const output: JsonReport = {
-    allPassed: entries.every(({ report }) => report.passed),
-    passed: totalPassed,
-    failed: totalFailed,
-    skipped: totalSkipped,
+    ...totals,
     durationMs: totalDurationMs,
     checklists,
   };

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -23,6 +23,7 @@ export type {
   Severity,
   SkippedResult,
   SkipResult,
+  SummaryCounts,
 } from './types.ts';
 
 // Type guards

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -1,6 +1,7 @@
 import { meetsThreshold } from './runRdy.ts';
-import type { FixLocation, Progress, RdyReport, RdyResult, Severity } from './types.ts';
+import type { FixLocation, Progress, RdyReport, RdyResult, Severity, SummaryCounts } from './types.ts';
 import { isPercentProgress } from './types.ts';
+import { pluralizeWithCount } from './utils/pluralize.ts';
 
 const ICON_PASSED = '\u{1F7E2}';
 const ICON_ERROR_FAILED = '\u{1F534}';
@@ -41,13 +42,74 @@ function formatProgress(progress: Progress): string {
   return `${progress.passedCount} of ${progress.count}`;
 }
 
-/** Build an icon-prefixed summary string, omitting counts that are zero. */
-export function formatSummaryCounts(passed: number, failed: number, skipped: number): string {
+/** Build a "Failed: ..." segment with per-severity counts. Returns null when nothing failed. */
+function formatFailedSegment(counts: SummaryCounts, withIcons: boolean): string | null {
   const parts: string[] = [];
-  if (passed > 0) parts.push(`${ICON_PASSED} ${passed} passed`);
-  if (failed > 0) parts.push(`${ICON_ERROR_FAILED} ${failed} failed`);
-  if (skipped > 0) parts.push(`${ICON_SKIPPED_PRECONDITION} ${skipped} skipped`);
-  return parts.join(', ');
+  if (counts.errors > 0) {
+    const label = pluralizeWithCount(counts.errors, 'error');
+    parts.push(withIcons ? `${ICON_ERROR_FAILED} ${label}` : label);
+  }
+  if (counts.warnings > 0) {
+    const label = pluralizeWithCount(counts.warnings, 'warning');
+    parts.push(withIcons ? `${ICON_WARN_FAILED} ${label}` : label);
+  }
+  if (counts.recommendations > 0) {
+    const label = pluralizeWithCount(counts.recommendations, 'recommendation');
+    parts.push(withIcons ? `${ICON_RECOMMEND_FAILED} ${label}` : label);
+  }
+  if (parts.length === 0) return null;
+  return `Failed: ${parts.join(', ')}`;
+}
+
+/** Build a "Skipped: ..." segment with per-reason counts. Returns null when nothing was skipped. */
+function formatSkippedSegment(counts: SummaryCounts, withIcons: boolean): string | null {
+  const parts: string[] = [];
+  if (counts.blocked > 0) {
+    const label = pluralizeWithCount(counts.blocked, 'blocked', 'blocked');
+    parts.push(withIcons ? `${ICON_SKIPPED_PRECONDITION} ${label}` : label);
+  }
+  if (counts.optional > 0) {
+    const label = pluralizeWithCount(counts.optional, 'optional', 'optional');
+    parts.push(withIcons ? `${ICON_SKIPPED_NA} ${label}` : label);
+  }
+  if (parts.length === 0) return null;
+  return `Skipped: ${parts.join(', ')}`;
+}
+
+/**
+ * Build an icon-prefixed summary string with per-severity failure counts and per-reason skip counts.
+ *
+ * Format: `🟢 N passed. Failed: 🔴 N error(s), 🟠 N warning(s), 🟡 N recommendation(s). Skipped: ⛔ N blocked, ⚪ N optional.`
+ * Zero-count entries and empty groups are omitted.
+ */
+export function formatSummaryCounts(counts: SummaryCounts): string {
+  return formatCounts(counts, true);
+}
+
+/**
+ * Build a summary string with the same granular format as `formatSummaryCounts` but
+ * without inline severity icons, for use in combined-summary table rows.
+ */
+export function formatSummaryCountsPlain(counts: SummaryCounts): string {
+  return formatCounts(counts, false);
+}
+
+/** Shared implementation for formatting granular summary counts, with or without icons. */
+function formatCounts(counts: SummaryCounts, withIcons: boolean): string {
+  const segments: string[] = [];
+
+  if (counts.passed > 0) {
+    const passedLabel = pluralizeWithCount(counts.passed, 'passed', 'passed');
+    segments.push(withIcons ? `${ICON_PASSED} ${passedLabel}` : passedLabel);
+  }
+
+  const failedSegment = formatFailedSegment(counts, withIcons);
+  if (failedSegment !== null) segments.push(failedSegment);
+
+  const skippedSegment = formatSkippedSegment(counts, withIcons);
+  if (skippedSegment !== null) segments.push(skippedSegment);
+
+  return segments.join('. ');
 }
 
 /** Collect inline detail lines (error and/or fix) for a failed result. */
@@ -77,21 +139,51 @@ function* iterateWithNaSuppression(results: RdyResult[]): Generator<RdyResult> {
   }
 }
 
-/** Count passed, failed, and skipped results after N/A descendant suppression. */
-function countResults(results: RdyResult[]): {
-  passed: number;
-  failed: number;
-  skipped: number;
-} {
-  let passed = 0;
-  let failed = 0;
-  let skipped = 0;
+/** Count results by severity and skip reason after N/A descendant suppression. */
+function countResults(results: RdyResult[]): SummaryCounts {
+  const counts: SummaryCounts = {
+    passed: 0,
+    errors: 0,
+    warnings: 0,
+    recommendations: 0,
+    blocked: 0,
+    optional: 0,
+    worstSeverity: null,
+  };
   for (const r of iterateWithNaSuppression(results)) {
-    if (r.status === 'passed') passed++;
-    else if (r.status === 'failed') failed++;
-    else skipped++;
+    tallyResult(counts, r);
   }
-  return { passed, failed, skipped };
+  return counts;
+}
+
+/**
+ * Update a `SummaryCounts` object in place with the contribution of a single result.
+ *
+ * Passed results increment `passed`. Failed results are bucketed by severity, and
+ * `worstSeverity` is updated if the failure is more severe than the current worst.
+ * Skipped results increment `blocked` (precondition) or `optional` (n/a).
+ */
+export function tallyResult(counts: SummaryCounts, result: RdyResult): void {
+  if (result.status === 'passed') {
+    counts.passed++;
+    return;
+  }
+  if (result.status === 'failed') {
+    if (result.severity === 'error') counts.errors++;
+    else if (result.severity === 'warn') counts.warnings++;
+    else counts.recommendations++;
+    counts.worstSeverity = worseSeverity(counts.worstSeverity, result.severity);
+    return;
+  }
+  if (result.skipReason === 'precondition') counts.blocked++;
+  else counts.optional++;
+}
+
+/** Return the more severe of two severity values. `error` > `warn` > `recommend` > `null`. */
+function worseSeverity(current: Severity | null, candidate: Severity): Severity {
+  if (current === 'error' || candidate === 'error') return 'error';
+  if (current === 'warn' || candidate === 'warn') return 'warn';
+  return 'recommend';
 }
 
 /**
@@ -132,8 +224,8 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
     }
   }
 
-  const { passed, failed, skipped } = countResults(visibleResults);
-  lines.push('', `${formatSummaryCounts(passed, failed, skipped)} (${formatDuration(report.durationMs)})`);
+  const counts = countResults(visibleResults);
+  lines.push('', `${formatSummaryCounts(counts)} (${formatDuration(report.durationMs)})`);
 
   if (fixLocation === 'end' && collectedFixes.length > 0) {
     lines.push('', 'Fixes:', ...collectedFixes.map((fix) => `  ${ICON_FIX} ${fix}`));

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -2,11 +2,12 @@ import { meetsThreshold } from './runRdy.ts';
 import type { FixLocation, Progress, RdyReport, RdyResult, Severity, SummaryCounts } from './types.ts';
 import { isPercentProgress } from './types.ts';
 import { pluralizeWithCount } from './utils/pluralize.ts';
+import { worseSeverity } from './utils/severity.ts';
 
-const ICON_PASSED = '\u{1F7E2}';
-const ICON_ERROR_FAILED = '\u{1F534}';
-const ICON_WARN_FAILED = '\u{1F7E0}';
-const ICON_RECOMMEND_FAILED = '\u{1F7E1}';
+export const ICON_PASSED = '\u{1F7E2}';
+export const ICON_ERROR_FAILED = '\u{1F534}';
+export const ICON_WARN_FAILED = '\u{1F7E0}';
+export const ICON_RECOMMEND_FAILED = '\u{1F7E1}';
 const ICON_SKIPPED_NA = '\u26AA';
 const ICON_SKIPPED_PRECONDITION = '\u26D4';
 const ICON_FIX = '\u{1F48A}';
@@ -177,13 +178,6 @@ export function tallyResult(counts: SummaryCounts, result: RdyResult): void {
   }
   if (result.skipReason === 'precondition') counts.blocked++;
   else counts.optional++;
-}
-
-/** Return the more severe of two severity values. `error` > `warn` > `recommend` > `null`. */
-function worseSeverity(current: Severity | null, candidate: Severity): Severity {
-  if (current === 'error' || candidate === 'error') return 'error';
-  if (current === 'warn' || candidate === 'warn') return 'warn';
-  return 'recommend';
 }
 
 /**

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -153,13 +153,26 @@ export interface RdyReport {
   durationMs: number;
 }
 
-/** Per-checklist aggregate for the combined summary table. */
-export interface ChecklistSummary {
-  name: string;
+/**
+ * Granular counts of check results by severity and skip reason.
+ *
+ * `errors`/`warnings`/`recommendations` replace the coarser `failed` bucket;
+ * `blocked` (precondition-skipped) and `optional` (n/a-skipped) replace `skipped`.
+ * `worstSeverity` is the highest-severity failed bucket (`null` when nothing failed).
+ */
+export interface SummaryCounts {
   passed: number;
-  failed: number;
-  skipped: number;
-  allPassed: boolean;
+  errors: number;
+  warnings: number;
+  recommendations: number;
+  blocked: number;
+  optional: number;
+  worstSeverity: Severity | null;
+}
+
+/** Per-checklist aggregate for the combined summary table. */
+export interface ChecklistSummary extends SummaryCounts {
+  name: string;
   durationMs: number;
 }
 
@@ -279,22 +292,14 @@ export interface JsonCheckEntry {
 }
 
 /** Shape of a single checklist entry in `--json` output. */
-export interface JsonChecklistEntry {
+export interface JsonChecklistEntry extends SummaryCounts {
   name: string;
-  passed: number;
-  failed: number;
-  skipped: number;
-  allPassed: boolean;
   durationMs: number;
   checks: JsonCheckEntry[];
 }
 
 /** Top-level shape of `--json` output. */
-export interface JsonReport {
-  allPassed: boolean;
-  passed: number;
-  failed: number;
-  skipped: number;
+export interface JsonReport extends SummaryCounts {
   durationMs: number;
   checklists: JsonChecklistEntry[];
 }

--- a/packages/readyup/src/utils/pluralize.ts
+++ b/packages/readyup/src/utils/pluralize.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns the singular or plural form of a word based on the count.
+ * If no plural form is provided, it defaults to the singular form with an 's' appended.
+ */
+export function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return Math.abs(count) === 1 ? singular : plural;
+}
+
+/**
+ * Returns the singular or plural form of a word based on the count, along with the count itself.
+ */
+export function pluralizeWithCount(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${pluralize(count, singular, plural)}`;
+}

--- a/packages/readyup/src/utils/severity.ts
+++ b/packages/readyup/src/utils/severity.ts
@@ -1,0 +1,9 @@
+import type { Severity } from '../types.ts';
+
+/** Return the more severe of two severity values. `error` > `warn` > `recommend` > `null`. */
+export function worseSeverity(current: Severity | null, candidate: Severity | null): Severity | null {
+  if (current === 'error' || candidate === 'error') return 'error';
+  if (current === 'warn' || candidate === 'warn') return 'warn';
+  if (current === 'recommend' || candidate === 'recommend') return 'recommend';
+  return null;
+}


### PR DESCRIPTION
## What

Replace readyup's three-bucket `passed`/`failed`/`skipped`/`allPassed` summary model with a granular `SummaryCounts` shape that tracks failures by severity (`errors`, `warnings`, `recommendations`), skips by reason (`blocked`, `optional`), and carries a `worstSeverity` indicator. The new shape is shared across `ChecklistSummary` (console) and `JsonChecklistEntry`/`JsonReport` (JSON). Console output now renders as `🟢 14 passed. Failed: 🔴 1 error, 🟠 1 warning, 🟡 2 recommendations. Skipped: ⛔ 5 blocked, ⚪ 2 optional` with zero-count entries and empty groups omitted, and combined-summary row icons reflect the worst failed severity per checklist instead of a binary 🟢/🔴 split.

## Why

The previous summary conflated different failure severities (errors lumped with warnings) and different skip reasons (blocked lumped with optional) into single buckets, and the JSON output mirrored the same lossy shape. Consumers of both the console and JSON output could not distinguish severity or skip-reason information at the summary level, and counts were not pluralized (`1 error` vs `1 errors`). The new granular shape preserves severity and skip-reason information end-to-end and makes per-severity row icons possible.

## Details

### Features

- New `SummaryCounts` shape in `src/types.ts` with `passed`, `errors`, `warnings`, `recommendations`, `blocked`, `optional`, and `worstSeverity: Severity | null`. `ChecklistSummary`, `JsonChecklistEntry`, and `JsonReport` all extend it.
- New exported `tallyResult` function in `reportRdy.ts` that increments the correct granular counter and monotonically escalates `worstSeverity` per the order `error > warn > recommend > null`. Used by both `countResults` and `cli.ts`'s `summarizeReport`.
- New `formatSummaryCounts` rendering with grouped pluralized labels. Zero-count entries and fully empty `Failed:` / `Skipped:` groups are omitted. New companion `formatSummaryCountsPlain` emits the same layout without per-count severity icons, for use in the combined summary table rows.
- New ported `pluralize` and `pluralizeWithCount` helpers in `src/utils/pluralize.ts` (vendored from the toolbelt strings package) providing the building blocks for count labels.
- Combined-summary row icons in `formatCombinedSummary.ts` now reflect `worstSeverity`: 🔴 for `error`, 🟠 for `warn`, 🟡 for `recommend`, 🟢 for `null` (all passed). The Total row aggregates child-checklist counts and propagates the worst severity via the shared `worseSeverity` helper.
- `formatJsonReport.ts` emits the granular counts (`errors`, `warnings`, `recommendations`, `blocked`, `optional`, `worstSeverity`) at both per-checklist and top level, replacing `failed`/`skipped`/`allPassed`. Zero counts are preserved in JSON for predictable shape.

### Refactoring

- Extracted `worseSeverity` into `src/utils/severity.ts` as a single `(Severity | null, Severity | null) => Severity | null` function, replacing three independent copies across `reportRdy.ts`, `formatCombinedSummary.ts`, and `formatJsonReport.ts`.
- Consolidated the `ICON_PASSED`, `ICON_ERROR_FAILED`, `ICON_WARN_FAILED`, and `ICON_RECOMMEND_FAILED` constants by exporting them from `reportRdy.ts` and importing them into `formatCombinedSummary.ts`, removing the module-private duplicates.
- Removed the trivial `formatRowCounts` wrapper in `formatCombinedSummary.ts` and called `formatSummaryCountsPlain(summary)` directly at the row-building site.
- Collapsed `buildCheckEntry` in `formatJsonReport.ts` into a single return statement with a conditional `skipReason`, eliminating the duplicated field list across two branches.

### Tests

- New `describe(tallyResult, ...)` block with direct unit tests for every bucketing branch: passed → `passed++`; failed-by-severity → correct counter + monotonic `worstSeverity` escalation (verified `null → recommend → warn → error` and non-de-escalation); skipped-by-reason → `blocked`/`optional` routing without touching `worstSeverity`.
- New `describe(formatSummaryCountsPlain, ...)` block verifying icon-free rendering, including a byte-for-byte equality test against the iconed output with icons stripped.
- New `Total:` row test in `formatCombinedSummary.test.ts` that locates the Total line and verifies `aggregateCounts` sums failure categories with per-category icons across checklists with different worst severities. The mislabeled mixed-severity row test was renamed to reflect what it actually asserts (per-row icons).
- New `src/utils/severity.ts` has a dedicated test file exercising the extracted `worseSeverity` helper against its nullable-severity ordering contract.
- New `src/utils/pluralize.ts` test file covers the ported `pluralize` and `pluralizeWithCount` helpers.
- Existing test factories (`makeSummary`, `makeCounts`) and assertions across `cli.test.ts`, `formatCombinedSummary.test.ts`, `formatJsonReport.test.ts`, and `reportRdy.test.ts` were updated to the new granular shape, with new cases covering severity selection, skip-reason distinction, and pluralization edge cases (1 vs 2 counts).

Closes #11 
