### PR TITLE
#13 Normalize CLI output alignment with uniform-width icons

### DIFF
--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -29,6 +29,7 @@ vi.mock('picomatch', () => ({
 }));
 
 import { compileCommand } from '../src/compile/compileCommand.ts';
+import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../src/reportRdy.ts';
 
 describe(compileCommand, () => {
   let stdoutSpy: MockInstance;
@@ -70,12 +71,12 @@ describe(compileCommand, () => {
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('→'));
   });
 
-  it('shows ⚪ indicator for an unchanged single file', async () => {
+  it('shows 🔍 indicator for an unchanged single file', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: false });
 
     await compileCommand(['input.ts']);
 
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('⚪'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(ICON_NO_CHANGES));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('no changes'));
   });
 
@@ -182,7 +183,7 @@ describe(compileCommand, () => {
     // Header + 2 status lines
     expect(stdoutSpy).toHaveBeenCalledTimes(3);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('📦 a.ts → a.js'));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('⚪ b.ts — no changes'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_NO_CHANGES} b.ts — no changes`));
   });
 
   it('returns 1 when --output is given without an input file', async () => {

--- a/packages/readyup/__tests__/formatCombinedSummary.test.ts
+++ b/packages/readyup/__tests__/formatCombinedSummary.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatCombinedSummary } from '../src/formatCombinedSummary.ts';
+import {
+  ICON_ERROR_FAILED,
+  ICON_PASSED,
+  ICON_RECOMMEND_FAILED,
+  ICON_SKIPPED_PRECONDITION,
+  ICON_WARN_FAILED,
+} from '../src/reportRdy.ts';
 import type { ChecklistSummary } from '../src/types.ts';
 
 function makeSummary(overrides?: Partial<ChecklistSummary>): ChecklistSummary {
@@ -26,30 +33,30 @@ describe(formatCombinedSummary, () => {
     expect(output.split('\n').at(-2)).toMatch(/^─+$/);
   });
 
-  it('shows 🟢 prefix when worstSeverity is null', () => {
+  it('shows passed prefix when worstSeverity is null', () => {
     const output = formatCombinedSummary([makeSummary({ name: 'deploy' })]);
 
-    expect(output).toContain('🟢 deploy');
+    expect(output).toContain(`${ICON_PASSED} deploy`);
   });
 
-  it('shows 🔴 prefix when worstSeverity is error', () => {
+  it('shows error prefix when worstSeverity is error', () => {
     const output = formatCombinedSummary([makeSummary({ name: 'deploy', errors: 1, worstSeverity: 'error' })]);
 
-    expect(output).toContain('🔴 deploy');
+    expect(output).toContain(`${ICON_ERROR_FAILED} deploy`);
   });
 
-  it('shows 🟠 prefix when worstSeverity is warn', () => {
+  it('shows warn prefix when worstSeverity is warn', () => {
     const output = formatCombinedSummary([makeSummary({ name: 'deploy', warnings: 1, worstSeverity: 'warn' })]);
 
-    expect(output).toContain('🟠 deploy');
+    expect(output).toContain(`${ICON_WARN_FAILED} deploy`);
   });
 
-  it('shows 🟡 prefix when worstSeverity is recommend', () => {
+  it('shows recommend prefix when worstSeverity is recommend', () => {
     const output = formatCombinedSummary([
       makeSummary({ name: 'deploy', recommendations: 1, worstSeverity: 'recommend' }),
     ]);
 
-    expect(output).toContain('🟡 deploy');
+    expect(output).toContain(`${ICON_RECOMMEND_FAILED} deploy`);
   });
 
   it('includes duration and grouped counts in each row', () => {
@@ -57,14 +64,14 @@ describe(formatCombinedSummary, () => {
       makeSummary({ name: 'infra', passed: 2, errors: 1, worstSeverity: 'error', durationMs: 45 }),
     ]);
 
-    expect(output).toContain('🔴 infra  45ms  2 passed. Failed: 1 error');
+    expect(output).toContain(`${ICON_ERROR_FAILED} infra  45ms  2 passed. Failed: 1 error`);
     expect(output).not.toContain('Skipped:');
   });
 
   it('omits zero-count categories from row', () => {
     const output = formatCombinedSummary([makeSummary({ name: 'deploy', passed: 5, durationMs: 200 })]);
 
-    expect(output).toContain('🟢 deploy  200ms  5 passed');
+    expect(output).toContain(`${ICON_PASSED} deploy  200ms  5 passed`);
     expect(output).not.toContain('Failed:');
     expect(output).not.toContain('Skipped:');
   });
@@ -82,7 +89,9 @@ describe(formatCombinedSummary, () => {
       }),
     ]);
 
-    expect(output).toContain('Total: 🟢 15 passed. Failed: 🔴 2 errors. Skipped: ⛔ 1 blocked (300ms)');
+    expect(output).toContain(
+      `Total: ${ICON_PASSED} 15 passed. Failed: ${ICON_ERROR_FAILED} 2 errors. Skipped: ${ICON_SKIPPED_PRECONDITION} 1 blocked (300ms)`,
+    );
   });
 
   it('omits zero-count groups from the Total line', () => {
@@ -91,7 +100,7 @@ describe(formatCombinedSummary, () => {
       makeSummary({ name: 'other', passed: 7, durationMs: 150 }),
     ]);
 
-    expect(output).toContain('Total: 🟢 10 passed (200ms)');
+    expect(output).toContain(`Total: ${ICON_PASSED} 10 passed (200ms)`);
     expect(output).not.toContain('Failed:');
     expect(output).not.toContain('Skipped:');
   });
@@ -104,8 +113,8 @@ describe(formatCombinedSummary, () => {
 
     const rows = output.split('\n').filter((l) => l.includes('passed'));
     // "ab" padded to length of "cdef", "5ms" padded to length of "1200ms"
-    expect(rows[0]).toContain('🟢 ab       5ms');
-    expect(rows[1]).toContain('🟢 cdef  1200ms');
+    expect(rows[0]).toContain(`${ICON_PASSED} ab       5ms`);
+    expect(rows[1]).toContain(`${ICON_PASSED} cdef  1200ms`);
   });
 
   it('includes skip groups in row when counts are non-zero', () => {
@@ -131,8 +140,8 @@ describe(formatCombinedSummary, () => {
 
     // Per-checklist rows get worst-severity icons; the Total row itself is always
     // prefixed with "Total:" and uses per-category icons from `formatSummaryCounts`.
-    expect(output).toContain('🟡 only-recommend');
-    expect(output).toContain('🟠 has-warn');
+    expect(output).toContain(`${ICON_RECOMMEND_FAILED} only-recommend`);
+    expect(output).toContain(`${ICON_WARN_FAILED} has-warn`);
   });
 
   it('aggregates mixed-severity checklists into a single Total line with per-category icons', () => {
@@ -150,7 +159,7 @@ describe(formatCombinedSummary, () => {
     const totalLine = output.split('\n').find((l) => l.startsWith('Total:'));
     expect(totalLine).toBeDefined();
     // Both failure categories are summed with their own per-category icons.
-    expect(totalLine).toContain('Failed: 🟠 1 warning, 🟡 1 recommendation');
+    expect(totalLine).toContain(`Failed: ${ICON_WARN_FAILED} 1 warning, ${ICON_RECOMMEND_FAILED} 1 recommendation`);
     expect(totalLine).toContain('(20ms)');
     expect(totalLine).not.toContain('passed');
   });

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatSummaryCounts, formatSummaryCountsPlain, reportRdy, tallyResult } from '../src/reportRdy.ts';
+import {
+  formatSummaryCounts,
+  formatSummaryCountsPlain,
+  ICON_ERROR_FAILED,
+  ICON_FIX,
+  ICON_PASSED,
+  ICON_RECOMMEND_FAILED,
+  ICON_SKIPPED_NA,
+  ICON_SKIPPED_PRECONDITION,
+  ICON_WARN_FAILED,
+  reportRdy,
+  tallyResult,
+} from '../src/reportRdy.ts';
 import type { FailedResult, PassedResult, RdyReport, RdyResult, SkippedResult, SummaryCounts } from '../src/types.ts';
 
 function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
@@ -69,7 +81,7 @@ describe(reportRdy, () => {
 
     const output = reportRdy(report);
 
-    expect(output).toContain('\u{1F7E2} check-a (10ms)');
+    expect(output).toContain(`${ICON_PASSED} check-a (10ms)`);
   });
 
   it('shows error-failed checks with red circle icon', () => {
@@ -80,7 +92,7 @@ describe(reportRdy, () => {
 
     const output = reportRdy(report);
 
-    expect(output).toContain('\u{1F534} check-b (5ms)');
+    expect(output).toContain(`${ICON_ERROR_FAILED} check-b (5ms)`);
   });
 
   it('shows warn-failed checks with orange circle icon', () => {
@@ -91,7 +103,7 @@ describe(reportRdy, () => {
 
     const output = reportRdy(report);
 
-    expect(output).toContain('\u{1F7E0} check-warn (5ms)');
+    expect(output).toContain(`${ICON_WARN_FAILED} check-warn (5ms)`);
   });
 
   it('shows recommend-failed checks with yellow circle icon', () => {
@@ -102,27 +114,27 @@ describe(reportRdy, () => {
 
     const output = reportRdy(report);
 
-    expect(output).toContain('\u{1F7E1} check-rec (5ms)');
+    expect(output).toContain(`${ICON_RECOMMEND_FAILED} check-rec (5ms)`);
   });
 
-  it('shows n/a-skipped checks with white circle icon', () => {
+  it('shows n/a-skipped checks with magnifying glass icon', () => {
     const report = makeReport({
       results: [makeSkippedResult({ name: 'check-na', skipReason: 'n/a' })],
     });
 
     const output = reportRdy(report);
 
-    expect(output).toContain('\u26AA check-na (0ms)');
+    expect(output).toContain(`${ICON_SKIPPED_NA} check-na (0ms)`);
   });
 
-  it('shows precondition-skipped checks with no-entry icon', () => {
+  it('shows precondition-skipped checks with prohibition icon', () => {
     const report = makeReport({
       results: [makeSkippedResult({ name: 'check-pre', skipReason: 'precondition' })],
     });
 
     const output = reportRdy(report);
 
-    expect(output).toContain('\u26D4 check-pre (0ms)');
+    expect(output).toContain(`${ICON_SKIPPED_PRECONDITION} check-pre (0ms)`);
   });
 
   it('renders the summary line with granular failure and skip groups', () => {
@@ -138,7 +150,9 @@ describe(reportRdy, () => {
 
     const output = reportRdy(report);
 
-    expect(output).toContain('\u{1F7E2} 1 passed. Failed: \u{1F534} 1 error. Skipped: \u26D4 1 blocked (142ms)');
+    expect(output).toContain(
+      `${ICON_PASSED} 1 passed. Failed: ${ICON_ERROR_FAILED} 1 error. Skipped: ${ICON_SKIPPED_PRECONDITION} 1 blocked (142ms)`,
+    );
   });
 
   it('omits zero counts from the summary line', () => {
@@ -149,7 +163,7 @@ describe(reportRdy, () => {
 
     const output = reportRdy(report);
 
-    expect(output).toContain('\u{1F7E2} 2 passed (25ms)');
+    expect(output).toContain(`${ICON_PASSED} 2 passed (25ms)`);
     expect(output).not.toContain('failed');
     expect(output).not.toContain('skipped');
   });
@@ -171,7 +185,7 @@ describe(reportRdy, () => {
       const lines = output.split('\n');
 
       expect(output).toContain('Error: Something went wrong');
-      expect(output).toContain('\u{1F48A} Fix: Run npm install');
+      expect(output).toContain(`${ICON_FIX} Fix: Run npm install`);
 
       const checkLineIndex = lines.findIndex((l) => l.includes('broken'));
       const errorLineIndex = lines.findIndex((l) => l.includes('Error: Something went wrong'));
@@ -186,7 +200,7 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report, { fixLocation: 'inline' });
 
-      expect(output).toContain('\u{1F48A} Fix: Run npm install');
+      expect(output).toContain(`${ICON_FIX} Fix: Run npm install`);
       expect(output).not.toContain('Error:');
     });
 
@@ -199,7 +213,7 @@ describe(reportRdy, () => {
       const output = reportRdy(report, { fixLocation: 'inline' });
 
       expect(output).toContain('Error: Missing file');
-      expect(output).not.toContain('\u{1F48A}');
+      expect(output).not.toContain(ICON_FIX);
     });
   });
 
@@ -224,7 +238,7 @@ describe(reportRdy, () => {
       expect(errorLineIndex).toBe(checkLineIndex + 1);
 
       expect(output).toContain('Fixes:');
-      expect(output).toContain(`  \u{1F48A} Update config file`);
+      expect(output).toContain(`  ${ICON_FIX} Update config file`);
     });
 
     it('omits Fixes section when no fixes are present', () => {
@@ -248,7 +262,7 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      expect(output).toContain('\u{1F7E2} check-a (10ms) \u2014 some info');
+      expect(output).toContain(`${ICON_PASSED} check-a (10ms) \u2014 some info`);
     });
 
     it('renders fraction progress', () => {
@@ -264,7 +278,7 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      expect(output).toContain('\u{1F534} check-b (5ms) \u2014 7 of 10');
+      expect(output).toContain(`${ICON_ERROR_FAILED} check-b (5ms) \u2014 7 of 10`);
     });
 
     it('renders percent progress', () => {
@@ -275,7 +289,7 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      expect(output).toContain('\u{1F534} check-c (3ms) \u2014 85%');
+      expect(output).toContain(`${ICON_ERROR_FAILED} check-c (3ms) \u2014 85%`);
     });
 
     it('renders both detail and progress as separate segments', () => {
@@ -292,7 +306,7 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      expect(output).toContain('\u{1F534} check-d (5ms) \u2014 some detail \u2014 7 of 10');
+      expect(output).toContain(`${ICON_ERROR_FAILED} check-d (5ms) \u2014 some detail \u2014 7 of 10`);
     });
 
     it('renders detail and progress on passing checks', () => {
@@ -309,7 +323,7 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      expect(output).toContain('\u{1F7E2} check-e (2ms) \u2014 all good \u2014 100%');
+      expect(output).toContain(`${ICON_PASSED} check-e (2ms) \u2014 all good \u2014 100%`);
     });
 
     it('omits detail segment when detail is null', () => {
@@ -319,7 +333,7 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      expect(output).toContain('\u{1F7E2} check-f (1ms)');
+      expect(output).toContain(`${ICON_PASSED} check-f (1ms)`);
       expect(output).not.toContain('\u2014');
     });
   });
@@ -339,7 +353,7 @@ describe(reportRdy, () => {
     const output = reportRdy(report);
 
     expect(output).toContain('Fixes:');
-    expect(output).toContain(`  \u{1F48A} Fix it`);
+    expect(output).toContain(`  ${ICON_FIX} Fix it`);
     expect(output).not.toContain('Fix: Fix it');
   });
 
@@ -356,9 +370,9 @@ describe(reportRdy, () => {
       const output = reportRdy(report);
       const lines = output.split('\n');
 
-      expect(lines[0]).toBe('\u{1F7E2} parent (10ms)');
-      expect(lines[1]).toBe('  \u{1F7E2} child (5ms)');
-      expect(lines[2]).toBe('    \u{1F7E2} grandchild (3ms)');
+      expect(lines[0]).toBe(`${ICON_PASSED} parent (10ms)`);
+      expect(lines[1]).toBe(`   ${ICON_PASSED} child (5ms)`);
+      expect(lines[2]).toBe(`      ${ICON_PASSED} grandchild (3ms)`);
     });
 
     it('renders top-level result at depth 0 with no indentation', () => {
@@ -369,7 +383,7 @@ describe(reportRdy, () => {
       const output = reportRdy(report);
       const lines = output.split('\n');
 
-      expect(lines[0]).toBe('\u{1F7E2} top-check (7ms)');
+      expect(lines[0]).toBe(`${ICON_PASSED} top-check (7ms)`);
     });
 
     it('shows n/a parent but suppresses descendants', () => {
@@ -406,9 +420,9 @@ describe(reportRdy, () => {
       const lines = output.split('\n');
 
       const childLine = lines.findIndex((l) => l.includes('child'));
-      expect(lines[childLine]).toMatch(/^ {2}/);
-      expect(lines[childLine + 1]).toBe('    Error: child error');
-      expect(lines[childLine + 2]).toBe('    \u{1F48A} Fix: fix child');
+      expect(lines[childLine]).toMatch(/^ {3}/);
+      expect(lines[childLine + 1]).toBe('      Error: child error');
+      expect(lines[childLine + 2]).toBe(`      ${ICON_FIX} Fix: fix child`);
     });
 
     it('collects fixes from nested failed checks in end mode', () => {
@@ -429,9 +443,9 @@ describe(reportRdy, () => {
       const lines = output.split('\n');
 
       const childLine = lines.findIndex((l) => l.includes('child'));
-      expect(lines[childLine + 1]).toBe('    Error: child error');
+      expect(lines[childLine + 1]).toBe('      Error: child error');
       expect(output).toContain('Fixes:');
-      expect(output).toContain(`  \u{1F48A} fix the child`);
+      expect(output).toContain(`  ${ICON_FIX} fix the child`);
       // Fix should not appear inline after the error line.
       expect(lines[childLine + 2]).not.toContain('fix the child');
     });
@@ -449,7 +463,7 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      expect(output).toContain('\u{1F7E2} 2 passed. Failed: \u{1F534} 1 error');
+      expect(output).toContain(`${ICON_PASSED} 2 passed. Failed: ${ICON_ERROR_FAILED} 1 error`);
     });
 
     it('counts n/a parent as optional skip and excludes suppressed descendants from summary', () => {
@@ -465,8 +479,8 @@ describe(reportRdy, () => {
       const output = reportRdy(report);
 
       // na-parent counts as optional skip; na-child is suppressed; sibling counts as passed.
-      expect(output).toContain('\u{1F7E2} 1 passed');
-      expect(output).toContain('\u26AA 1 optional');
+      expect(output).toContain(`${ICON_PASSED} 1 passed`);
+      expect(output).toContain(`${ICON_SKIPPED_NA} 1 optional`);
       expect(output).toContain('na-parent');
       expect(output).not.toContain('na-child');
     });
@@ -514,7 +528,7 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report, { reportOn: 'error' });
 
-      expect(output).toContain('\u{1F7E2} 1 passed');
+      expect(output).toContain(`${ICON_PASSED} 1 passed`);
       expect(output).not.toContain('2 passed');
     });
 
@@ -585,53 +599,59 @@ describe(formatSummaryCounts, () => {
     });
 
     expect(formatSummaryCounts(counts)).toBe(
-      '\u{1F7E2} 14 passed. Failed: \u{1F534} 1 error, \u{1F7E0} 1 warning, \u{1F7E1} 2 recommendations. Skipped: \u26D4 5 blocked, \u26AA 2 optional',
+      `${ICON_PASSED} 14 passed. Failed: ${ICON_ERROR_FAILED} 1 error, ${ICON_WARN_FAILED} 1 warning, ${ICON_RECOMMEND_FAILED} 2 recommendations. Skipped: ${ICON_SKIPPED_PRECONDITION} 5 blocked, ${ICON_SKIPPED_NA} 2 optional`,
     );
   });
 
   it('pluralizes errors correctly for counts of 1 and 2', () => {
-    expect(formatSummaryCounts(makeCounts({ errors: 1, worstSeverity: 'error' }))).toBe('Failed: \u{1F534} 1 error');
-    expect(formatSummaryCounts(makeCounts({ errors: 2, worstSeverity: 'error' }))).toBe('Failed: \u{1F534} 2 errors');
+    expect(formatSummaryCounts(makeCounts({ errors: 1, worstSeverity: 'error' }))).toBe(
+      `Failed: ${ICON_ERROR_FAILED} 1 error`,
+    );
+    expect(formatSummaryCounts(makeCounts({ errors: 2, worstSeverity: 'error' }))).toBe(
+      `Failed: ${ICON_ERROR_FAILED} 2 errors`,
+    );
   });
 
   it('pluralizes warnings correctly for counts of 1 and 2', () => {
-    expect(formatSummaryCounts(makeCounts({ warnings: 1, worstSeverity: 'warn' }))).toBe('Failed: \u{1F7E0} 1 warning');
+    expect(formatSummaryCounts(makeCounts({ warnings: 1, worstSeverity: 'warn' }))).toBe(
+      `Failed: ${ICON_WARN_FAILED} 1 warning`,
+    );
     expect(formatSummaryCounts(makeCounts({ warnings: 2, worstSeverity: 'warn' }))).toBe(
-      'Failed: \u{1F7E0} 2 warnings',
+      `Failed: ${ICON_WARN_FAILED} 2 warnings`,
     );
   });
 
   it('pluralizes recommendations correctly for counts of 1 and 2', () => {
     expect(formatSummaryCounts(makeCounts({ recommendations: 1, worstSeverity: 'recommend' }))).toBe(
-      'Failed: \u{1F7E1} 1 recommendation',
+      `Failed: ${ICON_RECOMMEND_FAILED} 1 recommendation`,
     );
     expect(formatSummaryCounts(makeCounts({ recommendations: 2, worstSeverity: 'recommend' }))).toBe(
-      'Failed: \u{1F7E1} 2 recommendations',
+      `Failed: ${ICON_RECOMMEND_FAILED} 2 recommendations`,
     );
   });
 
   it('keeps `blocked` and `optional` labels unchanged for any count', () => {
     expect(formatSummaryCounts(makeCounts({ blocked: 1, optional: 1 }))).toBe(
-      'Skipped: \u26D4 1 blocked, \u26AA 1 optional',
+      `Skipped: ${ICON_SKIPPED_PRECONDITION} 1 blocked, ${ICON_SKIPPED_NA} 1 optional`,
     );
     expect(formatSummaryCounts(makeCounts({ blocked: 3, optional: 4 }))).toBe(
-      'Skipped: \u26D4 3 blocked, \u26AA 4 optional',
+      `Skipped: ${ICON_SKIPPED_PRECONDITION} 3 blocked, ${ICON_SKIPPED_NA} 4 optional`,
     );
   });
 
   it('omits the Failed group when no failure categories have counts', () => {
-    expect(formatSummaryCounts(makeCounts({ passed: 5 }))).toBe('\u{1F7E2} 5 passed');
+    expect(formatSummaryCounts(makeCounts({ passed: 5 }))).toBe(`${ICON_PASSED} 5 passed`);
   });
 
   it('omits the Skipped group when no skip categories have counts', () => {
     expect(formatSummaryCounts(makeCounts({ passed: 5, errors: 1, worstSeverity: 'error' }))).toBe(
-      '\u{1F7E2} 5 passed. Failed: \u{1F534} 1 error',
+      `${ICON_PASSED} 5 passed. Failed: ${ICON_ERROR_FAILED} 1 error`,
     );
   });
 
   it('omits zero-count categories within an otherwise non-empty group', () => {
     expect(formatSummaryCounts(makeCounts({ errors: 2, recommendations: 1, worstSeverity: 'error' }))).toBe(
-      'Failed: \u{1F534} 2 errors, \u{1F7E1} 1 recommendation',
+      `Failed: ${ICON_ERROR_FAILED} 2 errors, ${ICON_RECOMMEND_FAILED} 1 recommendation`,
     );
   });
 
@@ -656,9 +676,9 @@ describe(formatSummaryCountsPlain, () => {
     const output = formatSummaryCountsPlain(counts);
 
     expect(output).toBe('Failed: 1 error, 2 warnings, 3 recommendations');
-    expect(output).not.toContain('\u{1F534}');
-    expect(output).not.toContain('\u{1F7E0}');
-    expect(output).not.toContain('\u{1F7E1}');
+    expect(output).not.toContain(ICON_ERROR_FAILED);
+    expect(output).not.toContain(ICON_WARN_FAILED);
+    expect(output).not.toContain(ICON_RECOMMEND_FAILED);
   });
 
   it('formats Skipped segment without per-count reason icons', () => {
@@ -667,8 +687,8 @@ describe(formatSummaryCountsPlain, () => {
     const output = formatSummaryCountsPlain(counts);
 
     expect(output).toBe('Skipped: 2 blocked, 3 optional');
-    expect(output).not.toContain('\u26D4');
-    expect(output).not.toContain('\u26AA');
+    expect(output).not.toContain(ICON_SKIPPED_PRECONDITION);
+    expect(output).not.toContain(ICON_SKIPPED_NA);
   });
 
   it('joins all three groups with icon-free counts', () => {
@@ -688,7 +708,7 @@ describe(formatSummaryCountsPlain, () => {
   });
 
   it('omits the 🟢 prefix from the passed count', () => {
-    expect(formatSummaryCountsPlain(makeCounts({ passed: 5 }))).not.toContain('\u{1F7E2}');
+    expect(formatSummaryCountsPlain(makeCounts({ passed: 5 }))).not.toContain(ICON_PASSED);
   });
 
   it('returns empty string when all counts are zero', () => {
@@ -708,12 +728,12 @@ describe(formatSummaryCountsPlain, () => {
 
     // Strip every known severity/skip icon (and the trailing space) from the iconed output.
     const iconStripped = formatSummaryCounts(counts)
-      .replace(/\u{1F7E2} /gu, '')
-      .replace(/\u{1F534} /gu, '')
-      .replace(/\u{1F7E0} /gu, '')
-      .replace(/\u{1F7E1} /gu, '')
-      .replace(/\u26D4 /gu, '')
-      .replace(/\u26AA /gu, '');
+      .replaceAll(`${ICON_PASSED} `, '')
+      .replaceAll(`${ICON_ERROR_FAILED} `, '')
+      .replaceAll(`${ICON_WARN_FAILED} `, '')
+      .replaceAll(`${ICON_RECOMMEND_FAILED} `, '')
+      .replaceAll(`${ICON_SKIPPED_PRECONDITION} `, '')
+      .replaceAll(`${ICON_SKIPPED_NA} `, '');
 
     expect(formatSummaryCountsPlain(counts)).toBe(iconStripped);
   });

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -6,6 +6,7 @@ import picomatch from 'picomatch';
 
 import { loadConfig } from '../loadConfig.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
+import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../reportRdy.ts';
 import { compileConfig } from './compileConfig.ts';
 import { validateCompiledOutput } from './validateCompiledOutput.ts';
 
@@ -136,5 +137,5 @@ async function compileBatch(): Promise<number> {
 
 /** Format a single compile-result line with a change indicator. */
 function formatResultLine(srcName: string, outName: string, changed: boolean): string {
-  return changed ? `  📦 ${srcName} → ${outName}\n` : `  ⚪ ${srcName} — no changes\n`;
+  return changed ? `  📦 ${srcName} → ${outName}\n` : `  ${ICON_NO_CHANGES} ${srcName} — no changes\n`;
 }

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -8,9 +8,9 @@ export const ICON_PASSED = '\u{1F7E2}';
 export const ICON_ERROR_FAILED = '\u{1F534}';
 export const ICON_WARN_FAILED = '\u{1F7E0}';
 export const ICON_RECOMMEND_FAILED = '\u{1F7E1}';
-const ICON_SKIPPED_NA = '\u26AA';
-const ICON_SKIPPED_PRECONDITION = '\u26D4';
-const ICON_FIX = '\u{1F48A}';
+export const ICON_SKIPPED_NA = '\u{1F50D}';
+export const ICON_SKIPPED_PRECONDITION = '\u{1F6AB}';
+export const ICON_FIX = '\u{1F48A}';
 
 /** Options controlling how the report is formatted. */
 export interface ReportRdyOptions {
@@ -80,8 +80,7 @@ function formatSkippedSegment(counts: SummaryCounts, withIcons: boolean): string
 /**
  * Build an icon-prefixed summary string with per-severity failure counts and per-reason skip counts.
  *
- * Format: `🟢 N passed. Failed: 🔴 N error(s), 🟠 N warning(s), 🟡 N recommendation(s). Skipped: ⛔ N blocked, ⚪ N optional.`
- * Zero-count entries and empty groups are omitted.
+ * Each segment is icon-prefixed and joined with `. `. Zero-count entries and empty groups are omitted.
  */
 export function formatSummaryCounts(counts: SummaryCounts): string {
   return formatCounts(counts, true);
@@ -116,11 +115,13 @@ function formatCounts(counts: SummaryCounts, withIcons: boolean): string {
 /** Collect inline detail lines (error and/or fix) for a failed result. */
 function collectInlineDetails(result: RdyResult, includeFix: boolean): string[] {
   const details: string[] = [];
+  // The 3-space lead-in matches the icon+space width on the check line above,
+  // so continuation text lands directly under the check name column.
   if (result.error !== null) {
-    details.push(`  Error: ${result.error.message}`);
+    details.push(`   Error: ${result.error.message}`);
   }
   if (includeFix && result.fix !== null) {
-    details.push(`  ${ICON_FIX} Fix: ${result.fix}`);
+    details.push(`   ${ICON_FIX} Fix: ${result.fix}`);
   }
   return details;
 }
@@ -196,7 +197,7 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
   const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
 
   for (const result of iterateWithNaSuppression(visibleResults)) {
-    const indent = '  '.repeat(result.depth);
+    const indent = '   '.repeat(result.depth);
     const icon = getIcon(result);
     let checkLine = `${indent}${icon} ${result.name} (${formatDuration(result.durationMs)})`;
     if (result.detail !== null) {


### PR DESCRIPTION
Closes #13

## What

Replace the two narrow `ICON_SKIPPED_*` constants in `reportRdy.ts` with their 2-cell-wide counterparts (⚪ → 🔍 and ⛔ → 🚫), bringing the entire icon set to a uniform terminal cell width. Increase the per-depth nesting indent and the continuation-line lead-in from 2 to 3 spaces each. Wire `compileCommand.ts` to import `ICON_SKIPPED_NA` from `reportRdy.ts` under a local alias `ICON_NO_CHANGES`. Migrate icon-using test assertions across three test files to reference imported constants instead of raw Unicode escape sequences.

## Why

The original icon set mixed wide colored emoji (2 cells) with two narrow legacy "Miscellaneous Symbols" glyphs (1 cell), causing same-depth check rows to drift one column whenever a narrow icon appeared. Selecting icons that are uniformly 2 cells wide is the root-cause fix and eliminates the need for any per-icon padding logic. The indent and lead-in bumps resolve two further alignment bugs visible in nested checks and continuation lines. The same icon-uniformity fix also resolves a parallel drift bug in `compile` command output, where the literal `⚪` used as the "no changes" indicator was 1 cell wide next to the 2-cell `📦`. Sharing the constant between the `run` and `compile` commands keeps a single source of truth, since "skipped n/a" and "compiled file unchanged" both express "examined and there was nothing to do". The test-assertion migration is opportunistic readability cleanup — anyone reading the test file shouldn't have to memorize Unicode codepoints to understand which icon a test is asserting.

## Details

### Fixes

- **Narrow-vs-wide icon column drift on check rows.** `⚪` U+26AA (Medium White Circle) and `⛔` U+26D4 (No Entry) live in the older "Miscellaneous Symbols" Unicode block and have text presentation by default, rendering at 1 cell on most terminals. The other icons in the set are emoji-presentation defaults that render at 2 cells. Replaced `⚪` with `🔍` (Magnifying Glass, U+1F50D) and `⛔` with `🚫` (Prohibition Sign, U+1F6AB), bringing every icon to uniform 2-cell width.
- **Continuation-line misalignment under check names.** Error and inline-fix continuation lines in `collectInlineDetails` previously used a hardcoded 2-space lead-in. The check line above has an icon+space lead-in occupying 3 visual cells, so continuation text landed one column to the left of the check name it described. Changed the lead-in to 3 spaces.
- **Nesting indent off-by-one.** Per-depth indent in the check-line builder was 2 spaces, putting child icons one column to the left of where their parent's name started. Changed to 3 spaces so child icons sit directly under the parent's first-name-character.
- **Parallel column-drift bug in `compile` command output.** `compileCommand.ts` used a literal `⚪` as the "no changes" indicator next to the 2-cell-wide `📦`, exhibiting the same drift in `rdy compile` output as the main report had. Resolved by importing `ICON_SKIPPED_NA` (now `🔍`) under a local alias `ICON_NO_CHANGES`.

### Refactoring

- Exported `ICON_SKIPPED_NA`, `ICON_SKIPPED_PRECONDITION`, and `ICON_FIX` from `reportRdy.ts`. They were previously file-local constants.
- Switched `compileCommand.ts` from a literal `⚪` to the imported `ICON_SKIPPED_NA as ICON_NO_CHANGES`. The compile command's "no changes" indicator and the run command's "n/a skipped" indicator now share the same glyph and the same source of truth.
- Simplified the doc comment for `formatSummaryCounts` to describe the format abstractly instead of embedding a literal-icon example (which had already drifted once during this work).

### Tests

- Migrated icon-using assertions in `reportRdy.test.ts`, `formatCombinedSummary.test.ts`, and `compileCommand.test.ts` from raw Unicode escape sequences (e.g., `\u{1F7E2}`) and literal glyphs to imported constant references via template literals.
- Replaced the bottom-of-file `.replace(/\u{XXXX} /gu, '')` regex chain in `reportRdy.test.ts` with a `.replaceAll(\`${ICON_NAME} \`, '')` chain that uses string-based replacement.
- Updated stale test names in `reportRdy.test.ts` that still described the old glyphs ("white circle icon" → "magnifying glass icon", "no-entry icon" → "prohibition icon").

## Test plan

- [ ] Visually verify aligned columns in `rdy run` output for a checklist mixing all six result states (passed, error-failed, warn-failed, recommend-failed, n/a-skipped, precondition-skipped) in iTerm2 and Terminal.app on macOS.
- [ ] Visually verify continuation lines (`Error: ...` and inline `💊 Fix: ...`) sit directly under the check name column.
- [ ] Visually verify nested child checks have their icons sitting under the parent's first-name-character.
- [ ] Visually verify `rdy compile` "no changes" rows align with "changed" rows.
