### PR TITLE
#18 Skip config load when `rdy run` uses external source flags

### DIFF
--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -476,6 +476,58 @@ describe(resolveKitSources, () => {
     ).toStrictEqual([{ name: 'deploy', source: { path: '.readyup/kits/internal/deploy.int.js' }, checklists: [] }]);
   });
 
+  // -- External sources without config fields --
+
+  it('resolves --file without internalDir/internalInfix', () => {
+    expect(
+      resolveKitSources({
+        filePath: 'custom/path.ts',
+        fromValue: undefined,
+        urlValue: undefined,
+        kitSpecifiers: [],
+        checklists: undefined,
+        jit: false,
+        internal: false,
+      }),
+    ).toStrictEqual([{ name: 'custom/path.ts', source: { path: 'custom/path.ts' }, checklists: [] }]);
+  });
+
+  it('resolves --url without internalDir/internalInfix', () => {
+    expect(
+      resolveKitSources({
+        filePath: undefined,
+        fromValue: undefined,
+        urlValue: 'https://example.com/kit.js',
+        kitSpecifiers: [],
+        checklists: undefined,
+        jit: false,
+        internal: false,
+      }),
+    ).toStrictEqual([
+      { name: 'https://example.com/kit.js', source: { url: 'https://example.com/kit.js' }, checklists: [] },
+    ]);
+  });
+
+  it('resolves --from without internalDir/internalInfix', () => {
+    expect(
+      resolveKitSources({
+        filePath: undefined,
+        fromValue: 'github:org/repo',
+        urlValue: undefined,
+        kitSpecifiers: [{ kitName: 'deploy', checklists: [] }],
+        checklists: undefined,
+        jit: false,
+        internal: false,
+      }),
+    ).toStrictEqual([
+      {
+        name: 'deploy',
+        source: { url: 'https://raw.githubusercontent.com/org/repo/main/.readyup/kits/deploy.js' },
+        checklists: [],
+      },
+    ]);
+  });
+
   // -- --file flag --
 
   it('resolves --file to a single path source entry', () => {

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -269,6 +269,105 @@ describe(routeCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('bad config'));
   });
 
