### PR TITLE
#22 Extract shared extractMessage utility from duplicated error-handling pattern

### DIFF
--- a/packages/readyup/__tests__/utils/extractMessage.test.ts
+++ b/packages/readyup/__tests__/utils/extractMessage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractMessage } from '../../src/utils/error-handling.ts';
+
+describe('extractMessage', () => {
+  it('returns the message from an Error instance', () => {
+    expect(extractMessage(new Error('something broke'))).toBe('something broke');
+  });
+
+  it('returns the message from an Error subclass', () => {
+    expect(extractMessage(new TypeError('bad type'))).toBe('bad type');
+  });
+
+  it('stringifies a plain string', () => {
+    expect(extractMessage('raw string')).toBe('raw string');
+  });
+
+  it('stringifies a number', () => {
+    expect(extractMessage(42)).toBe('42');
+  });
+
+  it('stringifies null', () => {
+    expect(extractMessage(null)).toBe('null');
+  });
+
+  it('stringifies undefined', () => {
+    expect(extractMessage(undefined)).toBe('undefined');
+  });
+
+  it('stringifies an object', () => {
+    expect(extractMessage({ code: 'ENOENT' })).toBe('[object Object]');
+  });
+});

--- a/packages/readyup/src/bin/rdy.ts
+++ b/packages/readyup/src/bin/rdy.ts
@@ -3,13 +3,14 @@
 
 import process from 'node:process';
 
+import { extractMessage } from '../utils/error-handling.ts';
 import { routeCommand } from './route.ts';
 
 let exitCode: number;
 try {
   exitCode = await routeCommand(process.argv.slice(2));
 } catch (error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = extractMessage(error);
   process.stderr.write(`rdy: unexpected error: ${message}\n`);
   exitCode = 1;
 }

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -6,15 +6,11 @@ import { initCommand } from '../init/initCommand.ts';
 import { listCommand } from '../list/listCommand.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
+import { extractMessage } from '../utils/error-handling.ts';
 import { VERSION } from '../version.ts';
 
 const SUBCOMMANDS = ['compile', 'init', 'list'];
 const MIN_PREFIX_LENGTH = 3;
