### PR TITLE
#19 Add utility functions for common check patterns

### DIFF
--- a/packages/readyup/__tests__/check-utils/filesystem.test.ts
+++ b/packages/readyup/__tests__/check-utils/filesystem.test.ts
@@ -1,10 +1,17 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import { fileContains, fileDoesNotContain, fileExists, readFile } from '../../src/check-utils/filesystem.ts';
+import {
+  commandExists,
+  fileContains,
+  fileDoesNotContain,
+  fileExists,
+  filesExist,
+  readFile,
+} from '../../src/check-utils/filesystem.ts';
 
 let tempDir: string;
 let cwdSpy: MockInstance;
@@ -75,5 +82,60 @@ describe(fileDoesNotContain, () => {
 
   it('returns true when the file does not exist', () => {
     expect(fileDoesNotContain('missing.txt', /anything/)).toBe(true);
+  });
+});
+
+describe(filesExist, () => {
+  it('returns ok when all files exist', () => {
+    writeFileSync(join(tempDir, 'a.txt'), '');
+    writeFileSync(join(tempDir, 'b.txt'), '');
+
+    const result = filesExist(['a.txt', 'b.txt']);
+
+    expect(result).toEqual({
+      ok: true,
+      progress: { type: 'fraction', passedCount: 2, count: 2 },
+    });
+  });
+
+  it('returns not ok with missing files listed', () => {
+    writeFileSync(join(tempDir, 'a.txt'), '');
+
+    const result = filesExist(['a.txt', 'b.txt', 'c.txt']);
+
+    expect(result).toEqual({
+      ok: false,
+      detail: 'Missing files: b.txt, c.txt',
+      progress: { type: 'fraction', passedCount: 1, count: 3 },
+    });
+  });
+
+  it('resolves paths relative to baseDir when provided', () => {
+    mkdirSync(join(tempDir, 'sub'), { recursive: true });
+    writeFileSync(join(tempDir, 'sub', 'found.txt'), '');
+
+    const result = filesExist(['found.txt', 'missing.txt'], { baseDir: 'sub' });
+
+    expect(result).toEqual({
+      ok: false,
+      detail: 'Missing files: missing.txt',
+      progress: { type: 'fraction', passedCount: 1, count: 2 },
+    });
+  });
+});
+
+describe(commandExists, () => {
+  it('returns true for a command that exists', () => {
+    expect(commandExists('node')).toBe(true);
+  });
+
+  it('returns false for a command that does not exist', () => {
+    expect(commandExists('nonexistent-command-xyz-99')).toBe(false);
+  });
+
+  it('returns false for names with shell metacharacters', () => {
+    expect(commandExists('node; echo hacked')).toBe(false);
+    expect(commandExists('node$(whoami)')).toBe(false);
+    expect(commandExists('node|cat')).toBe(false);
   });
 });

