### PR TITLE
#30 Use positional argument for kits in `rdy run`

### DIFF
--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -59,7 +59,7 @@ vi.mock('../src/loadRemoteKit.ts', () => ({
   loadRemoteKit: mockLoadRemoteKit,
 }));
 
-import { parseRunArgs, resolveKitSource, runCommand } from '../src/cli.ts';
+import { parseRunArgs, resolveKitSources, runCommand } from '../src/cli.ts';
 
 function makeKit(overrides?: Partial<RdyKit>): RdyKit {
   return {
@@ -72,10 +72,11 @@ function makeKit(overrides?: Partial<RdyKit>): RdyKit {
 }
 
 describe(parseRunArgs, () => {
-  it('returns undefined source flags when no flags are given', () => {
+  it('returns undefined checklists and empty specifiers when no flags are given', () => {
     const result = parseRunArgs([]);
 
-    expect(result.kitName).toBeUndefined();
+    expect(result.checklists).toBeUndefined();
+    expect(result.kitSpecifiers).toStrictEqual([]);
     expect(result.filePath).toBeUndefined();
     expect(result.githubValue).toBeUndefined();
     expect(result.localValue).toBeUndefined();
@@ -83,29 +84,61 @@ describe(parseRunArgs, () => {
     expect(result.json).toBe(false);
   });
 
-  it('parses positional names', () => {
+  it('parses positional kit specifiers', () => {
     const result = parseRunArgs(['deploy', 'infra']);
 
-    expect(result.names).toStrictEqual(['deploy', 'infra']);
+    expect(result.kitSpecifiers).toStrictEqual([
+      { kitName: 'deploy', checklists: [] },
+      { kitName: 'infra', checklists: [] },
+    ]);
   });
 
-  // --kit flag
-  it('parses --kit flag', () => {
-    const result = parseRunArgs(['--kit', 'deploy']);
+  it('parses positional kit specifiers with colon syntax', () => {
+    const result = parseRunArgs(['deploy:check1,check2']);
 
-    expect(result.kitName).toBe('deploy');
+    expect(result.kitSpecifiers).toStrictEqual([{ kitName: 'deploy', checklists: ['check1', 'check2'] }]);
   });
 
-  it('parses --kit with a slash-separated path', () => {
-    const result = parseRunArgs(['--kit', 'shared/deploy']);
+  // --checklists flag
+  it('parses --checklists with --file', () => {
+    const result = parseRunArgs(['--checklists', 'check1,check2', '--file', 'path.ts']);
 
-    expect(result.kitName).toBe('shared/deploy');
+    expect(result.checklists).toStrictEqual(['check1', 'check2']);
+    expect(result.filePath).toBe('path.ts');
   });
 
-  it('parses --kit= syntax', () => {
-    const result = parseRunArgs(['--kit=deploy']);
+  it('parses --checklists with --url', () => {
+    const result = parseRunArgs(['--checklists', 'check1', '--url', 'https://example.com/kit.js']);
 
-    expect(result.kitName).toBe('deploy');
+    expect(result.checklists).toStrictEqual(['check1']);
+  });
+
+  it('throws when --checklists is used without --file or --url', () => {
+    expect(() => parseRunArgs(['--checklists', 'check1'])).toThrow(
+      '--checklists can only be used with --file or --url',
+    );
+  });
+
+  it('throws when --checklists is used with --github', () => {
+    expect(() => parseRunArgs(['--checklists', 'check1', '--github', 'org/repo'])).toThrow(
+      '--checklists can only be used with --file or --url',
+    );
+  });
+
+  it('throws when --file is combined with positional args', () => {
+    expect(() => parseRunArgs(['--file', 'path.ts', 'deploy'])).toThrow(
+      '--file cannot be combined with positional kit arguments',
+    );
+  });
+
+  it('throws when --url is combined with positional args', () => {
+    expect(() => parseRunArgs(['--url', 'https://example.com/kit.js', 'deploy'])).toThrow(
+      '--url cannot be combined with positional kit arguments',
+    );
+  });
+
+  it('rejects --kit as an unknown flag', () => {
+    expect(() => parseRunArgs(['--kit', 'deploy'])).toThrow("unknown flag '--kit'");
   });
 
   // --file flag
@@ -113,7 +146,7 @@ describe(parseRunArgs, () => {
     const result = parseRunArgs(['--file', 'custom/path.ts']);
 
     expect(result.filePath).toBe('custom/path.ts');
-    expect(result.names).toStrictEqual([]);
+    expect(result.kitSpecifiers).toStrictEqual([]);
   });
 
   it('parses --file= syntax', () => {
@@ -135,14 +168,14 @@ describe(parseRunArgs, () => {
     const result = parseRunArgs(['--json']);
 
     expect(result.json).toBe(true);
-    expect(result.names).toStrictEqual([]);
+    expect(result.kitSpecifiers).toStrictEqual([]);
   });
 
-  it('parses --json with positional names', () => {
+  it('parses --json with positional kit names', () => {
     const result = parseRunArgs(['--json', 'deploy']);
 
     expect(result.json).toBe(true);
-    expect(result.names).toStrictEqual(['deploy']);
+    expect(result.kitSpecifiers).toStrictEqual([{ kitName: 'deploy', checklists: [] }]);
   });
 
   it('throws on unknown flags', () => {
@@ -155,10 +188,10 @@ describe(parseRunArgs, () => {
   });
 
   // Short options
-  it('parses -c as short form of --kit', () => {
-    const result = parseRunArgs(['-k', 'deploy']);
+  it('parses -c as short form of --checklists', () => {
+    const result = parseRunArgs(['-c', 'check1', '--file', 'path.ts']);
 
-    expect(result.kitName).toBe('deploy');
+    expect(result.checklists).toStrictEqual(['check1']);
   });
 
   it('parses -f as short form of --file', () => {
@@ -216,10 +249,6 @@ describe(parseRunArgs, () => {
 
   it('throws when --github= has an empty value', () => {
     expect(() => parseRunArgs(['--github='])).toThrow('--github requires a repository argument');
-  });
-
-  it('throws when --kit has no value', () => {
-    expect(() => parseRunArgs(['--kit'])).toThrow('--kit requires a kit name');
   });
 
   // --url flag
@@ -363,15 +392,18 @@ describe(parseRunArgs, () => {
   });
 });
 
-describe(resolveKitSource, () => {
+describe(resolveKitSources, () => {
   /** Build args with defaults for internal config. */
-  function resolve(overrides: Partial<Parameters<typeof resolveKitSource>[0]> = {}) {
-    return resolveKitSource({
+  function resolve(
+    overrides: Partial<Parameters<typeof resolveKitSources>[0]> = {},
+  ): ReturnType<typeof resolveKitSources> {
+    return resolveKitSources({
       filePath: undefined,
       githubValue: undefined,
       localValue: undefined,
       urlValue: undefined,
-      kitName: undefined,
+      kitSpecifiers: [],
+      checklists: undefined,
       internalDir: '.',
       internalExtension: '.ts',
       ...overrides,
@@ -379,117 +411,185 @@ describe(resolveKitSource, () => {
   }
 
   it('resolves default kit path with default internal config', () => {
-    expect(resolve()).toStrictEqual({ path: '.rdy/kits/default.ts' });
+    expect(resolve()).toStrictEqual([{ name: 'default', source: { path: '.rdy/kits/default.ts' }, checklists: [] }]);
   });
 
-  it('resolves named kit with default internal config', () => {
-    expect(resolve({ kitName: 'deploy' })).toStrictEqual({ path: '.rdy/kits/deploy.ts' });
+  it('resolves named kit from positional specifier', () => {
+    expect(resolve({ kitSpecifiers: [{ kitName: 'deploy', checklists: [] }] })).toStrictEqual([
+      { name: 'deploy', source: { path: '.rdy/kits/deploy.ts' }, checklists: [] },
+    ]);
   });
 
   it('resolves slash-separated kit name', () => {
-    expect(resolve({ kitName: 'shared/deploy' })).toStrictEqual({
-      path: '.rdy/kits/shared/deploy.ts',
-    });
+    expect(resolve({ kitSpecifiers: [{ kitName: 'shared/deploy', checklists: [] }] })).toStrictEqual([
+      { name: 'shared/deploy', source: { path: '.rdy/kits/shared/deploy.ts' }, checklists: [] },
+    ]);
   });
 
   it('applies custom internal dir and extension', () => {
-    expect(resolve({ internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual({
-      path: '.rdy/kits/internal/default.int.ts',
-    });
+    expect(resolve({ internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual([
+      { name: 'default', source: { path: '.rdy/kits/internal/default.int.ts' }, checklists: [] },
+    ]);
   });
 
   it('applies custom internal dir with named kit', () => {
-    expect(resolve({ kitName: 'deploy', internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual({
-      path: '.rdy/kits/internal/deploy.int.ts',
-    });
+    expect(
+      resolve({
+        kitSpecifiers: [{ kitName: 'deploy', checklists: [] }],
+        internalDir: 'internal',
+        internalExtension: '.int.ts',
+      }),
+    ).toStrictEqual([{ name: 'deploy', source: { path: '.rdy/kits/internal/deploy.int.ts' }, checklists: [] }]);
   });
 
-  it('resolves --file to a path source', () => {
-    expect(resolve({ filePath: 'custom/path.ts' })).toStrictEqual({ path: 'custom/path.ts' });
+  it('resolves --file to a single path source entry', () => {
+    expect(resolve({ filePath: 'custom/path.ts' })).toStrictEqual([
+      { name: 'custom/path.ts', source: { path: 'custom/path.ts' }, checklists: [] },
+    ]);
+  });
+
+  it('resolves --file with --checklists', () => {
+    expect(resolve({ filePath: 'custom/path.ts', checklists: ['c1', 'c2'] })).toStrictEqual([
+      { name: 'custom/path.ts', source: { path: 'custom/path.ts' }, checklists: ['c1', 'c2'] },
+    ]);
   });
 
   it('resolves --github without ref to a URL with main ref', () => {
-    expect(resolve({ githubValue: 'org/repo', kitName: 'nmr' })).toStrictEqual({
-      url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/nmr.js',
-    });
+    expect(resolve({ githubValue: 'org/repo', kitSpecifiers: [{ kitName: 'nmr', checklists: [] }] })).toStrictEqual([
+      {
+        name: 'nmr',
+        source: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/nmr.js' },
+        checklists: [],
+      },
+    ]);
   });
 
   it('resolves --github with ref to a URL with that ref', () => {
-    expect(resolve({ githubValue: 'org/repo@v1', kitName: 'nmr' })).toStrictEqual({
-      url: 'https://raw.githubusercontent.com/org/repo/v1/.rdy/kits/nmr.js',
-    });
+    expect(resolve({ githubValue: 'org/repo@v1', kitSpecifiers: [{ kitName: 'nmr', checklists: [] }] })).toStrictEqual([
+      {
+        name: 'nmr',
+        source: { url: 'https://raw.githubusercontent.com/org/repo/v1/.rdy/kits/nmr.js' },
+        checklists: [],
+      },
+    ]);
   });
 
   it('defaults --github kit to "default"', () => {
-    expect(resolve({ githubValue: 'org/repo' })).toStrictEqual({
-      url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/default.js',
-    });
+    expect(resolve({ githubValue: 'org/repo' })).toStrictEqual([
+      {
+        name: 'default',
+        source: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/default.js' },
+        checklists: [],
+      },
+    ]);
+  });
+
+  it('resolves multiple kits with --github', () => {
+    expect(
+      resolve({
+        githubValue: 'org/repo',
+        kitSpecifiers: [
+          { kitName: 'deploy', checklists: [] },
+          { kitName: 'infra', checklists: ['c1'] },
+        ],
+      }),
+    ).toStrictEqual([
+      {
+        name: 'deploy',
+        source: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/deploy.js' },
+        checklists: [],
+      },
+      {
+        name: 'infra',
+        source: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/infra.js' },
+        checklists: ['c1'],
+      },
+    ]);
   });
 
   it('resolves --local to a .js path under .rdy/kits/', () => {
-    expect(resolve({ localValue: '/path/to/repo' })).toStrictEqual({
-      path: '/path/to/repo/.rdy/kits/default.js',
-    });
+    expect(resolve({ localValue: '/path/to/repo' })).toStrictEqual([
+      { name: 'default', source: { path: '/path/to/repo/.rdy/kits/default.js' }, checklists: [] },
+    ]);
   });
 
-  it('resolves --local with --kit to a named .js file', () => {
-    expect(resolve({ localValue: '/path/to/repo', kitName: 'deploy' })).toStrictEqual({
-      path: '/path/to/repo/.rdy/kits/deploy.js',
-    });
+  it('resolves --local with named kit to a named .js file', () => {
+    expect(
+      resolve({ localValue: '/path/to/repo', kitSpecifiers: [{ kitName: 'deploy', checklists: [] }] }),
+    ).toStrictEqual([{ name: 'deploy', source: { path: '/path/to/repo/.rdy/kits/deploy.js' }, checklists: [] }]);
   });
 
   it('resolves --local with a relative path against cwd', () => {
     const expected = path.resolve(process.cwd(), '../sibling-repo');
 
-    expect(resolve({ localValue: '../sibling-repo' })).toStrictEqual({
-      path: `${expected}/.rdy/kits/default.js`,
-    });
+    expect(resolve({ localValue: '../sibling-repo' })).toStrictEqual([
+      { name: 'default', source: { path: `${expected}/.rdy/kits/default.js` }, checklists: [] },
+    ]);
+  });
+
+  it('resolves multiple kits with --local', () => {
+    expect(
+      resolve({
+        localValue: '/path/to/repo',
+        kitSpecifiers: [
+          { kitName: 'deploy', checklists: [] },
+          { kitName: 'infra', checklists: [] },
+        ],
+      }),
+    ).toStrictEqual([
+      { name: 'deploy', source: { path: '/path/to/repo/.rdy/kits/deploy.js' }, checklists: [] },
+      { name: 'infra', source: { path: '/path/to/repo/.rdy/kits/infra.js' }, checklists: [] },
+    ]);
   });
 
   it('resolves --url to a URL source', () => {
-    expect(resolve({ urlValue: 'https://example.com/config.js' })).toStrictEqual({
-      url: 'https://example.com/config.js',
-    });
+    expect(resolve({ urlValue: 'https://example.com/config.js' })).toStrictEqual([
+      { name: 'https://example.com/config.js', source: { url: 'https://example.com/config.js' }, checklists: [] },
+    ]);
   });
 
-  it('throws when --kit is combined with --file', () => {
-    expect(() => resolve({ filePath: 'path.ts', kitName: 'deploy' })).toThrow('--kit cannot be used with --file');
-  });
-
-  it('throws when --kit is combined with --url', () => {
-    expect(() => resolve({ urlValue: 'https://example.com/config.js', kitName: 'deploy' })).toThrow(
-      '--kit cannot be used with --url',
-    );
+  it('resolves --url with --checklists', () => {
+    expect(resolve({ urlValue: 'https://example.com/config.js', checklists: ['c1', 'c2'] })).toStrictEqual([
+      {
+        name: 'https://example.com/config.js',
+        source: { url: 'https://example.com/config.js' },
+        checklists: ['c1', 'c2'],
+      },
+    ]);
   });
 
   it('ignores internal config when --file is used', () => {
     expect(
       resolve({ filePath: 'custom/path.ts', internalDir: 'internal', internalExtension: '.int.ts' }),
-    ).toStrictEqual({
-      path: 'custom/path.ts',
-    });
+    ).toStrictEqual([{ name: 'custom/path.ts', source: { path: 'custom/path.ts' }, checklists: [] }]);
   });
 
   it('ignores internal config when --github is used', () => {
-    expect(resolve({ githubValue: 'org/repo', internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual({
-      url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/default.js',
-    });
+    expect(resolve({ githubValue: 'org/repo', internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual([
+      {
+        name: 'default',
+        source: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/default.js' },
+        checklists: [],
+      },
+    ]);
   });
 
   it('ignores internal config when --local is used', () => {
     expect(
       resolve({ localValue: '/path/to/repo', internalDir: 'internal', internalExtension: '.int.ts' }),
-    ).toStrictEqual({
-      path: '/path/to/repo/.rdy/kits/default.js',
-    });
+    ).toStrictEqual([{ name: 'default', source: { path: '/path/to/repo/.rdy/kits/default.js' }, checklists: [] }]);
   });
 
   it('ignores internal config when --url is used', () => {
     expect(
       resolve({ urlValue: 'https://example.com/config.js', internalDir: 'internal', internalExtension: '.int.ts' }),
-    ).toStrictEqual({
-      url: 'https://example.com/config.js',
-    });
+    ).toStrictEqual([
+      {
+        name: 'https://example.com/config.js',
+        source: { url: 'https://example.com/config.js' },
+        checklists: [],
+      },
+    ]);
   });
 });
 
@@ -516,14 +616,18 @@ describe(runCommand, () => {
     mockLoadRemoteKit.mockReset();
   });
 
-  it('runs all checklists when no names are given', async () => {
+  /** Build a single-kit entry for convenience. */
+  function singleKitEntry(checklists: string[] = []) {
+    return [{ name: 'default', source: { path: '.rdy/kits/default.ts' }, checklists }];
+  }
+
+  it('runs all checklists when no checklist filter is given', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue(kit);
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     const exitCode = await runCommand({
-      names: [],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(),
       json: false,
     });
 
@@ -537,8 +641,7 @@ describe(runCommand, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     const exitCode = await runCommand({
-      names: ['deploy'],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(['deploy']),
       json: false,
     });
 
@@ -555,8 +658,7 @@ describe(runCommand, () => {
     mockLoadRdyKit.mockResolvedValue(kit);
 
     const exitCode = await runCommand({
-      names: ['nonexistent'],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(['nonexistent']),
       json: false,
     });
 
@@ -572,8 +674,7 @@ describe(runCommand, () => {
       .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
 
     const exitCode = await runCommand({
-      names: [],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(),
       json: false,
     });
 
@@ -586,22 +687,20 @@ describe(runCommand, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
-      names: [],
-      kitSource: { path: 'custom/path.ts' },
+      kitEntries: [{ name: 'custom', source: { path: 'custom/path.ts' }, checklists: [] }],
       json: false,
     });
 
     expect(mockLoadRdyKit).toHaveBeenCalledWith('custom/path.ts');
   });
 
-  it('shows headers when running multiple checklists', async () => {
+  it('shows checklist headers when running multiple checklists in a single kit', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue(kit);
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
-      names: [],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(),
       json: false,
     });
 
@@ -610,19 +709,54 @@ describe(runCommand, () => {
     expect(allOutput).toContain('--- infra ---');
   });
 
-  it('does not show headers for a single checklist', async () => {
+  it('does not show checklist headers for a single checklist', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue(kit);
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
-      names: ['deploy'],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(['deploy']),
       json: false,
     });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(allOutput).not.toContain('---');
+  });
+
+  it('shows kit headers when running multiple kits', async () => {
+    const kit = makeKit({
+      checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
+    });
+    mockLoadRdyKit.mockResolvedValue(kit);
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runCommand({
+      kitEntries: [
+        { name: 'kit1', source: { path: '.rdy/kits/kit1.ts' }, checklists: [] },
+        { name: 'kit2', source: { path: '.rdy/kits/kit2.ts' }, checklists: [] },
+      ],
+      json: false,
+    });
+
+    const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(allOutput).toContain('=== kit1 ===');
+    expect(allOutput).toContain('=== kit2 ===');
+  });
+
+  it('does not print combined summary when running multiple kits', async () => {
+    const kit = makeKit();
+    mockLoadRdyKit.mockResolvedValue(kit);
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runCommand({
+      kitEntries: [
+        { name: 'kit1', source: { path: '.rdy/kits/kit1.ts' }, checklists: [] },
+        { name: 'kit2', source: { path: '.rdy/kits/kit2.ts' }, checklists: [] },
+      ],
+      json: false,
+    });
+
+    expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
   });
 
   it('uses per-checklist fixLocation over kit default', async () => {
@@ -634,8 +768,7 @@ describe(runCommand, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
-      names: [],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(),
       json: false,
     });
 
@@ -651,8 +784,7 @@ describe(runCommand, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
-      names: [],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(),
       json: false,
     });
 
@@ -663,8 +795,7 @@ describe(runCommand, () => {
     mockLoadRdyKit.mockRejectedValue(new Error('Kit not found'));
 
     const exitCode = await runCommand({
-      names: [],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(),
       json: false,
     });
 
@@ -672,56 +803,21 @@ describe(runCommand, () => {
     expect(exitCode).toBe(1);
   });
 
-  it('prints combined summary when multiple checklists run', async () => {
+  it('prints combined summary for a single kit with multiple checklists', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue(kit);
-    mockRunRdy.mockResolvedValue({
-      results: [
-        {
-          name: 'a',
-          status: 'passed',
-          ok: true,
-          severity: 'error',
-          detail: null,
-          fix: null,
-          error: null,
-          progress: null,
-          durationMs: 10,
-        },
-      ],
-      passed: true,
-      durationMs: 10,
-    });
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+    mockFormatCombinedSummary.mockReturnValue('Combined summary');
 
     await runCommand({
-      names: [],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(),
       json: false,
     });
 
     expect(mockFormatCombinedSummary).toHaveBeenCalledTimes(1);
-    expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
-      expect.objectContaining({
-        name: 'deploy',
-        passed: 1,
-        errors: 0,
-        warnings: 0,
-        recommendations: 0,
-        blocked: 0,
-        optional: 0,
-        worstSeverity: null,
-      }),
-      expect.objectContaining({
-        name: 'infra',
-        passed: 1,
-        errors: 0,
-        warnings: 0,
-        recommendations: 0,
-        blocked: 0,
-        optional: 0,
-        worstSeverity: null,
-      }),
-    ]);
+    expect(mockFormatCombinedSummary).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ name: 'deploy' }), expect.objectContaining({ name: 'infra' })]),
+    );
   });
 
   it('does not print combined summary for a single checklist', async () => {
@@ -730,93 +826,11 @@ describe(runCommand, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
-      names: ['deploy'],
-      kitSource: { path: '.rdy/kits/default.ts' },
+      kitEntries: singleKitEntry(['deploy']),
       json: false,
     });
 
     expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
-  });
-
-  it('includes failure counts in combined summary', async () => {
-    const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
-    mockRunRdy
-      .mockResolvedValueOnce({
-        results: [
-          {
-            name: 'a',
-            status: 'passed',
-            ok: true,
-            severity: 'error',
-            detail: null,
-            fix: null,
-            error: null,
-            progress: null,
-            durationMs: 10,
-          },
-          {
-            name: 'b',
-            status: 'failed',
-            ok: false,
-            severity: 'error',
-            detail: null,
-            fix: null,
-            error: null,
-            progress: null,
-            durationMs: 5,
-          },
-        ],
-        passed: false,
-        durationMs: 15,
-      })
-      .mockResolvedValueOnce({
-        results: [
-          {
-            name: 'c',
-            status: 'skipped',
-            ok: null,
-            severity: 'error',
-            skipReason: 'precondition',
-            detail: null,
-            fix: null,
-            error: null,
-            progress: null,
-            durationMs: 0,
-          },
-        ],
-        passed: false,
-        durationMs: 0,
-      });
-
-    await runCommand({
-      names: [],
-      kitSource: { path: '.rdy/kits/default.ts' },
-      json: false,
-    });
-
-    expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
-      expect.objectContaining({
-        name: 'deploy',
-        passed: 1,
-        errors: 1,
-        warnings: 0,
-        recommendations: 0,
-        blocked: 0,
-        optional: 0,
-        worstSeverity: 'error',
-      }),
-      expect.objectContaining({
-        name: 'infra',
-        passed: 0,
-        errors: 0,
-        warnings: 0,
-        recommendations: 0,
-        blocked: 1,
-        optional: 0,
-        worstSeverity: null,
-      }),
-    ]);
   });
 
   describe('threshold cascade', () => {
@@ -826,8 +840,7 @@ describe(runCommand, () => {
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
-        names: ['deploy'],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(['deploy']),
         json: false,
         failOn: 'warn',
       });
@@ -841,8 +854,7 @@ describe(runCommand, () => {
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
-        names: ['deploy'],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(['deploy']),
         json: false,
       });
 
@@ -855,8 +867,7 @@ describe(runCommand, () => {
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
-        names: ['deploy'],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(['deploy']),
         json: false,
       });
 
@@ -869,8 +880,7 @@ describe(runCommand, () => {
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
-        names: ['deploy'],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(['deploy']),
         json: false,
         reportOn: 'warn',
       });
@@ -885,8 +895,7 @@ describe(runCommand, () => {
       mockFormatJsonReport.mockReturnValue('{"worstSeverity":null}');
 
       await runCommand({
-        names: ['deploy'],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(['deploy']),
         json: true,
         reportOn: 'error',
       });
@@ -910,8 +919,7 @@ describe(runCommand, () => {
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       const exitCode = await runCommand({
-        names: [],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(),
         json: true,
       });
 
@@ -930,8 +938,7 @@ describe(runCommand, () => {
         .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
 
       const exitCode = await runCommand({
-        names: [],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(),
         json: true,
       });
 
@@ -942,8 +949,7 @@ describe(runCommand, () => {
       mockLoadRdyKit.mockRejectedValue(new Error('Kit not found'));
 
       const exitCode = await runCommand({
-        names: [],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(),
         json: true,
       });
 
@@ -958,8 +964,7 @@ describe(runCommand, () => {
       mockLoadRdyKit.mockResolvedValue(kit);
 
       const exitCode = await runCommand({
-        names: ['nonexistent'],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(['nonexistent']),
         json: true,
       });
 
@@ -968,7 +973,7 @@ describe(runCommand, () => {
       expect(exitCode).toBe(1);
     });
 
-    it('passes checklist name-report pairs to formatJsonReport', async () => {
+    it('passes kit-grouped entries to formatJsonReport', async () => {
       const kit = makeKit();
       mockLoadRdyKit.mockResolvedValue(kit);
       const report1 = { results: [], passed: true, durationMs: 10 };
@@ -976,15 +981,20 @@ describe(runCommand, () => {
       mockRunRdy.mockResolvedValueOnce(report1).mockResolvedValueOnce(report2);
 
       await runCommand({
-        names: [],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(),
         json: true,
       });
 
       expect(mockFormatJsonReport).toHaveBeenCalledWith(
         [
-          { name: 'deploy', report: report1 },
-          { name: 'infra', report: report2 },
+          {
+            name: 'default',
+            entries: [
+              { name: 'deploy', report: report1 },
+              { name: 'infra', report: report2 },
+            ],
+            passed: true,
+          },
         ],
         expect.objectContaining({ reportOn: 'recommend' }),
       );
@@ -996,8 +1006,7 @@ describe(runCommand, () => {
       mockRunRdy.mockRejectedValue(new Error('runner crashed'));
 
       const exitCode = await runCommand({
-        names: ['deploy'],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(['deploy']),
         json: true,
       });
 
@@ -1012,13 +1021,35 @@ describe(runCommand, () => {
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
-        names: [],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: singleKitEntry(),
         json: true,
       });
 
       const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(allOutput).not.toContain('---');
+    });
+
+    it('produces JSON output with multiple kit entries', async () => {
+      const kit = makeKit({
+        checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
+      });
+      mockLoadRdyKit.mockResolvedValue(kit);
+      mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      const exitCode = await runCommand({
+        kitEntries: [
+          { name: 'kit1', source: { path: '.rdy/kits/kit1.ts' }, checklists: [] },
+          { name: 'kit2', source: { path: '.rdy/kits/kit2.ts' }, checklists: [] },
+        ],
+        json: true,
+      });
+
+      expect(mockFormatJsonReport).toHaveBeenCalledTimes(1);
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: 'kit1' }), expect.objectContaining({ name: 'kit2' })]),
+        expect.anything(),
+      );
+      expect(exitCode).toBe(0);
     });
   });
 
@@ -1030,8 +1061,13 @@ describe(runCommand, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     const exitCode = await runCommand({
-      names: [],
-      kitSource: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/nmr.js' },
+      kitEntries: [
+        {
+          name: 'nmr',
+          source: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/nmr.js' },
+          checklists: [],
+        },
+      ],
       json: false,
     });
 
@@ -1050,8 +1086,13 @@ describe(runCommand, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
-      names: [],
-      kitSource: { url: 'https://raw.githubusercontent.com/org/repo/v2/.rdy/kits/nmr.js' },
+      kitEntries: [
+        {
+          name: 'nmr',
+          source: { url: 'https://raw.githubusercontent.com/org/repo/v2/.rdy/kits/nmr.js' },
+          checklists: [],
+        },
+      ],
       json: false,
     });
 
@@ -1068,8 +1109,7 @@ describe(runCommand, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     const exitCode = await runCommand({
-      names: [],
-      kitSource: { url: 'https://example.com/config.js' },
+      kitEntries: [{ name: 'config', source: { url: 'https://example.com/config.js' }, checklists: [] }],
       json: false,
     });
 
@@ -1084,8 +1124,7 @@ describe(runCommand, () => {
     mockLoadRemoteKit.mockRejectedValue(new Error('Failed to fetch remote kit'));
 
     const exitCode = await runCommand({
-      names: [],
-      kitSource: { url: 'https://example.com/config.js' },
+      kitEntries: [{ name: 'config', source: { url: 'https://example.com/config.js' }, checklists: [] }],
       json: false,
     });
 

--- a/packages/readyup/__tests__/formatJsonReport.test.ts
+++ b/packages/readyup/__tests__/formatJsonReport.test.ts
@@ -56,9 +56,14 @@ function makeReport(overrides?: Partial<RdyReport> & { results?: RdyResult[] }):
   return { results: [], passed: true, durationMs: 0, ...overrides };
 }
 
+/** Wrap a single checklist report as a single-kit input. */
+function singleKit(checklistName: string, report: RdyReport, kitName = 'deploy') {
+  return [{ name: kitName, entries: [{ name: checklistName, report }] }];
+}
+
 describe(formatJsonReport, () => {
   it('produces valid JSON', () => {
-    const output = formatJsonReport([{ name: 'deploy', report: makeReport() }]);
+    const output = formatJsonReport(singleKit('deploy', makeReport()));
 
     expect(() => {
       JSON.parse(output);
@@ -72,7 +77,7 @@ describe(formatJsonReport, () => {
       durationMs: 15,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
     expect(parsed).toMatchObject({
       passed: 1,
@@ -85,7 +90,7 @@ describe(formatJsonReport, () => {
     });
   });
 
-  it('aggregates granular counts across multiple checklists', () => {
+  it('aggregates granular counts across multiple checklists in a kit', () => {
     const report1 = makeReport({
       results: [makePassedResult({ name: 'a' }), makePassedResult({ name: 'b' })],
       passed: true,
@@ -99,8 +104,13 @@ describe(formatJsonReport, () => {
 
     const parsed: unknown = JSON.parse(
       formatJsonReport([
-        { name: 'deploy', report: report1 },
-        { name: 'infra', report: report2 },
+        {
+          name: 'deploy',
+          entries: [
+            { name: 'deploy', report: report1 },
+            { name: 'infra', report: report2 },
+          ],
+        },
       ]),
     );
 
@@ -112,7 +122,42 @@ describe(formatJsonReport, () => {
       blocked: 0,
       optional: 0,
       worstSeverity: 'error',
-      checklists: expect.arrayContaining([expect.anything(), expect.anything()]),
+      kits: [
+        {
+          name: 'deploy',
+          checklists: expect.arrayContaining([expect.anything(), expect.anything()]),
+        },
+      ],
+    });
+  });
+
+  it('aggregates counts across multiple kits', () => {
+    const report1 = makeReport({
+      results: [makePassedResult({ name: 'a' })],
+      passed: true,
+      durationMs: 10,
+    });
+    const report2 = makeReport({
+      results: [makeFailedResult({ name: 'b' })],
+      passed: false,
+      durationMs: 5,
+    });
+
+    const parsed: unknown = JSON.parse(
+      formatJsonReport([
+        { name: 'kit1', entries: [{ name: 'check1', report: report1 }] },
+        { name: 'kit2', entries: [{ name: 'check2', report: report2 }] },
+      ]),
+    );
+
+    expect(parsed).toMatchObject({
+      passed: 1,
+      errors: 1,
+      worstSeverity: 'error',
+      kits: [
+        { name: 'kit1', passed: 1, errors: 0 },
+        { name: 'kit2', passed: 0, errors: 1 },
+      ],
     });
   });
 
@@ -123,20 +168,25 @@ describe(formatJsonReport, () => {
       durationMs: 10,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
     expect(parsed).toMatchObject({
-      checklists: [
+      kits: [
         {
           name: 'deploy',
-          passed: 1,
-          errors: 0,
-          warnings: 0,
-          recommendations: 0,
-          blocked: 0,
-          optional: 0,
-          worstSeverity: null,
-          durationMs: 10,
+          checklists: [
+            {
+              name: 'deploy',
+              passed: 1,
+              errors: 0,
+              warnings: 0,
+              recommendations: 0,
+              blocked: 0,
+              optional: 0,
+              worstSeverity: null,
+              durationMs: 10,
+            },
+          ],
         },
       ],
     });
@@ -149,7 +199,7 @@ describe(formatJsonReport, () => {
       durationMs: 0,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
     expect(parsed).toMatchObject({
       passed: 0,
@@ -162,23 +212,23 @@ describe(formatJsonReport, () => {
     });
   });
 
-  it('emits the expected top-level shape with granular fields', () => {
+  it('emits the expected top-level shape with kits array', () => {
     const report = makeReport({
       results: [makePassedResult({ name: 'a' })],
       passed: true,
       durationMs: 10,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
     if (typeof parsed !== 'object' || parsed === null) throw new Error('expected object');
     // eslint-disable-next-line unicorn/no-array-sort -- toSorted requires Node 20+; engine target is >=18.17.0
     const topLevelKeys = Object.keys(parsed).sort();
 
     expect(topLevelKeys).toStrictEqual([
       'blocked',
-      'checklists',
       'durationMs',
       'errors',
+      'kits',
       'optional',
       'passed',
       'recommendations',
@@ -198,7 +248,7 @@ describe(formatJsonReport, () => {
       durationMs: 0,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
     expect(parsed).toMatchObject({
       errors: 1,
@@ -218,7 +268,7 @@ describe(formatJsonReport, () => {
       durationMs: 0,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
     expect(parsed).toMatchObject({
       blocked: 1,
@@ -233,10 +283,10 @@ describe(formatJsonReport, () => {
       durationMs: 5,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
     expect(parsed).toMatchObject({
-      checklists: [{ checks: [{ error: 'connection refused' }] }],
+      kits: [{ checklists: [{ checks: [{ error: 'connection refused' }] }] }],
     });
   });
 
@@ -247,23 +297,27 @@ describe(formatJsonReport, () => {
       durationMs: 10,
     });
 
-    const output = formatJsonReport([{ name: 'deploy', report }]);
+    const output = formatJsonReport(singleKit('deploy', report));
     const parsed: unknown = JSON.parse(output);
 
     expect(parsed).toMatchObject({
-      checklists: [
+      kits: [
         {
-          checks: [
+          checklists: [
             {
-              name: 'a',
-              status: 'passed',
-              ok: true,
-              severity: 'error',
-              skipReason: null,
-              detail: null,
-              fix: null,
-              error: null,
-              progress: null,
+              checks: [
+                {
+                  name: 'a',
+                  status: 'passed',
+                  ok: true,
+                  severity: 'error',
+                  skipReason: null,
+                  detail: null,
+                  fix: null,
+                  error: null,
+                  progress: null,
+                },
+              ],
             },
           ],
         },
@@ -282,15 +336,19 @@ describe(formatJsonReport, () => {
       durationMs: 15,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
     expect(parsed).toMatchObject({
-      checklists: [
+      kits: [
         {
-          checks: [
-            { severity: 'warn', ok: true, skipReason: null },
-            { severity: 'error', ok: false, skipReason: null },
-            { severity: 'recommend', ok: null, skipReason: 'n/a' },
+          checklists: [
+            {
+              checks: [
+                { severity: 'warn', ok: true, skipReason: null },
+                { severity: 'error', ok: false, skipReason: null },
+                { severity: 'recommend', ok: null, skipReason: 'n/a' },
+              ],
+            },
           ],
         },
       ],
@@ -311,16 +369,20 @@ describe(formatJsonReport, () => {
       durationMs: 10,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
     expect(parsed).toMatchObject({
-      checklists: [
+      kits: [
         {
-          checks: [
+          checklists: [
             {
-              fix: 'run npm install',
-              detail: 'missing dependency',
-              progress: { type: 'fraction', passedCount: 3, count: 5 },
+              checks: [
+                {
+                  fix: 'run npm install',
+                  detail: 'missing dependency',
+                  progress: { type: 'fraction', passedCount: 3, count: 5 },
+                },
+              ],
             },
           ],
         },
@@ -340,10 +402,10 @@ describe(formatJsonReport, () => {
       durationMs: 10,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
     expect(parsed).toMatchObject({
-      checklists: [{ checks: [{ progress: { type: 'percent', percent: 75 } }] }],
+      kits: [{ checklists: [{ checks: [{ progress: { type: 'percent', percent: 75 } }] }] }],
     });
   });
 
@@ -355,15 +417,19 @@ describe(formatJsonReport, () => {
         durationMs: 20,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
-        checklists: [
+        kits: [
           {
-            checks: [
+            checklists: [
               {
-                name: 'parent',
-                checks: [{ name: 'child', checks: [] }],
+                checks: [
+                  {
+                    name: 'parent',
+                    checks: [{ name: 'child', checks: [] }],
+                  },
+                ],
               },
             ],
           },
@@ -378,10 +444,10 @@ describe(formatJsonReport, () => {
         durationMs: 10,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
-        checklists: [{ checks: [{ name: 'top-check', checks: [] }] }],
+        kits: [{ checklists: [{ checks: [{ name: 'top-check', checks: [] }] }] }],
       });
     });
 
@@ -398,22 +464,26 @@ describe(formatJsonReport, () => {
         durationMs: 50,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
-        checklists: [
+        kits: [
           {
-            checks: [
+            checklists: [
               {
-                name: 'A',
                 checks: [
-                  { name: 'A1', checks: [] },
-                  { name: 'A2', checks: [] },
+                  {
+                    name: 'A',
+                    checks: [
+                      { name: 'A1', checks: [] },
+                      { name: 'A2', checks: [] },
+                    ],
+                  },
+                  {
+                    name: 'B',
+                    checks: [{ name: 'B1', checks: [] }],
+                  },
                 ],
-              },
-              {
-                name: 'B',
-                checks: [{ name: 'B1', checks: [] }],
               },
             ],
           },
@@ -428,10 +498,10 @@ describe(formatJsonReport, () => {
         durationMs: 10,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
-        checklists: [{ checks: [{ name: 'leaf', checks: [] }] }],
+        kits: [{ checklists: [{ checks: [{ name: 'leaf', checks: [] }] }] }],
       });
     });
 
@@ -445,15 +515,19 @@ describe(formatJsonReport, () => {
         durationMs: 0,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
-        checklists: [
+        kits: [
           {
-            checks: [
+            checklists: [
               {
-                name: 'na-parent',
-                checks: [{ name: 'na-child' }],
+                checks: [
+                  {
+                    name: 'na-parent',
+                    checks: [{ name: 'na-child' }],
+                  },
+                ],
               },
             ],
           },
@@ -473,14 +547,14 @@ describe(formatJsonReport, () => {
         durationMs: 30,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
         passed: 2,
         errors: 1,
         blocked: 1,
         worstSeverity: 'error',
-        checklists: [{ passed: 2, errors: 1, blocked: 1, worstSeverity: 'error' }],
+        kits: [{ checklists: [{ passed: 2, errors: 1, blocked: 1, worstSeverity: 'error' }] }],
       });
     });
 
@@ -495,18 +569,22 @@ describe(formatJsonReport, () => {
         durationMs: 30,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }]));
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
-        checklists: [
+        kits: [
           {
-            checks: [
+            checklists: [
               {
-                name: 'L0',
                 checks: [
                   {
-                    name: 'L1',
-                    checks: [{ name: 'L2', checks: [] }],
+                    name: 'L0',
+                    checks: [
+                      {
+                        name: 'L1',
+                        checks: [{ name: 'L2', checks: [] }],
+                      },
+                    ],
                   },
                 ],
               },
@@ -528,10 +606,10 @@ describe(formatJsonReport, () => {
         durationMs: 20,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }], { reportOn: 'error' }));
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report), { reportOn: 'error' }));
 
       expect(parsed).toMatchObject({
-        checklists: [{ checks: [{ name: 'error-check' }] }],
+        kits: [{ checklists: [{ checks: [{ name: 'error-check' }] }] }],
       });
     });
 
@@ -545,7 +623,7 @@ describe(formatJsonReport, () => {
         durationMs: 15,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport([{ name: 'deploy', report }], { reportOn: 'error' }));
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report), { reportOn: 'error' }));
 
       expect(parsed).toMatchObject({
         passed: 1,

--- a/packages/readyup/__tests__/parseKitSpecifiers.test.ts
+++ b/packages/readyup/__tests__/parseKitSpecifiers.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseKitSpecifiers } from '../src/parseKitSpecifiers.ts';
+
+describe(parseKitSpecifiers, () => {
+  it('parses a single kit name without checklists', () => {
+    expect(parseKitSpecifiers(['deploy'])).toStrictEqual([{ kitName: 'deploy', checklists: [] }]);
+  });
+
+  it('parses a kit name with comma-separated checklists', () => {
+    expect(parseKitSpecifiers(['deploy:check1,check2'])).toStrictEqual([
+      { kitName: 'deploy', checklists: ['check1', 'check2'] },
+    ]);
+  });
+
+  it('parses multiple positional args into separate entries', () => {
+    expect(parseKitSpecifiers(['deploy:check1', 'infra'])).toStrictEqual([
+      { kitName: 'deploy', checklists: ['check1'] },
+      { kitName: 'infra', checklists: [] },
+    ]);
+  });
+
+  it('supports kit names with slashes', () => {
+    expect(parseKitSpecifiers(['shared/deploy:check1'])).toStrictEqual([
+      { kitName: 'shared/deploy', checklists: ['check1'] },
+    ]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(parseKitSpecifiers([])).toStrictEqual([]);
+  });
+
+  it('throws for an empty kit name before the colon', () => {
+    expect(() => parseKitSpecifiers([':check1'])).toThrow('kit name must not be empty');
+  });
+
+  it('throws for a trailing colon with no checklists', () => {
+    expect(() => parseKitSpecifiers(['deploy:'])).toThrow('checklist list after ":" must not be empty');
+  });
+
+  it('parses a single checklist after the colon', () => {
+    expect(parseKitSpecifiers(['deploy:check1'])).toStrictEqual([{ kitName: 'deploy', checklists: ['check1'] }]);
+  });
+
+  it('splits on only the first colon', () => {
+    expect(parseKitSpecifiers(['deploy:ns:check1'])).toStrictEqual([{ kitName: 'deploy', checklists: ['ns:check1'] }]);
+  });
+});

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -5,12 +5,12 @@ const mockInitCommand = vi.hoisted(() => vi.fn());
 const mockCompileCommand = vi.hoisted(() => vi.fn());
 const mockListCommand = vi.hoisted(() => vi.fn());
 const mockParseRunArgs = vi.hoisted(() => vi.fn());
-const mockResolveKitSource = vi.hoisted(() => vi.fn());
+const mockResolveKitSources = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/cli.ts', () => ({
   parseRunArgs: mockParseRunArgs,
-  resolveKitSource: mockResolveKitSource,
+  resolveKitSources: mockResolveKitSources,
   runCommand: mockRunCommand,
 }));
 
@@ -47,7 +47,9 @@ describe(routeCommand, () => {
       compile: { srcDir: '.rdy/kits', outDir: '.rdy/kits', include: undefined },
       internal: { dir: '.', extension: '.ts' },
     });
-    mockResolveKitSource.mockReturnValue({ path: '.rdy/kits/default.ts' });
+    mockResolveKitSources.mockReturnValue([
+      { name: 'default', source: { path: '.rdy/kits/default.ts' }, checklists: [] },
+    ]);
   });
 
   afterEach(() => {
@@ -57,7 +59,7 @@ describe(routeCommand, () => {
     mockInitCommand.mockReset();
     mockListCommand.mockReset();
     mockParseRunArgs.mockReset();
-    mockResolveKitSource.mockReset();
+    mockResolveKitSources.mockReset();
     mockLoadConfig.mockReset();
   });
 
@@ -105,9 +107,16 @@ describe(routeCommand, () => {
     expect(output).toContain('--github, -g');
     expect(output).toContain('--local, -l');
     expect(output).toContain('--url, -u');
-    expect(output).toContain('--kit, -k');
+    expect(output).toContain('--checklists, -c');
     expect(output).toContain('--json, -j');
     expect(output).toContain('--version, -V');
+  });
+
+  it('does not include --kit in top-level help', async () => {
+    await routeCommand(['--help']);
+
+    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).not.toContain('--kit');
   });
 
   it('marks run as the default command in top-level help', async () => {
@@ -141,8 +150,8 @@ describe(routeCommand, () => {
 
   it('delegates to runCommand for run subcommand', async () => {
     mockParseRunArgs.mockReturnValue({
-      names: ['deploy'],
-      kitName: undefined,
+      kitSpecifiers: [{ kitName: 'deploy', checklists: [] }],
+      checklists: undefined,
       filePath: undefined,
       githubValue: undefined,
       localValue: undefined,
@@ -156,8 +165,7 @@ describe(routeCommand, () => {
     expect(mockParseRunArgs).toHaveBeenCalledWith(['deploy']);
     expect(mockRunCommand).toHaveBeenCalledWith(
       expect.objectContaining({
-        names: ['deploy'],
-        kitSource: { path: '.rdy/kits/default.ts' },
+        kitEntries: [{ name: 'default', source: { path: '.rdy/kits/default.ts' }, checklists: [] }],
         json: false,
       }),
     );
@@ -166,8 +174,8 @@ describe(routeCommand, () => {
 
   it('passes --json flag through to runCommand', async () => {
     mockParseRunArgs.mockReturnValue({
-      names: [],
-      kitName: undefined,
+      kitSpecifiers: [],
+      checklists: undefined,
       filePath: undefined,
       githubValue: undefined,
       localValue: undefined,
@@ -180,8 +188,6 @@ describe(routeCommand, () => {
 
     expect(mockRunCommand).toHaveBeenCalledWith(
       expect.objectContaining({
-        names: [],
-        kitSource: { path: '.rdy/kits/default.ts' },
         json: true,
       }),
     );
@@ -206,30 +212,30 @@ describe(routeCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("unknown flag '--bad'"));
   });
 
-  it('returns 1 and writes to stderr when resolveKitSource throws', async () => {
+  it('returns 1 and writes to stderr when resolveKitSources throws', async () => {
     mockParseRunArgs.mockReturnValue({
-      names: [],
-      kitName: 'deploy',
+      kitSpecifiers: [],
+      checklists: undefined,
       filePath: 'path.ts',
       githubValue: undefined,
       localValue: undefined,
       urlValue: undefined,
       json: false,
     });
-    mockResolveKitSource.mockImplementation(() => {
-      throw new Error('--kit cannot be used with --file');
+    mockResolveKitSources.mockImplementation(() => {
+      throw new Error('resolution failed');
     });
 
-    const exitCode = await routeCommand(['run', '--file', 'path.ts', '--kit', 'deploy']);
+    const exitCode = await routeCommand(['run', '--file', 'path.ts']);
 
     expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--kit cannot be used with --file'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('resolution failed'));
   });
 
   it('returns 1 and writes to stderr when loadConfig rejects', async () => {
     mockParseRunArgs.mockReturnValue({
-      names: [],
-      kitName: undefined,
+      kitSpecifiers: [],
+      checklists: undefined,
       filePath: undefined,
       githubValue: undefined,
       localValue: undefined,
@@ -360,8 +366,8 @@ describe(routeCommand, () => {
   describe('default command routing', () => {
     it('routes flags to run when no subcommand is given', async () => {
       mockParseRunArgs.mockReturnValue({
-        names: [],
-        kitName: undefined,
+        kitSpecifiers: [],
+        checklists: undefined,
         filePath: 'foo.ts',
         githubValue: undefined,
         localValue: undefined,
@@ -376,10 +382,10 @@ describe(routeCommand, () => {
       expect(exitCode).toBe(0);
     });
 
-    it('routes positional args to run as checklist names', async () => {
+    it('routes positional args to run as kit specifiers', async () => {
       mockParseRunArgs.mockReturnValue({
-        names: ['onboarding'],
-        kitName: undefined,
+        kitSpecifiers: [{ kitName: 'onboarding', checklists: [] }],
+        checklists: undefined,
         filePath: undefined,
         githubValue: undefined,
         localValue: undefined,
@@ -411,8 +417,8 @@ describe(routeCommand, () => {
 
     it('does not suggest for prefixes shorter than 3 characters', async () => {
       mockParseRunArgs.mockReturnValue({
-        names: ['co'],
-        kitName: undefined,
+        kitSpecifiers: [{ kitName: 'co', checklists: [] }],
+        checklists: undefined,
         filePath: undefined,
         githubValue: undefined,
         localValue: undefined,
@@ -429,8 +435,8 @@ describe(routeCommand, () => {
 
     it('does not suggest when input matches a subcommand exactly', async () => {
       mockParseRunArgs.mockReturnValue({
-        names: [],
-        kitName: undefined,
+        kitSpecifiers: [],
+        checklists: undefined,
         filePath: undefined,
         githubValue: undefined,
         localValue: undefined,

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-import { parseRunArgs, resolveKitSource, runCommand } from '../cli.ts';
+import { parseRunArgs, resolveKitSources, runCommand } from '../cli.ts';
 import { compileCommand } from '../compile/compileCommand.ts';
 import { initCommand } from '../init/initCommand.ts';
 import { listCommand } from '../list/listCommand.ts';
@@ -14,21 +14,21 @@ const MIN_PREFIX_LENGTH = 3;
 
 function showHelp(): void {
   console.info(`
-Usage: rdy [names...] [options]
+Usage: rdy [kit[:checklist,...] ...] [options]
        rdy <command> [options]
 
 Commands:
-  run [names...]       Run rdy checklists (default)
-  compile [file]       Bundle TypeScript kit(s) into self-contained ESM file(s)
-  init                 Scaffold a starter config and kit
-  list                 List available kits
+  run [kit[:checklist,...] ...]  Run rdy checklists (default)
+  compile [file]                Bundle TypeScript kit(s) into self-contained ESM file(s)
+  init                          Scaffold a starter config and kit
+  list                          List available kits
 
 Run options:
   --file, -f <path>                  Path to a local kit file
   --github, -g <org/repo[@ref]>      Fetch kit from a GitHub repository
   --local, -l <path>                 Load compiled kit from a local repository
   --url, -u <url>                    Fetch kit from a URL
-  --kit, -k <name>                   Kit name (default: "default")
+  --checklists, -c <name,...>        Filter checklists (with --file or --url only)
   --json, -j                         Output results as JSON
   --fail-on, -F <severity>           Fail on this severity or above (error, warn, recommend)
   --report-on, -R <severity>         Report this severity or above (error, warn, recommend)
@@ -41,9 +41,11 @@ Global options:
 
 function showRunHelp(): void {
   console.info(`
-Usage: rdy run [names...] [options]
+Usage: rdy run [kit[:checklist,...] ...] [options]
 
-Run rdy checklists. If no names are given, all checklists are run.
+Run rdy checklists. Positional arguments select kits to run; use colon syntax
+to filter checklists within a kit (e.g., deploy:check1,check2).
+If no arguments are given, all checklists in the default kit are run.
 
 Kit source (mutually exclusive):
   --file, -f <path>                  Path to a local kit file
@@ -52,13 +54,13 @@ Kit source (mutually exclusive):
   --url, -u <url>                    Fetch kit from a URL
 
 Options:
-  --kit, -k <name>                   Kit name (default: "default")
+  --checklists, -c <name,...>        Filter checklists (with --file or --url only)
   --json, -j                         Output results as JSON
   --fail-on, -F <severity>           Fail on this severity or above (error, warn, recommend)
   --report-on, -R <severity>         Report this severity or above (error, warn, recommend)
   --help, -h                         Show this help message
 
---kit accepts relative paths (e.g., --kit shared/deploy).
+Positional args accept relative paths (e.g., shared/deploy).
 Defaults to .rdy/kits/default.ts when no source is given.
 `);
 }
@@ -233,14 +235,15 @@ async function handleRun(flags: string[]): Promise<number> {
     return 1;
   }
 
-  let kitSource;
+  let kitEntries;
   try {
-    kitSource = resolveKitSource({
+    kitEntries = resolveKitSources({
       filePath: parsed.filePath,
       githubValue: parsed.githubValue,
       localValue: parsed.localValue,
       urlValue: parsed.urlValue,
-      kitName: parsed.kitName,
+      kitSpecifiers: parsed.kitSpecifiers,
+      checklists: parsed.checklists,
       internalDir: config.internal.dir,
       internalExtension: config.internal.extension,
     });
@@ -250,9 +253,8 @@ async function handleRun(flags: string[]): Promise<number> {
   }
 
   return runCommand({
-    kitSource,
+    kitEntries,
     json: parsed.json,
-    names: parsed.names,
     ...(parsed.failOn !== undefined && { failOn: parsed.failOn }),
     ...(parsed.reportOn !== undefined && { reportOn: parsed.reportOn }),
   });

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -7,6 +7,7 @@ import { formatJsonError } from './formatJsonError.ts';
 import { formatJsonReport } from './formatJsonReport.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { parseArgs } from './parseArgs.ts';
+import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
 import { reportRdy, tallyResult } from './reportRdy.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
 import { resolveRequestedNames } from './resolveRequestedNames.ts';
@@ -29,23 +30,30 @@ const VALID_SEVERITIES = new Set<string>(['error', 'warn', 'recommend']);
 /** Discriminated union describing how to locate the rdy kit. */
 export type KitSource = { path: string } | { url: string };
 
-interface ParsedRunArgs {
-  kitName: string | undefined;
+/** A resolved kit entry with its source and checklist filter. */
+export interface ResolvedKitEntry {
+  name: string;
+  source: KitSource;
+  checklists: string[];
+}
+
+export interface ParsedRunArgs {
+  checklists: string[] | undefined;
   failOn?: Severity;
   filePath: string | undefined;
   githubValue: string | undefined;
   json: boolean;
+  kitSpecifiers: KitSpecifier[];
   localValue: string | undefined;
-  names: string[];
   reportOn?: Severity;
   urlValue: string | undefined;
 }
 
 const runFlagSchema = {
+  checklists: { long: '--checklists', type: 'string' as const, short: '-c' },
   file: { long: '--file', type: 'string' as const, short: '-f' },
   github: { long: '--github', type: 'string' as const, short: '-g' },
   url: { long: '--url', type: 'string' as const, short: '-u' },
-  kit: { long: '--kit', type: 'string' as const, short: '-k' },
   local: { long: '--local', type: 'string' as const, short: '-l' },
   json: { long: '--json', type: 'boolean' as const, short: '-j' },
   failOn: { long: '--fail-on', type: 'string' as const, short: '-F' },
@@ -98,7 +106,7 @@ function buildGitHubKitUrl(repo: string, ref: string, kit: string): string {
 
 /** Map generic "requires a value" errors to domain-specific hints for run-subcommand flags. */
 const flagErrorHints: Record<string, string> = {
-  '--kit': '--kit requires a kit name',
+  '--checklists': '--checklists requires a comma-separated list of checklist names',
   '--fail-on': '--fail-on requires a severity level (error, warn, recommend)',
   '--file': '--file requires a path argument',
   '--github': '--github requires a repository argument (org/repo[@ref])',
@@ -150,17 +158,34 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
     sourceType = 'url';
   }
 
+  // Validate --checklists co-dependencies.
+  const checklistsValue = parsed.checklists;
+  if (checklistsValue !== undefined && sourceType !== 'file' && sourceType !== 'url') {
+    throw new Error('--checklists can only be used with --file or --url');
+  }
+
+  // Validate that file/url sources cannot be combined with positional args.
+  if ((sourceType === 'file' || sourceType === 'url') && positionals.length > 0) {
+    throw new Error(`--${sourceType} cannot be combined with positional kit arguments`);
+  }
+
+  // Parse checklists from the flag value.
+  const checklists = checklistsValue !== undefined ? checklistsValue.split(',').filter((s) => s !== '') : undefined;
+
+  // Parse kit specifiers from positional args.
+  const kitSpecifiers = parseKitSpecifiers(positionals);
+
   // Validate severity flags.
   const failOn = parsed.failOn !== undefined ? parseSeverityFlag('--fail-on', parsed.failOn) : undefined;
   const reportOn = parsed.reportOn !== undefined ? parseSeverityFlag('--report-on', parsed.reportOn) : undefined;
 
   const parsedArgs: ParsedRunArgs = {
-    kitName: parsed.kit,
+    checklists,
     filePath: parsed.file,
     githubValue: parsed.github,
     json: parsed.json,
+    kitSpecifiers,
     localValue: parsed.local,
-    names: positionals,
     urlValue: parsed.url,
   };
   if (failOn !== undefined) parsedArgs.failOn = failOn;
@@ -168,13 +193,14 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   return parsedArgs;
 }
 
-/** Validate flag co-dependencies and build the KitSource from parsed flag state. */
-export function resolveKitSource({
+/** Resolve parsed flags into an array of kit entries to execute. */
+export function resolveKitSources({
   filePath,
   githubValue,
   localValue,
   urlValue,
-  kitName,
+  kitSpecifiers,
+  checklists,
   internalDir,
   internalExtension,
 }: {
@@ -182,34 +208,44 @@ export function resolveKitSource({
   githubValue: string | undefined;
   localValue: string | undefined;
   urlValue: string | undefined;
-  kitName: string | undefined;
+  kitSpecifiers: KitSpecifier[];
+  checklists: string[] | undefined;
   internalDir: string;
   internalExtension: string;
-}): KitSource {
+}): ResolvedKitEntry[] {
   if (filePath !== undefined) {
-    if (kitName !== undefined) {
-      throw new Error('--kit cannot be used with --file');
-    }
-    return { path: filePath };
-  }
-  if (githubValue !== undefined) {
-    const name = kitName ?? 'default';
-    const { repo, ref } = parseGitHubArg(githubValue);
-    return { url: buildGitHubKitUrl(repo, ref, name) };
-  }
-  if (localValue !== undefined) {
-    const name = kitName ?? 'default';
-    const resolvedBase = path.resolve(process.cwd(), localValue);
-    return { path: path.join(resolvedBase, KITS_DIR, `${name}.js`) };
+    return [{ name: filePath, source: { path: filePath }, checklists: checklists ?? [] }];
   }
   if (urlValue !== undefined) {
-    if (kitName !== undefined) {
-      throw new Error('--kit cannot be used with --url');
-    }
-    return { url: urlValue };
+    return [{ name: urlValue, source: { url: urlValue }, checklists: checklists ?? [] }];
   }
-  const name = kitName ?? 'default';
-  return { path: path.join(KITS_DIR, internalDir, `${name}${internalExtension}`) };
+
+  const specs = kitSpecifiers.length > 0 ? kitSpecifiers : [{ kitName: 'default', checklists: [] }];
+
+  if (githubValue !== undefined) {
+    const { repo, ref } = parseGitHubArg(githubValue);
+    return specs.map((spec) => ({
+      name: spec.kitName,
+      source: { url: buildGitHubKitUrl(repo, ref, spec.kitName) },
+      checklists: spec.checklists,
+    }));
+  }
+
+  if (localValue !== undefined) {
+    const resolvedBase = path.resolve(process.cwd(), localValue);
+    return specs.map((spec) => ({
+      name: spec.kitName,
+      source: { path: path.join(resolvedBase, KITS_DIR, `${spec.kitName}.js`) },
+      checklists: spec.checklists,
+    }));
+  }
+
+  // Internal/default case.
+  return specs.map((spec) => ({
+    name: spec.kitName,
+    source: { path: path.join(KITS_DIR, internalDir, `${spec.kitName}${internalExtension}`) },
+    checklists: spec.checklists,
+  }));
 }
 
 /** Resolve the effective fixLocation for a checklist, falling back to the kit-level default. */
@@ -249,9 +285,8 @@ function resolveThresholds(
 }
 
 interface RunCommandOptions {
-  kitSource: KitSource;
+  kitEntries: ResolvedKitEntry[];
   json: boolean;
-  names: string[];
   failOn?: Severity;
   reportOn?: Severity;
 }
@@ -271,48 +306,125 @@ async function loadKit(source: KitSource): Promise<RdyKit> {
   return loadRdyKit(source.path);
 }
 
-/** Run rdy checklists. Returns a numeric exit code. */
-export async function runCommand({ names, kitSource, json, failOn, reportOn }: RunCommandOptions): Promise<number> {
-  let kit: RdyKit;
-  try {
-    kit = await loadKit(kitSource);
-  } catch (error: unknown) {
-    const message = extractMessage(error);
-    if (json) {
-      process.stdout.write(formatJsonError(message) + '\n');
-    } else {
-      process.stderr.write(`Error: ${message}\n`);
-    }
-    return 1;
+/** Run rdy checklists across one or more kits. Returns a numeric exit code. */
+export async function runCommand({ kitEntries, json, failOn, reportOn }: RunCommandOptions): Promise<number> {
+  if (json) {
+    return runMultiKitJsonMode(kitEntries, failOn, reportOn);
   }
-
-  return runSingleKit(kit, names, json, failOn, reportOn);
+  return runMultiKitHumanMode(kitEntries, failOn, reportOn);
 }
 
-/** Run checklists from a single kit. */
-async function runSingleKit(
-  kit: RdyKit,
-  names: string[],
-  json: boolean,
+/** Run all kit entries in JSON mode, producing a single JSON report. */
+async function runMultiKitJsonMode(
+  kitEntries: ResolvedKitEntry[],
   failOn: Severity | undefined,
   reportOn: Severity | undefined,
 ): Promise<number> {
-  // Resolve requested names (expanding suite names) and filter checklists
+  const kitResults: Array<{
+    name: string;
+    entries: Array<{ name: string; report: RdyReport }>;
+    passed: boolean;
+  }> = [];
+
+  for (const entry of kitEntries) {
+    let kit: RdyKit;
+    try {
+      kit = await loadKit(entry.source);
+    } catch (error: unknown) {
+      const message = extractMessage(error);
+      process.stdout.write(formatJsonError(message) + '\n');
+      return 1;
+    }
+
+    const thresholds = resolveThresholds(kit, failOn, reportOn);
+    let resolvedNames: string[];
+    try {
+      resolvedNames = resolveRequestedNames(entry.checklists, kit);
+    } catch (error: unknown) {
+      const message = extractMessage(error);
+      process.stdout.write(formatJsonError(message) + '\n');
+      return 1;
+    }
+
+    const checklistByName = new Map(kit.checklists.map((c) => [c.name, c]));
+    const checklists = resolvedNames.flatMap((name) => {
+      const checklist = checklistByName.get(name);
+      return checklist !== undefined ? [checklist] : [];
+    });
+
+    const entries: Array<{ name: string; report: RdyReport }> = [];
+    let kitPassed = true;
+
+    try {
+      for (const checklist of checklists) {
+        const report = await runRdy(checklist, {
+          defaultSeverity: thresholds.defaultSeverity,
+          failOn: thresholds.failOn,
+        });
+        entries.push({ name: checklist.name, report });
+        if (!report.passed) kitPassed = false;
+      }
+    } catch (error: unknown) {
+      const message = extractMessage(error);
+      process.stdout.write(formatJsonError(message) + '\n');
+      return 1;
+    }
+
+    kitResults.push({ name: entry.name, entries, passed: kitPassed });
+  }
+
+  const resolvedReportOn = reportOn ?? 'recommend';
+  process.stdout.write(formatJsonReport(kitResults, { reportOn: resolvedReportOn }) + '\n');
+  const allPassed = kitResults.every((k) => k.passed);
+  return allPassed ? 0 : 1;
+}
+
+/** Run all kit entries in human-readable mode. */
+async function runMultiKitHumanMode(
+  kitEntries: ResolvedKitEntry[],
+  failOn: Severity | undefined,
+  reportOn: Severity | undefined,
+): Promise<number> {
+  const showKitHeader = kitEntries.length > 1;
+  let allPassed = true;
+  for (const entry of kitEntries) {
+    let kit: RdyKit;
+    try {
+      kit = await loadKit(entry.source);
+    } catch (error: unknown) {
+      const message = extractMessage(error);
+      process.stderr.write(`Error: ${message}\n`);
+      return 1;
+    }
+
+    if (showKitHeader) {
+      process.stdout.write(`\n=== ${entry.name} ===\n`);
+    }
+
+    const exitCode = await runSingleKitHumanMode(kit, entry.checklists, failOn, reportOn, showKitHeader);
+    if (exitCode !== 0) allPassed = false;
+  }
+
+  return allPassed ? 0 : 1;
+}
+
+/** Run checklists from a single kit in human-readable mode. */
+async function runSingleKitHumanMode(
+  kit: RdyKit,
+  checklistFilter: string[],
+  failOn: Severity | undefined,
+  reportOn: Severity | undefined,
+  isMultiKit: boolean,
+): Promise<number> {
   let resolvedNames: string[];
   try {
-    resolvedNames = resolveRequestedNames(names, kit);
+    resolvedNames = resolveRequestedNames(checklistFilter, kit);
   } catch (error: unknown) {
     const message = extractMessage(error);
-    if (json) {
-      process.stdout.write(formatJsonError(message) + '\n');
-    } else {
-      process.stderr.write(`Error: ${message}\n`);
-    }
+    process.stderr.write(`Error: ${message}\n`);
     return 1;
   }
 
-  // All names in `resolvedNames` are guaranteed valid by `resolveRequestedNames`; the
-  // flatMap guard serves only as a type-narrowing filter for the `Map.get` return type.
   const checklistByName = new Map(kit.checklists.map((c) => [c.name, c]));
   const checklists = resolvedNames.flatMap((name) => {
     const checklist = checklistByName.get(name);
@@ -320,54 +432,13 @@ async function runSingleKit(
   });
 
   const thresholds = resolveThresholds(kit, failOn, reportOn);
-
-  if (json) {
-    return runJsonMode(checklists, thresholds);
-  }
-
-  return runHumanMode(checklists, kit, thresholds);
-}
-
-/** Run checklists and emit a single JSON object to stdout. */
-async function runJsonMode(
-  checklists: Array<RdyChecklist | RdyStagedChecklist>,
-  thresholds: { defaultSeverity: Severity; failOn: Severity; reportOn: Severity },
-): Promise<number> {
-  const entries: Array<{ name: string; report: RdyReport }> = [];
-  let allPassed = true;
-
-  try {
-    for (const checklist of checklists) {
-      const report = await runRdy(checklist, {
-        defaultSeverity: thresholds.defaultSeverity,
-        failOn: thresholds.failOn,
-      });
-      entries.push({ name: checklist.name, report });
-      if (!report.passed) allPassed = false;
-    }
-  } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stdout.write(formatJsonError(message) + '\n');
-    return 1;
-  }
-
-  process.stdout.write(formatJsonReport(entries, { reportOn: thresholds.reportOn }) + '\n');
-  return allPassed ? 0 : 1;
-}
-
-/** Run checklists with human-readable output. */
-async function runHumanMode(
-  checklists: Array<RdyChecklist | RdyStagedChecklist>,
-  kit: RdyKit,
-  thresholds: { defaultSeverity: Severity; failOn: Severity; reportOn: Severity },
-): Promise<number> {
-  const showHeader = checklists.length > 1;
+  const showChecklistHeader = checklists.length > 1;
   let allPassed = true;
   const summaries: ChecklistSummary[] = [];
 
   try {
     for (const checklist of checklists) {
-      if (showHeader) {
+      if (showChecklistHeader) {
         process.stdout.write(`\n--- ${checklist.name} ---\n\n`);
       }
 
@@ -383,7 +454,7 @@ async function runHumanMode(
         allPassed = false;
       }
 
-      if (showHeader) {
+      if (showChecklistHeader) {
         summaries.push(summarizeReport(checklist.name, report, thresholds.reportOn));
       }
     }
@@ -393,7 +464,7 @@ async function runHumanMode(
     return 1;
   }
 
-  if (summaries.length > 1) {
+  if (summaries.length > 1 && !isMultiKit) {
     process.stdout.write('\n' + formatCombinedSummary(summaries) + '\n');
   }
 

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -3,6 +3,7 @@ import { meetsThreshold } from './runRdy.ts';
 import type {
   JsonCheckEntry,
   JsonChecklistEntry,
+  JsonKitEntry,
   JsonReport,
   RdyReport,
   RdyResult,
@@ -14,6 +15,11 @@ import { worseSeverity } from './utils/severity.ts';
 interface ChecklistEntry {
   name: string;
   report: RdyReport;
+}
+
+interface KitInput {
+  name: string;
+  entries: ChecklistEntry[];
 }
 
 /** Options controlling which results appear in JSON output. */
@@ -34,47 +40,66 @@ function emptyCounts(): SummaryCounts {
   };
 }
 
-/** Transform an array of checklist results into a JSON-serializable report string. */
-export function formatJsonReport(entries: ChecklistEntry[], options?: FormatJsonReportOptions): string {
+/** Aggregate `source` counts into `target` in place. */
+function mergeCounts(target: SummaryCounts, source: SummaryCounts): void {
+  target.passed += source.passed;
+  target.errors += source.errors;
+  target.warnings += source.warnings;
+  target.recommendations += source.recommendations;
+  target.blocked += source.blocked;
+  target.optional += source.optional;
+  target.worstSeverity = worseSeverity(target.worstSeverity, source.worstSeverity);
+}
+
+/** Build a single checklist entry from a name and report. */
+function buildChecklistEntry(name: string, report: RdyReport, reportOn: Severity): JsonChecklistEntry {
+  const counts = emptyCounts();
+  const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
+
+  for (const result of visibleResults) {
+    tallyResult(counts, result);
+  }
+
+  const { entries: checks } = buildCheckEntries(visibleResults, 0, 0);
+
+  return {
+    name,
+    durationMs: report.durationMs,
+    ...counts,
+    checks,
+  };
+}
+
+/** Transform kit-grouped checklist results into a JSON-serializable report string. */
+export function formatJsonReport(kitInputs: KitInput[], options?: FormatJsonReportOptions): string {
   const reportOn = options?.reportOn ?? 'recommend';
   const totals = emptyCounts();
 
-  const checklists: JsonChecklistEntry[] = entries.map(({ name, report }) => {
-    const counts = emptyCounts();
+  const kits: JsonKitEntry[] = kitInputs.map(({ name, entries }) => {
+    const kitCounts = emptyCounts();
+    const checklists: JsonChecklistEntry[] = entries.map(({ name: checklistName, report }) => {
+      const entry = buildChecklistEntry(checklistName, report, reportOn);
+      mergeCounts(kitCounts, entry);
+      return entry;
+    });
 
-    // Filter results by reporting threshold.
-    const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
-
-    // Count all visible results (flat count across all nesting levels).
-    for (const result of visibleResults) {
-      tallyResult(counts, result);
-    }
-
-    // Reconstruct tree from flat depth-first results.
-    const { entries: checks } = buildCheckEntries(visibleResults, 0, 0);
-
-    totals.passed += counts.passed;
-    totals.errors += counts.errors;
-    totals.warnings += counts.warnings;
-    totals.recommendations += counts.recommendations;
-    totals.blocked += counts.blocked;
-    totals.optional += counts.optional;
-    totals.worstSeverity = worseSeverity(totals.worstSeverity, counts.worstSeverity);
+    const kitDurationMs = checklists.reduce((sum, c) => sum + c.durationMs, 0);
+    mergeCounts(totals, kitCounts);
 
     return {
       name,
-      durationMs: report.durationMs,
-      ...counts,
-      checks,
+      durationMs: kitDurationMs,
+      ...kitCounts,
+      checklists,
     };
   });
 
-  const totalDurationMs = checklists.reduce((sum, c) => sum + c.durationMs, 0);
+  const totalDurationMs = kits.reduce((sum, k) => sum + k.durationMs, 0);
 
   const output: JsonReport = {
     ...totals,
     durationMs: totalDurationMs,
-    checklists,
+    kits,
   };
 
   return JSON.stringify(output);

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -8,6 +8,7 @@ export type {
   FractionProgress,
   JsonCheckEntry,
   JsonChecklistEntry,
+  JsonKitEntry,
   JsonReport,
   PassedResult,
   PercentProgress,

--- a/packages/readyup/src/parseKitSpecifiers.ts
+++ b/packages/readyup/src/parseKitSpecifiers.ts
@@ -1,0 +1,38 @@
+/** Parsed kit specifier from a positional argument. */
+export interface KitSpecifier {
+  kitName: string;
+  checklists: string[];
+}
+
+/**
+ * Parse positional arguments in `kit[:checklist,...]` format into structured specifiers.
+ *
+ * Splits each positional on the first `:` to separate kit name from comma-separated
+ * checklist/suite names. Kit names may contain `/` (e.g., `shared/deploy`).
+ */
+export function parseKitSpecifiers(positionals: string[]): KitSpecifier[] {
+  return positionals.map(parseOneSpecifier);
+}
+
+/** Parse a single `kit[:checklist,...]` string into a `KitSpecifier`. */
+function parseOneSpecifier(arg: string): KitSpecifier {
+  const colonIndex = arg.indexOf(':');
+  if (colonIndex === -1) {
+    return { kitName: arg, checklists: [] };
+  }
+
+  const kitName = arg.slice(0, colonIndex);
+  if (kitName === '') {
+    throw new Error(`Invalid kit specifier "${arg}": kit name must not be empty`);
+  }
+
+  const checklists = arg
+    .slice(colonIndex + 1)
+    .split(',')
+    .filter((s) => s !== '');
+  if (checklists.length === 0) {
+    throw new Error(`Invalid kit specifier "${arg}": checklist list after ":" must not be empty`);
+  }
+
+  return { kitName, checklists };
+}

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -298,8 +298,15 @@ export interface JsonChecklistEntry extends SummaryCounts {
   checks: JsonCheckEntry[];
 }
 
+/** Per-kit entry in JSON output, grouping checklists with per-kit summary counts. */
+export interface JsonKitEntry extends SummaryCounts {
+  name: string;
+  durationMs: number;
+  checklists: JsonChecklistEntry[];
+}
+
 /** Top-level shape of `--json` output. */
 export interface JsonReport extends SummaryCounts {
   durationMs: number;
-  checklists: JsonChecklistEntry[];
+  kits: JsonKitEntry[];
 }


### PR DESCRIPTION
## What

Promotes kit names to positional arguments (`rdy run mykit1 mykit2`) and adds colon syntax for per-kit checklist filtering (`mykit:check1,check2`). Removes the `--kit` flag and adds `--checklists` for filtering with `--file`/`--url` sources. Restructures JSON output to use a `kits` array with per-kit summary counts, and supports running multiple kits in a single invocation.

## Why

The most common `rdy run` invocation is running a single kit by name, but the existing API required `--kit {name}` while positional args were reserved for the less-common checklist selection. This inverted the frequency of use — the common case needed a flag while the rare case was positional.

## Details

### Features

- Kit names are now positional: `rdy run deploy`, `rdy run deploy infra`
- Colon syntax filters checklists per kit: `rdy run deploy:check1,check2`
- `--checklists` flag for checklist filtering with `--file`/`--url` sources (mutually exclusive with positional args)
- Multi-kit human-mode output prints `=== kitName ===` headers; combined summary is suppressed in multi-kit mode but retained for single-kit multi-checklist runs
- `JsonReport` gains a `kits` array of `JsonKitEntry` objects with per-kit `SummaryCounts`, `durationMs`, and `checklists`; top-level counts aggregate across all kits
- `JsonKitEntry` exported from the package

### Refactoring

- `resolveKitSource` (singular) replaced by `resolveKitSources` returning `ResolvedKitEntry[]`
- `runCommand` split into `runMultiKitJsonMode` and `runMultiKitHumanMode`
- `formatJsonReport` accepts kit-grouped `KitInput[]` input; extracted `mergeCounts` and `buildChecklistEntry` helpers
- New `parseKitSpecifiers` module for parsing `kit[:checklist,...]` syntax

### Tests

- New `parseKitSpecifiers.test.ts` with 9 tests covering parsing, edge cases, and validation errors
- Updated `cli.test.ts` for new API surface: multi-kit resolution, kit headers, combined summary suppression, multi-kit JSON mode integration
- Updated `formatJsonReport.test.ts` for `kits` array structure with per-kit and aggregated counts
- Updated `route.test.ts` for renamed functions and new help text

## Test plan

- [ ] `rdy run` (no args) runs default kit
- [ ] `rdy run deploy` runs named kit
- [ ] `rdy run deploy:check1,check2` filters checklists
- [ ] `rdy run kit1 kit2` runs multiple kits with headers
- [ ] `rdy run --file path --checklists c1,c2` filters with file source
- [ ] `rdy run --json` produces `kits` array structure
- [ ] `rdy run --kit foo` errors (flag removed)

Closes #30