### PR TITLE
#37 Add `pickJson` compile-time JSON inlining

### DIFF
--- a/packages/readyup/__tests__/compile/extractJsonPaths.test.ts
+++ b/packages/readyup/__tests__/compile/extractJsonPaths.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractJsonPaths } from '../../src/compile/extractJsonPaths.ts';
+
+describe(extractJsonPaths, () => {
+  it('extracts a top-level key by string', () => {
+    const obj = { name: 'my-pkg', version: '1.0.0' };
+
+    expect(extractJsonPaths(obj, ['name'])).toEqual({ name: 'my-pkg' });
+  });
+
+  it('extracts multiple top-level keys', () => {
+    const obj = { name: 'my-pkg', version: '1.0.0', license: 'MIT' };
+
+    expect(extractJsonPaths(obj, ['name', 'version'])).toEqual({
+      name: 'my-pkg',
+      version: '1.0.0',
+    });
+  });
+
+  it('extracts a nested key by array path', () => {
+    const obj = { publishConfig: { access: 'public', registry: 'https://npm.pkg.github.com' } };
+
+    expect(extractJsonPaths(obj, [['publishConfig', 'access']])).toEqual({
+      publishConfig: { access: 'public' },
+    });
+  });
+
+  it('extracts mixed top-level and nested paths in a single call', () => {
+    const obj = {
+      name: 'my-pkg',
+      version: '1.0.0',
+      repository: { type: 'git', url: 'https://example.com' },
+    };
+
+    expect(extractJsonPaths(obj, ['name', ['repository', 'url']])).toEqual({
+      name: 'my-pkg',
+      repository: { url: 'https://example.com' },
+    });
+  });
+
+  it('preserves nested structure when extracting sibling nested paths', () => {
+    const obj = { a: { b: 1, c: 2, d: 3 } };
+
+    expect(
+      extractJsonPaths(obj, [
+        ['a', 'b'],
+        ['a', 'c'],
+      ]),
+    ).toEqual({
+      a: { b: 1, c: 2 },
+    });
+  });
+
+  it('preserves deeply nested values', () => {
+    const obj = { a: { b: { c: { d: 42 } } } };
+
+    expect(extractJsonPaths(obj, [['a', 'b', 'c', 'd']])).toEqual({
+      a: { b: { c: { d: 42 } } },
+    });
+  });
+
+  it('throws when a top-level path is missing', () => {
+    const obj = { name: 'my-pkg' };
+
+    expect(() => extractJsonPaths(obj, ['missing'])).toThrow('Path not found in JSON: missing');
+  });
+
+  it('throws when a nested path is missing', () => {
+    const obj = { a: { b: 1 } };
+
+    expect(() => extractJsonPaths(obj, [['a', 'c']])).toThrow('Path not found in JSON: a.c');
+  });
+
+  it('throws when an intermediate segment is not an object', () => {
+    const obj = { a: 'string-value' };
+
+    expect(() => extractJsonPaths(obj, [['a', 'b']])).toThrow('Path not found in JSON: a.b');
+  });
+
+  it('extracts null values without throwing', () => {
+    const obj = { key: null };
+
+    expect(extractJsonPaths(obj, ['key'])).toEqual({ key: null });
+  });
+
+  it('returns an empty object when given no paths', () => {
+    expect(extractJsonPaths({ a: 1 }, [])).toEqual({});
+  });
+
+  it('skips empty array paths', () => {
+    expect(extractJsonPaths({ a: 1 }, [[], 'a'])).toEqual({ a: 1 });
+  });
+
+  it('handles duplicate path requests by deduplicating', () => {
+    const obj = { name: 'my-pkg', version: '1.0.0' };
+
+    const result = extractJsonPaths(obj, ['name', 'name']);
+
+    expect(result).toEqual({ name: 'my-pkg' });
+    expect(Object.keys(result)).toEqual(['name']);
+  });
+});

--- a/packages/readyup/__tests__/compile/pickJson.test.ts
+++ b/packages/readyup/__tests__/compile/pickJson.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { pickJson } from '../../src/compile/pickJson.ts';
+
+describe(pickJson, () => {
+  it('throws when called at runtime', () => {
+    expect(() => pickJson('package.json', ['name'])).toThrow('pickJson is a compile-time-only function');
+  });
+
+  it('includes guidance to compile the kit in the error message', () => {
+    expect(() => pickJson('package.json', ['name'])).toThrow('rdy compile');
+  });
+});

