### PR TITLE
#25 Add safeJsonParse utility for safe JSON parsing

### DIFF
--- a/packages/readyup/__tests__/safeJsonParse.test.ts
+++ b/packages/readyup/__tests__/safeJsonParse.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { safeJsonParse } from '../src/safeJsonParse.ts';
+
+describe(safeJsonParse, () => {
+  it('parses a valid JSON object', () => {
+    expect(safeJsonParse('{"key":"value"}')).toEqual({ key: 'value' });
+  });
+
+  it('parses a valid JSON array', () => {
+    expect(safeJsonParse('[1,2,3]')).toEqual([1, 2, 3]);
+  });
+
+  it('parses a JSON number', () => {
+    expect(safeJsonParse('42')).toBe(42);
+  });
+
+  it('parses a JSON string', () => {
+    expect(safeJsonParse('"hello"')).toBe('hello');
+  });
+
+  it('parses a JSON boolean', () => {
+    expect(safeJsonParse('true')).toBe(true);
+  });
+
+  it('parses JSON null', () => {
+    expect(safeJsonParse('null')).toBeNull();
+  });
+
+  it('returns undefined for malformed JSON', () => {
+    expect(safeJsonParse('{ not valid json }}}')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(safeJsonParse('')).toBeUndefined();
+  });
+});

--- a/packages/readyup/src/check-utils/json.ts
+++ b/packages/readyup/src/check-utils/json.ts
@@ -1,4 +1,5 @@
 import { isRecord } from '../isRecord.ts';
+import { safeJsonParse } from '../safeJsonParse.ts';
 import type { CheckOutcome } from '../types.ts';
 import { readFile } from './filesystem.ts';
 import { missingFrom } from './missingFrom.ts';
@@ -7,12 +8,7 @@ import { missingFrom } from './missingFrom.ts';
 export function readJsonFile(relativePath: string): Record<string, unknown> | undefined {
   const content = readFile(relativePath);
   if (content === undefined) return undefined;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(content);
-  } catch {
-    return undefined;
-  }
+  const parsed = safeJsonParse(content);
   if (!isRecord(parsed)) return undefined;
   return parsed;
 }

--- a/packages/readyup/src/safeJsonParse.ts
+++ b/packages/readyup/src/safeJsonParse.ts
@@ -1,0 +1,9 @@
+/** Parse a JSON string, returning `undefined` instead of throwing on invalid input. */
+export function safeJsonParse(content: string): unknown {
+  try {
+    const parsed: unknown = JSON.parse(content);
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## What

Adds a reusable `safeJsonParse` utility that wraps `JSON.parse` in a try/catch, returning `undefined` on invalid input instead of throwing. Refactors the existing `readJsonFile` check utility to use it, eliminating inline error handling.

## Why

The try/catch JSON parsing pattern was inlined in `readJsonFile` and would need to be duplicated anywhere else that needs safe parsing. Extracting it into a dedicated utility makes the safe path the default and keeps future JSON-reading code concise.

## Details

### Features

- New `safeJsonParse(content: string): unknown` utility in `packages/readyup/src/safeJsonParse.ts`
- Internal-only (not exported from the package entry point), following the same pattern as `isRecord`

### Refactoring

- `readJsonFile` in `packages/readyup/src/check-utils/json.ts` now delegates to `safeJsonParse` instead of inlining try/catch

### Tests

- New test suite in `packages/readyup/__tests__/safeJsonParse.test.ts` covering valid JSON types (object, array, number, string, boolean, null) and invalid input (malformed JSON, empty string)

Closes #25  