### PR TITLE
#27 Add fileMatchesHash check utility

### DIFF
--- a/packages/readyup/__tests__/check-utils/hashing.test.ts
+++ b/packages/readyup/__tests__/check-utils/hashing.test.ts
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { computeHash, fileMatchesHash } from '../../src/check-utils/hashing.ts';
+
+let tempDir: string;
+let cwdSpy: MockInstance;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rdy-hash-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+});
+
+describe(computeHash, () => {
+  it('returns a SHA-256 hex digest of the given string', () => {
+    const content = 'hello world';
+    const expected = createHash('sha256').update(content).digest('hex');
+
+    expect(computeHash(content)).toBe(expected);
+  });
+
+  it('returns a different hash for different content', () => {
+    expect(computeHash('abc')).not.toBe(computeHash('def'));
+  });
+
+  it('returns a deterministic hash for the same content', () => {
+    expect(computeHash('same')).toBe(computeHash('same'));
+  });
+});
+
+describe(fileMatchesHash, () => {
+  it('returns true when the file content matches the expected hash', () => {
+    const content = 'exact content';
+    writeFileSync(join(tempDir, 'config.js'), content);
+    const hash = createHash('sha256').update(content).digest('hex');
+
+    expect(fileMatchesHash('config.js', hash)).toBe(true);
+  });
+
+  it('returns false when the file content does not match the expected hash', () => {
+    writeFileSync(join(tempDir, 'config.js'), 'actual content');
+
+    expect(fileMatchesHash('config.js', 'wrong-hash')).toBe(false);
+  });
+
+  it('returns false when the file does not exist', () => {
+    expect(fileMatchesHash('missing.js', 'any-hash')).toBe(false);
+  });
+});

--- a/packages/readyup/src/check-utils/hashing.ts
+++ b/packages/readyup/src/check-utils/hashing.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto';
+
+import { readFile } from './filesystem.ts';
+
+/** Compute the SHA-256 hex digest of a string. */
+export function computeHash(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+/** Check whether a file's content matches an expected SHA-256 hash. */
+export function fileMatchesHash(relativePath: string, expectedHash: string): boolean {
+  const content = readFile(relativePath);
+  if (content === undefined) return false;
+  return computeHash(content) === expectedHash;
+}

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -1,4 +1,5 @@
 export { commandExists, fileContains, fileDoesNotContain, fileExists, filesExist, readFile } from './filesystem.ts';
+export { computeHash, fileMatchesHash } from './hashing.ts';
 export { hasJsonField, hasJsonFields, readJsonFile } from './json.ts';
 export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
 export { compareVersions } from './semver.ts';

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -42,9 +42,11 @@ export {
 export {
   commandExists,
   compareVersions,
+  computeHash,
   fileContains,
   fileDoesNotContain,
   fileExists,
+  fileMatchesHash,
   filesExist,
   hasDevDependency,
   hasJsonField,


### PR DESCRIPTION
## What

Adds hash-based file comparison to the readyup check-utils, enabling kits to detect configuration file drift by comparing SHA-256 digests rather than using brittle regex patterns or embedding full file content.

## Why

Kit authors need a compact, exact way to verify that configuration files (e.g., `.prettierrc.js`, `.editorconfig`) match a known-good template version. Without a shared utility, each kit implements its own hashing with inconsistent algorithm and encoding choices.

## Details

### Features

- `computeHash(content)` — pure function returning the SHA-256 hex digest of a string via `node:crypto`.
- `fileMatchesHash(path, expectedHash)` — composes `readFile` + `computeHash` + strict equality. Returns `false` for missing files, consistent with `fileContains`.
- Both functions exported from the `check-utils` barrel and the package's public API.

### Tests

- 6 tests covering `computeHash` correctness (determinism, uniqueness) and all three `fileMatchesHash` outcomes (match, mismatch, missing file).

Closes #27