### PR TITLE
#7 Add `rdy list` subcommand for local kit enumeration

### DIFF
--- a/packages/readyup/__tests__/list/enumerateKits.test.ts
+++ b/packages/readyup/__tests__/list/enumerateKits.test.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { enumerateKits } from '../../src/list/enumerateKits.ts';
+
+describe(enumerateKits, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'enumerateKits-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns base names matching the given extension, sorted alphabetically', () => {
+    fs.writeFileSync(path.join(tempDir, 'b.ts'), '');
+    fs.writeFileSync(path.join(tempDir, 'a.ts'), '');
+    fs.writeFileSync(path.join(tempDir, 'c.js'), '');
+
+    const result = enumerateKits({ dir: tempDir, extension: '.ts' });
+
+    expect(result).toEqual(['a', 'b']);
+  });
+
+  it('returns empty array when directory does not exist', () => {
+    const result = enumerateKits({ dir: path.join(tempDir, 'nonexistent'), extension: '.ts' });
+
+    expect(result).toEqual([]);
+  });
+
+  it('excludes hidden files', () => {
+    fs.writeFileSync(path.join(tempDir, '.hidden.ts'), '');
+    fs.writeFileSync(path.join(tempDir, 'visible.ts'), '');
+
+    const result = enumerateKits({ dir: tempDir, extension: '.ts' });
+
+    expect(result).toEqual(['visible']);
+  });
+
+  it('excludes subdirectories even if their names match the extension', () => {
+    fs.mkdirSync(path.join(tempDir, 'subdir.ts'));
+    fs.writeFileSync(path.join(tempDir, 'file.ts'), '');
+
+    const result = enumerateKits({ dir: tempDir, extension: '.ts' });
+
+    expect(result).toEqual(['file']);
+  });
+
+  it('returns empty array when no files match the extension', () => {
+    fs.writeFileSync(path.join(tempDir, 'file.js'), '');
+
+    const result = enumerateKits({ dir: tempDir, extension: '.ts' });
+
+    expect(result).toEqual([]);
+  });
+
+  it('strips the extension from results', () => {
+    fs.writeFileSync(path.join(tempDir, 'default.js'), '');
+
+    const result = enumerateKits({ dir: tempDir, extension: '.js' });
+
+    expect(result).toEqual(['default']);
+  });
+});

--- a/packages/readyup/__tests__/list/enumerateKits.test.ts
+++ b/packages/readyup/__tests__/list/enumerateKits.test.ts
@@ -66,4 +66,15 @@ describe(enumerateKits, () => {
 
     expect(result).toEqual(['default']);
   });