-
-/** Extract a displayable message from an unknown thrown value. */
-function extractMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 function showHelp(): void {
   console.info(`

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -21,6 +21,7 @@ import type {
   Severity,
   SummaryCounts,
 } from './types.ts';
+import { extractMessage } from './utils/error-handling.ts';
 
 /** Valid severity values for CLI flag validation. */
 const VALID_SEVERITIES = new Set<string>(['error', 'warn', 'recommend']);
@@ -276,7 +277,7 @@ export async function runCommand({ names, kitSource, json, failOn, reportOn }: R
   try {
     kit = await loadKit(kitSource);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     if (json) {
       process.stdout.write(formatJsonError(message) + '\n');
     } else {
@@ -301,7 +302,7 @@ async function runSingleKit(
   try {
     resolvedNames = resolveRequestedNames(names, kit);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     if (json) {
       process.stdout.write(formatJsonError(message) + '\n');
     } else {
@@ -345,7 +346,7 @@ async function runJsonMode(
       if (!report.passed) allPassed = false;
     }
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     process.stdout.write(formatJsonError(message) + '\n');
     return 1;
   }
@@ -387,7 +388,7 @@ async function runHumanMode(
       }
     }
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     process.stderr.write(`Error: ${message}\n`);
     return 1;
   }

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -7,6 +7,7 @@ import picomatch from 'picomatch';
 import { loadConfig } from '../loadConfig.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../reportRdy.ts';
+import { extractMessage } from '../utils/error-handling.ts';
 import { compileConfig } from './compileConfig.ts';
 import { validateCompiledOutput } from './validateCompiledOutput.ts';
 
@@ -24,7 +25,7 @@ export async function compileCommand(args: string[]): Promise<number> {
   try {
     parsed = parseArgs(args, compileFlagSchema);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     // Translate generic "requires a value" to domain hint.
     if (message === '--output requires a value') {
       process.stderr.write('Error: --output requires a path argument\n');
@@ -55,7 +56,7 @@ export async function compileCommand(args: string[]): Promise<number> {
       process.stdout.write(formatResultLine(relInput, relOutput, result.changed));
       return 0;
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = extractMessage(error);
       process.stderr.write(`Error: ${message}\n`);
       return 1;
     }
@@ -84,7 +85,7 @@ async function compileBatch(): Promise<number> {
   try {
     config = await loadConfig();
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     process.stderr.write(`Error: ${message}\n`);
     return 1;
   }
@@ -101,7 +102,7 @@ async function compileBatch(): Promise<number> {
   try {
     tsFiles = collectSourceFiles(srcDir, config.compile.include);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     process.stderr.write(`Error: Failed to read source directory: ${message}\n`);
     return 1;
   }
@@ -126,7 +127,7 @@ async function compileBatch(): Promise<number> {
       const outName = fileName.replace(/\.ts$/, '.js');
       process.stdout.write(formatResultLine(fileName, outName, result.changed));
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = extractMessage(error);
       process.stderr.write(`Error compiling ${fileName}: ${message}\n`);
       return 1;
     }

--- a/packages/readyup/src/compile/validateCompiledOutput.ts
+++ b/packages/readyup/src/compile/validateCompiledOutput.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { assertIsRdyKit } from '../assertIsRdyKit.ts';
 import { isRecord } from '../isRecord.ts';
 import { resolveKitExports } from '../resolveKitExports.ts';
+import { extractMessage } from '../utils/error-handling.ts';
 import { validateKit } from '../validateKit.ts';
 
 /**
@@ -18,7 +19,7 @@ export async function validateCompiledOutput(outputPath: string): Promise<void> 
     imported = await import(fileUrl);
   } catch (error: unknown) {
     rmSync(outputPath, { force: true });
-    const detail = error instanceof Error ? error.message : String(error);
+    const detail = extractMessage(error);
     throw new Error(`Failed to load compiled output for validation: ${detail}`);
   }
 

--- a/packages/readyup/src/init/initCommand.ts
+++ b/packages/readyup/src/init/initCommand.ts
@@ -1,4 +1,5 @@
 import { printError, printStep, reportWriteResult } from '../terminal.ts';
+import { extractMessage } from '../utils/error-handling.ts';
 import { scaffoldConfig } from './scaffold.ts';
 
 interface InitOptions {
@@ -22,7 +23,7 @@ export function initCommand({ dryRun, force }: InitOptions): number {
   try {
     result = scaffoldConfig({ dryRun, force });
   } catch (error: unknown) {
-    printError(`Failed to scaffold config: ${error instanceof Error ? error.message : String(error)}`);
+    printError(`Failed to scaffold config: ${extractMessage(error)}`);
     return 1;
   }
 

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -3,6 +3,7 @@ import process from 'node:process';
 
 import { loadConfig } from '../loadConfig.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
+import { extractMessage } from '../utils/error-handling.ts';
 import { enumerateKits } from './enumerateKits.ts';
 import type { CompiledStyle } from './formatList.ts';
 import { formatConsumerView, formatOwnerView } from './formatList.ts';
@@ -42,7 +43,7 @@ function runConsumerMode(localPathArg: string): number {
   try {
     compiledKits = enumerateKits({ dir: kitsDir, extension: '.js' });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     process.stderr.write(`Error: ${message}\n`);
     return 1;
   }
@@ -60,7 +61,7 @@ async function runOwnerMode(): Promise<number> {
   try {
     config = await loadConfig();
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     process.stderr.write(`Error: ${message}\n`);
     return 1;
   }
@@ -74,7 +75,7 @@ async function runOwnerMode(): Promise<number> {
     internalKits = enumerateKits({ dir: internalDir, extension: config.internal.extension });
     compiledKits = enumerateKits({ dir: compiledDir, extension: '.js' });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     process.stderr.write(`Error: ${message}\n`);
     return 1;
   }

--- a/packages/readyup/src/parseArgs.ts
+++ b/packages/readyup/src/parseArgs.ts
@@ -1,3 +1,5 @@
+import { extractMessage } from './utils/error-handling.ts';
+
 /** Schema entry describing a single CLI flag. */
 export interface FlagDefinition {
   long: string;
@@ -166,7 +168,7 @@ export function parseArgs<S extends FlagSchema>(argv: string[], schema: S): Pars
  * passes other messages through unchanged.
  */
 export function translateParseError(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = extractMessage(error);
   const flagMatch = message.match(/^unknown flag '(.+)'$/);
   if (flagMatch?.[1] !== undefined) {
     return `Unknown option: ${flagMatch[1]}`;

--- a/packages/readyup/src/utils/error-handling.ts
+++ b/packages/readyup/src/utils/error-handling.ts
@@ -1,0 +1,4 @@
+/** Extract a displayable message from an unknown thrown value. */
+export function extractMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/readyup/src/writeFileWithCheck.ts
+++ b/packages/readyup/src/writeFileWithCheck.ts
@@ -1,6 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
+import { extractMessage } from './utils/error-handling.ts';
+
 /** Outcome of a `writeFileWithCheck` call. */
 export type WriteOutcome = 'created' | 'overwritten' | 'up-to-date' | 'skipped' | 'failed';
 
@@ -43,7 +45,7 @@ export function writeFileWithCheck(
         return { filePath, outcome: 'up-to-date' };
       }
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = extractMessage(error);
       return { filePath, outcome: 'skipped', error: message };
     }
     return { filePath, outcome: 'skipped' };
@@ -58,14 +60,14 @@ export function writeFileWithCheck(
   try {
     mkdirSync(dirname(filePath), { recursive: true });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     return { filePath, outcome: 'failed', error: message };
   }
 
   try {
     writeFileSync(filePath, content, 'utf8');
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractMessage(error);
     return { filePath, outcome: 'failed', error: message };
   }
 


### PR DESCRIPTION
## What

Consolidates 20 inline `error instanceof Error ? error.message : String(error)` occurrences across the `readyup` package into a single shared `extractMessage` utility in `src/utils/error-handling.ts`.

## Why

The same error-message extraction pattern was duplicated across 9 files, creating a maintenance burden and risking inconsistent formatting if the logic ever needs to change.

## Details

### Refactoring

- Create `src/utils/error-handling.ts` exporting `extractMessage(error: unknown): string`.
- Replace all 20 inline occurrences across `listCommand.ts`, `compileCommand.ts`, `cli.ts`, `route.ts`, `rdy.ts`, `writeFileWithCheck.ts`, `parseArgs.ts`, `initCommand.ts`, and `validateCompiledOutput.ts`.
- Remove the private `extractMessage` helper previously defined in `route.ts`.

### Tests

- Add `__tests__/utils/extractMessage.test.ts` covering `Error` instances, `Error` subclasses, strings, numbers, `null`, `undefined`, and objects.

Closes #22 