### PR TITLE
#42 Update list output and README to reflect --from and positional kit args

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -72,19 +72,46 @@ rdy <command> [options]
 | `run [names...]` | Run checklists (default)                         |
 | `compile [file]` | Bundle TypeScript kit(s) into self-contained ESM |
 | `init`           | Scaffold a starter config and kit                |
+| `list`           | List available kits                              |
 
 ### Run options
 
-| Option                          | Description                               |
-| ------------------------------- | ----------------------------------------- |
-| `--file, -f <path>`             | Path to a local kit file                  |
-| `--github, -g <org/repo[@ref]>` | Fetch kit from a GitHub repository        |
-| `--local, -l <path>`            | Load compiled kit from a local repository |
-| `--url, -u <url>`               | Fetch kit from a URL                      |
-| `--kit, -k <name>`              | Kit name (default: `"default"`)           |
-| `--json, -j`                    | Output results as JSON                    |
-| `--fail-on, -F <severity>`      | Fail on this severity or above            |
-| `--report-on, -R <severity>`    | Report this severity or above             |
+| Option                        | Description                                                   |
+| ----------------------------- | ------------------------------------------------------------- |
+| `--from <source>`             | Kit source (see [kit sources](#kit-sources) below)            |
+| `--file, -f <path>`           | Path to a local kit file                                      |
+| `--url, -u <url>`             | Fetch kit from a URL                                          |
+| `--jit, -J`                   | Run from TypeScript source instead of compiled JS             |
+| `--internal, -i`              | Use internal kit directory and infix from config              |
+| `--checklists, -c <name,...>` | Filter checklists (with `--file` or `--url` only)             |
+| `--json, -j`                  | Output results as JSON                                        |
+| `--fail-on, -F <severity>`    | Fail on this severity or above (`error`, `warn`, `recommend`) |
+| `--report-on, -R <severity>`  | Report this severity or above (`error`, `warn`, `recommend`)  |
+
+### Kit sources
+
+The `--from` flag accepts these source types:
+
+| Source     | Format                    | Example                                                 |
+| ---------- | ------------------------- | ------------------------------------------------------- |
+| Bitbucket  | `bitbucket:ws/repo[@ref]` | `--from bitbucket:team/ops`                             |
+| GitHub     | `github:org/repo[@ref]`   | `--from github:acme/ops` or `--from github:acme/ops@v2` |
+| Local repo | `<path>`                  | `--from .` or `--from ../other-repo`                    |
+| Global     | `global`                  | `--from global`                                         |
+| Directory  | `dir:<path>`              | `--from dir:/shared/kits`                               |
+
+`@ref` defaults to `main` when omitted. Local repo paths look for kits in `<path>/.rdy/kits/`, while `dir:` paths are used directly.
+
+### List
+
+```
+rdy list                       List internal and compiled kits (owner view)
+rdy list --from <path>         List compiled kits at a local path
+rdy list --from global         List compiled kits in the global directory
+rdy list --from dir:<path>     List kits in an arbitrary directory
+```
+
+Listing from GitHub/Bitbucket sources is not yet supported.
 
 ## Authoring API
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -138,10 +138,6 @@ describe(parseRunArgs, () => {
     );
   });
 
-  it('rejects --kit as an unknown flag', () => {
-    expect(() => parseRunArgs(['--kit', 'deploy'])).toThrow("unknown flag '--kit'");
-  });
-
   // --file flag
   it('parses --file flag', () => {
     const result = parseRunArgs(['--file', 'custom/path.ts']);

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -27,7 +27,7 @@ describe(formatOwnerView, () => {
     expect(result).toContain('deploy');
   });
 
-  it('uses brackets in internal hint and omits them in compiled hint when default is only in internal', () => {
+  it('uses brackets around positional name in internal hint when default exists', () => {
     const result = formatOwnerView({
       internalKits: ['default'],
       compiledKits: ['deploy'],
@@ -38,8 +38,8 @@ describe(formatOwnerView, () => {
     const internalHeader = lines.find((l) => l.startsWith('Internal:'));
     const compiledHeader = lines.find((l) => l.startsWith('Compiled:'));
 
-    expect(internalHeader).toContain('[--kit <name>]');
-    expect(compiledHeader).not.toContain('[--kit <name>]');
+    expect(internalHeader).toContain('rdy run --jit [<name>]');
+    expect(compiledHeader).toContain('rdy run <name>');
   });
 
   it('uses brackets in compiled hint when default is in compiled kits', () => {
@@ -53,19 +53,34 @@ describe(formatOwnerView, () => {
     const internalHeader = lines.find((l) => l.startsWith('Internal:'));
     const compiledHeader = lines.find((l) => l.startsWith('Compiled:'));
 
-    expect(internalHeader).not.toContain('[--kit <name>]');
-    expect(compiledHeader).toContain('[--kit <name>]');
+    expect(internalHeader).toContain('rdy run --jit <name>');
+    expect(compiledHeader).toContain('rdy run [<name>]');
   });
 
-  it('omits brackets around --kit when no default kit exists', () => {
+  it('omits brackets around positional name when no default kit exists', () => {
     const result = formatOwnerView({
       internalKits: ['deploy'],
       compiledKits: [],
       compiledStyle: { kind: 'local-convention' },
     });
 
-    expect(result).toContain('--kit <name>');
-    expect(result).not.toContain('[--kit <name>]');
+    expect(result).toContain('rdy run --jit <name>');
+    expect(result).not.toContain('[<name>]');
+  });
+
+  it('includes --jit in internal hints but not compiled hints', () => {
+    const result = formatOwnerView({
+      internalKits: ['default'],
+      compiledKits: ['deploy'],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    const lines = result.split('\n');
+    const internalHeader = lines.find((l) => l.startsWith('Internal:'));
+    const compiledHeader = lines.find((l) => l.startsWith('Compiled:'));
+
+    expect(internalHeader).toContain('--jit');
+    expect(compiledHeader).not.toContain('--jit');
   });
 
   it('renders custom outDir style with file paths', () => {
@@ -127,25 +142,25 @@ describe(formatConsumerView, () => {
     expect(result).toContain('rdy run --from /other');
   });
 
-  it('uses brackets around --kit when default kit exists', () => {
+  it('uses brackets around positional name when default kit exists', () => {
     const result = formatConsumerView({
       compiledKits: ['default'],
       fromArg: '.',
       kitsDir: '/resolved/.rdy/kits',
     });
 
-    expect(result).toContain('[--kit <name>]');
+    expect(result).toContain('rdy run --from . [<name>]');
   });
 
-  it('omits brackets around --kit when default kit is absent', () => {
+  it('omits brackets around positional name when default kit is absent', () => {
     const result = formatConsumerView({
       compiledKits: ['deploy'],
       fromArg: '.',
       kitsDir: '/resolved/.rdy/kits',
     });
 
-    expect(result).toContain('--kit <name>');
-    expect(result).not.toContain('[--kit <name>]');
+    expect(result).toContain('rdy run --from . <name>');
+    expect(result).not.toContain('[<name>]');
   });
 
   it('returns empty message with resolved kitsDir for local path', () => {

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -113,13 +113,6 @@ describe(routeCommand, () => {
     expect(output).toContain('--version, -V');
   });
 
-  it('does not include --kit in top-level help', async () => {
-    await routeCommand(['--help']);
-
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(output).not.toContain('--kit');
-  });
-
   it('marks run as the default command in top-level help', async () => {
     await routeCommand(['--help']);
 

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -1,9 +1,9 @@
 const ICON_INTERNAL = '📄';
 const ICON_COMPILED = '📦';
 
-/** Build the `--kit` flag hint with brackets when a default kit exists. */
+/** Build the positional name hint, bracketed when a default kit exists. */
 function buildKitHint(kits: string[]): string {
-  return kits.includes('default') ? '[--kit <name>]' : '--kit <name>';
+  return kits.includes('default') ? '[<name>]' : '<name>';
 }
 
 // -- Compiled-section style discriminants --
@@ -40,13 +40,13 @@ export function formatOwnerView({ internalKits, compiledKits, compiledStyle }: O
   const sections: string[] = [];
 
   if (internalKits.length > 0) {
-    const hint = `rdy run ${buildKitHint(internalKits)}`;
+    const hint = `rdy run --jit ${buildKitHint(internalKits)}`;
     sections.push(formatSection('Internal', hint, internalKits, ICON_INTERNAL));
   }
 
   if (compiledKits.length > 0) {
     if (compiledStyle.kind === 'local-convention') {
-      const hint = `rdy run --from . ${buildKitHint(compiledKits)}`;
+      const hint = `rdy run ${buildKitHint(compiledKits)}`;
       sections.push(formatSection('Compiled', hint, compiledKits, ICON_COMPILED));
     } else {
       const hint = `rdy run --file <file path>`;


### PR DESCRIPTION
## What

Fixes the `rdy list` output to show positional kit syntax (`rdy run --jit [<name>]` for internal, `rdy run [<name>]` for compiled) instead of the stale `--kit <name>` flag syntax. Rewrites the README CLI reference to document all current flags, the five `--from` source types, and the `list` command.

## Why

PR #38 unified kit source selectors into `--from` and made positional kit arguments the standard, but the `formatList.ts` usage hints and README were not updated to match, leaving users with incorrect guidance on how to run kits.

## Details

### Fixes

- `buildKitHint` returns positional `[<name>]`/`<name>` instead of `[--kit <name>]`/`--kit <name>`.
- Internal section hint now includes `--jit` since TypeScript source kits require it.
- Compiled `local-convention` hint drops the redundant `--from .` since compiled kits in the current repo are the default source.

### Documentation

- README commands table adds `list`.
- README run options table replaces `--github`, `--local`, `--kit` with `--from`, `--jit`, `--internal`, `--checklists`.
- New "Kit sources" section documents the five `--from` source types with format and examples.
- New "List" section documents the `list` command modes.

### Tests

- All `formatList` test assertions updated from `--kit` to positional syntax.
- Added test verifying `--jit` appears in internal hints but not compiled hints.
- Removed two tests that guarded against the removed `--kit` flag (no lasting value — any arbitrary string would also be rejected as unknown).

## Test plan

- [x] `pnpm --filter readyup exec vitest run` — 689 tests pass
- [x] Grep for `--kit`, `--github`, `--local` in modified files returns no hits

Closes #42