### PR TITLE
#32 Unify kit source selectors into `--from` and default to compiled JS

### DIFF
--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -320,6 +320,18 @@ describe(parseRunArgs, () => {
     );
   });
 
+  it('throws when --jit is combined with --url', () => {
+    expect(() => parseRunArgs(['--jit', '--url', 'https://example.com'])).toThrow(
+      '--jit cannot be combined with --url',
+    );
+  });
+
+  it('throws when --internal is combined with --file', () => {
+    expect(() => parseRunArgs(['--internal', '--file', 'path.ts'])).toThrow(
+      '--internal cannot be combined with --file',
+    );
+  });
+
   it('throws when a flag name is passed as value to another flag', () => {
     expect(() => parseRunArgs(['--from', '--url'])).toThrow('--from requires a source argument');
     expect(() => parseRunArgs(['--url', '--from'])).toThrow('--url requires a URL argument');

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -609,7 +609,7 @@ describe(resolveKitSources, () => {
   // -- --from global --
 
   it('resolves --from global to home directory', () => {
-    const homeDir = process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
+    const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '~';
 
     expect(resolve({ fromValue: 'global' })).toStrictEqual([
       { name: 'default', source: { path: `${homeDir}/.rdy/kits/default.js` }, checklists: [] },

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -78,10 +78,11 @@ describe(parseRunArgs, () => {
     expect(result.checklists).toBeUndefined();
     expect(result.kitSpecifiers).toStrictEqual([]);
     expect(result.filePath).toBeUndefined();
-    expect(result.githubValue).toBeUndefined();
-    expect(result.localValue).toBeUndefined();
+    expect(result.fromValue).toBeUndefined();
     expect(result.urlValue).toBeUndefined();
     expect(result.json).toBe(false);
+    expect(result.jit).toBe(false);
+    expect(result.internal).toBe(false);
   });
 
   it('parses positional kit specifiers', () => {
@@ -119,8 +120,8 @@ describe(parseRunArgs, () => {
     );
   });
 
-  it('throws when --checklists is used with --github', () => {
-    expect(() => parseRunArgs(['--checklists', 'check1', '--github', 'org/repo'])).toThrow(
+  it('throws when --checklists is used with --from', () => {
+    expect(() => parseRunArgs(['--checklists', 'check1', '--from', 'github:org/repo'])).toThrow(
       '--checklists can only be used with --file or --url',
     );
   });
@@ -163,6 +164,43 @@ describe(parseRunArgs, () => {
     expect(() => parseRunArgs(['--file='])).toThrow('--file requires a path argument');
   });
 
+  // --from flag
+  it('parses --from flag', () => {
+    const result = parseRunArgs(['--from', 'github:org/repo']);
+
+    expect(result.fromValue).toBe('github:org/repo');
+  });
+
+  it('throws when --from has no value', () => {
+    expect(() => parseRunArgs(['--from'])).toThrow('--from requires a source argument');
+  });
+
+  // --jit flag
+  it('parses --jit flag', () => {
+    const result = parseRunArgs(['--jit']);
+
+    expect(result.jit).toBe(true);
+  });
+
+  it('parses -J as short form of --jit', () => {
+    const result = parseRunArgs(['-J']);
+
+    expect(result.jit).toBe(true);
+  });
+
+  // --internal flag
+  it('parses --internal flag', () => {
+    const result = parseRunArgs(['--internal']);
+
+    expect(result.internal).toBe(true);
+  });
+
+  it('parses -i as short form of --internal', () => {
+    const result = parseRunArgs(['-i']);
+
+    expect(result.internal).toBe(true);
+  });
+
   // --json flag
   it('parses --json flag', () => {
     const result = parseRunArgs(['--json']);
@@ -200,12 +238,6 @@ describe(parseRunArgs, () => {
     expect(result.filePath).toBe('custom/path.ts');
   });
 
-  it('parses -g as short form of --github', () => {
-    const result = parseRunArgs(['-g', 'org/repo']);
-
-    expect(result.githubValue).toBe('org/repo');
-  });
-
   it('parses -u as short form of --url', () => {
     const result = parseRunArgs(['-u', 'https://example.com/config.js']);
 
@@ -230,27 +262,6 @@ describe(parseRunArgs, () => {
     expect(result.reportOn).toBe('error');
   });
 
-  // --github flag
-  it('parses --github with ref', () => {
-    const result = parseRunArgs(['--github', 'org/repo@v1']);
-
-    expect(result.githubValue).toBe('org/repo@v1');
-  });
-
-  it('parses --github= syntax', () => {
-    const result = parseRunArgs(['--github=org/repo']);
-
-    expect(result.githubValue).toBe('org/repo');
-  });
-
-  it('throws when --github has no value', () => {
-    expect(() => parseRunArgs(['--github'])).toThrow('--github requires a repository argument');
-  });
-
-  it('throws when --github= has an empty value', () => {
-    expect(() => parseRunArgs(['--github='])).toThrow('--github requires a repository argument');
-  });
-
   // --url flag
   it('parses --url flag with space-separated value', () => {
     const result = parseRunArgs(['--url', 'https://example.com/config.js']);
@@ -272,70 +283,47 @@ describe(parseRunArgs, () => {
     expect(() => parseRunArgs(['--url='])).toThrow('--url requires a URL argument');
   });
 
-  // --local flag
-  it('parses --local flag', () => {
-    const result = parseRunArgs(['--local', '/path/to/repo']);
-
-    expect(result.localValue).toBe('/path/to/repo');
-  });
-
-  it('parses -l as short form of --local', () => {
-    const result = parseRunArgs(['-l', '/path/to/repo']);
-
-    expect(result.localValue).toBe('/path/to/repo');
-  });
-
-  it('throws when --local has no value', () => {
-    expect(() => parseRunArgs(['--local'])).toThrow('--local requires a path to a local repository');
-  });
-
   // Mutual exclusivity
-  it('throws when --file and --github are combined', () => {
-    expect(() => parseRunArgs(['--file', 'path.ts', '--github', 'org/repo'])).toThrow(
-      'Cannot combine --file, --github, --local, and --url flags',
-    );
-  });
-
-  it('throws when --github and --file are combined (reverse order)', () => {
-    expect(() => parseRunArgs(['--github', 'org/repo', '--file', 'path.ts'])).toThrow(
-      'Cannot combine --file, --github, --local, and --url flags',
+  it('throws when --file and --from are combined', () => {
+    expect(() => parseRunArgs(['--file', 'path.ts', '--from', '/other/repo'])).toThrow(
+      'Cannot combine --file, --from flags',
     );
   });
 
   it('throws when --file and --url are combined', () => {
     expect(() => parseRunArgs(['--file', 'path.ts', '--url', 'https://example.com/config.js'])).toThrow(
-      'Cannot combine --file, --github, --local, and --url flags',
+      'Cannot combine --file, --url flags',
+    );
+  });
+
+  it('throws when --from and --url are combined', () => {
+    expect(() => parseRunArgs(['--from', '/path', '--url', 'https://example.com/config.js'])).toThrow(
+      'Cannot combine --from, --url flags',
+    );
+  });
+
+  it('throws when --jit is combined with --from', () => {
+    expect(() => parseRunArgs(['--jit', '--from', '/path'])).toThrow('--jit cannot be combined with --from');
+  });
+
+  it('throws when --jit is combined with --file', () => {
+    expect(() => parseRunArgs(['--jit', '--file', 'path.ts'])).toThrow('--jit cannot be combined with --file');
+  });
+
+  it('throws when --internal is combined with --from', () => {
+    expect(() => parseRunArgs(['--internal', '--from', '/path'])).toThrow('--internal cannot be combined with --from');
+  });
+
+  it('throws when --internal is combined with --url', () => {
+    expect(() => parseRunArgs(['--internal', '--url', 'https://example.com'])).toThrow(
+      '--internal cannot be combined with --url',
     );
   });
 
   it('throws when a flag name is passed as value to another flag', () => {
-    expect(() => parseRunArgs(['--github', '--url'])).toThrow('--github requires a repository argument');
-    expect(() => parseRunArgs(['--url', '--github'])).toThrow('--url requires a URL argument');
-    expect(() => parseRunArgs(['--file', '--github'])).toThrow('--file requires a path argument');
-  });
-
-  it('throws when --github and --url are combined', () => {
-    expect(() => parseRunArgs(['--github', 'org/repo', '--url', 'https://example.com/config.js'])).toThrow(
-      'Cannot combine --file, --github, --local, and --url flags',
-    );
-  });
-
-  it('throws when --local and --file are combined', () => {
-    expect(() => parseRunArgs(['--file', 'path.ts', '--local', '/other/repo'])).toThrow(
-      'Cannot combine --file, --github, --local, and --url flags',
-    );
-  });
-
-  it('throws when --local and --url are combined', () => {
-    expect(() => parseRunArgs(['--local', '/other/repo', '--url', 'https://example.com/config.js'])).toThrow(
-      'Cannot combine --file, --github, --local, and --url flags',
-    );
-  });
-
-  it('throws when --github and --local are combined', () => {
-    expect(() => parseRunArgs(['--github', 'org/repo', '--local', '/path'])).toThrow(
-      'Cannot combine --file, --github, --local, and --url flags',
-    );
+    expect(() => parseRunArgs(['--from', '--url'])).toThrow('--from requires a source argument');
+    expect(() => parseRunArgs(['--url', '--from'])).toThrow('--url requires a URL argument');
+    expect(() => parseRunArgs(['--file', '--from'])).toThrow('--file requires a path argument');
   });
 
   // --fail-on flag
@@ -399,48 +387,76 @@ describe(resolveKitSources, () => {
   ): ReturnType<typeof resolveKitSources> {
     return resolveKitSources({
       filePath: undefined,
-      githubValue: undefined,
-      localValue: undefined,
+      fromValue: undefined,
       urlValue: undefined,
       kitSpecifiers: [],
       checklists: undefined,
+      jit: false,
+      internal: false,
       internalDir: '.',
-      internalExtension: '.ts',
+      internalInfix: undefined,
       ...overrides,
     });
   }
 
-  it('resolves default kit path with default internal config', () => {
-    expect(resolve()).toStrictEqual([{ name: 'default', source: { path: '.rdy/kits/default.ts' }, checklists: [] }]);
+  // -- Default resolution (compiled .js) --
+
+  it('resolves default kit path to .js', () => {
+    expect(resolve()).toStrictEqual([{ name: 'default', source: { path: '.rdy/kits/default.js' }, checklists: [] }]);
   });
 
   it('resolves named kit from positional specifier', () => {
     expect(resolve({ kitSpecifiers: [{ kitName: 'deploy', checklists: [] }] })).toStrictEqual([
-      { name: 'deploy', source: { path: '.rdy/kits/deploy.ts' }, checklists: [] },
+      { name: 'deploy', source: { path: '.rdy/kits/deploy.js' }, checklists: [] },
     ]);
   });
 
   it('resolves slash-separated kit name', () => {
     expect(resolve({ kitSpecifiers: [{ kitName: 'shared/deploy', checklists: [] }] })).toStrictEqual([
-      { name: 'shared/deploy', source: { path: '.rdy/kits/shared/deploy.ts' }, checklists: [] },
+      { name: 'shared/deploy', source: { path: '.rdy/kits/shared/deploy.js' }, checklists: [] },
     ]);
   });
 
-  it('applies custom internal dir and extension', () => {
-    expect(resolve({ internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual([
+  // -- --jit flag --
+
+  it('resolves to .ts with --jit', () => {
+    expect(resolve({ jit: true })).toStrictEqual([
+      { name: 'default', source: { path: '.rdy/kits/default.ts' }, checklists: [] },
+    ]);
+  });
+
+  // -- --internal flag --
+
+  it('applies internal dir with --internal', () => {
+    expect(resolve({ internal: true, internalDir: 'internal' })).toStrictEqual([
+      { name: 'default', source: { path: '.rdy/kits/internal/default.js' }, checklists: [] },
+    ]);
+  });
+
+  it('applies internal dir and infix with --internal', () => {
+    expect(resolve({ internal: true, internalDir: 'internal', internalInfix: 'int' })).toStrictEqual([
+      { name: 'default', source: { path: '.rdy/kits/internal/default.int.js' }, checklists: [] },
+    ]);
+  });
+
+  it('combines --jit and --internal', () => {
+    expect(resolve({ jit: true, internal: true, internalDir: 'internal', internalInfix: 'int' })).toStrictEqual([
       { name: 'default', source: { path: '.rdy/kits/internal/default.int.ts' }, checklists: [] },
     ]);
   });
 
-  it('applies custom internal dir with named kit', () => {
+  it('applies internal dir with named kit', () => {
     expect(
       resolve({
         kitSpecifiers: [{ kitName: 'deploy', checklists: [] }],
+        internal: true,
         internalDir: 'internal',
-        internalExtension: '.int.ts',
+        internalInfix: 'int',
       }),
-    ).toStrictEqual([{ name: 'deploy', source: { path: '.rdy/kits/internal/deploy.int.ts' }, checklists: [] }]);
+    ).toStrictEqual([{ name: 'deploy', source: { path: '.rdy/kits/internal/deploy.int.js' }, checklists: [] }]);
   });
+
+  // -- --file flag --
 
   it('resolves --file to a single path source entry', () => {
     expect(resolve({ filePath: 'custom/path.ts' })).toStrictEqual([
@@ -454,8 +470,12 @@ describe(resolveKitSources, () => {
     ]);
   });
 
-  it('resolves --github without ref to a URL with main ref', () => {
-    expect(resolve({ githubValue: 'org/repo', kitSpecifiers: [{ kitName: 'nmr', checklists: [] }] })).toStrictEqual([
+  // -- --from github: --
+
+  it('resolves --from github: without ref to a URL with main ref', () => {
+    expect(
+      resolve({ fromValue: 'github:org/repo', kitSpecifiers: [{ kitName: 'nmr', checklists: [] }] }),
+    ).toStrictEqual([
       {
         name: 'nmr',
         source: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/nmr.js' },
@@ -464,8 +484,10 @@ describe(resolveKitSources, () => {
     ]);
   });
 
-  it('resolves --github with ref to a URL with that ref', () => {
-    expect(resolve({ githubValue: 'org/repo@v1', kitSpecifiers: [{ kitName: 'nmr', checklists: [] }] })).toStrictEqual([
+  it('resolves --from github: with ref', () => {
+    expect(
+      resolve({ fromValue: 'github:org/repo@v1', kitSpecifiers: [{ kitName: 'nmr', checklists: [] }] }),
+    ).toStrictEqual([
       {
         name: 'nmr',
         source: { url: 'https://raw.githubusercontent.com/org/repo/v1/.rdy/kits/nmr.js' },
@@ -474,8 +496,8 @@ describe(resolveKitSources, () => {
     ]);
   });
 
-  it('defaults --github kit to "default"', () => {
-    expect(resolve({ githubValue: 'org/repo' })).toStrictEqual([
+  it('defaults --from github: kit to "default"', () => {
+    expect(resolve({ fromValue: 'github:org/repo' })).toStrictEqual([
       {
         name: 'default',
         source: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/default.js' },
@@ -484,10 +506,10 @@ describe(resolveKitSources, () => {
     ]);
   });
 
-  it('resolves multiple kits with --github', () => {
+  it('resolves multiple kits with --from github:', () => {
     expect(
       resolve({
-        githubValue: 'org/repo',
+        fromValue: 'github:org/repo',
         kitSpecifiers: [
           { kitName: 'deploy', checklists: [] },
           { kitName: 'infra', checklists: ['c1'] },
@@ -507,30 +529,50 @@ describe(resolveKitSources, () => {
     ]);
   });
 
-  it('resolves --local to a .js path under .rdy/kits/', () => {
-    expect(resolve({ localValue: '/path/to/repo' })).toStrictEqual([
+  // -- --from bitbucket: --
+
+  it('resolves --from bitbucket: to a Bitbucket raw URL', () => {
+    expect(
+      resolve({ fromValue: 'bitbucket:myteam/deploy-checks', kitSpecifiers: [{ kitName: 'deploy', checklists: [] }] }),
+    ).toStrictEqual([
+      {
+        name: 'deploy',
+        source: { url: 'https://bitbucket.org/myteam/deploy-checks/raw/main/.rdy/kits/deploy.js' },
+        checklists: [],
+      },
+    ]);
+  });
+
+  it('resolves --from bitbucket: with ref', () => {
+    expect(resolve({ fromValue: 'bitbucket:myteam/repo@v2' })).toStrictEqual([
+      {
+        name: 'default',
+        source: { url: 'https://bitbucket.org/myteam/repo/raw/v2/.rdy/kits/default.js' },
+        checklists: [],
+      },
+    ]);
+  });
+
+  // -- --from local path --
+
+  it('resolves --from with local path to a .js path under .rdy/kits/', () => {
+    expect(resolve({ fromValue: '/path/to/repo' })).toStrictEqual([
       { name: 'default', source: { path: '/path/to/repo/.rdy/kits/default.js' }, checklists: [] },
     ]);
   });
 
-  it('resolves --local with named kit to a named .js file', () => {
-    expect(
-      resolve({ localValue: '/path/to/repo', kitSpecifiers: [{ kitName: 'deploy', checklists: [] }] }),
-    ).toStrictEqual([{ name: 'deploy', source: { path: '/path/to/repo/.rdy/kits/deploy.js' }, checklists: [] }]);
-  });
-
-  it('resolves --local with a relative path against cwd', () => {
+  it('resolves --from with relative local path against cwd', () => {
     const expected = path.resolve(process.cwd(), '../sibling-repo');
 
-    expect(resolve({ localValue: '../sibling-repo' })).toStrictEqual([
+    expect(resolve({ fromValue: '../sibling-repo' })).toStrictEqual([
       { name: 'default', source: { path: `${expected}/.rdy/kits/default.js` }, checklists: [] },
     ]);
   });
 
-  it('resolves multiple kits with --local', () => {
+  it('resolves multiple kits with --from local path', () => {
     expect(
       resolve({
-        localValue: '/path/to/repo',
+        fromValue: '/path/to/repo',
         kitSpecifiers: [
           { kitName: 'deploy', checklists: [] },
           { kitName: 'infra', checklists: [] },
@@ -541,6 +583,28 @@ describe(resolveKitSources, () => {
       { name: 'infra', source: { path: '/path/to/repo/.rdy/kits/infra.js' }, checklists: [] },
     ]);
   });
+
+  // -- --from global --
+
+  it('resolves --from global to home directory', () => {
+    const homeDir = process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
+
+    expect(resolve({ fromValue: 'global' })).toStrictEqual([
+      { name: 'default', source: { path: `${homeDir}/.rdy/kits/default.js` }, checklists: [] },
+    ]);
+  });
+
+  // -- --from dir: --
+
+  it('resolves --from dir: to an arbitrary directory', () => {
+    const resolved = path.resolve(process.cwd(), 'custom/kits');
+
+    expect(resolve({ fromValue: 'dir:custom/kits' })).toStrictEqual([
+      { name: 'default', source: { path: `${resolved}/default.js` }, checklists: [] },
+    ]);
+  });
+
+  // -- --url flag --
 
   it('resolves --url to a URL source', () => {
     expect(resolve({ urlValue: 'https://example.com/config.js' })).toStrictEqual([
@@ -558,14 +622,18 @@ describe(resolveKitSources, () => {
     ]);
   });
 
+  // -- Isolation of internal config with source flags --
+
   it('ignores internal config when --file is used', () => {
     expect(
-      resolve({ filePath: 'custom/path.ts', internalDir: 'internal', internalExtension: '.int.ts' }),
+      resolve({ filePath: 'custom/path.ts', internal: true, internalDir: 'internal', internalInfix: 'int' }),
     ).toStrictEqual([{ name: 'custom/path.ts', source: { path: 'custom/path.ts' }, checklists: [] }]);
   });
 
-  it('ignores internal config when --github is used', () => {
-    expect(resolve({ githubValue: 'org/repo', internalDir: 'internal', internalExtension: '.int.ts' })).toStrictEqual([
+  it('ignores internal config when --from is used', () => {
+    expect(
+      resolve({ fromValue: 'github:org/repo', internal: false, internalDir: 'internal', internalInfix: 'int' }),
+    ).toStrictEqual([
       {
         name: 'default',
         source: { url: 'https://raw.githubusercontent.com/org/repo/main/.rdy/kits/default.js' },
@@ -574,15 +642,14 @@ describe(resolveKitSources, () => {
     ]);
   });
 
-  it('ignores internal config when --local is used', () => {
-    expect(
-      resolve({ localValue: '/path/to/repo', internalDir: 'internal', internalExtension: '.int.ts' }),
-    ).toStrictEqual([{ name: 'default', source: { path: '/path/to/repo/.rdy/kits/default.js' }, checklists: [] }]);
-  });
-
   it('ignores internal config when --url is used', () => {
     expect(
-      resolve({ urlValue: 'https://example.com/config.js', internalDir: 'internal', internalExtension: '.int.ts' }),
+      resolve({
+        urlValue: 'https://example.com/config.js',
+        internal: true,
+        internalDir: 'internal',
+        internalInfix: 'int',
+      }),
     ).toStrictEqual([
       {
         name: 'https://example.com/config.js',
@@ -618,7 +685,7 @@ describe(runCommand, () => {
 
   /** Build a single-kit entry for convenience. */
   function singleKitEntry(checklists: string[] = []) {
-    return [{ name: 'default', source: { path: '.rdy/kits/default.ts' }, checklists }];
+    return [{ name: 'default', source: { path: '.rdy/kits/default.js' }, checklists }];
   }
 
   it('runs all checklists when no checklist filter is given', async () => {
@@ -732,8 +799,8 @@ describe(runCommand, () => {
 
     await runCommand({
       kitEntries: [
-        { name: 'kit1', source: { path: '.rdy/kits/kit1.ts' }, checklists: [] },
-        { name: 'kit2', source: { path: '.rdy/kits/kit2.ts' }, checklists: [] },
+        { name: 'kit1', source: { path: '.rdy/kits/kit1.js' }, checklists: [] },
+        { name: 'kit2', source: { path: '.rdy/kits/kit2.js' }, checklists: [] },
       ],
       json: false,
     });
@@ -750,8 +817,8 @@ describe(runCommand, () => {
 
     await runCommand({
       kitEntries: [
-        { name: 'kit1', source: { path: '.rdy/kits/kit1.ts' }, checklists: [] },
-        { name: 'kit2', source: { path: '.rdy/kits/kit2.ts' }, checklists: [] },
+        { name: 'kit1', source: { path: '.rdy/kits/kit1.js' }, checklists: [] },
+        { name: 'kit2', source: { path: '.rdy/kits/kit2.js' }, checklists: [] },
       ],
       json: false,
     });
@@ -831,6 +898,43 @@ describe(runCommand, () => {
     });
 
     expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
+  });
+
+  // -- --jit error handling (Task 6) --
+
+  it('throws friendly error when --jit kit import fails due to missing readyup', async () => {
+    const moduleError = Object.assign(new Error("Cannot find package 'readyup'"), {
+      code: 'MODULE_NOT_FOUND',
+    });
+    mockLoadRdyKit.mockRejectedValue(moduleError);
+
+    const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'Error: Running from source requires readyup to be installed as a project dependency.\n',
+    );
+    expect(exitCode).toBe(1);
+  });
+
+  it('passes through non-readyup module errors even with --jit', async () => {
+    const moduleError = Object.assign(new Error("Cannot find package 'chalk'"), {
+      code: 'MODULE_NOT_FOUND',
+    });
+    mockLoadRdyKit.mockRejectedValue(moduleError);
+
+    const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
+
+    expect(stderrSpy).toHaveBeenCalledWith("Error: Cannot find package 'chalk'\n");
+    expect(exitCode).toBe(1);
+  });
+
+  it('passes through non-module errors with --jit', async () => {
+    mockLoadRdyKit.mockRejectedValue(new Error('Syntax error in kit'));
+
+    const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
+
+    expect(stderrSpy).toHaveBeenCalledWith('Error: Syntax error in kit\n');
+    expect(exitCode).toBe(1);
   });
 
   describe('threshold cascade', () => {
@@ -1038,8 +1142,8 @@ describe(runCommand, () => {
 
       const exitCode = await runCommand({
         kitEntries: [
-          { name: 'kit1', source: { path: '.rdy/kits/kit1.ts' }, checklists: [] },
-          { name: 'kit2', source: { path: '.rdy/kits/kit2.ts' }, checklists: [] },
+          { name: 'kit1', source: { path: '.rdy/kits/kit1.js' }, checklists: [] },
+          { name: 'kit2', source: { path: '.rdy/kits/kit2.js' }, checklists: [] },
         ],
         json: true,
       });

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -175,6 +175,16 @@ describe(parseRunArgs, () => {
     expect(() => parseRunArgs(['--from'])).toThrow('--from requires a source argument');
   });
 
+  it('parses --from= syntax', () => {
+    const result = parseRunArgs(['--from=github:org/repo']);
+
+    expect(result.fromValue).toBe('github:org/repo');
+  });
+
+  it('throws when --from= has an empty value', () => {
+    expect(() => parseRunArgs(['--from='])).toThrow('--from requires a source argument');
+  });
+
   // --jit flag
   it('parses --jit flag', () => {
     const result = parseRunArgs(['--jit']);

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -111,7 +111,7 @@ describe(formatConsumerView, () => {
       localPathArg: '.',
     });
 
-    expect(result).toContain('rdy run --local .');
+    expect(result).toContain('rdy run --from .');
     expect(result).toContain('default');
     expect(result).toContain('deploy');
   });
@@ -122,7 +122,7 @@ describe(formatConsumerView, () => {
       localPathArg: '/other',
     });
 
-    expect(result).toContain('rdy run --local /other');
+    expect(result).toContain('rdy run --from /other');
   });
 
   it('uses brackets around --kit when default kit exists', () => {

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -105,10 +105,11 @@ describe(formatOwnerView, () => {
 });
 
 describe(formatConsumerView, () => {
-  it('renders compiled kits with the local path in the hint', () => {
+  it('renders compiled kits with the from arg in the hint', () => {
     const result = formatConsumerView({
       compiledKits: ['default', 'deploy'],
-      localPathArg: '.',
+      fromArg: '.',
+      kitsDir: '/resolved/.rdy/kits',
     });
 
     expect(result).toContain('rdy run --from .');
@@ -116,10 +117,11 @@ describe(formatConsumerView, () => {
     expect(result).toContain('deploy');
   });
 
-  it('preserves the exact localPathArg in the hint', () => {
+  it('preserves the exact fromArg in the hint', () => {
     const result = formatConsumerView({
       compiledKits: ['deploy'],
-      localPathArg: '/other',
+      fromArg: '/other',
+      kitsDir: '/other/.rdy/kits',
     });
 
     expect(result).toContain('rdy run --from /other');
@@ -128,7 +130,8 @@ describe(formatConsumerView, () => {
   it('uses brackets around --kit when default kit exists', () => {
     const result = formatConsumerView({
       compiledKits: ['default'],
-      localPathArg: '.',
+      fromArg: '.',
+      kitsDir: '/resolved/.rdy/kits',
     });
 
     expect(result).toContain('[--kit <name>]');
@@ -137,20 +140,42 @@ describe(formatConsumerView, () => {
   it('omits brackets around --kit when default kit is absent', () => {
     const result = formatConsumerView({
       compiledKits: ['deploy'],
-      localPathArg: '.',
+      fromArg: '.',
+      kitsDir: '/resolved/.rdy/kits',
     });
 
     expect(result).toContain('--kit <name>');
     expect(result).not.toContain('[--kit <name>]');
   });
 
-  it('returns empty-consumer message when kit list is empty', () => {
+  it('returns empty message with resolved kitsDir for local path', () => {
     const result = formatConsumerView({
       compiledKits: [],
-      localPathArg: '.',
+      fromArg: '.',
+      kitsDir: '/resolved/.rdy/kits',
     });
 
-    expect(result).toBe('No compiled kits found at ./.rdy/kits/.');
+    expect(result).toBe('No compiled kits found at /resolved/.rdy/kits.');
+  });
+
+  it('returns empty message with home-based path for global source', () => {
+    const result = formatConsumerView({
+      compiledKits: [],
+      fromArg: 'global',
+      kitsDir: '/home/user/.rdy/kits',
+    });
+
+    expect(result).toBe('No compiled kits found at /home/user/.rdy/kits.');
+  });
+
+  it('returns empty message with directory path for dir: source', () => {
+    const result = formatConsumerView({
+      compiledKits: [],
+      fromArg: 'dir:/custom/path',
+      kitsDir: '/custom/path',
+    });
+
+    expect(result).toBe('No compiled kits found at /custom/path.');
   });
 });
 
@@ -162,15 +187,15 @@ describe(formatEmpty, () => {
     expect(result).toContain('rdy compile');
   });
 
-  it('returns consumer message with the provided path', () => {
-    const result = formatEmpty('consumer', '/some/path');
+  it('returns consumer message with the provided kitsDir', () => {
+    const result = formatEmpty('consumer', '/home/user/.rdy/kits');
 
-    expect(result).toBe('No compiled kits found at /some/path/.rdy/kits/.');
+    expect(result).toBe('No compiled kits found at /home/user/.rdy/kits.');
   });
 
-  it('defaults consumer path to "." when omitted', () => {
+  it('defaults consumer kitsDir to ".rdy/kits" when omitted', () => {
     const result = formatEmpty('consumer');
 
-    expect(result).toContain('./.rdy/kits/');
+    expect(result).toBe('No compiled kits found at .rdy/kits.');
   });
 });

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -3,9 +3,10 @@ import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
+import type { enumerateKits } from '../../src/list/enumerateKits.ts';
 import { listCommand } from '../../src/list/listCommand.ts';
 
-const mockEnumerateKits = vi.hoisted(() => vi.fn());
+const mockEnumerateKits = vi.hoisted(() => vi.fn<typeof enumerateKits>());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/list/enumerateKits.ts', () => ({
@@ -38,7 +39,7 @@ describe(listCommand, () => {
     const exitCode = await listCommand(['--from', 'global']);
 
     expect(exitCode).toBe(0);
-    const calledDir = mockEnumerateKits.mock.calls[0][0].dir as string;
+    const calledDir = mockEnumerateKits.mock.calls[0]![0].dir;
     expect(calledDir).toMatch(/\/.rdy\/kits$/);
     expect(stdoutSpy).toHaveBeenCalled();
   });
@@ -49,7 +50,7 @@ describe(listCommand, () => {
     const exitCode = await listCommand(['--from', 'dir:/some/path']);
 
     expect(exitCode).toBe(0);
-    const calledDir = mockEnumerateKits.mock.calls[0][0].dir as string;
+    const calledDir = mockEnumerateKits.mock.calls[0]![0].dir;
     expect(calledDir).toBe(path.resolve('/some/path'));
     // Directory source does not append .rdy/kits.
     expect(calledDir).not.toContain('.rdy/kits');
@@ -61,7 +62,7 @@ describe(listCommand, () => {
     const exitCode = await listCommand(['--from', '/some/repo']);
 
     expect(exitCode).toBe(0);
-    const calledDir = mockEnumerateKits.mock.calls[0][0].dir as string;
+    const calledDir = mockEnumerateKits.mock.calls[0]![0].dir;
     expect(calledDir).toBe(path.join(path.resolve('/some/repo'), '.rdy/kits'));
   });
 

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -1,0 +1,76 @@
+import path from 'node:path';
+import process from 'node:process';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { listCommand } from '../../src/list/listCommand.ts';
+
+const mockEnumerateKits = vi.hoisted(() => vi.fn());
+const mockLoadConfig = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/list/enumerateKits.ts', () => ({
+  enumerateKits: mockEnumerateKits,
+}));
+
+vi.mock('../../src/loadConfig.ts', () => ({
+  loadConfig: mockLoadConfig,
+}));
+
+describe(listCommand, () => {
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    mockEnumerateKits.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockEnumerateKits.mockReset();
+    mockLoadConfig.mockReset();
+  });
+
+  it('with --from global, enumerates kits from the home-based .rdy/kits directory', async () => {
+    mockEnumerateKits.mockReturnValue(['default']);
+
+    const exitCode = await listCommand(['--from', 'global']);
+
+    expect(exitCode).toBe(0);
+    const calledDir = mockEnumerateKits.mock.calls[0][0].dir as string;
+    expect(calledDir).toMatch(/\/.rdy\/kits$/);
+    expect(stdoutSpy).toHaveBeenCalled();
+  });
+
+  it('with --from dir:/some/path, enumerates kits from the resolved absolute path', async () => {
+    mockEnumerateKits.mockReturnValue(['my-kit']);
+
+    const exitCode = await listCommand(['--from', 'dir:/some/path']);
+
+    expect(exitCode).toBe(0);
+    const calledDir = mockEnumerateKits.mock.calls[0][0].dir as string;
+    expect(calledDir).toBe(path.resolve('/some/path'));
+    // Directory source does not append .rdy/kits.
+    expect(calledDir).not.toContain('.rdy/kits');
+  });
+
+  it('with --from <local-path>, enumerates kits from .rdy/kits under the local path', async () => {
+    mockEnumerateKits.mockReturnValue(['default']);
+
+    const exitCode = await listCommand(['--from', '/some/repo']);
+
+    expect(exitCode).toBe(0);
+    const calledDir = mockEnumerateKits.mock.calls[0][0].dir as string;
+    expect(calledDir).toBe(path.join(path.resolve('/some/repo'), '.rdy/kits'));
+  });
+
+  it('returns exit code 1 with a user-readable error for malformed --from values', async () => {
+    const exitCode = await listCommand(['--from', 'http://example.com']);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error:'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('URLs are not accepted by --from'));
+    expect(mockEnumerateKits).not.toHaveBeenCalled();
+  });
+});

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -39,7 +40,9 @@ describe(listCommand, () => {
     const exitCode = await listCommand(['--from', 'global']);
 
     expect(exitCode).toBe(0);
-    const calledDir = mockEnumerateKits.mock.calls[0]![0].dir;
+    const firstCall = mockEnumerateKits.mock.calls[0];
+    assert.ok(firstCall, 'expected enumerateKits to have been called');
+    const calledDir = firstCall[0].dir;
     expect(calledDir).toMatch(/\/.rdy\/kits$/);
     expect(stdoutSpy).toHaveBeenCalled();
   });
@@ -50,7 +53,9 @@ describe(listCommand, () => {
     const exitCode = await listCommand(['--from', 'dir:/some/path']);
 
     expect(exitCode).toBe(0);
-    const calledDir = mockEnumerateKits.mock.calls[0]![0].dir;
+    const firstCall = mockEnumerateKits.mock.calls[0];
+    assert.ok(firstCall, 'expected enumerateKits to have been called');
+    const calledDir = firstCall[0].dir;
     expect(calledDir).toBe(path.resolve('/some/path'));
     // Directory source does not append .rdy/kits.
     expect(calledDir).not.toContain('.rdy/kits');
@@ -62,7 +67,9 @@ describe(listCommand, () => {
     const exitCode = await listCommand(['--from', '/some/repo']);
 
     expect(exitCode).toBe(0);
-    const calledDir = mockEnumerateKits.mock.calls[0]![0].dir;
+    const firstCall = mockEnumerateKits.mock.calls[0];
+    assert.ok(firstCall, 'expected enumerateKits to have been called');
+    const calledDir = firstCall[0].dir;
     expect(calledDir).toBe(path.join(path.resolve('/some/repo'), '.rdy/kits'));
   });
 

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -153,7 +153,7 @@ describe(listCommand, () => {
 
       expect(exitCode).toBe(0);
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('No compiled kits found at /nonexistent/.rdy/kits/.');
+      expect(output).toContain('No compiled kits found at /nonexistent/.rdy/kits.');
     });
 
     it('returns 1 and writes to stderr when enumerateKits throws', async () => {

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -22,7 +22,7 @@ describe(listCommand, () => {
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.rdy/kits', outDir: '.rdy/kits', include: undefined },
-      internal: { dir: '.', extension: '.ts' },
+      internal: { dir: '.', infix: undefined },
     });
     mockEnumerateKits.mockReturnValue([]);
   });
@@ -53,6 +53,19 @@ describe(listCommand, () => {
       expect(output).toContain('Compiled:');
     });
 
+    it('uses infix-based extension for internal kits when configured', async () => {
+      mockLoadConfig.mockResolvedValue({
+        compile: { srcDir: '.rdy/kits', outDir: '.rdy/kits', include: undefined },
+        internal: { dir: '.', infix: 'int' },
+      });
+      mockEnumerateKits.mockReturnValueOnce(['default']).mockReturnValueOnce([]);
+
+      const exitCode = await listCommand([]);
+
+      expect(exitCode).toBe(0);
+      expect(mockEnumerateKits).toHaveBeenCalledWith(expect.objectContaining({ extension: '.int.ts' }));
+    });
+
     it('renders only Internal section when no compiled kits exist', async () => {
       mockEnumerateKits.mockReturnValueOnce(['default']).mockReturnValueOnce([]);
 
@@ -67,7 +80,7 @@ describe(listCommand, () => {
     it('uses custom-outDir style when outDir differs from default', async () => {
       mockLoadConfig.mockResolvedValue({
         compile: { srcDir: 'src/kits', outDir: 'dist/kits', include: undefined },
-        internal: { dir: '.', extension: '.ts' },
+        internal: { dir: '.', infix: undefined },
       });
       mockEnumerateKits.mockReturnValueOnce([]).mockReturnValueOnce(['deploy']);
 
@@ -109,20 +122,20 @@ describe(listCommand, () => {
     });
   });
 
-  describe('consumer mode', () => {
-    it('does not load config when --local is given', async () => {
+  describe('from mode', () => {
+    it('does not load config when --from is given', async () => {
       mockEnumerateKits.mockReturnValue([]);
 
-      const exitCode = await listCommand(['--local', '.']);
+      const exitCode = await listCommand(['--from', '.']);
 
       expect(exitCode).toBe(0);
       expect(mockLoadConfig).not.toHaveBeenCalled();
     });
 
-    it('enumerates compiled kits from the local path', async () => {
+    it('enumerates compiled kits from a local path', async () => {
       mockEnumerateKits.mockReturnValue(['deploy']);
 
-      const exitCode = await listCommand(['--local', '.']);
+      const exitCode = await listCommand(['--from', '.']);
 
       expect(exitCode).toBe(0);
       expect(mockEnumerateKits).toHaveBeenCalledWith(
@@ -136,7 +149,7 @@ describe(listCommand, () => {
     it('prints empty-consumer message when no kits exist at the local path', async () => {
       mockEnumerateKits.mockReturnValue([]);
 
-      const exitCode = await listCommand(['--local', '/nonexistent']);
+      const exitCode = await listCommand(['--from', '/nonexistent']);
 
       expect(exitCode).toBe(0);
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
@@ -149,19 +162,24 @@ describe(listCommand, () => {
         throw permError;
       });
 
-      const exitCode = await listCommand(['--local', '.']);
+      const exitCode = await listCommand(['--from', '.']);
 
       expect(exitCode).toBe(1);
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
     });
 
-    it('accepts -l as short form of --local', async () => {
-      mockEnumerateKits.mockReturnValue(['default']);
+    it('returns 1 for github: scheme with not-yet-supported message', async () => {
+      const exitCode = await listCommand(['--from', 'github:org/repo']);
 
-      const exitCode = await listCommand(['-l', '.']);
+      expect(exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('not yet supported'));
+    });
 
-      expect(exitCode).toBe(0);
-      expect(mockLoadConfig).not.toHaveBeenCalled();
+    it('returns 1 for bitbucket: scheme with not-yet-supported message', async () => {
+      const exitCode = await listCommand(['--from', 'bitbucket:team/repo']);
+
+      expect(exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('not yet supported'));
     });
   });
 

--- a/packages/readyup/__tests__/loadConfig.test.ts
+++ b/packages/readyup/__tests__/loadConfig.test.ts
@@ -27,7 +27,7 @@ describe(loadConfig, () => {
 
     expect(config).toStrictEqual({
       compile: { srcDir: '.rdy/kits', outDir: '.rdy/kits', include: undefined },
-      internal: { dir: '.', extension: '.ts' },
+      internal: { dir: '.', infix: undefined },
     });
   });
 
@@ -152,13 +152,13 @@ describe(loadConfig, () => {
   it('resolves internal block from config', async () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({
-      default: { internal: { dir: 'internal', extension: '.int.ts' } },
+      default: { internal: { dir: 'internal', infix: 'int' } },
     });
 
     const config = await loadConfig('config.ts');
 
     expect(config.internal.dir).toBe('internal');
-    expect(config.internal.extension).toBe('.int.ts');
+    expect(config.internal.infix).toBe('int');
   });
 
   it('applies internal defaults when internal block is absent', async () => {
@@ -168,7 +168,7 @@ describe(loadConfig, () => {
     const config = await loadConfig('config.ts');
 
     expect(config.internal.dir).toBe('.');
-    expect(config.internal.extension).toBe('.ts');
+    expect(config.internal.infix).toBeUndefined();
   });
 
   it('applies internal defaults for missing fields within internal block', async () => {
@@ -178,7 +178,7 @@ describe(loadConfig, () => {
     const config = await loadConfig('config.ts');
 
     expect(config.internal.dir).toBe('custom');
-    expect(config.internal.extension).toBe('.ts');
+    expect(config.internal.infix).toBeUndefined();
   });
 
   it('throws when internal.dir is not a string', async () => {
@@ -188,9 +188,9 @@ describe(loadConfig, () => {
     await expect(loadConfig('config.ts')).rejects.toThrow(ZodError);
   });
 
-  it('throws when internal.extension is not a string', async () => {
+  it('throws when internal.infix is not a string', async () => {
     mockExistsSync.mockReturnValue(true);
-    mockJitiImport.mockResolvedValue({ default: { internal: { extension: false } } });
+    mockJitiImport.mockResolvedValue({ default: { internal: { infix: false } } });
 
     await expect(loadConfig('config.ts')).rejects.toThrow(ZodError);
   });

--- a/packages/readyup/__tests__/parseFromValue.test.ts
+++ b/packages/readyup/__tests__/parseFromValue.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFromValue } from '../src/parseFromValue.ts';
+
+describe(parseFromValue, () => {
+  // -- github scheme --
+
+  it('parses github: with org/repo defaulting ref to main', () => {
+    expect(parseFromValue('github:acme/toolkit')).toStrictEqual({
+      type: 'github',
+      org: 'acme',
+      repo: 'toolkit',
+      ref: 'main',
+    });
+  });
+
+  it('parses github: with explicit ref', () => {
+    expect(parseFromValue('github:acme/toolkit@v2')).toStrictEqual({
+      type: 'github',
+      org: 'acme',
+      repo: 'toolkit',
+      ref: 'v2',
+    });
+  });
+
+  it('throws for github: with empty ref', () => {
+    expect(() => parseFromValue('github:acme/toolkit@')).toThrow("ref after '@' must not be empty");
+  });
+
+  it('throws for github: without slash-separated org/repo', () => {
+    expect(() => parseFromValue('github:toolkit')).toThrow('expected "owner/repo" format');
+  });
+
+  // -- bitbucket scheme --
+
+  it('parses bitbucket: with workspace/repo defaulting ref to main', () => {
+    expect(parseFromValue('bitbucket:myteam/deploy-checks')).toStrictEqual({
+      type: 'bitbucket',
+      workspace: 'myteam',
+      repo: 'deploy-checks',
+      ref: 'main',
+    });
+  });
+
+  it('parses bitbucket: with explicit ref', () => {
+    expect(parseFromValue('bitbucket:myteam/deploy-checks@release/1.0')).toStrictEqual({
+      type: 'bitbucket',
+      workspace: 'myteam',
+      repo: 'deploy-checks',
+      ref: 'release/1.0',
+    });
+  });
+
+  it('throws for bitbucket: with missing repo', () => {
+    expect(() => parseFromValue('bitbucket:myteam')).toThrow('expected "owner/repo" format');
+  });
+
+  // -- URL rejection --
+
+  it('throws for https:// values with helpful message', () => {
+    expect(() => parseFromValue('https://example.com/kit.js')).toThrow('Use --url instead');
+  });
+
+  it('throws for http:// values with helpful message', () => {
+    expect(() => parseFromValue('http://example.com/kit.js')).toThrow('Use --url instead');
+  });
+
+  // -- global keyword --
+
+  it('parses "global" keyword', () => {
+    expect(parseFromValue('global')).toStrictEqual({ type: 'global' });
+  });
+
+  // -- dir: scheme --
+
+  it('parses dir: with absolute path', () => {
+    expect(parseFromValue('dir:/opt/kits')).toStrictEqual({ type: 'directory', path: '/opt/kits' });
+  });
+
+  it('parses dir: with relative path', () => {
+    expect(parseFromValue('dir:../shared/kits')).toStrictEqual({ type: 'directory', path: '../shared/kits' });
+  });
+
+  // -- local path fallback --
+
+  it('treats absolute path as local source', () => {
+    expect(parseFromValue('/path/to/repo')).toStrictEqual({ type: 'local', path: '/path/to/repo' });
+  });
+
+  it('treats relative path as local source', () => {
+    expect(parseFromValue('../sibling-repo')).toStrictEqual({ type: 'local', path: '../sibling-repo' });
+  });
+
+  it('treats tilde-prefixed path as local source', () => {
+    expect(parseFromValue('~/projects/other')).toStrictEqual({ type: 'local', path: '~/projects/other' });
+  });
+
+  it('treats bare name as local source', () => {
+    expect(parseFromValue('.')).toStrictEqual({ type: 'local', path: '.' });
+  });
+});

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -45,10 +45,10 @@ describe(routeCommand, () => {
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.rdy/kits', outDir: '.rdy/kits', include: undefined },
-      internal: { dir: '.', extension: '.ts' },
+      internal: { dir: '.', infix: undefined },
     });
     mockResolveKitSources.mockReturnValue([
-      { name: 'default', source: { path: '.rdy/kits/default.ts' }, checklists: [] },
+      { name: 'default', source: { path: '.rdy/kits/default.js' }, checklists: [] },
     ]);
   });
 
@@ -103,10 +103,11 @@ describe(routeCommand, () => {
     await routeCommand(['--help']);
 
     const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('--from');
     expect(output).toContain('--file, -f');
-    expect(output).toContain('--github, -g');
-    expect(output).toContain('--local, -l');
     expect(output).toContain('--url, -u');
+    expect(output).toContain('--jit, -J');
+    expect(output).toContain('--internal, -i');
     expect(output).toContain('--checklists, -c');
     expect(output).toContain('--json, -j');
     expect(output).toContain('--version, -V');
@@ -153,9 +154,10 @@ describe(routeCommand, () => {
       kitSpecifiers: [{ kitName: 'deploy', checklists: [] }],
       checklists: undefined,
       filePath: undefined,
-      githubValue: undefined,
-      localValue: undefined,
+      fromValue: undefined,
       urlValue: undefined,
+      jit: false,
+      internal: false,
       json: false,
     });
     mockRunCommand.mockResolvedValue(0);
@@ -165,9 +167,10 @@ describe(routeCommand, () => {
     expect(mockParseRunArgs).toHaveBeenCalledWith(['deploy']);
     expect(mockRunCommand).toHaveBeenCalledWith(
       expect.objectContaining({
-        kitEntries: [{ name: 'default', source: { path: '.rdy/kits/default.ts' }, checklists: [] }],
+        kitEntries: [{ name: 'default', source: { path: '.rdy/kits/default.js' }, checklists: [] }],
         json: false,
       }),
+      false,
     );
     expect(exitCode).toBe(0);
   });
@@ -177,9 +180,10 @@ describe(routeCommand, () => {
       kitSpecifiers: [],
       checklists: undefined,
       filePath: undefined,
-      githubValue: undefined,
-      localValue: undefined,
+      fromValue: undefined,
       urlValue: undefined,
+      jit: false,
+      internal: false,
       json: true,
     });
     mockRunCommand.mockResolvedValue(0);
@@ -190,6 +194,7 @@ describe(routeCommand, () => {
       expect.objectContaining({
         json: true,
       }),
+      false,
     );
     expect(exitCode).toBe(0);
   });
@@ -217,9 +222,10 @@ describe(routeCommand, () => {
       kitSpecifiers: [],
       checklists: undefined,
       filePath: 'path.ts',
-      githubValue: undefined,
-      localValue: undefined,
+      fromValue: undefined,
       urlValue: undefined,
+      jit: false,
+      internal: false,
       json: false,
     });
     mockResolveKitSources.mockImplementation(() => {
@@ -237,9 +243,10 @@ describe(routeCommand, () => {
       kitSpecifiers: [],
       checklists: undefined,
       filePath: undefined,
-      githubValue: undefined,
-      localValue: undefined,
+      fromValue: undefined,
       urlValue: undefined,
+      jit: false,
+      internal: false,
       json: false,
     });
     mockLoadConfig.mockRejectedValue(new Error('bad config'));
@@ -347,12 +354,12 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(0);
   });
 
-  it('passes --local flag through to listCommand', async () => {
+  it('passes --from flag through to listCommand', async () => {
     mockListCommand.mockResolvedValue(0);
 
-    const exitCode = await routeCommand(['list', '--local', '.']);
+    const exitCode = await routeCommand(['list', '--from', '.']);
 
-    expect(mockListCommand).toHaveBeenCalledWith(['--local', '.']);
+    expect(mockListCommand).toHaveBeenCalledWith(['--from', '.']);
     expect(exitCode).toBe(0);
   });
 
@@ -369,9 +376,10 @@ describe(routeCommand, () => {
         kitSpecifiers: [],
         checklists: undefined,
         filePath: 'foo.ts',
-        githubValue: undefined,
-        localValue: undefined,
+        fromValue: undefined,
         urlValue: undefined,
+        jit: false,
+        internal: false,
         json: false,
       });
       mockRunCommand.mockResolvedValue(0);
@@ -387,9 +395,10 @@ describe(routeCommand, () => {
         kitSpecifiers: [{ kitName: 'onboarding', checklists: [] }],
         checklists: undefined,
         filePath: undefined,
-        githubValue: undefined,
-        localValue: undefined,
+        fromValue: undefined,
         urlValue: undefined,
+        jit: false,
+        internal: false,
         json: false,
       });
       mockRunCommand.mockResolvedValue(0);
@@ -420,9 +429,10 @@ describe(routeCommand, () => {
         kitSpecifiers: [{ kitName: 'co', checklists: [] }],
         checklists: undefined,
         filePath: undefined,
-        githubValue: undefined,
-        localValue: undefined,
+        fromValue: undefined,
         urlValue: undefined,
+        jit: false,
+        internal: false,
         json: false,
       });
       mockRunCommand.mockResolvedValue(0);
@@ -438,9 +448,10 @@ describe(routeCommand, () => {
         kitSpecifiers: [],
         checklists: undefined,
         filePath: undefined,
-        githubValue: undefined,
-        localValue: undefined,
+        fromValue: undefined,
         urlValue: undefined,
+        jit: false,
+        internal: false,
         json: false,
       });
       mockRunCommand.mockResolvedValue(0);

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -175,6 +175,25 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(0);
   });
 
+  it('forwards jit flag to runCommand when --jit is set', async () => {
+    mockParseRunArgs.mockReturnValue({
+      kitSpecifiers: [],
+      checklists: undefined,
+      filePath: undefined,
+      fromValue: undefined,
+      urlValue: undefined,
+      jit: true,
+      internal: false,
+      json: false,
+    });
+    mockRunCommand.mockResolvedValue(0);
+
+    const exitCode = await routeCommand(['run', '--jit']);
+
+    expect(mockRunCommand).toHaveBeenCalledWith(expect.anything(), true);
+    expect(exitCode).toBe(0);
+  });
+
   it('passes --json flag through to runCommand', async () => {
     mockParseRunArgs.mockReturnValue({
       kitSpecifiers: [],

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -24,10 +24,11 @@ Commands:
   list                          List available kits
 
 Run options:
+  --from <source>                    Kit source (github:org/repo, bitbucket:ws/repo, global, dir:path, or local path)
   --file, -f <path>                  Path to a local kit file
-  --github, -g <org/repo[@ref]>      Fetch kit from a GitHub repository
-  --local, -l <path>                 Load compiled kit from a local repository
   --url, -u <url>                    Fetch kit from a URL
+  --jit, -J                          Run from TypeScript source instead of compiled JS
+  --internal, -i                     Use internal kit directory and infix from config
   --checklists, -c <name,...>        Filter checklists (with --file or --url only)
   --json, -j                         Output results as JSON
   --fail-on, -F <severity>           Fail on this severity or above (error, warn, recommend)
@@ -48,10 +49,14 @@ to filter checklists within a kit (e.g., deploy:check1,check2).
 If no arguments are given, all checklists in the default kit are run.
 
 Kit source (mutually exclusive):
+  --from <source>                    Kit source (github:org/repo[@ref], bitbucket:ws/repo[@ref],
+                                     global, dir:path, or local repo path)
   --file, -f <path>                  Path to a local kit file
-  --github, -g <org/repo[@ref]>      Fetch kit from a GitHub repository
-  --local, -l <path>                 Load compiled kit from a local repository
   --url, -u <url>                    Fetch kit from a URL
+
+Mode flags (incompatible with --from, --file, --url):
+  --jit, -J                          Run from TypeScript source instead of compiled JS
+  --internal, -i                     Use internal kit directory and infix from config
 
 Options:
   --checklists, -c <name,...>        Filter checklists (with --file or --url only)
@@ -61,7 +66,7 @@ Options:
   --help, -h                         Show this help message
 
 Positional args accept relative paths (e.g., shared/deploy).
-Defaults to .rdy/kits/default.ts when no source is given.
+Defaults to .rdy/kits/default.js when no source is given.
 `);
 }
 
@@ -89,16 +94,19 @@ Usage: rdy list [options]
 List available kits without running them.
 
 Modes:
-  rdy list                  List internal and compiled kits (owner view)
-  rdy list --local <path>   List compiled kits at a local path (consumer view)
+  rdy list                       List internal and compiled kits (owner view)
+  rdy list --from <path>         List compiled kits at a local path (consumer view)
+  rdy list --from global         List compiled kits in the global directory
+  rdy list --from dir:<path>     List kits in an arbitrary directory
 
 Options:
-  --local, -l <path>  Path to a local repository with compiled kits
-  --help, -h          Show this help message
+  --from <source>  Kit source (local path, global, or dir:path)
+  --help, -h       Show this help message
 
 Examples:
-  rdy list             Show kits in the current project
-  rdy list --local .   Show compiled kits in the current directory
+  rdy list                Show kits in the current project
+  rdy list --from .       Show compiled kits in the current directory
+  rdy list --from global  Show kits in the global directory
 `);
 }
 
@@ -239,23 +247,27 @@ async function handleRun(flags: string[]): Promise<number> {
   try {
     kitEntries = resolveKitSources({
       filePath: parsed.filePath,
-      githubValue: parsed.githubValue,
-      localValue: parsed.localValue,
+      fromValue: parsed.fromValue,
       urlValue: parsed.urlValue,
       kitSpecifiers: parsed.kitSpecifiers,
       checklists: parsed.checklists,
+      jit: parsed.jit,
+      internal: parsed.internal,
       internalDir: config.internal.dir,
-      internalExtension: config.internal.extension,
+      internalInfix: config.internal.infix,
     });
   } catch (error: unknown) {
     process.stderr.write(`Error: ${extractMessage(error)}\n`);
     return 1;
   }
 
-  return runCommand({
-    kitEntries,
-    json: parsed.json,
-    ...(parsed.failOn !== undefined && { failOn: parsed.failOn }),
-    ...(parsed.reportOn !== undefined && { reportOn: parsed.reportOn }),
-  });
+  return runCommand(
+    {
+      kitEntries,
+      json: parsed.json,
+      ...(parsed.failOn !== undefined && { failOn: parsed.failOn }),
+      ...(parsed.reportOn !== undefined && { reportOn: parsed.reportOn }),
+    },
+    parsed.jit,
+  );
 }

--- a/packages/readyup/src/buildKitFilename.ts
+++ b/packages/readyup/src/buildKitFilename.ts
@@ -1,0 +1,7 @@
+/** Build a kit filename from a kit name, optional infix, and extension. */
+export function buildKitFilename(kitName: string, infix: string | undefined, extension: string): string {
+  if (infix !== undefined) {
+    return `${kitName}.${infix}${extension}`;
+  }
+  return `${kitName}${extension}`;
+}

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -205,6 +205,7 @@ export function resolveKitSources({
     return [{ name: urlValue, source: { url: urlValue }, checklists: checklists ?? [] }];
   }
 
+  // Assume `jit` is always false when `fromValue` is present; `parseRunArgs` enforces this constraint.
   const extension = jit ? '.ts' : '.js';
   const specs = kitSpecifiers.length > 0 ? kitSpecifiers : [{ kitName: 'default', checklists: [] }];
 

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -1,12 +1,14 @@
 import path from 'node:path';
 import process from 'node:process';
 
+import { buildKitFilename } from './buildKitFilename.ts';
 import { loadRdyKit } from './config.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonError } from './formatJsonError.ts';
 import { formatJsonReport } from './formatJsonReport.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { parseArgs } from './parseArgs.ts';
+import { parseFromValue, type FromSource } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
 import { reportRdy, tallyResult } from './reportRdy.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
@@ -41,10 +43,11 @@ export interface ParsedRunArgs {
   checklists: string[] | undefined;
   failOn?: Severity;
   filePath: string | undefined;
-  githubValue: string | undefined;
+  fromValue: string | undefined;
+  internal: boolean;
+  jit: boolean;
   json: boolean;
   kitSpecifiers: KitSpecifier[];
-  localValue: string | undefined;
   reportOn?: Severity;
   urlValue: string | undefined;
 }
@@ -52,45 +55,20 @@ export interface ParsedRunArgs {
 const runFlagSchema = {
   checklists: { long: '--checklists', type: 'string' as const, short: '-c' },
   file: { long: '--file', type: 'string' as const, short: '-f' },
-  github: { long: '--github', type: 'string' as const, short: '-g' },
+  from: { long: '--from', type: 'string' as const },
   url: { long: '--url', type: 'string' as const, short: '-u' },
-  local: { long: '--local', type: 'string' as const, short: '-l' },
+  jit: { long: '--jit', type: 'boolean' as const, short: '-J' },
+  internal: { long: '--internal', type: 'boolean' as const, short: '-i' },
   json: { long: '--json', type: 'boolean' as const, short: '-j' },
   failOn: { long: '--fail-on', type: 'string' as const, short: '-F' },
   reportOn: { long: '--report-on', type: 'string' as const, short: '-R' },
 };
-
-/** Throw if a kit source flag has already been set. */
-function assertNoExistingSource(existing: string | undefined): void {
-  if (existing !== undefined) {
-    throw new Error('Cannot combine --file, --github, --local, and --url flags');
-  }
-}
-
-/**
- * Parse `org/repo[@ref]` into repo and ref components.
- *
- * The `@ref` part is optional; defaults to `main`.
- */
-function parseGitHubArg(value: string): { repo: string; ref: string } {
-  const atIndex = value.lastIndexOf('@');
-  if (atIndex === -1) {
-    return { repo: value, ref: 'main' };
-  }
-  const repo = value.slice(0, atIndex);
-  const ref = value.slice(atIndex + 1);
-  if (ref === '') {
-    throw new Error(`Invalid --github value: ref after '@' must not be empty in "${value}"`);
-  }
-  return { repo, ref };
-}
 
 /** Validate and narrow a string to a Severity value. */
 function parseSeverityFlag(flagName: string, value: string): Severity {
   if (!VALID_SEVERITIES.has(value)) {
     throw new Error(`${flagName} must be one of: error, warn, recommend (got "${value}")`);
   }
-  // Validated above; narrow without assertion by returning the matched literal.
   if (value === 'error') return 'error';
   if (value === 'warn') return 'warn';
   return 'recommend';
@@ -100,8 +78,13 @@ function parseSeverityFlag(flagName: string, value: string): Severity {
 const KITS_DIR = '.rdy/kits';
 
 /** Build the GitHub raw content URL for a kit. */
-function buildGitHubKitUrl(repo: string, ref: string, kit: string): string {
-  return `https://raw.githubusercontent.com/${repo}/${ref}/${KITS_DIR}/${kit}.js`;
+function buildGitHubKitUrl(org: string, repo: string, ref: string, kit: string, extension: string): string {
+  return `https://raw.githubusercontent.com/${org}/${repo}/${ref}/${KITS_DIR}/${kit}${extension}`;
+}
+
+/** Build the Bitbucket raw content URL for a kit. */
+function buildBitbucketKitUrl(workspace: string, repo: string, ref: string, kit: string, extension: string): string {
+  return `https://bitbucket.org/${workspace}/${repo}/raw/${ref}/${KITS_DIR}/${kit}${extension}`;
 }
 
 /** Map generic "requires a value" errors to domain-specific hints for run-subcommand flags. */
@@ -109,8 +92,7 @@ const flagErrorHints: Record<string, string> = {
   '--checklists': '--checklists requires a comma-separated list of checklist names',
   '--fail-on': '--fail-on requires a severity level (error, warn, recommend)',
   '--file': '--file requires a path argument',
-  '--github': '--github requires a repository argument (org/repo[@ref])',
-  '--local': '--local requires a path to a local repository',
+  '--from': '--from requires a source argument (path, github:org/repo, global, dir:path)',
   '--report-on': '--report-on requires a severity level (error, warn, recommend)',
   '--url': '--url requires a URL argument',
 };
@@ -139,34 +121,34 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   }
   const { flags: parsed, positionals } = result;
 
-  // Validate mutual exclusivity of source flags.
-  let sourceType: string | undefined;
-  if (parsed.file !== undefined) {
-    assertNoExistingSource(sourceType);
-    sourceType = 'file';
+  // Count source flags for mutual exclusivity.
+  const sourceFlags: string[] = [];
+  if (parsed.file !== undefined) sourceFlags.push('--file');
+  if (parsed.from !== undefined) sourceFlags.push('--from');
+  if (parsed.url !== undefined) sourceFlags.push('--url');
+
+  if (sourceFlags.length > 1) {
+    throw new Error(`Cannot combine ${sourceFlags.join(', ')} flags`);
   }
-  if (parsed.github !== undefined) {
-    assertNoExistingSource(sourceType);
-    sourceType = 'github';
+
+  // Validate --jit and --internal incompatibility with source flags.
+  if (parsed.jit && sourceFlags.length > 0) {
+    throw new Error(`--jit cannot be combined with ${sourceFlags[0]}`);
   }
-  if (parsed.local !== undefined) {
-    assertNoExistingSource(sourceType);
-    sourceType = 'local';
-  }
-  if (parsed.url !== undefined) {
-    assertNoExistingSource(sourceType);
-    sourceType = 'url';
+  if (parsed.internal && sourceFlags.length > 0) {
+    throw new Error(`--internal cannot be combined with ${sourceFlags[0]}`);
   }
 
   // Validate --checklists co-dependencies.
   const checklistsValue = parsed.checklists;
-  if (checklistsValue !== undefined && sourceType !== 'file' && sourceType !== 'url') {
+  const sourceType = sourceFlags[0];
+  if (checklistsValue !== undefined && sourceType !== '--file' && sourceType !== '--url') {
     throw new Error('--checklists can only be used with --file or --url');
   }
 
   // Validate that file/url sources cannot be combined with positional args.
-  if ((sourceType === 'file' || sourceType === 'url') && positionals.length > 0) {
-    throw new Error(`--${sourceType} cannot be combined with positional kit arguments`);
+  if ((sourceType === '--file' || sourceType === '--url') && positionals.length > 0) {
+    throw new Error(`${sourceType} cannot be combined with positional kit arguments`);
   }
 
   // Parse checklists from the flag value.
@@ -182,10 +164,11 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   const parsedArgs: ParsedRunArgs = {
     checklists,
     filePath: parsed.file,
-    githubValue: parsed.github,
+    fromValue: parsed.from,
+    internal: parsed.internal,
+    jit: parsed.jit,
     json: parsed.json,
     kitSpecifiers,
-    localValue: parsed.local,
     urlValue: parsed.url,
   };
   if (failOn !== undefined) parsedArgs.failOn = failOn;
@@ -196,22 +179,24 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
 /** Resolve parsed flags into an array of kit entries to execute. */
 export function resolveKitSources({
   filePath,
-  githubValue,
-  localValue,
+  fromValue,
   urlValue,
   kitSpecifiers,
   checklists,
+  jit,
+  internal,
   internalDir,
-  internalExtension,
+  internalInfix,
 }: {
   filePath: string | undefined;
-  githubValue: string | undefined;
-  localValue: string | undefined;
+  fromValue: string | undefined;
   urlValue: string | undefined;
   kitSpecifiers: KitSpecifier[];
   checklists: string[] | undefined;
+  jit: boolean;
+  internal: boolean;
   internalDir: string;
-  internalExtension: string;
+  internalInfix: string | undefined;
 }): ResolvedKitEntry[] {
   if (filePath !== undefined) {
     return [{ name: filePath, source: { path: filePath }, checklists: checklists ?? [] }];
@@ -220,32 +205,71 @@ export function resolveKitSources({
     return [{ name: urlValue, source: { url: urlValue }, checklists: checklists ?? [] }];
   }
 
+  const extension = jit ? '.ts' : '.js';
   const specs = kitSpecifiers.length > 0 ? kitSpecifiers : [{ kitName: 'default', checklists: [] }];
 
-  if (githubValue !== undefined) {
-    const { repo, ref } = parseGitHubArg(githubValue);
+  if (fromValue !== undefined) {
+    return resolveFromSource(parseFromValue(fromValue), specs, extension);
+  }
+
+  // Default/internal case: resolve from the current repo.
+  if (internal) {
     return specs.map((spec) => ({
       name: spec.kitName,
-      source: { url: buildGitHubKitUrl(repo, ref, spec.kitName) },
+      source: { path: path.join(KITS_DIR, internalDir, buildKitFilename(spec.kitName, internalInfix, extension)) },
       checklists: spec.checklists,
     }));
   }
 
-  if (localValue !== undefined) {
-    const resolvedBase = path.resolve(process.cwd(), localValue);
-    return specs.map((spec) => ({
-      name: spec.kitName,
-      source: { path: path.join(resolvedBase, KITS_DIR, `${spec.kitName}.js`) },
-      checklists: spec.checklists,
-    }));
-  }
-
-  // Internal/default case.
   return specs.map((spec) => ({
     name: spec.kitName,
-    source: { path: path.join(KITS_DIR, internalDir, `${spec.kitName}${internalExtension}`) },
+    source: { path: path.join(KITS_DIR, `${spec.kitName}${extension}`) },
     checklists: spec.checklists,
   }));
+}
+
+/** Resolve kit entries from a parsed `--from` source. */
+function resolveFromSource(source: FromSource, specs: KitSpecifier[], extension: string): ResolvedKitEntry[] {
+  switch (source.type) {
+    case 'github':
+      return specs.map((spec) => ({
+        name: spec.kitName,
+        source: { url: buildGitHubKitUrl(source.org, source.repo, source.ref, spec.kitName, extension) },
+        checklists: spec.checklists,
+      }));
+
+    case 'bitbucket':
+      return specs.map((spec) => ({
+        name: spec.kitName,
+        source: { url: buildBitbucketKitUrl(source.workspace, source.repo, source.ref, spec.kitName, extension) },
+        checklists: spec.checklists,
+      }));
+
+    case 'global': {
+      const homeDir = process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
+      return specs.map((spec) => ({
+        name: spec.kitName,
+        source: { path: path.join(homeDir, KITS_DIR, `${spec.kitName}${extension}`) },
+        checklists: spec.checklists,
+      }));
+    }
+
+    case 'directory':
+      return specs.map((spec) => ({
+        name: spec.kitName,
+        source: { path: path.join(path.resolve(process.cwd(), source.path), `${spec.kitName}${extension}`) },
+        checklists: spec.checklists,
+      }));
+
+    case 'local': {
+      const resolvedBase = path.resolve(process.cwd(), source.path);
+      return specs.map((spec) => ({
+        name: spec.kitName,
+        source: { path: path.join(resolvedBase, KITS_DIR, `${spec.kitName}${extension}`) },
+        checklists: spec.checklists,
+      }));
+    }
+  }
 }
 
 /** Resolve the effective fixLocation for a checklist, falling back to the kit-level default. */
@@ -292,7 +316,7 @@ interface RunCommandOptions {
 }
 
 /** Load a rdy kit from a path or URL source. */
-async function loadKit(source: KitSource): Promise<RdyKit> {
+async function loadKit(source: KitSource, isJit: boolean): Promise<RdyKit> {
   if ('url' in source) {
     const options: LoadRemoteKitOptions = { url: source.url };
     if (source.url.includes('raw.githubusercontent.com')) {
@@ -303,15 +327,34 @@ async function loadKit(source: KitSource): Promise<RdyKit> {
     }
     return loadRemoteKit(options);
   }
-  return loadRdyKit(source.path);
+
+  try {
+    return await loadRdyKit(source.path);
+  } catch (error: unknown) {
+    if (isJit && isModuleNotFoundError(error, 'readyup')) {
+      throw new Error('Running from source requires readyup to be installed as a project dependency.');
+    }
+    throw error;
+  }
+}
+
+/** Detect module-not-found errors that mention a specific package name. */
+function isModuleNotFoundError(error: unknown, packageName: string): boolean {
+  if (!(error instanceof Error)) return false;
+  if (!('code' in error)) return false;
+  if (error.code !== 'MODULE_NOT_FOUND' && error.code !== 'ERR_MODULE_NOT_FOUND') return false;
+  return error.message.includes(packageName);
 }
 
 /** Run rdy checklists across one or more kits. Returns a numeric exit code. */
-export async function runCommand({ kitEntries, json, failOn, reportOn }: RunCommandOptions): Promise<number> {
+export async function runCommand(
+  { kitEntries, json, failOn, reportOn }: RunCommandOptions,
+  isJit = false,
+): Promise<number> {
   if (json) {
-    return runMultiKitJsonMode(kitEntries, failOn, reportOn);
+    return runMultiKitJsonMode(kitEntries, failOn, reportOn, isJit);
   }
-  return runMultiKitHumanMode(kitEntries, failOn, reportOn);
+  return runMultiKitHumanMode(kitEntries, failOn, reportOn, isJit);
 }
 
 /** Run all kit entries in JSON mode, producing a single JSON report. */
@@ -319,6 +362,7 @@ async function runMultiKitJsonMode(
   kitEntries: ResolvedKitEntry[],
   failOn: Severity | undefined,
   reportOn: Severity | undefined,
+  isJit: boolean,
 ): Promise<number> {
   const kitResults: Array<{
     name: string;
@@ -329,7 +373,7 @@ async function runMultiKitJsonMode(
   for (const entry of kitEntries) {
     let kit: RdyKit;
     try {
-      kit = await loadKit(entry.source);
+      kit = await loadKit(entry.source, isJit);
     } catch (error: unknown) {
       const message = extractMessage(error);
       process.stdout.write(formatJsonError(message) + '\n');
@@ -384,13 +428,14 @@ async function runMultiKitHumanMode(
   kitEntries: ResolvedKitEntry[],
   failOn: Severity | undefined,
   reportOn: Severity | undefined,
+  isJit: boolean,
 ): Promise<number> {
   const showKitHeader = kitEntries.length > 1;
   let allPassed = true;
   for (const entry of kitEntries) {
     let kit: RdyKit;
     try {
-      kit = await loadKit(entry.source);
+      kit = await loadKit(entry.source, isJit);
     } catch (error: unknown) {
       const message = extractMessage(error);
       process.stderr.write(`Error: ${message}\n`);

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -8,7 +8,7 @@ import { formatJsonError } from './formatJsonError.ts';
 import { formatJsonReport } from './formatJsonReport.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { parseArgs } from './parseArgs.ts';
-import { parseFromValue, type FromSource } from './parseFromValue.ts';
+import { type FromSource, parseFromValue } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
 import { reportRdy, tallyResult } from './reportRdy.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
@@ -111,6 +111,47 @@ function translateParseError(error: unknown): never {
   throw error;
 }
 
+/** Collect active source flags and validate mutual exclusivity and mode-flag constraints. */
+function validateFlagConstraints(
+  parsed: {
+    file: string | undefined;
+    from: string | undefined;
+    url: string | undefined;
+    jit: boolean;
+    internal: boolean;
+    checklists: string | undefined;
+  },
+  positionalCount: number,
+): string | undefined {
+  const sourceFlags: string[] = [];
+  if (parsed.file !== undefined) sourceFlags.push('--file');
+  if (parsed.from !== undefined) sourceFlags.push('--from');
+  if (parsed.url !== undefined) sourceFlags.push('--url');
+
+  if (sourceFlags.length > 1) {
+    throw new Error(`Cannot combine ${sourceFlags.join(', ')} flags`);
+  }
+
+  const sourceType = sourceFlags[0];
+
+  if (parsed.jit && sourceType !== undefined) {
+    throw new Error(`--jit cannot be combined with ${sourceType}`);
+  }
+  if (parsed.internal && sourceType !== undefined) {
+    throw new Error(`--internal cannot be combined with ${sourceType}`);
+  }
+
+  if (parsed.checklists !== undefined && sourceType !== '--file' && sourceType !== '--url') {
+    throw new Error('--checklists can only be used with --file or --url');
+  }
+
+  if ((sourceType === '--file' || sourceType === '--url') && positionalCount > 0) {
+    throw new Error(`${sourceType} cannot be combined with positional kit arguments`);
+  }
+
+  return sourceType;
+}
+
 /** Parse run-subcommand flags into a structured object. */
 export function parseRunArgs(flags: string[]): ParsedRunArgs {
   let result;
@@ -121,38 +162,10 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   }
   const { flags: parsed, positionals } = result;
 
-  // Count source flags for mutual exclusivity.
-  const sourceFlags: string[] = [];
-  if (parsed.file !== undefined) sourceFlags.push('--file');
-  if (parsed.from !== undefined) sourceFlags.push('--from');
-  if (parsed.url !== undefined) sourceFlags.push('--url');
-
-  if (sourceFlags.length > 1) {
-    throw new Error(`Cannot combine ${sourceFlags.join(', ')} flags`);
-  }
-
-  // Validate --jit and --internal incompatibility with source flags.
-  if (parsed.jit && sourceFlags.length > 0) {
-    throw new Error(`--jit cannot be combined with ${sourceFlags[0]}`);
-  }
-  if (parsed.internal && sourceFlags.length > 0) {
-    throw new Error(`--internal cannot be combined with ${sourceFlags[0]}`);
-  }
-
-  // Validate --checklists co-dependencies.
-  const checklistsValue = parsed.checklists;
-  const sourceType = sourceFlags[0];
-  if (checklistsValue !== undefined && sourceType !== '--file' && sourceType !== '--url') {
-    throw new Error('--checklists can only be used with --file or --url');
-  }
-
-  // Validate that file/url sources cannot be combined with positional args.
-  if ((sourceType === '--file' || sourceType === '--url') && positionals.length > 0) {
-    throw new Error(`${sourceType} cannot be combined with positional kit arguments`);
-  }
+  validateFlagConstraints(parsed, positionals.length);
 
   // Parse checklists from the flag value.
-  const checklists = checklistsValue !== undefined ? checklistsValue.split(',').filter((s) => s !== '') : undefined;
+  const checklists = parsed.checklists !== undefined ? parsed.checklists.split(',').filter((s) => s !== '') : undefined;
 
   // Parse kit specifiers from positional args.
   const kitSpecifiers = parseKitSpecifiers(positionals);
@@ -247,7 +260,7 @@ function resolveFromSource(source: FromSource, specs: KitSpecifier[], extension:
       }));
 
     case 'global': {
-      const homeDir = process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
+      const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '~';
       return specs.map((spec) => ({
         name: spec.kitName,
         source: { path: path.join(homeDir, KITS_DIR, `${spec.kitName}${extension}`) },

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -62,7 +62,8 @@ export function formatOwnerView({ internalKits, compiledKits, compiledStyle }: O
 
 interface ConsumerViewOptions {
   compiledKits: string[];
-  localPathArg: string;
+  fromArg: string;
+  kitsDir: string;
 }
 
 /**
@@ -70,21 +71,21 @@ interface ConsumerViewOptions {
  *
  * Returns the empty-consumer message when the kit list is empty.
  */
-export function formatConsumerView({ compiledKits, localPathArg }: ConsumerViewOptions): string {
+export function formatConsumerView({ compiledKits, fromArg, kitsDir }: ConsumerViewOptions): string {
   if (compiledKits.length === 0) {
-    return formatEmpty('consumer', localPathArg);
+    return formatEmpty('consumer', kitsDir);
   }
 
-  const hint = `rdy run --from ${localPathArg} ${buildKitHint(compiledKits)}`;
+  const hint = `rdy run --from ${fromArg} ${buildKitHint(compiledKits)}`;
   return formatSection('Compiled', hint, compiledKits, ICON_COMPILED);
 }
 
 // -- Empty messages --
 
 /** Format the "no kits found" message appropriate to the given mode. */
-export function formatEmpty(mode: 'owner' | 'consumer', localPathArg?: string): string {
+export function formatEmpty(mode: 'owner' | 'consumer', kitsDir?: string): string {
   if (mode === 'consumer') {
-    return `No compiled kits found at ${localPathArg ?? '.'}/.rdy/kits/.`;
+    return `No compiled kits found at ${kitsDir ?? '.rdy/kits'}.`;
   }
   return 'No kits found.\nRun `rdy init` to scaffold an internal kit or `rdy compile` to compile a kit from source.';
 }

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -46,7 +46,7 @@ export function formatOwnerView({ internalKits, compiledKits, compiledStyle }: O
 
   if (compiledKits.length > 0) {
     if (compiledStyle.kind === 'local-convention') {
-      const hint = `rdy run --local . ${buildKitHint(compiledKits)}`;
+      const hint = `rdy run --from . ${buildKitHint(compiledKits)}`;
       sections.push(formatSection('Compiled', hint, compiledKits, ICON_COMPILED));
     } else {
       const hint = `rdy run --file <file path>`;
@@ -75,7 +75,7 @@ export function formatConsumerView({ compiledKits, localPathArg }: ConsumerViewO
     return formatEmpty('consumer', localPathArg);
   }
 
-  const hint = `rdy run --local ${localPathArg} ${buildKitHint(compiledKits)}`;
+  const hint = `rdy run --from ${localPathArg} ${buildKitHint(compiledKits)}`;
   return formatSection('Compiled', hint, compiledKits, ICON_COMPILED);
 }
 

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -3,13 +3,14 @@ import process from 'node:process';
 
 import { loadConfig } from '../loadConfig.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
+import { parseFromValue } from '../parseFromValue.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { enumerateKits } from './enumerateKits.ts';
 import type { CompiledStyle } from './formatList.ts';
 import { formatConsumerView, formatOwnerView } from './formatList.ts';
 
 const listFlagSchema = {
-  local: { long: '--local', type: 'string' as const, short: '-l' },
+  from: { long: '--from', type: 'string' as const },
 };
 
 /**
@@ -26,18 +27,34 @@ export async function listCommand(args: string[]): Promise<number> {
     return 1;
   }
 
-  const localPathArg = parsed.flags.local;
+  const fromArg = parsed.flags.from;
 
-  if (localPathArg !== undefined) {
-    return runConsumerMode(localPathArg);
+  if (fromArg !== undefined) {
+    return runFromMode(fromArg);
   }
 
   return runOwnerMode();
 }
 
-/** Enumerate kits from a local path without loading config. */
-function runConsumerMode(localPathArg: string): number {
-  const kitsDir = path.join(path.resolve(localPathArg), '.rdy/kits');
+/** Enumerate kits from a `--from` source. */
+function runFromMode(fromArg: string): number {
+  const source = parseFromValue(fromArg);
+
+  if (source.type === 'github' || source.type === 'bitbucket') {
+    process.stderr.write(`Error: Listing kits from ${source.type} repositories is not yet supported.\n`);
+    return 1;
+  }
+
+  let kitsDir: string;
+  if (source.type === 'global') {
+    const homeDir = process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
+    kitsDir = path.join(homeDir, '.rdy/kits');
+  } else if (source.type === 'directory') {
+    kitsDir = path.resolve(source.path);
+  } else {
+    // local path
+    kitsDir = path.join(path.resolve(source.path), '.rdy/kits');
+  }
 
   let compiledKits;
   try {
@@ -48,7 +65,7 @@ function runConsumerMode(localPathArg: string): number {
     return 1;
   }
 
-  const output = formatConsumerView({ compiledKits, localPathArg });
+  const output = formatConsumerView({ compiledKits, localPathArg: fromArg });
   process.stdout.write(output + '\n');
   return 0;
 }
@@ -69,10 +86,12 @@ async function runOwnerMode(): Promise<number> {
   const internalDir = path.join(cwd, '.rdy/kits', config.internal.dir);
   const compiledDir = path.resolve(cwd, config.compile.outDir);
 
+  const internalExtension = config.internal.infix !== undefined ? `.${config.internal.infix}.ts` : '.ts';
+
   let internalKits;
   let compiledKits;
   try {
-    internalKits = enumerateKits({ dir: internalDir, extension: config.internal.extension });
+    internalKits = enumerateKits({ dir: internalDir, extension: internalExtension });
     compiledKits = enumerateKits({ dir: compiledDir, extension: '.js' });
   } catch (error: unknown) {
     const message = extractMessage(error);

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -38,7 +38,14 @@ export async function listCommand(args: string[]): Promise<number> {
 
 /** Enumerate kits from a `--from` source. */
 function runFromMode(fromArg: string): number {
-  const source = parseFromValue(fromArg);
+  let source;
+  try {
+    source = parseFromValue(fromArg);
+  } catch (error: unknown) {
+    const message = extractMessage(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
+  }
 
   if (source.type === 'github' || source.type === 'bitbucket') {
     process.stderr.write(`Error: Listing kits from ${source.type} repositories is not yet supported.\n`);

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -72,7 +72,7 @@ function runFromMode(fromArg: string): number {
     return 1;
   }
 
-  const output = formatConsumerView({ compiledKits, localPathArg: fromArg });
+  const output = formatConsumerView({ compiledKits, fromArg, kitsDir });
   process.stdout.write(output + '\n');
   return 0;
 }

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -54,7 +54,7 @@ function runFromMode(fromArg: string): number {
 
   let kitsDir: string;
   if (source.type === 'global') {
-    const homeDir = process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
+    const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '~';
     kitsDir = path.join(homeDir, '.rdy/kits');
   } else if (source.type === 'directory') {
     kitsDir = path.resolve(source.path);

--- a/packages/readyup/src/loadConfig.ts
+++ b/packages/readyup/src/loadConfig.ts
@@ -16,7 +16,7 @@ const DEFAULT_CONFIG: ResolvedRdyConfig = {
   },
   internal: {
     dir: '.',
-    extension: '.ts',
+    infix: undefined,
   },
 };
 
@@ -35,7 +35,7 @@ const RdyConfigSchema = z.looseObject({
   internal: z
     .looseObject({
       dir: z.string().optional(),
-      extension: z.string().optional(),
+      infix: z.string().optional(),
     })
     .optional(),
 });
@@ -96,7 +96,7 @@ export async function loadConfig(overridePath?: string): Promise<ResolvedRdyConf
     },
     internal: {
       dir: typeof internal?.dir === 'string' ? internal.dir : DEFAULT_CONFIG.internal.dir,
-      extension: typeof internal?.extension === 'string' ? internal.extension : DEFAULT_CONFIG.internal.extension,
+      infix: typeof internal?.infix === 'string' ? internal.infix : DEFAULT_CONFIG.internal.infix,
     },
   };
 }

--- a/packages/readyup/src/parseFromValue.ts
+++ b/packages/readyup/src/parseFromValue.ts
@@ -1,0 +1,86 @@
+/** Parsed result for the `github:` scheme. */
+export interface GitHubSource {
+  type: 'github';
+  org: string;
+  repo: string;
+  ref: string;
+}
+
+/** Parsed result for the `bitbucket:` scheme. */
+export interface BitbucketSource {
+  type: 'bitbucket';
+  workspace: string;
+  repo: string;
+  ref: string;
+}
+
+/** Parsed result for the `global` keyword. */
+export interface GlobalSource {
+  type: 'global';
+}
+
+/** Parsed result for the `dir:` scheme. */
+export interface DirectorySource {
+  type: 'directory';
+  path: string;
+}
+
+/** Parsed result for a local repo path (fallback). */
+export interface LocalSource {
+  type: 'local';
+  path: string;
+}
+
+/** Discriminated union of all `--from` value interpretations. */
+export type FromSource = GitHubSource | BitbucketSource | GlobalSource | DirectorySource | LocalSource;
+
+/**
+ * Parse `owner/name[@ref]` into owner, name, and ref components.
+ *
+ * The `@ref` part is optional; defaults to `main`.
+ */
+function parseOrgRepo(value: string): { owner: string; name: string; ref: string } {
+  const atIndex = value.lastIndexOf('@');
+  const slug = atIndex === -1 ? value : value.slice(0, atIndex);
+  const ref = atIndex === -1 ? 'main' : value.slice(atIndex + 1);
+
+  if (ref === '') {
+    throw new Error(`Invalid --from value: ref after '@' must not be empty in "${value}"`);
+  }
+
+  const slashIndex = slug.indexOf('/');
+  if (slashIndex === -1 || slashIndex === 0 || slashIndex === slug.length - 1) {
+    throw new Error(`Invalid --from value: expected "owner/repo" format, got "${slug}"`);
+  }
+
+  return { owner: slug.slice(0, slashIndex), name: slug.slice(slashIndex + 1), ref };
+}
+
+/** Parse the `--from` flag value into a discriminated source union. */
+export function parseFromValue(value: string): FromSource {
+  if (value.startsWith('github:')) {
+    const body = value.slice('github:'.length);
+    const { owner, name, ref } = parseOrgRepo(body);
+    return { type: 'github', org: owner, repo: name, ref };
+  }
+
+  if (value.startsWith('bitbucket:')) {
+    const body = value.slice('bitbucket:'.length);
+    const { owner, name, ref } = parseOrgRepo(body);
+    return { type: 'bitbucket', workspace: owner, repo: name, ref };
+  }
+
+  if (value.startsWith('http://') || value.startsWith('https://')) {
+    throw new Error(`URLs are not accepted by --from. Use --url instead: ${value}`);
+  }
+
+  if (value === 'global') {
+    return { type: 'global' };
+  }
+
+  if (value.startsWith('dir:')) {
+    return { type: 'directory', path: value.slice('dir:'.length) };
+  }
+
+  return { type: 'local', path: value };
+}

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -252,7 +252,7 @@ export interface RdyConfig {
   };
   internal?: {
     dir?: string;
-    extension?: string;
+    infix?: string;
   };
 }
 
@@ -265,7 +265,7 @@ export interface ResolvedRdyConfig {
   };
   internal: {
     dir: string;
-    extension: string;
+    infix: string | undefined;
   };
 }
 


### PR DESCRIPTION
## What

Defaults `rdy run` to compiled `.js` kits and replaces the `--local` and `--github` source flags with a single `--from` flag that uses scheme detection to select the kit source. Adds `--jit` (`-J`) for running from TypeScript source and `--internal` (`-i`) for resolving kits from the configured internal subdirectory.

## Why

Users found the existing CLI confusing: the default resolved to `.ts` source files, running a compiled kit from the current repo required the unintuitive `rdy run --local . mykit`, and four mutually exclusive source flags (`--local`, `--github`, `--file`, `--url`) made the constraint implicit rather than structural.

## Details

### Features

- `--from` flag with scheme detection: `github:org/repo[@ref]`, `bitbucket:workspace/repo[@ref]`, `global`, `dir:/path`, and bare local paths
- `--jit` flag switches resolution from `.js` to `.ts`; produces a friendly error when `readyup` is not installed as a project dependency
- `--internal` flag resolves kits from the configured `internal.dir` subdirectory, applying the optional infix
- `rdy list` accepts `--from` with `global`, `dir:`, and local path schemes; `github:` and `bitbucket:` return a "not yet supported" error
- Help text updated across `showHelp`, `showRunHelp`, and `showListHelp`

### Refactoring

- `internal.extension` config replaced by `internal.infix`, separating file identification from file extension
- `buildKitFilename` helper encapsulates kit filename construction with optional infix
- `parseFromValue` module provides a discriminated-union parser for the `--from` flag
- `validateFlagConstraints` extracted from `parseRunArgs` to reduce cyclomatic complexity
- `formatConsumerView` accepts resolved `kitsDir` for accurate empty-state messages

### Tests

- 659 tests passing (previously 648)
- New test file: `parseFromValue.test.ts` covering all scheme variants, edge cases, and error paths
- New test file: `__tests__/list/listCommand.test.ts` covering `--from global`, `--from dir:`, `--from <local>`, and malformed input error handling
- Extended `cli.test.ts` with `--from`, `--jit`, `--internal`, mutual exclusivity, `--from=` syntax, and Bitbucket URL resolution tests
- Extended `route.test.ts` with `--jit` forwarding verification
- Extended `formatList.test.ts` with resolved-path empty-state message tests

## Test plan

- [ ] Manual smoke test: `rdy run default` resolves to `.js`; `rdy run --jit default` resolves to `.ts`
- [ ] `rdy run --from global default` resolves to `~/.rdy/kits/default.js`
- [ ] `rdy list --from global` lists kits from home directory
- [ ] `rdy run --from github:org/repo` builds correct raw URL

Closes #32 