+
+  it('rethrows non-ENOENT filesystem errors', () => {
+    // Make directory unreadable to trigger EACCES
+    fs.mkdirSync(path.join(tempDir, 'restricted'));
+    fs.chmodSync(path.join(tempDir, 'restricted'), 0o000);
+
+    expect(() => enumerateKits({ dir: path.join(tempDir, 'restricted'), extension: '.ts' })).toThrow();
+
+    // Restore permissions for cleanup
+    fs.chmodSync(path.join(tempDir, 'restricted'), 0o755);
+  });
 });

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatConsumerView, formatEmpty, formatOwnerView } from '../../src/list/formatList.ts';
+
+describe(formatOwnerView, () => {
+  it('renders only the Internal section when compiled kits are empty', () => {
+    const result = formatOwnerView({
+      internalKits: ['default', 'deploy'],
+      compiledKits: [],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    expect(result).toContain('Internal:');
+    expect(result).not.toContain('Compiled:');
+    expect(result).toContain('deploy');
+  });
+
+  it('renders only the Compiled section when internal kits are empty', () => {
+    const result = formatOwnerView({
+      internalKits: [],
+      compiledKits: ['deploy'],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    expect(result).not.toContain('Internal:');
+    expect(result).toContain('Compiled:');
+    expect(result).toContain('deploy');
+  });
+
+  it('uses brackets around --kit when default kit exists in internal', () => {
+    const result = formatOwnerView({
+      internalKits: ['default'],
+      compiledKits: ['deploy'],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    expect(result).toContain('[--kit <name>]');
+  });
+
+  it('omits brackets around --kit when no default kit exists', () => {
+    const result = formatOwnerView({
+      internalKits: ['deploy'],
+      compiledKits: [],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    expect(result).toContain('--kit <name>');
+    expect(result).not.toContain('[--kit <name>]');
+  });
+
+  it('renders custom outDir style with file paths', () => {
+    const result = formatOwnerView({
+      internalKits: [],
+      compiledKits: ['deploy', 'monitor'],
+      compiledStyle: { kind: 'custom-outDir', outDirRel: 'dist/kits' },
+    });
+
+    expect(result).toContain('rdy run --file <file path>');
+    expect(result).toContain('dist/kits/deploy.js');
+    expect(result).toContain('dist/kits/monitor.js');
+  });
+
+  it('returns empty-owner message when both lists are empty', () => {
+    const result = formatOwnerView({
+      internalKits: [],
+      compiledKits: [],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    expect(result).toBe(
+      'No kits found.\nRun `rdy init` to scaffold an internal kit or `rdy compile` to compile a kit from source.',
+    );
+  });
+
+  it('renders both sections when both have kits', () => {
+    const result = formatOwnerView({
+      internalKits: ['default'],
+      compiledKits: ['deploy'],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    expect(result).toContain('Internal:');
+    expect(result).toContain('Compiled:');
+  });
+});
+
+describe(formatConsumerView, () => {
+  it('renders compiled kits with the local path in the hint', () => {
+    const result = formatConsumerView({
+      compiledKits: ['default', 'deploy'],
+      localPathArg: '.',
+    });
+
+    expect(result).toContain('rdy run --local .');
+    expect(result).toContain('default');
+    expect(result).toContain('deploy');
+  });
+
+  it('preserves the exact localPathArg in the hint', () => {
+    const result = formatConsumerView({
+      compiledKits: ['deploy'],
+      localPathArg: '/other',
+    });
+
+    expect(result).toContain('rdy run --local /other');
+  });
+
+  it('uses brackets around --kit when default kit exists', () => {
+    const result = formatConsumerView({
+      compiledKits: ['default'],
+      localPathArg: '.',
+    });
+
+    expect(result).toContain('[--kit <name>]');
+  });
+
+  it('returns empty-consumer message when kit list is empty', () => {
+    const result = formatConsumerView({
+      compiledKits: [],
+      localPathArg: '.',
+    });
+
+    expect(result).toBe('No compiled kits found at ./.rdy/kits/.');
+  });
+});
+
+describe(formatEmpty, () => {
+  it('returns owner message for owner mode', () => {
+    const result = formatEmpty('owner');
+
+    expect(result).toContain('rdy init');
+    expect(result).toContain('rdy compile');
+  });
+
+  it('returns consumer message with the provided path', () => {
+    const result = formatEmpty('consumer', '/some/path');
+
+    expect(result).toBe('No compiled kits found at /some/path/.rdy/kits/.');
+  });
+
+  it('defaults consumer path to "." when omitted', () => {
+    const result = formatEmpty('consumer');
+
+    expect(result).toContain('./.rdy/kits/');
+  });
+});

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -27,14 +27,34 @@ describe(formatOwnerView, () => {
     expect(result).toContain('deploy');
   });
 
-  it('uses brackets around --kit when default kit exists in internal', () => {
+  it('uses brackets in internal hint and omits them in compiled hint when default is only in internal', () => {
     const result = formatOwnerView({
       internalKits: ['default'],
       compiledKits: ['deploy'],
       compiledStyle: { kind: 'local-convention' },
     });
 
-    expect(result).toContain('[--kit <name>]');
+    const lines = result.split('\n');
+    const internalHeader = lines.find((l) => l.startsWith('Internal:'));
+    const compiledHeader = lines.find((l) => l.startsWith('Compiled:'));
+
+    expect(internalHeader).toContain('[--kit <name>]');
+    expect(compiledHeader).not.toContain('[--kit <name>]');
+  });
+
+  it('uses brackets in compiled hint when default is in compiled kits', () => {
+    const result = formatOwnerView({
+      internalKits: ['deploy'],
+      compiledKits: ['default', 'monitor'],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    const lines = result.split('\n');
+    const internalHeader = lines.find((l) => l.startsWith('Internal:'));
+    const compiledHeader = lines.find((l) => l.startsWith('Compiled:'));
+
+    expect(internalHeader).not.toContain('[--kit <name>]');
+    expect(compiledHeader).toContain('[--kit <name>]');
   });
 
   it('omits brackets around --kit when no default kit exists', () => {

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -134,6 +134,16 @@ describe(formatConsumerView, () => {
     expect(result).toContain('[--kit <name>]');
   });
 
+  it('omits brackets around --kit when default kit is absent', () => {
+    const result = formatConsumerView({
+      compiledKits: ['deploy'],
+      localPathArg: '.',
+    });
+
+    expect(result).toContain('--kit <name>');
+    expect(result).not.toContain('[--kit <name>]');
+  });
+
   it('returns empty-consumer message when kit list is empty', () => {
     const result = formatConsumerView({
       compiledKits: [],

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+const mockLoadConfig = vi.hoisted(() => vi.fn());
+const mockEnumerateKits = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/loadConfig.ts', () => ({
+  loadConfig: mockLoadConfig,
+}));
+
+vi.mock('../src/list/enumerateKits.ts', () => ({
+  enumerateKits: mockEnumerateKits,
+}));
+
+import { listCommand } from '../src/list/listCommand.ts';
+
+describe(listCommand, () => {
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.rdy/kits', outDir: '.rdy/kits', include: undefined },
+      internal: { dir: '.', extension: '.ts' },
+    });
+    mockEnumerateKits.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockLoadConfig.mockReset();
+    mockEnumerateKits.mockReset();
+  });
+
+  describe('owner mode', () => {
+    it('loads config and enumerates both internal and compiled kits', async () => {
+      mockEnumerateKits.mockReturnValueOnce(['default']).mockReturnValueOnce(['deploy']);
+
+      const exitCode = await listCommand([]);
+
+      expect(exitCode).toBe(0);
+      expect(mockLoadConfig).toHaveBeenCalled();
+      expect(mockEnumerateKits).toHaveBeenCalledTimes(2);
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('Internal:');
+      expect(output).toContain('Compiled:');
+    });
+
+    it('renders only Internal section when no compiled kits exist', async () => {
+      mockEnumerateKits.mockReturnValueOnce(['default']).mockReturnValueOnce([]);
+
+      const exitCode = await listCommand([]);
+
+      expect(exitCode).toBe(0);
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('Internal:');
+      expect(output).not.toContain('Compiled:');
+    });
+
+    it('uses custom-outDir style when outDir differs from default', async () => {
+      mockLoadConfig.mockResolvedValue({
+        compile: { srcDir: 'src/kits', outDir: 'dist/kits', include: undefined },
+        internal: { dir: '.', extension: '.ts' },
+      });
+      mockEnumerateKits.mockReturnValueOnce([]).mockReturnValueOnce(['deploy']);
+
+      const exitCode = await listCommand([]);
+
+      expect(exitCode).toBe(0);
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('dist/kits/deploy.js');
+      expect(output).toContain('--file');
+    });
+
+    it('prints empty-owner message when no kits exist', async () => {
+      const exitCode = await listCommand([]);
+
+      expect(exitCode).toBe(0);
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('No kits found.');
+    });
+
+    it('returns 1 and writes to stderr when config load fails', async () => {
+      mockLoadConfig.mockRejectedValue(new Error('bad config'));
+
+      const exitCode = await listCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('bad config'));
+    });
+  });
+
+  describe('consumer mode', () => {
+    it('does not load config when --local is given', async () => {
+      mockEnumerateKits.mockReturnValue([]);
+
+      const exitCode = await listCommand(['--local', '.']);
+
+      expect(exitCode).toBe(0);
+      expect(mockLoadConfig).not.toHaveBeenCalled();
+    });
+
+    it('enumerates compiled kits from the local path', async () => {
+      mockEnumerateKits.mockReturnValue(['deploy']);
+
+      const exitCode = await listCommand(['--local', '.']);
+
+      expect(exitCode).toBe(0);
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('Compiled:');
+      expect(output).toContain('deploy');
+    });
+
+    it('prints empty-consumer message when no kits exist at the local path', async () => {
+      mockEnumerateKits.mockReturnValue([]);
+
+      const exitCode = await listCommand(['--local', '/nonexistent']);
+
+      expect(exitCode).toBe(0);
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('No compiled kits found at /nonexistent/.rdy/kits/.');
+    });
+
+    it('accepts -l as short form of --local', async () => {
+      mockEnumerateKits.mockReturnValue(['default']);
+
+      const exitCode = await listCommand(['-l', '.']);
+
+      expect(exitCode).toBe(0);
+      expect(mockLoadConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  it('returns 1 for unknown flags', async () => {
+    const exitCode = await listCommand(['--unknown']);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown option: --unknown'));
+  });
+});

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -42,6 +42,12 @@ describe(listCommand, () => {
       expect(exitCode).toBe(0);
       expect(mockLoadConfig).toHaveBeenCalled();
       expect(mockEnumerateKits).toHaveBeenCalledTimes(2);
+      expect(mockEnumerateKits).toHaveBeenCalledWith(
+        expect.objectContaining({ dir: expect.stringContaining('.rdy/kits'), extension: '.ts' }),
+      );
+      expect(mockEnumerateKits).toHaveBeenCalledWith(
+        expect.objectContaining({ dir: expect.stringContaining('.rdy/kits'), extension: '.js' }),
+      );
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(output).toContain('Internal:');
       expect(output).toContain('Compiled:');
@@ -89,6 +95,18 @@ describe(listCommand, () => {
       expect(exitCode).toBe(1);
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('bad config'));
     });
+
+    it('returns 1 and writes to stderr when enumerateKits throws', async () => {
+      const permError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      mockEnumerateKits.mockImplementation(() => {
+        throw permError;
+      });
+
+      const exitCode = await listCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
+    });
   });
 
   describe('consumer mode', () => {
@@ -107,6 +125,9 @@ describe(listCommand, () => {
       const exitCode = await listCommand(['--local', '.']);
 
       expect(exitCode).toBe(0);
+      expect(mockEnumerateKits).toHaveBeenCalledWith(
+        expect.objectContaining({ dir: expect.stringContaining('.rdy/kits'), extension: '.js' }),
+      );
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(output).toContain('Compiled:');
       expect(output).toContain('deploy');
@@ -120,6 +141,18 @@ describe(listCommand, () => {
       expect(exitCode).toBe(0);
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(output).toContain('No compiled kits found at /nonexistent/.rdy/kits/.');
+    });
+
+    it('returns 1 and writes to stderr when enumerateKits throws', async () => {
+      const permError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      mockEnumerateKits.mockImplementation(() => {
+        throw permError;
+      });
+
+      const exitCode = await listCommand(['--local', '.']);
+
+      expect(exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
     });
 
     it('accepts -l as short form of --local', async () => {

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 const mockRunCommand = vi.hoisted(() => vi.fn());
 const mockInitCommand = vi.hoisted(() => vi.fn());
 const mockCompileCommand = vi.hoisted(() => vi.fn());
+const mockListCommand = vi.hoisted(() => vi.fn());
 const mockParseRunArgs = vi.hoisted(() => vi.fn());
 const mockResolveKitSource = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
@@ -23,6 +24,10 @@ vi.mock('../src/compile/compileCommand.ts', () => ({
 
 vi.mock('../src/init/initCommand.ts', () => ({
   initCommand: mockInitCommand,
+}));
+
+vi.mock('../src/list/listCommand.ts', () => ({
+  listCommand: mockListCommand,
 }));
 
 vi.mock('../src/version.ts', () => ({
@@ -50,6 +55,7 @@ describe(routeCommand, () => {
     mockRunCommand.mockReset();
     mockCompileCommand.mockReset();
     mockInitCommand.mockReset();
+    mockListCommand.mockReset();
     mockParseRunArgs.mockReset();
     mockResolveKitSource.mockReset();
     mockLoadConfig.mockReset();
@@ -312,6 +318,45 @@ describe(routeCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown option: --unknown'));
   });
 
+  it('shows list help and returns 0 for list --help', async () => {
+    const exitCode = await routeCommand(['list', '--help']);
+
+    expect(exitCode).toBe(0);
+    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('Usage: rdy list');
+  });
+
+  it('shows list help and returns 0 for list -h', async () => {
+    const exitCode = await routeCommand(['list', '-h']);
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('delegates to listCommand for list subcommand', async () => {
+    mockListCommand.mockResolvedValue(0);
+
+    const exitCode = await routeCommand(['list']);
+
+    expect(mockListCommand).toHaveBeenCalledWith([]);
+    expect(exitCode).toBe(0);
+  });
+
+  it('passes --local flag through to listCommand', async () => {
+    mockListCommand.mockResolvedValue(0);
+
+    const exitCode = await routeCommand(['list', '--local', '.']);
+
+    expect(mockListCommand).toHaveBeenCalledWith(['--local', '.']);
+    expect(exitCode).toBe(0);
+  });
+
+  it('lists list in top-level help', async () => {
+    await routeCommand([]);
+
+    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('list');
+  });
+
   describe('default command routing', () => {
     it('routes flags to run when no subcommand is given', async () => {
       mockParseRunArgs.mockReturnValue({
@@ -356,6 +401,7 @@ describe(routeCommand, () => {
       ['compi', 'compile'],
       ['comp', 'compile'],
       ['ini', 'init'],
+      ['lis', 'list'],
     ])('suggests "%s" -> "%s"', async (input, expected) => {
       const exitCode = await routeCommand([input]);
 

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -3,11 +3,12 @@ import process from 'node:process';
 import { parseRunArgs, resolveKitSource, runCommand } from '../cli.ts';
 import { compileCommand } from '../compile/compileCommand.ts';
 import { initCommand } from '../init/initCommand.ts';
+import { listCommand } from '../list/listCommand.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { VERSION } from '../version.ts';
 
-const SUBCOMMANDS = ['compile', 'init'];
+const SUBCOMMANDS = ['compile', 'init', 'list'];
 const MIN_PREFIX_LENGTH = 3;
 
 /** Extract a displayable message from an unknown thrown value. */
@@ -24,6 +25,7 @@ Commands:
   run [names...]       Run rdy checklists (default)
   compile [file]       Bundle TypeScript kit(s) into self-contained ESM file(s)
   init                 Scaffold a starter config and kit
+  list                 List available kits
 
 Run options:
   --file, -f <path>                  Path to a local kit file
@@ -79,6 +81,26 @@ Modes:
 Options:
   --output, -o <path>  Output file path (single-file mode only)
   --help, -h           Show this help message
+`);
+}
+
+function showListHelp(): void {
+  console.info(`
+Usage: rdy list [options]
+
+List available kits without running them.
+
+Modes:
+  rdy list                  List internal and compiled kits (owner view)
+  rdy list --local <path>   List compiled kits at a local path (consumer view)
+
+Options:
+  --local, -l <path>  Path to a local repository with compiled kits
+  --help, -h          Show this help message
+
+Examples:
+  rdy list             Show kits in the current project
+  rdy list --local .   Show compiled kits in the current directory
 `);
 }
 
@@ -165,6 +187,20 @@ export async function routeCommand(args: string[]): Promise<number> {
     }
 
     return initCommand({ dryRun: parsed.flags.dryRun, force: parsed.flags.force });
+  }
+
+  if (command === 'list') {
+    const flags = args.slice(1);
+    if (flags.some((f) => f === '--help' || f === '-h')) {
+      showListHelp();
+      return 0;
+    }
+    try {
+      return await listCommand(flags);
+    } catch (error: unknown) {
+      process.stderr.write(`Error: ${extractMessage(error)}\n`);
+      return 1;
+    }
   }
 
   // Check for typos before falling through to the default command

--- a/packages/readyup/src/list/enumerateKits.ts
+++ b/packages/readyup/src/list/enumerateKits.ts
@@ -1,0 +1,38 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+
+interface EnumerateKitsOptions {
+  dir: string;
+  extension: string;
+}
+
+/**
+ * Return sorted base names (extension stripped) of files in `dir` matching `extension`.
+ *
+ * Non-recursive. Hidden files (starting with `.`) are excluded. Returns `[]` when
+ * `dir` does not exist; rethrows other filesystem errors (e.g., `EACCES`).
+ */
+export function enumerateKits({ dir, extension }: EnumerateKitsOptions): string[] {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+
+  return (
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(extension) && !entry.name.startsWith('.'))
+      .map((entry) => path.basename(entry.name, extension))
+      // eslint-disable-next-line unicorn/no-array-sort
+      .sort()
+  );
+}
+
+/** Type guard for Node.js filesystem errors with a `code` property. */
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -1,14 +1,9 @@
 const ICON_INTERNAL = '📄';
 const ICON_COMPILED = '📦';
 
-/** Check whether a kit list contains a "default" entry. */
-function hasDefault(kits: string[]): boolean {
-  return kits.includes('default');
-}
-
 /** Build the `--kit` flag hint with brackets when a default kit exists. */
 function buildKitHint(kits: string[]): string {
-  return hasDefault(kits) ? '[--kit <name>]' : '--kit <name>';
+  return kits.includes('default') ? '[--kit <name>]' : '--kit <name>';
 }
 
 // -- Compiled-section style discriminants --
@@ -55,8 +50,8 @@ export function formatOwnerView({ internalKits, compiledKits, compiledStyle }: O
       sections.push(formatSection('Compiled', hint, compiledKits, ICON_COMPILED));
     } else {
       const hint = `rdy run --file <file path>`;
-      const items = compiledKits.map((name) => `  ${ICON_COMPILED} ${compiledStyle.outDirRel}/${name}.js`);
-      sections.push(`Compiled: ${hint}\n${items.join('\n')}`);
+      const pathItems = compiledKits.map((name) => `${compiledStyle.outDirRel}/${name}.js`);
+      sections.push(formatSection('Compiled', hint, pathItems, ICON_COMPILED));
     }
   }
 

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -1,0 +1,103 @@
+const ICON_INTERNAL = '📄';
+const ICON_COMPILED = '📦';
+
+/** Check whether a kit list contains a "default" entry. */
+function hasDefault(kits: string[]): boolean {
+  return kits.includes('default');
+}
+
+/** Build the `--kit` flag hint with brackets when a default kit exists. */
+function kitHint(kits: string[]): string {
+  return hasDefault(kits) ? '[--kit <name>]' : '--kit <name>';
+}
+
+// -- Compiled-section style discriminants --
+
+export interface LocalConventionStyle {
+  kind: 'local-convention';
+}
+
+export interface CustomOutDirStyle {
+  kind: 'custom-outDir';
+  outDirRel: string;
+}
+
+export type CompiledStyle = LocalConventionStyle | CustomOutDirStyle;
+
+// -- Owner view --
+
+interface OwnerViewOptions {
+  internalKits: string[];
+  compiledKits: string[];
+  compiledStyle: CompiledStyle;
+}
+
+/**
+ * Format the owner-mode output showing internal and compiled kit sections.
+ *
+ * Empty sections are omitted. Returns the empty-owner message when both lists are empty.
+ */
+export function formatOwnerView({ internalKits, compiledKits, compiledStyle }: OwnerViewOptions): string {
+  if (internalKits.length === 0 && compiledKits.length === 0) {
+    return formatEmpty('owner');
+  }
+
+  const sections: string[] = [];
+
+  if (internalKits.length > 0) {
+    const hint = `rdy run ${kitHint(internalKits)}`;
+    sections.push(formatSection('Internal', hint, internalKits, ICON_INTERNAL));
+  }
+
+  if (compiledKits.length > 0) {
+    if (compiledStyle.kind === 'local-convention') {
+      const hint = `rdy run --local . ${kitHint(compiledKits)}`;
+      sections.push(formatSection('Compiled', hint, compiledKits, ICON_COMPILED));
+    } else {
+      const hint = `rdy run --file <file path>`;
+      const items = compiledKits.map((name) => `  ${ICON_COMPILED} ${compiledStyle.outDirRel}/${name}.js`);
+      sections.push(`Compiled: ${hint}\n${items.join('\n')}`);
+    }
+  }
+
+  return sections.join('\n\n');
+}
+
+// -- Consumer view --
+
+interface ConsumerViewOptions {
+  compiledKits: string[];
+  localPathArg: string;
+}
+
+/**
+ * Format the consumer-mode output showing compiled kits at a local path.
+ *
+ * Returns the empty-consumer message when the kit list is empty.
+ */
+export function formatConsumerView({ compiledKits, localPathArg }: ConsumerViewOptions): string {
+  if (compiledKits.length === 0) {
+    return formatEmpty('consumer', localPathArg);
+  }
+
+  const hint = `rdy run --local ${localPathArg} ${kitHint(compiledKits)}`;
+  return formatSection('Compiled', hint, compiledKits, ICON_COMPILED);
+}
+
+// -- Empty messages --
+
+/** Format the "no kits found" message appropriate to the given mode. */
+export function formatEmpty(mode: 'owner' | 'consumer', localPathArg?: string): string {
+  if (mode === 'consumer') {
+    return `No compiled kits found at ${localPathArg ?? '.'}/.rdy/kits/.`;
+  }
+  return 'No kits found.\nRun `rdy init` to scaffold an internal kit or `rdy compile` to compile a kit from source.';
+}
+
+// -- Helpers --
+
+/** Build a titled section with a usage hint and indented item list. */
+function formatSection(title: string, hint: string, kits: string[], icon: string): string {
+  const items = kits.map((name) => `  ${icon} ${name}`);
+  return `${title}: ${hint}\n${items.join('\n')}`;
+}

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -7,7 +7,7 @@ function hasDefault(kits: string[]): boolean {
 }
 
 /** Build the `--kit` flag hint with brackets when a default kit exists. */
-function kitHint(kits: string[]): string {
+function buildKitHint(kits: string[]): string {
   return hasDefault(kits) ? '[--kit <name>]' : '--kit <name>';
 }
 
@@ -45,13 +45,13 @@ export function formatOwnerView({ internalKits, compiledKits, compiledStyle }: O
   const sections: string[] = [];
 
   if (internalKits.length > 0) {
-    const hint = `rdy run ${kitHint(internalKits)}`;
+    const hint = `rdy run ${buildKitHint(internalKits)}`;
     sections.push(formatSection('Internal', hint, internalKits, ICON_INTERNAL));
   }
 
   if (compiledKits.length > 0) {
     if (compiledStyle.kind === 'local-convention') {
-      const hint = `rdy run --local . ${kitHint(compiledKits)}`;
+      const hint = `rdy run --local . ${buildKitHint(compiledKits)}`;
       sections.push(formatSection('Compiled', hint, compiledKits, ICON_COMPILED));
     } else {
       const hint = `rdy run --file <file path>`;
@@ -80,7 +80,7 @@ export function formatConsumerView({ compiledKits, localPathArg }: ConsumerViewO
     return formatEmpty('consumer', localPathArg);
   }
 
-  const hint = `rdy run --local ${localPathArg} ${kitHint(compiledKits)}`;
+  const hint = `rdy run --local ${localPathArg} ${buildKitHint(compiledKits)}`;
   return formatSection('Compiled', hint, compiledKits, ICON_COMPILED);
 }
 

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -3,9 +3,9 @@ import process from 'node:process';
 
 import { loadConfig } from '../loadConfig.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
+import { enumerateKits } from './enumerateKits.ts';
 import type { CompiledStyle } from './formatList.ts';
 import { formatConsumerView, formatOwnerView } from './formatList.ts';
-import { enumerateKits } from './enumerateKits.ts';
 
 const listFlagSchema = {
   local: { long: '--local', type: 'string' as const, short: '-l' },
@@ -36,8 +36,7 @@ export async function listCommand(args: string[]): Promise<number> {
 
 /** Enumerate kits from a local path without loading config. */
 function runConsumerMode(localPathArg: string): number {
-  const cwd = process.cwd();
-  const kitsDir = path.join(path.resolve(cwd, localPathArg), '.rdy/kits');
+  const kitsDir = path.join(path.resolve(localPathArg), '.rdy/kits');
 
   let compiledKits;
   try {

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -1,0 +1,84 @@
+import path from 'node:path';
+import process from 'node:process';
+
+import { loadConfig } from '../loadConfig.ts';
+import { parseArgs, translateParseError } from '../parseArgs.ts';
+import type { CompiledStyle } from './formatList.ts';
+import { formatConsumerView, formatOwnerView } from './formatList.ts';
+import { enumerateKits } from './enumerateKits.ts';
+
+const listFlagSchema = {
+  local: { long: '--local', type: 'string' as const, short: '-l' },
+};
+
+/**
+ * Handle the `list` subcommand: enumerate kits from the filesystem and print their names.
+ *
+ * Returns a numeric exit code.
+ */
+export async function listCommand(args: string[]): Promise<number> {
+  let parsed;
+  try {
+    parsed = parseArgs(args, listFlagSchema);
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${translateParseError(error)}\n`);
+    return 1;
+  }
+
+  const localPathArg = parsed.flags.local;
+
+  if (localPathArg !== undefined) {
+    return runConsumerMode(localPathArg);
+  }
+
+  return runOwnerMode();
+}
+
+/** Enumerate kits from a local path without loading config. */
+function runConsumerMode(localPathArg: string): number {
+  const cwd = process.cwd();
+  const kitsDir = path.join(path.resolve(cwd, localPathArg), '.rdy/kits');
+  const compiledKits = enumerateKits({ dir: kitsDir, extension: '.js' });
+
+  const output = formatConsumerView({ compiledKits, localPathArg });
+  process.stdout.write(output + '\n');
+  return 0;
+}
+
+/** Enumerate kits using the project config. */
+async function runOwnerMode(): Promise<number> {
+  const cwd = process.cwd();
+
+  let config;
+  try {
+    config = await loadConfig();
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
+  }
+
+  const internalDir = path.join(cwd, '.rdy/kits', config.internal.dir);
+  const compiledDir = path.resolve(cwd, config.compile.outDir);
+
+  const internalKits = enumerateKits({ dir: internalDir, extension: config.internal.extension });
+  const compiledKits = enumerateKits({ dir: compiledDir, extension: '.js' });
+
+  const compiledStyle = resolveCompiledStyle(cwd, config.compile.outDir);
+  const output = formatOwnerView({ internalKits, compiledKits, compiledStyle });
+  process.stdout.write(output + '\n');
+  return 0;
+}
+
+/** Determine the compiled-section display style based on the outDir setting. */
+function resolveCompiledStyle(cwd: string, outDir: string): CompiledStyle {
+  const resolvedOutDir = path.resolve(cwd, outDir);
+  const defaultOutDir = path.resolve(cwd, '.rdy/kits');
+
+  if (resolvedOutDir === defaultOutDir) {
+    return { kind: 'local-convention' };
+  }
+
+  const outDirRel = path.relative(cwd, resolvedOutDir);
+  return { kind: 'custom-outDir', outDirRel };
+}

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -38,7 +38,15 @@ export async function listCommand(args: string[]): Promise<number> {
 function runConsumerMode(localPathArg: string): number {
   const cwd = process.cwd();
   const kitsDir = path.join(path.resolve(cwd, localPathArg), '.rdy/kits');
-  const compiledKits = enumerateKits({ dir: kitsDir, extension: '.js' });
+
+  let compiledKits;
+  try {
+    compiledKits = enumerateKits({ dir: kitsDir, extension: '.js' });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
+  }
 
   const output = formatConsumerView({ compiledKits, localPathArg });
   process.stdout.write(output + '\n');
@@ -61,8 +69,16 @@ async function runOwnerMode(): Promise<number> {
   const internalDir = path.join(cwd, '.rdy/kits', config.internal.dir);
   const compiledDir = path.resolve(cwd, config.compile.outDir);
 
-  const internalKits = enumerateKits({ dir: internalDir, extension: config.internal.extension });
-  const compiledKits = enumerateKits({ dir: compiledDir, extension: '.js' });
+  let internalKits;
+  let compiledKits;
+  try {
+    internalKits = enumerateKits({ dir: internalDir, extension: config.internal.extension });
+    compiledKits = enumerateKits({ dir: compiledDir, extension: '.js' });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
+  }
 
   const compiledStyle = resolveCompiledStyle(cwd, config.compile.outDir);
   const output = formatOwnerView({ internalKits, compiledKits, compiledStyle });


### PR DESCRIPTION
## What

Adds a `rdy list` subcommand that enumerates available kits from the filesystem without loading or executing kit code. Supports two modes: an owner view that loads project config and shows both internal and compiled kits in separate sections, and an external-consumer view (`--local <path>`) that skips config and shows only compiled kits at the target path.

## Why

There was no way to discover which kits are available in a project without browsing the filesystem manually. With the recent split between internal kits and compiled kits, this was especially confusing — a repo can own kits in either or both categories, and there was no at-a-glance view of what's invokable or which invocation form (`rdy run`, `--local`, `--file`) to use.

## Details

### Features

- `rdy list` (owner mode): loads config, enumerates internal kits from `.rdy/kits/{config.internal.dir}/` and compiled kits from `compile.outDir`. Display branches on whether `outDir` resolves to the default `.rdy/kits` (bare names with `--local .` hint) or a custom path (file paths with `--file` hint).
- `rdy list --local <path>` (consumer mode): skips config, hardcodes `.rdy/kits/*.js`, shows only a Compiled section with the user's path preserved in the hint.
- Section headers include `[--kit <name>]` brackets only when a kit named `default` exists in that section.
- Empty sections are omitted; fully empty results show context-aware "no kits found" messages with actionable hints.
- `rdy list --help` / `-h` shows per-command help; top-level `rdy --help` includes `list`; `rdy li` suggests `rdy list` via typo detection.

### Fixes

- `listCommand` catches filesystem errors (e.g., `EACCES`) in both modes and returns exit code 1 with a stderr message, matching the error-handling contract of other command handlers.

### Refactoring

- Inlined single-use `hasDefault` helper into `buildKitHint`.
- Routed custom-outDir branch through `formatSection` for consistent rendering.
- Removed redundant `process.cwd()` capture in `runConsumerMode`.

### Tests

- `enumerateKits.test.ts`: extension filtering, hidden file exclusion, subdirectory exclusion, missing directory, EACCES propagation, sorting.
- `formatList.test.ts`: owner view (internal-only, compiled-only, both, custom outDir, empty), consumer view (with/without default, path preservation, empty), bracket logic per section.
- `listCommand.test.ts`: owner mode (internal kits, compiled kits, Case A/B style, empty, config failure, filesystem errors), consumer mode (kits found, missing dir, filesystem errors, `-l` short flag), path and extension assertions.
- `route.test.ts`: `list` dispatch, `--help` handling, typo suggestion, top-level help entry.

Closes #7