--- a/packages/readyup/__tests__/compile/pickJsonPlugin.test.ts
+++ b/packages/readyup/__tests__/compile/pickJsonPlugin.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readFileSync: mockReadFileSync,
+  writeFileSync: vi.fn(),
+}));
+
+import { pickJsonPlugin } from '../../src/compile/pickJsonPlugin.ts';
+
+interface LoadCallback {
+  (args: { path: string }): { contents: string; loader: string } | null | undefined;
+}
+
+/** Capture the onLoad callback registered by the plugin. */
+function captureOnLoad(): LoadCallback {
+  let captured: LoadCallback | undefined;
+  const plugin = pickJsonPlugin();
+  void plugin.setup({
+    onLoad(_options: { filter: RegExp }, callback: LoadCallback) {
+      captured = callback;
+    },
+  });
+  if (captured === undefined) {
+    throw new Error('onLoad callback was not registered');
+  }
+  return captured;
+}
+
+describe(pickJsonPlugin, () => {
+  it('returns a plugin with the name "pick-json"', () => {
+    const plugin = pickJsonPlugin();
+
+    expect(plugin.name).toBe('pick-json');
+  });
+
+  it('returns null for files that do not contain pickJson', () => {
+    const onLoad = captureOnLoad();
+    mockReadFileSync.mockReturnValue('const x = 1;');
+
+    const result = onLoad({ path: '/project/src/kit.ts' });
+
+    expect(result).toBeNull();
+  });
+
+  it('replaces a pickJson call with an inlined object literal', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson('./package.json', ['name', 'version']);`;
+    const jsonContent = JSON.stringify({ name: 'my-pkg', version: '1.0.0', license: 'MIT' });
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockReturnValueOnce(jsonContent);
+
+    const result = onLoad({ path: '/project/src/kit.ts' });
+
+    expect(result).not.toBeNull();
+    expect(result?.contents).toBe(`const meta = ${JSON.stringify({ name: 'my-pkg', version: '1.0.0' })};`);
+    expect(result?.loader).toBe('ts');
+  });
+
+  it('replaces multiple pickJson calls in a single file', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = [`const a = pickJson('./a.json', ['x']);`, `const b = pickJson('./b.json', ['y']);`].join('\n');
+    const jsonA = JSON.stringify({ x: 1, extra: true });
+    const jsonB = JSON.stringify({ y: 2, extra: true });
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockReturnValueOnce(jsonA).mockReturnValueOnce(jsonB);
+
+    const result = onLoad({ path: '/project/src/kit.ts' });
+
+    expect(result).not.toBeNull();
+    expect(result?.contents).toContain(JSON.stringify({ x: 1 }));
+    expect(result?.contents).toContain(JSON.stringify({ y: 2 }));
+  });
+
+  it('extracts nested paths from JSON', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson('./data.json', [['config', 'debug']]);`;
+    const jsonContent = JSON.stringify({ config: { debug: true, verbose: false } });
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockReturnValueOnce(jsonContent);
+
+    const result = onLoad({ path: '/project/src/kit.ts' });
+
+    expect(result).not.toBeNull();
+    expect(result?.contents).toBe(`const meta = ${JSON.stringify({ config: { debug: true } })};`);
+  });
+
+  it('resolves the JSON path relative to the source file', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson('../data.json', ['name']);`;
+    const jsonContent = JSON.stringify({ name: 'root-pkg' });
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockReturnValueOnce(jsonContent);
+
+    onLoad({ path: '/project/src/kit.ts' });
+
+    // Second call to readFileSync is for the JSON file.
+    expect(mockReadFileSync).toHaveBeenCalledWith('/project/data.json', 'utf8');
+  });
+
+  it('throws when the JSON file cannot be read', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson('./missing.json', ['name']);`;
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockImplementationOnce(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(() => onLoad({ path: '/project/src/kit.ts' })).toThrow('Cannot read JSON file');
+  });
+
+  it('throws when a requested path is not found in the JSON', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson('./data.json', ['missing']);`;
+    const jsonContent = JSON.stringify({ name: 'my-pkg' });
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockReturnValueOnce(jsonContent);
+
+    expect(() => onLoad({ path: '/project/src/kit.ts' })).toThrow('Path not found in JSON: missing');
+  });
+
+  it('throws when pickJson arguments cannot be parsed', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson(someVar, ['name']);`;
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode);
+
+    expect(() => onLoad({ path: '/project/src/kit.ts' })).toThrow('Cannot parse pickJson arguments');
+  });
+
+  it('throws when the JSON file contains invalid JSON', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson('./bad.json', ['name']);`;
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockReturnValueOnce('{broken');
+
+    expect(() => onLoad({ path: '/project/src/kit.ts' })).toThrow('Invalid JSON');
+  });
+
+  it('throws when the JSON root is not an object', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson('./array.json', ['name']);`;
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockReturnValueOnce('[1,2,3]');
+
+    expect(() => onLoad({ path: '/project/src/kit.ts' })).toThrow('Expected a JSON object');
+  });
+
+  it('throws when a path element is neither a string nor a string array', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson('./data.json', [42]);`;
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode);
+
+    expect(() => onLoad({ path: '/project/src/kit.ts' })).toThrow('Invalid path in pickJson paths array');
+  });
+
+  it('throws when the source file cannot be read', () => {
+    const onLoad = captureOnLoad();
+
+    mockReadFileSync.mockImplementationOnce(() => {
+      throw new Error('EACCES');
+    });
+
+    expect(() => onLoad({ path: '/project/src/kit.ts' })).toThrow('Cannot read source file');
+  });
+
+  it('returns null when pickJson appears only in a comment', () => {
+    const onLoad = captureOnLoad();
+    mockReadFileSync.mockReturnValue('// pickJson is handled at compile time\nconst x = 1;');
+
+    const result = onLoad({ path: '/project/src/kit.ts' });
+
+    expect(result).toBeNull();
+  });
+
+  it('supports single-quoted string arguments', () => {
+    const onLoad = captureOnLoad();
+    const sourceCode = `const meta = pickJson('./data.json', ['name']);`;
+    const jsonContent = JSON.stringify({ name: 'my-pkg', version: '1.0.0' });
+
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockReturnValueOnce(jsonContent);
+
+    const result = onLoad({ path: '/project/src/kit.ts' });
+
+    expect(result).not.toBeNull();
+    expect(result?.contents).toContain('"name":"my-pkg"');
+  });
+
+  it('registers onLoad filter for TypeScript extensions only', () => {
+    let capturedFilter: RegExp | undefined;
+    const plugin = pickJsonPlugin();
+    void plugin.setup({
+      onLoad(options: { filter: RegExp }, _callback: LoadCallback) {
+        capturedFilter = options.filter;
+      },
+    });
+
+    expect(capturedFilter).toBeDefined();
+    // TypeScript extensions match.
+    expect(capturedFilter?.test('file.ts')).toBe(true);
+    expect(capturedFilter?.test('file.mts')).toBe(true);
+    expect(capturedFilter?.test('file.cts')).toBe(true);
+    // Non-TypeScript extensions do not match.
+    expect(capturedFilter?.test('file.js')).toBe(false);
+    expect(capturedFilter?.test('file.jsx')).toBe(false);
+    expect(capturedFilter?.test('file.tsx')).toBe(false);
+  });
+});

--- a/packages/readyup/__tests__/compileConfig.test.ts
+++ b/packages/readyup/__tests__/compileConfig.test.ts
@@ -48,6 +48,7 @@ describe(compileConfig, () => {
       platform: 'node',
       target: 'es2022',
       external: ['node:*'],
+      plugins: [expect.objectContaining({ name: 'pick-json' })],
       banner: { js: expect.stringContaining('@generated') },
       write: false,
     });

--- a/packages/readyup/src/compile/compileConfig.ts
+++ b/packages/readyup/src/compile/compileConfig.ts
@@ -1,6 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { pickJsonPlugin } from './pickJsonPlugin.ts';
+
 /** Result of a successful compilation. */
 export interface CompileResult {
   outputPath: string;
@@ -50,6 +52,7 @@ export async function compileConfig(inputPath: string, outputPath?: string): Pro
     platform: 'node',
     target: 'es2022',
     external: ['node:*'],
+    plugins: [pickJsonPlugin()],
     banner: { js: GENERATED_HEADER },
     write: false,
   });

--- a/packages/readyup/src/compile/extractJsonPaths.ts
+++ b/packages/readyup/src/compile/extractJsonPaths.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+
+import { isRecord } from '../isRecord.ts';
+
+/**
+ * Extract selected paths from a parsed JSON object, preserving original nesting structure.
+ *
+ * Each path is either a single string (top-level key) or an array of strings (nested key path).
+ * Throws if any requested path does not exist in the source object.
+ */
+export function extractJsonPaths(
+  obj: Record<string, unknown>,
+  paths: Array<string | Array<string>>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const raw of paths) {
+    const keys = typeof raw === 'string' ? [raw] : raw;
+    if (keys.length === 0) continue;
+
+    // Traverse the source object to verify the path exists.
+    let current: unknown = obj;
+    for (const key of keys) {
+      if (!isRecord(current) || !(key in current)) {
+        throw new Error(`Path not found in JSON: ${keys.join('.')}`);
+      }
+      current = current[key];
+    }
+
+    // Reconstruct the nested structure in the result.
+    let target: Record<string, unknown> = result;
+    for (let i = 0; i < keys.length - 1; i++) {
+      const segment = keys[i];
+      assert.ok(segment !== undefined);
+      if (!isRecord(target[segment])) {
+        target[segment] = {};
+      }
+      const next = target[segment];
+      assert.ok(isRecord(next));
+      target = next;
+    }
+    const lastKey = keys.at(-1);
+    assert.ok(lastKey !== undefined);
+    target[lastKey] = current;
+  }
+
+  return result;
+}

--- a/packages/readyup/src/compile/pickJson.ts
+++ b/packages/readyup/src/compile/pickJson.ts
@@ -1,0 +1,10 @@
+/**
+ * Declare selected JSON paths for compile-time inlining.
+ *
+ * This function exists only for type-checking in kit source files. At compile time, the
+ * `pickJsonPlugin` replaces every call with an object literal containing only the requested
+ * fields. If this function executes at runtime, it means the kit was not compiled.
+ */
+export function pickJson(_relativePath: string, _paths: Array<string | Array<string>>): Record<string, unknown> {
+  throw new Error('pickJson is a compile-time-only function. Compile the kit with `rdy compile` before running it.');
+}

--- a/packages/readyup/src/compile/pickJsonPlugin.ts
+++ b/packages/readyup/src/compile/pickJsonPlugin.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import type { Plugin } from 'esbuild';
+
+import { isRecord } from '../isRecord.ts';
+import { extractJsonPaths } from './extractJsonPaths.ts';
+
+/**
+ * Regex that matches a `pickJson(...)` call expression in source text.
+ *
+ * Limitations of regex-based matching:
+ * - Matches call syntax anywhere in source, including inside comments and string literals.
+ *   A commented-out call like `// pickJson('./pkg.json', ['name'])` will be processed.
+ *   This fails loudly (file-not-found or unexpected rewrite) rather than silently.
+ * - `[^)]+` cannot handle file paths or key names containing `)`.
+ */
+const PICK_JSON_RE = /\bpickJson\s*\((?<args>[^)]+)\)/g;
+
+/**
+ * Parse the static arguments from a `pickJson(...)` call's argument string.
+ *
+ * Expects a JSON file path string and an array of path specifiers (strings or string arrays).
+ * Only static literals are supported; expressions or template literals produce an error.
+ */
+function parsePickJsonArgs(argsText: string): { relativePath: string; paths: Array<string | Array<string>> } {
+  // Trim and strip potential trailing comma.
+  const trimmed = argsText.trim().replace(/,\s*$/, '');
+
+  // Split on the boundary between the first string argument and the array argument.
+  // Match: "path" or 'path', then a comma, then the rest starting with [.
+  const match = /^(?<q>["'])(?<relPath>.+?)\k<q>\s*,\s*(?<rest>\[[\s\S]*\])$/.exec(trimmed);
+  if (!match) {
+    throw new Error(
+      `Cannot parse pickJson arguments. Only static string and array literals are supported. Got: pickJson(${argsText})`,
+    );
+  }
+
+  assert.ok(match.groups);
+  const relativePath = match.groups.relPath;
+  const rest = match.groups.rest;
+  assert.ok(relativePath !== undefined);
+  assert.ok(rest !== undefined);
+
+  let parsed: unknown;
+  try {
+    // JSON.parse requires double quotes — replace single-quote delimiters only (not interior chars).
+    // Path keys must be plain identifiers (no embedded quotes or special characters).
+    const jsonText = rest.replace(/'([^']*?)'/g, '"$1"');
+    parsed = JSON.parse(jsonText);
+  } catch {
+    throw new Error(
+      `Cannot parse pickJson paths array. Only static string and array literals are supported. Got: ${rest}`,
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new TypeError(`pickJson paths argument must be an array. Got: ${rest}`);
+  }
+
+  const paths: Array<string | Array<string>> = [];
+  for (const item of parsed) {
+    if (typeof item === 'string') {
+      paths.push(item);
+    } else if (Array.isArray(item) && item.every((v) => typeof v === 'string')) {
+      paths.push(item);
+    } else {
+      throw new Error(`Invalid path in pickJson paths array: ${JSON.stringify(item)}`);
+    }
+  }
+
+  return { relativePath, paths };
+}
+
+/**
+ * Create an esbuild plugin that replaces `pickJson(...)` calls with inlined object literals.
+ *
+ * The plugin intercepts TypeScript file loads, scans for `pickJson` calls, resolves
+ * the referenced JSON file relative to the source file, extracts the requested paths,
+ * and substitutes the call with a static object expression.
+ */
+export function pickJsonPlugin(): Plugin {
+  return {
+    name: 'pick-json',
+    setup(build) {
+      build.onLoad({ filter: /\.[cm]?ts$/ }, (args) => {
+        let source: string;
+        try {
+          source = readFileSync(args.path, 'utf8');
+        } catch {
+          throw new Error(`pickJson: Cannot read source file "${args.path}"`);
+        }
+
+        // Fast bail: skip files that don't reference pickJson.
+        if (!source.includes('pickJson')) return null;
+
+        // Replace each pickJson(...) call with an inlined object literal.
+        const replaced = source.replace(PICK_JSON_RE, (_fullMatch, argsText: string) => {
+          const { relativePath, paths } = parsePickJsonArgs(argsText);
+          const jsonFilePath = path.resolve(path.dirname(args.path), relativePath);
+
+          let jsonContent: string;
+          try {
+            jsonContent = readFileSync(jsonFilePath, 'utf8');
+          } catch {
+            throw new Error(`pickJson: Cannot read JSON file "${relativePath}" (resolved to ${jsonFilePath})`);
+          }
+
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(jsonContent);
+          } catch {
+            throw new Error(`pickJson: Invalid JSON in "${relativePath}" (resolved to ${jsonFilePath})`);
+          }
+
+          if (!isRecord(parsed)) {
+            throw new Error(`pickJson: Expected a JSON object in "${relativePath}", got ${typeof parsed}`);
+          }
+
+          const extracted = extractJsonPaths(parsed, paths);
+          return JSON.stringify(extracted);
+        });
+
+        if (replaced === source) return null;
+
+        return { contents: replaced, loader: 'ts' };
+      });
+    },
+  };
+}

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -39,6 +39,9 @@ export {
   defineRdyStagedChecklist,
 } from './authoring.ts';
 
+// Compile utilities
+export { pickJson } from './compile/pickJson.ts';
+
 // Check utilities
 export {
   commandExists,


### PR DESCRIPTION
## What

Adds compile-time selective JSON field extraction to readyup's esbuild pipeline, so kit authors can inline only specific fields from JSON files instead of bundling the entire file into compiled output.

## Why

When a kit imports a JSON file like `package.json`, esbuild inlines the entire file — even if the kit only needs one field. The source files aren't available at runtime in consuming repos, so deferring to runtime resolution isn't an option. esbuild doesn't support JSON tree-shaking.

## Details

### Features

- `pickJson(relativePath, paths)` — a runtime stub exported from the package that throws with a "compile first" message. Exists for type-checking and IDE support during kit authoring; all calls are replaced at compile time.
- `extractJsonPaths(obj, paths)` — a pure function that prunes a parsed JSON object to only the requested key paths, preserving nesting structure. Supports top-level string keys and nested array paths following the existing `getJsonValue` convention.
- `pickJsonPlugin()` — an esbuild `onLoad` plugin that regex-matches `pickJson(...)` calls in TypeScript source, resolves the referenced JSON file relative to the source file, extracts requested fields, and replaces the call with an inlined object literal. Integrated into `compileConfig.ts` via the `plugins` array.
- Error handling covers unreadable source files, missing JSON files, invalid JSON, non-object roots, missing paths, and invalid argument types.

### Tests

- 103 lines for `extractJsonPaths` covering happy paths, edge cases (null values, empty paths, deeply nested, sibling merging, duplicate paths), and error conditions.
- 13 lines for `pickJson` runtime stub verifying the throw behavior and error message.
- 212 lines for `pickJsonPlugin` covering substitution, path resolution, multiple calls per file, all error branches (invalid JSON, non-object root, missing path, unreadable source, invalid argument types), comment-only references, and extension filtering.
- Updated `compileConfig.test.ts` to assert the plugin is registered.

## Test plan

- [ ] Manual: add a `pickJson` call to a test kit, run `rdy compile`, confirm output contains only the requested fields as an inlined object literal
- [ ] Manual: verify that existing kits with raw JSON imports still compile without warnings

Closes #37