### PR TITLE
#39 Add integration test for pickJson compile pipeline

### DIFF
--- a/packages/readyup/__tests__/compile/fixtures/fixture-data.json
+++ b/packages/readyup/__tests__/compile/fixtures/fixture-data.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-kit",
+  "version": "1.0.0",
+  "description": "A fixture for integration testing"
+}

--- a/packages/readyup/__tests__/compile/fixtures/pick-json-fixture.ts
+++ b/packages/readyup/__tests__/compile/fixtures/pick-json-fixture.ts
@@ -1,0 +1,3 @@
+import { pickJson } from '../../../src/compile/pickJson.ts';
+
+export const metadata = pickJson('./fixture-data.json', ['name', 'version']);

--- a/packages/readyup/__tests__/compile/pickJsonPlugin.integration.test.ts
+++ b/packages/readyup/__tests__/compile/pickJsonPlugin.integration.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { compileConfig } from '../../src/compile/compileConfig.ts';
+import { isRecord } from '../../src/isRecord.ts';
+
+const FIXTURE_PATH = path.resolve(import.meta.dirname, 'fixtures/pick-json-fixture.ts');
+
+describe('pickJsonPlugin integration', () => {
+  let outputDir: string;
+  let outputPath: string;
+  let compiledSource: string;
+
+  beforeAll(async () => {
+    outputDir = await mkdtemp(path.join(tmpdir(), 'pickjson-integration-'));
+    outputPath = path.join(outputDir, 'pick-json-fixture.js');
+
+    await compileConfig(FIXTURE_PATH, outputPath);
+    compiledSource = await readFile(outputPath, 'utf8');
+  });
+
+  afterAll(async () => {
+    await rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('inlines the picked JSON values into the compiled output', () => {
+    expect(compiledSource).toContain('"test-kit"');
+    expect(compiledSource).toContain('"1.0.0"');
+  });
+
+  it('does not contain the pickJson runtime stub', () => {
+    expect(compiledSource).not.toContain('pickJson');
+  });
+
+  it('produces valid ESM that exports the expected values', async () => {
+    const mod: unknown = await import(outputPath);
+    assert.ok(isRecord(mod));
+    expect(mod.metadata).toStrictEqual({ name: 'test-kit', version: '1.0.0' });
+  });
+});


### PR DESCRIPTION
## What

Adds an integration test that exercises the full `pickJson` compile pipeline — plugin registration, JSON inlining, runtime stub elimination, and valid ESM output — using real fixture files and `compileConfig`.

## Why

The existing unit tests mock `readFileSync` and capture esbuild's `onLoad` callback, so the full pipeline path (esbuild plugin wiring, tree-shaking of the stub import, and importable ESM output) was never exercised end-to-end.

## Details

### Tests

- Adds a `.ts` fixture that calls `pickJson` on a companion `.json` file, picking 2 of 3 keys.
- Adds an integration test (`pickJsonPlugin.integration.test.ts`) with three assertions: inlined values present, `pickJson` stub absent, and dynamic import succeeds with expected exports.
- Compiles to a temp directory via `compileConfig`; cleans up in `afterAll`.

## Test plan

- [ ] Integration test passes: `npx vitest run __tests__/compile/pickJsonPlugin.integration.test.ts`
- [ ] All existing compile tests still pass: `npx vitest run __tests__/compile/`

Closes #39 