+  // -- Config loading: external sources skip loadConfig --
+
+  it('does not call loadConfig when --file is used', async () => {
+    mockParseRunArgs.mockReturnValue({
+      kitSpecifiers: [],
+      checklists: undefined,
+      filePath: 'kit.ts',
+      fromValue: undefined,
+      urlValue: undefined,
+      jit: false,
+      internal: false,
+      json: false,
+    });
+    mockResolveKitSources.mockReturnValue([{ name: 'kit.ts', source: { path: 'kit.ts' }, checklists: [] }]);
+    mockRunCommand.mockResolvedValue(0);
+
+    await routeCommand(['run', '--file', 'kit.ts']);
+
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+  });
+
+  it('does not call loadConfig when --from is used', async () => {
+    mockParseRunArgs.mockReturnValue({
+      kitSpecifiers: [{ kitName: 'deploy', checklists: [] }],
+      checklists: undefined,
+      filePath: undefined,
+      fromValue: 'github:org/repo',
+      urlValue: undefined,
+      jit: false,
+      internal: false,
+      json: false,
+    });
+    mockResolveKitSources.mockReturnValue([
+      { name: 'deploy', source: { url: 'https://example.com/deploy.js' }, checklists: [] },
+    ]);
+    mockRunCommand.mockResolvedValue(0);
+
+    await routeCommand(['run', '--from', 'github:org/repo', 'deploy']);
+
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+  });
+
+  it('does not call loadConfig when --url is used', async () => {
+    mockParseRunArgs.mockReturnValue({
+      kitSpecifiers: [],
+      checklists: undefined,
+      filePath: undefined,
+      fromValue: undefined,
+      urlValue: 'https://example.com/kit.js',
+      jit: false,
+      internal: false,
+      json: false,
+    });
+    mockResolveKitSources.mockReturnValue([
+      { name: 'https://example.com/kit.js', source: { url: 'https://example.com/kit.js' }, checklists: [] },
+    ]);
+    mockRunCommand.mockResolvedValue(0);
+
+    await routeCommand(['run', '--url', 'https://example.com/kit.js']);
+
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+  });
+
+  it('calls loadConfig for default run (no source flags)', async () => {
+    mockParseRunArgs.mockReturnValue({
+      kitSpecifiers: [],
+      checklists: undefined,
+      filePath: undefined,
+      fromValue: undefined,
+      urlValue: undefined,
+      jit: false,
+      internal: false,
+      json: false,
+    });
+    mockRunCommand.mockResolvedValue(0);
+
+    await routeCommand(['run']);
+
+    expect(mockLoadConfig).toHaveBeenCalled();
+  });
+
+  it('calls loadConfig when --internal is used', async () => {
+    mockParseRunArgs.mockReturnValue({
+      kitSpecifiers: [],
+      checklists: undefined,
+      filePath: undefined,
+      fromValue: undefined,
+      urlValue: undefined,
+      jit: false,
+      internal: true,
+      json: false,
+    });
+    mockRunCommand.mockResolvedValue(0);
+
+    await routeCommand(['run', '--internal']);
+
+    expect(mockLoadConfig).toHaveBeenCalled();
+  });
+
   it('shows compile help and returns 0 for compile --help', async () => {
     const exitCode = await routeCommand(['compile', '--help']);
 

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -235,12 +235,20 @@ async function handleRun(flags: string[]): Promise<number> {
     return 1;
   }
 
-  let config;
-  try {
-    config = await loadConfig();
-  } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
-    return 1;
+  // Skip config when an external source flag is active — external modes don't use config values.
+  const hasExternalSource =
+    parsed.filePath !== undefined || parsed.fromValue !== undefined || parsed.urlValue !== undefined;
+
+  let configFields: { internalDir: string; internalInfix: string | undefined } | undefined;
+  if (!hasExternalSource) {
+    let config;
+    try {
+      config = await loadConfig();
+    } catch (error: unknown) {
+      process.stderr.write(`Error: ${extractMessage(error)}\n`);
+      return 1;
+    }
+    configFields = { internalDir: config.internal.dir, internalInfix: config.internal.infix };
   }
 
   let kitEntries;
@@ -253,8 +261,7 @@ async function handleRun(flags: string[]): Promise<number> {
       checklists: parsed.checklists,
       jit: parsed.jit,
       internal: parsed.internal,
-      internalDir: config.internal.dir,
-      internalInfix: config.internal.infix,
+      ...configFields,
     });
   } catch (error: unknown) {
     process.stderr.write(`Error: ${extractMessage(error)}\n`);

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -208,8 +208,8 @@ export function resolveKitSources({
   checklists: string[] | undefined;
   jit: boolean;
   internal: boolean;
-  internalDir: string;
-  internalInfix: string | undefined;
+  internalDir?: string | undefined;
+  internalInfix?: string | undefined;
 }): ResolvedKitEntry[] {
   if (filePath !== undefined) {
     return [{ name: filePath, source: { path: filePath }, checklists: checklists ?? [] }];
@@ -230,7 +230,9 @@ export function resolveKitSources({
   if (internal) {
     return specs.map((spec) => ({
       name: spec.kitName,
-      source: { path: path.join(KITS_DIR, internalDir, buildKitFilename(spec.kitName, internalInfix, extension)) },
+      source: {
+        path: path.join(KITS_DIR, internalDir ?? '.', buildKitFilename(spec.kitName, internalInfix, extension)),
+      },
       checklists: spec.checklists,
     }));
   }


### PR DESCRIPTION
## What

Aligns `rdy run` with the rule established by `rdy list`: when an external source flag (`--from`, `--file`, `--url`) is active, project config is not loaded. Makes `internalDir` and `internalInfix` optional in `resolveKitSources`, making the API contract explicit.

## Why

`handleRun` unconditionally called `loadConfig()` and passed config-derived fields into `resolveKitSources`, but external-source branches never consumed them. This was mildly inefficient and conceptually misleading — external consumer modes shouldn't depend on the current project's config.

## Details

### Refactoring

- `handleRun` in `route.ts` now checks for external source flags after parsing and skips `loadConfig()` when any is active. Config fields are conditionally spread into the `resolveKitSources` call.
- `resolveKitSources` in `cli.ts` now accepts `internalDir` and `internalInfix` as optional parameters. The `internal` branch falls back to `'.'` for `internalDir` if not provided.

### Tests

- Added 3 tests in `cli.test.ts` verifying `resolveKitSources` works without config fields for `--file`, `--url`, and `--from`.
- Added 5 tests in `route.test.ts` verifying `loadConfig` is not called for each external source flag and is called for default and `--internal` modes.

## Test plan

- [ ] Verify `rdy run --file <path>` works without a config file present
- [ ] Verify `rdy run --from <source>` works without a config file present
- [ ] Verify `rdy run` (default mode) still loads and uses config
- [ ] Verify `rdy run --internal` still loads and uses config

Closes #18