--- a/packages/readyup/__tests__/check-utils/filesystem.test.ts
+++ b/packages/readyup/__tests__/check-utils/filesystem.test.ts
@@ -86,6 +86,15 @@ describe(fileDoesNotContain, () => {
 });
 
 describe(filesExist, () => {
+  it('returns ok with zero counts when paths array is empty', () => {
+    const result = filesExist([]);
+
+    expect(result).toEqual({
+      ok: true,
+      progress: { type: 'fraction', passedCount: 0, count: 0 },
+    });
+  });
+
   it('returns ok when all files exist', () => {
     writeFileSync(join(tempDir, 'a.txt'), '');
     writeFileSync(join(tempDir, 'b.txt'), '');

--- a/packages/readyup/__tests__/check-utils/json.test.ts
+++ b/packages/readyup/__tests__/check-utils/json.test.ts
@@ -22,6 +22,10 @@ function writeJson(filename: string, content: unknown): void {
   writeFileSync(join(tempDir, filename), JSON.stringify(content));
 }
 
+function writeRaw(filename: string, content: string): void {
+  writeFileSync(join(tempDir, filename), content);
+}
+
 describe(readJsonFile, () => {
   it('returns the parsed object from a JSON file', () => {
     writeJson('config.json', { key: 'value' });
@@ -37,6 +41,12 @@ describe(readJsonFile, () => {
     writeJson('array.json', [1, 2, 3]);
 
     expect(readJsonFile('array.json')).toBeUndefined();
+  });
+
+  it('returns undefined when the file contains malformed JSON', () => {
+    writeRaw('bad.json', '{ not valid json }}}');
+
+    expect(readJsonFile('bad.json')).toBeUndefined();
   });
 });
 
@@ -91,6 +101,17 @@ describe(hasJsonFields, () => {
       ok: false,
       detail: 'Missing fields: version, type',
       progress: { type: 'fraction', passedCount: 1, count: 3 },
+    });
+  });
+
+  it('returns ok with zero counts when fields array is empty', () => {
+    writeJson('data.json', { name: 'test' });
+
+    const result = hasJsonFields('data.json', []);
+
+    expect(result).toEqual({
+      ok: true,
+      progress: { type: 'fraction', passedCount: 0, count: 0 },
     });
   });
 

--- a/packages/readyup/__tests__/check-utils/json.test.ts
+++ b/packages/readyup/__tests__/check-utils/json.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { hasJsonField, hasJsonFields, readJsonFile } from '../../src/check-utils/json.ts';
+
+let tempDir: string;
+let cwdSpy: MockInstance;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rdy-json-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+});
+
+function writeJson(filename: string, content: unknown): void {
+  writeFileSync(join(tempDir, filename), JSON.stringify(content));
+}
+
+describe(readJsonFile, () => {
+  it('returns the parsed object from a JSON file', () => {
+    writeJson('config.json', { key: 'value' });
+
+    expect(readJsonFile('config.json')).toEqual({ key: 'value' });
+  });
+
+  it('returns undefined when the file does not exist', () => {
+    expect(readJsonFile('missing.json')).toBeUndefined();
+  });
+
+  it('returns undefined when the file content is not an object', () => {
+    writeJson('array.json', [1, 2, 3]);
+
+    expect(readJsonFile('array.json')).toBeUndefined();
+  });
+});
+
+describe(hasJsonField, () => {
+  it('returns true when the field exists', () => {
+    writeJson('data.json', { type: 'module' });
+
+    expect(hasJsonField('data.json', 'type')).toBe(true);
+  });
+
+  it('returns false when the field does not exist', () => {
+    writeJson('data.json', {});
+
+    expect(hasJsonField('data.json', 'type')).toBe(false);
+  });
+
+  it('returns true when the field matches the expected value', () => {
+    writeJson('data.json', { type: 'module' });
+
+    expect(hasJsonField('data.json', 'type', 'module')).toBe(true);
+  });
+
+  it('returns false when the field does not match the expected value', () => {
+    writeJson('data.json', { type: 'commonjs' });
+
+    expect(hasJsonField('data.json', 'type', 'module')).toBe(false);
+  });
+
+  it('returns false when the file does not exist', () => {
+    expect(hasJsonField('missing.json', 'type')).toBe(false);
+  });
+});
+
+describe(hasJsonFields, () => {
+  it('returns ok when all fields are present', () => {
+    writeJson('data.json', { name: 'test', version: '1.0.0' });
+
+    const result = hasJsonFields('data.json', ['name', 'version']);
+
+    expect(result).toEqual({
+      ok: true,
+      progress: { type: 'fraction', passedCount: 2, count: 2 },
+    });
+  });
+
+  it('returns not ok with missing fields listed', () => {
+    writeJson('data.json', { name: 'test' });
+
+    const result = hasJsonFields('data.json', ['name', 'version', 'type']);
+
+    expect(result).toEqual({
+      ok: false,
+      detail: 'Missing fields: version, type',
+      progress: { type: 'fraction', passedCount: 1, count: 3 },
+    });
+  });
+
+  it('returns not ok with all fields missing when file does not exist', () => {
+    const result = hasJsonFields('missing.json', ['name', 'version']);
+
+    expect(result).toEqual({
+      ok: false,
+      detail: 'Missing fields: name, version',
+      progress: { type: 'fraction', passedCount: 0, count: 2 },
+    });
+  });
+});

--- a/packages/readyup/__tests__/check-utils/missingFrom.test.ts
+++ b/packages/readyup/__tests__/check-utils/missingFrom.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { missingFrom } from '../../src/check-utils/missingFrom.ts';
+
+describe(missingFrom, () => {
+  it('returns ok with progress when all expected items are present', () => {
+    const result = missingFrom('files', ['a', 'b'], ['a', 'b', 'c']);
+
+    expect(result).toEqual({
+      ok: true,
+      progress: { type: 'fraction', passedCount: 2, count: 2 },
+    });
+  });
+
+  it('returns not ok with missing items listed when some are absent', () => {
+    const result = missingFrom('fields', ['a', 'b', 'c'], ['b']);
+
+    expect(result).toEqual({
+      ok: false,
+      detail: 'Missing fields: a, c',
+      progress: { type: 'fraction', passedCount: 1, count: 3 },
+    });
+  });
+
+  it('returns not ok when all items are missing', () => {
+    const result = missingFrom('deps', ['x', 'y'], []);
+
+    expect(result).toEqual({
+      ok: false,
+      detail: 'Missing deps: x, y',
+      progress: { type: 'fraction', passedCount: 0, count: 2 },
+    });
+  });
+
+  it('returns ok with zero counts for an empty expected list', () => {
+    const result = missingFrom('files', [], ['a']);
+
+    expect(result).toEqual({
+      ok: true,
+      progress: { type: 'fraction', passedCount: 0, count: 0 },
+    });
+  });
+});

--- a/packages/readyup/src/check-utils/filesystem.ts
+++ b/packages/readyup/src/check-utils/filesystem.ts
@@ -1,5 +1,12 @@
+import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+
+import type { CheckOutcome } from '../types.ts';
+import { missingFrom } from './missingFrom.ts';
+
+/** Regex matching only safe command names (alphanumeric, dash, underscore, dot). */
+const SAFE_COMMAND_NAME = /^[a-zA-Z0-9._-]+$/;
 
 /** Check whether a file exists relative to the working directory. */
 export function fileExists(relativePath: string): boolean {
@@ -25,4 +32,24 @@ export function fileDoesNotContain(relativePath: string, pattern: RegExp): boole
   const content = readFile(relativePath);
   if (content === undefined) return true;
   return !pattern.test(content);
+}
+
+/** Check whether all specified files exist, with optional base directory. */
+export function filesExist(paths: string[], options?: { baseDir?: string }): CheckOutcome {
+  const base = options?.baseDir ? join(process.cwd(), options.baseDir) : process.cwd();
+  const presentPaths = paths.filter((p) => existsSync(join(base, p)));
+  return missingFrom('files', paths, presentPaths);
+}
+
+/** Check whether a command is available on PATH. Rejects names with shell metacharacters. */
+export function commandExists(name: string): boolean {
+  if (!SAFE_COMMAND_NAME.test(name)) {
+    return false;
+  }
+  try {
+    execSync(`command -v ${name}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -1,3 +1,4 @@
-export { fileContains, fileDoesNotContain, fileExists, readFile } from './filesystem.ts';
+export { commandExists, fileContains, fileDoesNotContain, fileExists, filesExist, readFile } from './filesystem.ts';
+export { hasJsonField, hasJsonFields, readJsonFile } from './json.ts';
 export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
 export { compareVersions } from './semver.ts';

--- a/packages/readyup/src/check-utils/json.ts
+++ b/packages/readyup/src/check-utils/json.ts
@@ -7,9 +7,14 @@ import { missingFrom } from './missingFrom.ts';
 export function readJsonFile(relativePath: string): Record<string, unknown> | undefined {
   const content = readFile(relativePath);
   if (content === undefined) return undefined;
-  const parsed: unknown = JSON.parse(content);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return undefined;
+  }
   if (!isRecord(parsed)) return undefined;
-  return Object.fromEntries(Object.entries(parsed));
+  return parsed;
 }
 
 /** Check whether a JSON file has a field, optionally with a specific value. */

--- a/packages/readyup/src/check-utils/json.ts
+++ b/packages/readyup/src/check-utils/json.ts
@@ -1,0 +1,31 @@
+import { isRecord } from '../isRecord.ts';
+import type { CheckOutcome } from '../types.ts';
+import { readFile } from './filesystem.ts';
+import { missingFrom } from './missingFrom.ts';
+
+/** Read and parse a JSON file relative to cwd. Return undefined if it doesn't exist or isn't an object. */
+export function readJsonFile(relativePath: string): Record<string, unknown> | undefined {
+  const content = readFile(relativePath);
+  if (content === undefined) return undefined;
+  const parsed: unknown = JSON.parse(content);
+  if (!isRecord(parsed)) return undefined;
+  return Object.fromEntries(Object.entries(parsed));
+}
+
+/** Check whether a JSON file has a field, optionally with a specific value. */
+export function hasJsonField(relativePath: string, field: string, expectedValue?: string): boolean {
+  const data = readJsonFile(relativePath);
+  if (data === undefined) return false;
+  if (expectedValue !== undefined) return data[field] === expectedValue;
+  return field in data;
+}
+
+/** Check whether a JSON file has all of the specified fields. */
+export function hasJsonFields(relativePath: string, fields: string[]): CheckOutcome {
+  const data = readJsonFile(relativePath);
+  if (data === undefined) {
+    return missingFrom('fields', fields, []);
+  }
+  const presentFields = fields.filter((field) => field in data);
+  return missingFrom('fields', fields, presentFields);
+}

--- a/packages/readyup/src/check-utils/json.ts
+++ b/packages/readyup/src/check-utils/json.ts
@@ -27,10 +27,7 @@ export function hasJsonField(relativePath: string, field: string, expectedValue?
 
 /** Check whether a JSON file has all of the specified fields. */
 export function hasJsonFields(relativePath: string, fields: string[]): CheckOutcome {
-  const data = readJsonFile(relativePath);
-  if (data === undefined) {
-    return missingFrom('fields', fields, []);
-  }
+  const data = readJsonFile(relativePath) ?? {};
   const presentFields = fields.filter((field) => field in data);
   return missingFrom('fields', fields, presentFields);
 }

--- a/packages/readyup/src/check-utils/missingFrom.ts
+++ b/packages/readyup/src/check-utils/missingFrom.ts
@@ -1,0 +1,24 @@
+import type { CheckOutcome, FractionProgress } from '../types.ts';
+
+/** Build a `CheckOutcome` with `FractionProgress` from expected vs. actual arrays. */
+export function missingFrom(category: string, expected: string[], actual: string[]): CheckOutcome {
+  const actualSet = new Set(actual);
+  const missing = expected.filter((item) => !actualSet.has(item));
+  const passedCount = expected.length - missing.length;
+
+  const progress: FractionProgress = {
+    type: 'fraction',
+    passedCount,
+    count: expected.length,
+  };
+
+  if (missing.length === 0) {
+    return { ok: true, progress };
+  }
+
+  return {
+    ok: false,
+    detail: `Missing ${category}: ${missing.join(', ')}`,
+    progress,
+  };
+}

--- a/packages/readyup/src/check-utils/package-json.ts
+++ b/packages/readyup/src/check-utils/package-json.ts
@@ -1,27 +1,20 @@
 import { isRecord } from '../isRecord.ts';
-import { readFile } from './filesystem.ts';
+import { hasJsonField, readJsonFile } from './json.ts';
 import { compareVersions } from './semver.ts';
 
 /** Read and parse the root package.json. Return undefined if it doesn't exist or isn't an object. */
 export function readPackageJson(): Record<string, unknown> | undefined {
-  const content = readFile('package.json');
-  if (content === undefined) return undefined;
-  const parsed: unknown = JSON.parse(content);
-  if (!isRecord(parsed)) return undefined;
-  return Object.fromEntries(Object.entries(parsed));
+  return readJsonFile('package.json');
 }
 
 /** Check whether package.json has a field, optionally with a specific value. */
 export function hasPackageJsonField(field: string, expectedValue?: string): boolean {
-  const pkg = readPackageJson();
-  if (pkg === undefined) return false;
-  if (expectedValue !== undefined) return pkg[field] === expectedValue;
-  return field in pkg;
+  return hasJsonField('package.json', field, expectedValue);
 }
 
 /** Check whether a dev dependency is present in package.json. */
 export function hasDevDependency(name: string): boolean {
-  const pkg = readPackageJson();
+  const pkg = readJsonFile('package.json');
   if (pkg === undefined) return false;
   const devDeps = pkg.devDependencies;
   return isRecord(devDeps) && name in devDeps;
@@ -33,7 +26,7 @@ export function hasMinDevDependencyVersion(
   minVersion: string,
   options?: { exempt?: (range: string) => boolean },
 ): boolean {
-  const pkg = readPackageJson();
+  const pkg = readJsonFile('package.json');
   if (pkg === undefined) return false;
   const devDeps = pkg.devDependencies;
   if (!isRecord(devDeps) || !(name in devDeps)) return false;

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -40,13 +40,18 @@ export {
 
 // Check utilities
 export {
+  commandExists,
   compareVersions,
   fileContains,
   fileDoesNotContain,
   fileExists,
+  filesExist,
   hasDevDependency,
+  hasJsonField,
+  hasJsonFields,
   hasMinDevDependencyVersion,
   hasPackageJsonField,
   readFile,
+  readJsonFile,
   readPackageJson,
 } from './check-utils/index.ts';


### PR DESCRIPTION
## What

Adds generic JSON, multi-file, and command-exists utilities to readyup's `check-utils`, giving kit authors ready-made functions for the common "check several things and report what's missing" pattern. Reimplements the package.json helpers as thin wrappers around the new generic forms, eliminating duplicated parsing logic.

## Why

Kit authors were hand-rolling filter-and-format logic every time they needed to check multiple items (JSON fields, files, CLI tools) and report which were missing. The only built-in helpers were single-item (`fileExists`, `hasPackageJsonField`), and nothing produced `FractionProgress` for progress reporting.

## Details

### Features

- `missingFrom(category, expected, actual)` — internal helper that builds `CheckOutcome` with `FractionProgress` from expected vs. actual arrays; not exported from the package
- `readJsonFile(path)` — reads and parses any JSON file by relative path, returning `undefined` for missing, malformed, or non-object files
- `hasJsonField(path, field, value?)` — checks field presence in any JSON file with optional value matching
- `hasJsonFields(path, fields[])` — checks multiple fields, returns `CheckOutcome` with `FractionProgress` and detail listing missing fields
- `filesExist(paths[], { baseDir? })` — checks multiple file paths with optional base directory, returns `CheckOutcome` with `FractionProgress`
- `commandExists(name)` — checks whether a command is on PATH via `command -v`, with input sanitization to reject shell metacharacters

### Refactoring

- `readPackageJson()` reimplemented as `readJsonFile('package.json')`
- `hasPackageJsonField(field, value?)` reimplemented as `hasJsonField('package.json', field, value)`
- `hasDevDependency` and `hasMinDevDependencyVersion` switched from `readPackageJson()` to `readJsonFile('package.json')` internally

### Tests

- New test suites for `missingFrom`, `readJsonFile`, `hasJsonField`, `hasJsonFields`
- Extended filesystem tests with `filesExist` (including `baseDir` and empty-array edge cases) and `commandExists` (including shell metacharacter rejection)
- Existing `package-json.test.ts` passes unchanged, validating no behavior change in the wrapper refactor

Closes #19 