### PR TITLE
#15 Add git freshness check utilities

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -133,17 +133,22 @@ Reusable check functions for common assertions:
 import { fileExists, fileContains, hasPackageJsonField } from 'readyup';
 ```
 
-| Function                                    | Description                                            |
-| ------------------------------------------- | ------------------------------------------------------ |
-| `fileExists(path)`                          | File exists at path                                    |
-| `fileContains(path, pattern)`               | File matches a string or regex                         |
-| `fileDoesNotContain(path, pattern)`         | File does not match                                    |
-| `readFile(path)`                            | Read file contents (returns `undefined` if missing)    |
-| `hasPackageJsonField(field, value?)`        | package.json has a field (optionally matching a value) |
-| `hasDevDependency(name)`                    | package.json has a dev dependency                      |
-| `hasMinDevDependencyVersion(name, version)` | Dev dependency meets minimum version                   |
-| `readPackageJson()`                         | Parse package.json                                     |
-| `compareVersions(a, b)`                     | Compare semver strings                                 |
+| Function                                    | Description                                                |
+| ------------------------------------------- | ---------------------------------------------------------- |
+| `fileExists(path)`                          | File exists at path                                        |
+| `fileContains(path, pattern)`               | File matches a string or regex                             |
+| `fileDoesNotContain(path, pattern)`         | File does not match                                        |
+| `readFile(path)`                            | Read file contents (returns `undefined` if missing)        |
+| `hasPackageJsonField(field, value?)`        | package.json has a field (optionally matching a value)     |
+| `hasDevDependency(name)`                    | package.json has a dev dependency                          |
+| `hasMinDevDependencyVersion(name, version)` | Dev dependency meets minimum version                       |
+| `readPackageJson()`                         | Parse package.json                                         |
+| `compareVersions(a, b)`                     | Compare semver strings                                     |
+| `runGit(path, ...args)`                     | Run a git command and return trimmed stdout                |
+| `compareLocalRefs(path, refA, refB)`        | Compare two local refs (discriminated-union result)        |
+| `compareRefToRemote(path, ref, remote?)`    | Compare a local ref to its remote counterpart              |
+| `makeLocalRefSyncCheck(options)`            | Check factory: verify two local refs match                 |
+| `makeRemoteRefSyncCheck(options)`           | Check factory: verify a ref matches its remote counterpart |
 
 ## License
 

--- a/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
@@ -1,88 +1,176 @@
 import assert from 'node:assert';
-import { execSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { compareLocalRefs } from '../../../src/check-utils/git/compare-local-refs.ts';
 import * as runGitModule from '../../../src/check-utils/git/run-git.ts';
 
-function createTempRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'rdy-cmp-'));
-  execSync('git init', { cwd: dir, stdio: 'ignore' });
-  execSync('git commit --allow-empty -m "init"', { cwd: dir, stdio: 'ignore' });
-  return dir;
+vi.mock('../../../src/check-utils/git/run-git.ts', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../src/check-utils/git/run-git.ts')>();
+  return {
+    ...original,
+    runGit: vi.fn(),
+  };
+});
+
+const runGit = vi.mocked(runGitModule.runGit);
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Stub `runGit` to route calls by git subcommand and arguments. */
+function stubRunGit(routes: Record<string, string | Error>): void {
+  runGit.mockImplementation(async (_path: string, ...args: string[]) => {
+    const key = args.join(' ');
+    for (const [pattern, value] of Object.entries(routes)) {
+      if (key.includes(pattern)) {
+        if (value instanceof Error) throw value;
+        return value;
+      }
+    }
+    throw new Error(`Unexpected runGit call: git ${args.join(' ')}`);
+  });
 }
 
-function commit(dir: string, message: string): void {
-  writeFileSync(join(dir, `${Date.now()}.txt`), message);
-  execSync('git add .', { cwd: dir, stdio: 'ignore' });
-  execSync(`git commit -m "${message}"`, { cwd: dir, stdio: 'ignore' });
+function makeRefMissingError(ref: string): Error {
+  return Object.assign(new Error(`unknown revision: ${ref}`), {
+    code: 128,
+    stderr: `fatal: ambiguous argument '${ref}': unknown revision or path not in the working tree.`,
+  });
 }
 
 describe(compareLocalRefs, () => {
-  it('returns match when both refs point to the same commit', async () => {
-    const repo = createTempRepo();
-    execSync('git branch test-branch', { cwd: repo, stdio: 'ignore' });
+  it('returns match when both refs resolve to the same SHA', async () => {
+    const sha = 'abc123def456abc123def456abc123def456abc1';
+    stubRunGit({
+      'rev-parse --verify refA': sha,
+      'rev-parse --verify refB': sha,
+      'rev-parse refA': sha,
+      'rev-parse refB': sha,
+    });
 
-    const result = await compareLocalRefs(repo, 'HEAD', 'test-branch');
+    const result = await compareLocalRefs('/repo', 'refA', 'refB');
 
     expect(result.status).toBe('match');
     assert.ok(result.status === 'match');
-    expect(result.shaA).toBe(result.shaB);
-    expect(result.shaA).toMatch(/^[0-9a-f]{40}$/);
+    expect(result.shaA).toBe(sha);
+    expect(result.shaB).toBe(sha);
   });
 
-  it('returns mismatch with ahead/behind when refs diverge', async () => {
-    const repo = createTempRepo();
-    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
-    commit(repo, 'main-only');
+  it('returns mismatch with ahead count when refA is ahead', async () => {
+    stubRunGit({
+      'rev-parse --verify refA': 'aaa',
+      'rev-parse --verify refB': 'bbb',
+      'rev-parse refA': 'aaa111',
+      'rev-parse refB': 'bbb222',
+      'rev-list --count --left-right': '3\t0',
+    });
 
-    const result = await compareLocalRefs(repo, 'HEAD', 'feature');
+    const result = await compareLocalRefs('/repo', 'refA', 'refB');
 
     expect(result.status).toBe('mismatch');
     assert.ok(result.status === 'mismatch');
-    expect(result.shaA).not.toBe(result.shaB);
-    expect(result.aheadBehind).toEqual({ ahead: 1, behind: 0 });
+    expect(result.shaA).toBe('aaa111');
+    expect(result.shaB).toBe('bbb222');
+    expect(result.aheadBehind).toEqual({ ahead: 3, behind: 0 });
   });
 
-  it('returns mismatch with behind count when the first ref is behind', async () => {
-    const repo = createTempRepo();
-    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
-    commit(repo, 'main-advance');
+  it('returns mismatch with behind count when refA is behind', async () => {
+    stubRunGit({
+      'rev-parse --verify refA': 'aaa',
+      'rev-parse --verify refB': 'bbb',
+      'rev-parse refA': 'aaa111',
+      'rev-parse refB': 'bbb222',
+      'rev-list --count --left-right': '0\t2',
+    });
 
-    // feature is behind HEAD by 1 commit
-    const result = await compareLocalRefs(repo, 'feature', 'HEAD');
+    const result = await compareLocalRefs('/repo', 'refA', 'refB');
 
     expect(result.status).toBe('mismatch');
     assert.ok(result.status === 'mismatch');
-    expect(result.aheadBehind).toEqual({ ahead: 0, behind: 1 });
+    expect(result.aheadBehind).toEqual({ ahead: 0, behind: 2 });
   });
 
-  it('returns ref-missing when the first ref does not exist', async () => {
-    const repo = createTempRepo();
+  it('returns mismatch with both counts when refs have diverged', async () => {
+    stubRunGit({
+      'rev-parse --verify refA': 'aaa',
+      'rev-parse --verify refB': 'bbb',
+      'rev-parse refA': 'aaa111',
+      'rev-parse refB': 'bbb222',
+      'rev-list --count --left-right': '2\t3',
+    });
 
-    const result = await compareLocalRefs(repo, 'nonexistent', 'HEAD');
+    const result = await compareLocalRefs('/repo', 'refA', 'refB');
 
-    expect(result).toEqual({ status: 'ref-missing', ref: 'nonexistent' });
+    expect(result.status).toBe('mismatch');
+    assert.ok(result.status === 'mismatch');
+    expect(result.aheadBehind).toEqual({ ahead: 2, behind: 3 });
   });
 
-  it('returns ref-missing when the second ref does not exist', async () => {
-    const repo = createTempRepo();
+  it('returns ref-missing when refA does not exist', async () => {
+    stubRunGit({
+      'rev-parse --verify refA': makeRefMissingError('refA'),
+      'rev-parse --verify refB': 'exists',
+    });
 
-    const result = await compareLocalRefs(repo, 'HEAD', 'nonexistent');
+    const result = await compareLocalRefs('/repo', 'refA', 'refB');
 
-    expect(result).toEqual({ status: 'ref-missing', ref: 'nonexistent' });
+    expect(result).toEqual({ status: 'ref-missing', ref: 'refA' });
   });
 
-  it('rethrows non-ref-missing git errors instead of returning ref-missing', async () => {
-    const gitError = Object.assign(new Error('git failed'), { code: 1, stderr: 'permission denied' });
-    const spy = vi.spyOn(runGitModule, 'runGit').mockRejectedValue(gitError);
+  it('returns ref-missing when refB does not exist', async () => {
+    stubRunGit({
+      'rev-parse --verify refA': 'exists',
+      'rev-parse --verify refB': makeRefMissingError('refB'),
+    });
 
-    await expect(compareLocalRefs('/tmp', 'a', 'b')).rejects.toThrow('git failed');
+    const result = await compareLocalRefs('/repo', 'refA', 'refB');
 
-    spy.mockRestore();
+    expect(result).toEqual({ status: 'ref-missing', ref: 'refB' });
+  });
+
+  it('rethrows non-ref-missing errors', async () => {
+    const infraError = Object.assign(new Error('not a git repo'), {
+      code: 128,
+      stderr: 'fatal: not a git repository (or any of the parent directories): .git',
+    });
+    stubRunGit({
+      'rev-parse --verify refA': infraError,
+    });
+
+    await expect(compareLocalRefs('/repo', 'refA', 'refB')).rejects.toThrow('not a git repo');
+  });
+
+  it('omits aheadBehind when rev-list output is malformed', async () => {
+    stubRunGit({
+      'rev-parse --verify refA': 'aaa',
+      'rev-parse --verify refB': 'bbb',
+      'rev-parse refA': 'aaa111',
+      'rev-parse refB': 'bbb222',
+      'rev-list --count --left-right': 'garbage',
+    });
+
+    const result = await compareLocalRefs('/repo', 'refA', 'refB');
+
+    expect(result.status).toBe('mismatch');
+    assert.ok(result.status === 'mismatch');
+    expect(result.aheadBehind).toBeUndefined();
+  });
+
+  it('omits aheadBehind when rev-list fails', async () => {
+    stubRunGit({
+      'rev-parse --verify refA': 'aaa',
+      'rev-parse --verify refB': 'bbb',
+      'rev-parse refA': 'aaa111',
+      'rev-parse refB': 'bbb222',
+      'rev-list --count --left-right': new Error('rev-list failed'),
+    });
+
+    const result = await compareLocalRefs('/repo', 'refA', 'refB');
+
+    expect(result.status).toBe('mismatch');
+    assert.ok(result.status === 'mismatch');
+    expect(result.aheadBehind).toBeUndefined();
   });
 });

--- a/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
@@ -4,9 +4,10 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { compareLocalRefs } from '../../../src/check-utils/git/compare-local-refs.ts';
+import * as runGitModule from '../../../src/check-utils/git/run-git.ts';
 
 function createTempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'rdy-cmp-'));
@@ -74,5 +75,14 @@ describe(compareLocalRefs, () => {
     const result = await compareLocalRefs(repo, 'HEAD', 'nonexistent');
 
     expect(result).toEqual({ status: 'ref-missing', ref: 'nonexistent' });
+  });
+
+  it('rethrows non-ref-missing git errors instead of returning ref-missing', async () => {
+    const gitError = Object.assign(new Error('git failed'), { code: 1, stderr: 'permission denied' });
+    const spy = vi.spyOn(runGitModule, 'runGit').mockRejectedValue(gitError);
+
+    await expect(compareLocalRefs('/tmp', 'a', 'b')).rejects.toThrow('git failed');
+
+    spy.mockRestore();
   });
 });

--- a/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import { execSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -28,10 +29,9 @@ describe(compareLocalRefs, () => {
     const result = await compareLocalRefs(repo, 'HEAD', 'test-branch');
 
     expect(result.status).toBe('match');
-    if (result.status === 'match') {
-      expect(result.shaA).toBe(result.shaB);
-      expect(result.shaA).toMatch(/^[0-9a-f]{40}$/);
-    }
+    assert.ok(result.status === 'match');
+    expect(result.shaA).toBe(result.shaB);
+    expect(result.shaA).toMatch(/^[0-9a-f]{40}$/);
   });
 
   it('returns mismatch with ahead/behind when refs diverge', async () => {
@@ -42,10 +42,9 @@ describe(compareLocalRefs, () => {
     const result = await compareLocalRefs(repo, 'HEAD', 'feature');
 
     expect(result.status).toBe('mismatch');
-    if (result.status === 'mismatch') {
-      expect(result.shaA).not.toBe(result.shaB);
-      expect(result.aheadBehind).toEqual({ ahead: 1, behind: 0 });
-    }
+    assert.ok(result.status === 'mismatch');
+    expect(result.shaA).not.toBe(result.shaB);
+    expect(result.aheadBehind).toEqual({ ahead: 1, behind: 0 });
   });
 
   it('returns mismatch with behind count when the first ref is behind', async () => {
@@ -57,9 +56,8 @@ describe(compareLocalRefs, () => {
     const result = await compareLocalRefs(repo, 'feature', 'HEAD');
 
     expect(result.status).toBe('mismatch');
-    if (result.status === 'mismatch') {
-      expect(result.aheadBehind).toEqual({ ahead: 0, behind: 1 });
-    }
+    assert.ok(result.status === 'mismatch');
+    expect(result.aheadBehind).toEqual({ ahead: 0, behind: 1 });
   });
 
   it('returns ref-missing when the first ref does not exist', async () => {

--- a/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
@@ -1,0 +1,80 @@
+import { execSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { compareLocalRefs } from '../../../src/check-utils/git/compare-local-refs.ts';
+
+function createTempRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'rdy-cmp-'));
+  execSync('git init', { cwd: dir, stdio: 'ignore' });
+  execSync('git commit --allow-empty -m "init"', { cwd: dir, stdio: 'ignore' });
+  return dir;
+}
+
+function commit(dir: string, message: string): void {
+  writeFileSync(join(dir, `${Date.now()}.txt`), message);
+  execSync('git add .', { cwd: dir, stdio: 'ignore' });
+  execSync(`git commit -m "${message}"`, { cwd: dir, stdio: 'ignore' });
+}
+
+describe(compareLocalRefs, () => {
+  it('returns match when both refs point to the same commit', async () => {
+    const repo = createTempRepo();
+    execSync('git branch test-branch', { cwd: repo, stdio: 'ignore' });
+
+    const result = await compareLocalRefs(repo, 'HEAD', 'test-branch');
+
+    expect(result.status).toBe('match');
+    if (result.status === 'match') {
+      expect(result.shaA).toBe(result.shaB);
+      expect(result.shaA).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it('returns mismatch with ahead/behind when refs diverge', async () => {
+    const repo = createTempRepo();
+    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
+    commit(repo, 'main-only');
+
+    const result = await compareLocalRefs(repo, 'HEAD', 'feature');
+
+    expect(result.status).toBe('mismatch');
+    if (result.status === 'mismatch') {
+      expect(result.shaA).not.toBe(result.shaB);
+      expect(result.aheadBehind).toEqual({ ahead: 1, behind: 0 });
+    }
+  });
+
+  it('returns mismatch with behind count when the first ref is behind', async () => {
+    const repo = createTempRepo();
+    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
+    commit(repo, 'main-advance');
+
+    // feature is behind HEAD by 1 commit
+    const result = await compareLocalRefs(repo, 'feature', 'HEAD');
+
+    expect(result.status).toBe('mismatch');
+    if (result.status === 'mismatch') {
+      expect(result.aheadBehind).toEqual({ ahead: 0, behind: 1 });
+    }
+  });
+
+  it('returns ref-missing when the first ref does not exist', async () => {
+    const repo = createTempRepo();
+
+    const result = await compareLocalRefs(repo, 'nonexistent', 'HEAD');
+
+    expect(result).toEqual({ status: 'ref-missing', ref: 'nonexistent' });
+  });
+
+  it('returns ref-missing when the second ref does not exist', async () => {
+    const repo = createTempRepo();
+
+    const result = await compareLocalRefs(repo, 'HEAD', 'nonexistent');
+
+    expect(result).toEqual({ status: 'ref-missing', ref: 'nonexistent' });
+  });
+});

--- a/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-local-refs.test.ts
@@ -21,15 +21,15 @@ beforeEach(() => {
 
 /** Stub `runGit` to route calls by git subcommand and arguments. */
 function stubRunGit(routes: Record<string, string | Error>): void {
-  runGit.mockImplementation(async (_path: string, ...args: string[]) => {
+  runGit.mockImplementation((_path: string, ...args: string[]) => {
     const key = args.join(' ');
     for (const [pattern, value] of Object.entries(routes)) {
       if (key.includes(pattern)) {
-        if (value instanceof Error) throw value;
-        return value;
+        if (value instanceof Error) return Promise.reject(value);
+        return Promise.resolve(value);
       }
     }
-    throw new Error(`Unexpected runGit call: git ${args.join(' ')}`);
+    return Promise.reject(new Error(`Unexpected runGit call: git ${args.join(' ')}`));
   });
 }
 

--- a/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
@@ -1,122 +1,176 @@
 import assert from 'node:assert';
-import { execSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { compareRefToRemote } from '../../../src/check-utils/git/compare-ref-to-remote.ts';
 import * as runGitModule from '../../../src/check-utils/git/run-git.ts';
 
-function createTempRepoWithRemote(): { local: string; remote: string } {
-  const remote = mkdtempSync(join(tmpdir(), 'rdy-remote-'));
-  execSync('git init --bare', { cwd: remote, stdio: 'ignore' });
+vi.mock('../../../src/check-utils/git/run-git.ts', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../src/check-utils/git/run-git.ts')>();
+  return {
+    ...original,
+    runGit: vi.fn(),
+  };
+});
 
-  const local = mkdtempSync(join(tmpdir(), 'rdy-local-'));
-  execSync('git init', { cwd: local, stdio: 'ignore' });
-  execSync(`git remote add origin ${remote}`, { cwd: local, stdio: 'ignore' });
-  execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
-  execSync('git push -u origin HEAD', { cwd: local, stdio: 'ignore' });
+const runGit = vi.mocked(runGitModule.runGit);
 
-  return { local, remote };
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Stub `runGit` to route calls by git subcommand and arguments. */
+function stubRunGit(routes: Record<string, string | Error>): void {
+  runGit.mockImplementation(async (_path: string, ...args: string[]) => {
+    const key = args.join(' ');
+    for (const [pattern, value] of Object.entries(routes)) {
+      if (key.includes(pattern)) {
+        if (value instanceof Error) throw value;
+        return value;
+      }
+    }
+    throw new Error(`Unexpected runGit call: git ${args.join(' ')}`);
+  });
 }
 
-function commit(dir: string, message: string): void {
-  writeFileSync(join(dir, `${Date.now()}.txt`), message);
-  execSync('git add .', { cwd: dir, stdio: 'ignore' });
-  execSync(`git commit -m "${message}"`, { cwd: dir, stdio: 'ignore' });
+function makeRefMissingError(ref: string): Error {
+  return Object.assign(new Error(`unknown revision: ${ref}`), {
+    code: 128,
+    stderr: `fatal: ambiguous argument '${ref}': unknown revision or path not in the working tree.`,
+  });
 }
 
-function currentBranch(dir: string): string {
-  return execSync('git rev-parse --abbrev-ref HEAD', { cwd: dir }).toString().trim();
-}
+const LOCAL_SHA = 'aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111';
+const REMOTE_SHA = 'bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222';
 
 describe(compareRefToRemote, () => {
-  it('returns in-sync when local and remote match', async () => {
-    const { local } = createTempRepoWithRemote();
-    const branch = currentBranch(local);
+  it('returns in-sync when local and remote SHAs match', async () => {
+    stubRunGit({
+      'rev-parse --verify main': LOCAL_SHA,
+      'ls-remote origin main': `${LOCAL_SHA}\trefs/heads/main`,
+    });
 
-    const result = await compareRefToRemote(local, branch);
+    const result = await compareRefToRemote('/repo', 'main');
 
     expect(result.status).toBe('in-sync');
     assert.ok(result.status === 'in-sync');
-    expect(result.localSha).toBe(result.remoteSha);
-    expect(result.localSha).toMatch(/^[0-9a-f]{40}$/);
+    expect(result.localSha).toBe(LOCAL_SHA);
+    expect(result.remoteSha).toBe(LOCAL_SHA);
   });
 
-  it('returns out-of-sync when local is ahead of remote', async () => {
-    const { local } = createTempRepoWithRemote();
-    const branch = currentBranch(local);
-    commit(local, 'local-only');
+  it('returns out-of-sync with ahead count when local is ahead', async () => {
+    stubRunGit({
+      'rev-parse --verify main': LOCAL_SHA,
+      'ls-remote origin main': `${REMOTE_SHA}\trefs/heads/main`,
+      'rev-list --count --left-right': '1\t0',
+    });
 
-    const result = await compareRefToRemote(local, branch);
+    const result = await compareRefToRemote('/repo', 'main');
 
     expect(result.status).toBe('out-of-sync');
     assert.ok(result.status === 'out-of-sync');
-    expect(result.localSha).not.toBe(result.remoteSha);
+    expect(result.localSha).toBe(LOCAL_SHA);
+    expect(result.remoteSha).toBe(REMOTE_SHA);
     expect(result.aheadBehind).toEqual({ ahead: 1, behind: 0 });
   });
 
-  it('returns out-of-sync when local is behind remote', async () => {
-    const { local, remote } = createTempRepoWithRemote();
-    const branch = currentBranch(local);
+  it('returns out-of-sync with behind count when local is behind', async () => {
+    stubRunGit({
+      'rev-parse --verify main': LOCAL_SHA,
+      'ls-remote origin main': `${REMOTE_SHA}\trefs/heads/main`,
+      'rev-list --count --left-right': '0\t3',
+    });
 
-    // Advance remote via a second clone without fetching locally.
-    const clone2 = mkdtempSync(join(tmpdir(), 'rdy-clone2-'));
-    execSync(`git clone ${remote} ${clone2}`, { stdio: 'ignore' });
-    commit(clone2, 'remote-advance');
-    execSync('git push', { cwd: clone2, stdio: 'ignore' });
-
-    // Fetch so the local tracking ref sees the remote advance.
-    execSync('git fetch origin', { cwd: local, stdio: 'ignore' });
-
-    const result = await compareRefToRemote(local, branch);
+    const result = await compareRefToRemote('/repo', 'main');
 
     expect(result.status).toBe('out-of-sync');
     assert.ok(result.status === 'out-of-sync');
-    expect(result.localSha).not.toBe(result.remoteSha);
-    expect(result.aheadBehind).toEqual({ ahead: 0, behind: 1 });
+    expect(result.aheadBehind).toEqual({ ahead: 0, behind: 3 });
+  });
+
+  it('returns out-of-sync with both counts when diverged', async () => {
+    stubRunGit({
+      'rev-parse --verify main': LOCAL_SHA,
+      'ls-remote origin main': `${REMOTE_SHA}\trefs/heads/main`,
+      'rev-list --count --left-right': '2\t5',
+    });
+
+    const result = await compareRefToRemote('/repo', 'main');
+
+    expect(result.status).toBe('out-of-sync');
+    assert.ok(result.status === 'out-of-sync');
+    expect(result.aheadBehind).toEqual({ ahead: 2, behind: 5 });
   });
 
   it('returns ref-missing when local ref does not exist', async () => {
-    const { local } = createTempRepoWithRemote();
+    stubRunGit({
+      'rev-parse --verify nonexistent': makeRefMissingError('nonexistent'),
+    });
 
-    const result = await compareRefToRemote(local, 'nonexistent-branch');
+    const result = await compareRefToRemote('/repo', 'nonexistent');
 
-    expect(result).toEqual({ status: 'ref-missing', ref: 'nonexistent-branch' });
+    expect(result).toEqual({ status: 'ref-missing', ref: 'nonexistent' });
   });
 
   it('returns ref-missing when remote ref does not exist', async () => {
-    const { local } = createTempRepoWithRemote();
-    execSync('git checkout -b only-local', { cwd: local, stdio: 'ignore' });
-    execSync('git commit --allow-empty -m "local"', { cwd: local, stdio: 'ignore' });
+    stubRunGit({
+      'rev-parse --verify main': LOCAL_SHA,
+      'ls-remote origin main': '',
+    });
 
-    const result = await compareRefToRemote(local, 'only-local');
+    const result = await compareRefToRemote('/repo', 'main');
 
-    expect(result).toEqual({ status: 'ref-missing', ref: 'origin/only-local' });
+    expect(result).toEqual({ status: 'ref-missing', ref: 'origin/main' });
   });
 
-  it('rethrows non-ref-missing git errors instead of returning ref-missing', async () => {
-    const gitError = Object.assign(new Error('git failed'), { code: 1, stderr: 'permission denied' });
-    const spy = vi.spyOn(runGitModule, 'runGit').mockRejectedValue(gitError);
+  it('returns unreachable when ls-remote throws', async () => {
+    const networkError = new Error('Could not resolve host');
+    stubRunGit({
+      'rev-parse --verify main': LOCAL_SHA,
+      'ls-remote origin main': networkError,
+    });
 
-    await expect(compareRefToRemote('/tmp', 'main')).rejects.toThrow('git failed');
-
-    spy.mockRestore();
-  });
-
-  it('returns unreachable when the remote cannot be contacted', async () => {
-    const local = mkdtempSync(join(tmpdir(), 'rdy-unreachable-'));
-    execSync('git init', { cwd: local, stdio: 'ignore' });
-    execSync('git remote add origin https://invalid.example.test/repo.git', { cwd: local, stdio: 'ignore' });
-    execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
-    const branch = currentBranch(local);
-
-    const result = await compareRefToRemote(local, branch);
+    const result = await compareRefToRemote('/repo', 'main');
 
     expect(result.status).toBe('unreachable');
     assert.ok(result.status === 'unreachable');
-    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error).toBe(networkError);
+  });
+
+  it('rethrows non-ref-missing errors from ref resolution', async () => {
+    const infraError = Object.assign(new Error('not a git repo'), {
+      code: 128,
+      stderr: 'fatal: not a git repository (or any of the parent directories): .git',
+    });
+    stubRunGit({
+      'rev-parse --verify main': infraError,
+    });
+
+    await expect(compareRefToRemote('/repo', 'main')).rejects.toThrow('not a git repo');
+  });
+
+  it('uses custom remote name', async () => {
+    stubRunGit({
+      'rev-parse --verify main': LOCAL_SHA,
+      'ls-remote upstream main': `${LOCAL_SHA}\trefs/heads/main`,
+    });
+
+    const result = await compareRefToRemote('/repo', 'main', 'upstream');
+
+    expect(result.status).toBe('in-sync');
+  });
+
+  it('omits aheadBehind when rev-list output is malformed', async () => {
+    stubRunGit({
+      'rev-parse --verify main': LOCAL_SHA,
+      'ls-remote origin main': `${REMOTE_SHA}\trefs/heads/main`,
+      'rev-list --count --left-right': 'not-a-number',
+    });
+
+    const result = await compareRefToRemote('/repo', 'main');
+
+    expect(result.status).toBe('out-of-sync');
+    assert.ok(result.status === 'out-of-sync');
+    expect(result.aheadBehind).toBeUndefined();
   });
 });

--- a/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import { execSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -38,10 +39,9 @@ describe(compareRefToRemote, () => {
     const result = await compareRefToRemote(local, branch);
 
     expect(result.status).toBe('in-sync');
-    if (result.status === 'in-sync') {
-      expect(result.localSha).toBe(result.remoteSha);
-      expect(result.localSha).toMatch(/^[0-9a-f]{40}$/);
-    }
+    assert.ok(result.status === 'in-sync');
+    expect(result.localSha).toBe(result.remoteSha);
+    expect(result.localSha).toMatch(/^[0-9a-f]{40}$/);
   });
 
   it('returns out-of-sync when local is ahead of remote', async () => {
@@ -52,9 +52,9 @@ describe(compareRefToRemote, () => {
     const result = await compareRefToRemote(local, branch);
 
     expect(result.status).toBe('out-of-sync');
-    if (result.status === 'out-of-sync') {
-      expect(result.localSha).not.toBe(result.remoteSha);
-    }
+    assert.ok(result.status === 'out-of-sync');
+    expect(result.localSha).not.toBe(result.remoteSha);
+    expect(result.aheadBehind).toEqual({ ahead: 1, behind: 0 });
   });
 
   it('returns ref-missing when local ref does not exist', async () => {
@@ -85,8 +85,7 @@ describe(compareRefToRemote, () => {
     const result = await compareRefToRemote(local, branch);
 
     expect(result.status).toBe('unreachable');
-    if (result.status === 'unreachable') {
-      expect(result.error).toBeInstanceOf(Error);
-    }
+    assert.ok(result.status === 'unreachable');
+    expect(result.error).toBeInstanceOf(Error);
   });
 });

--- a/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
@@ -1,0 +1,92 @@
+import { execSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { compareRefToRemote } from '../../../src/check-utils/git/compare-ref-to-remote.ts';
+
+function createTempRepoWithRemote(): { local: string; remote: string } {
+  const remote = mkdtempSync(join(tmpdir(), 'rdy-remote-'));
+  execSync('git init --bare', { cwd: remote, stdio: 'ignore' });
+
+  const local = mkdtempSync(join(tmpdir(), 'rdy-local-'));
+  execSync('git init', { cwd: local, stdio: 'ignore' });
+  execSync(`git remote add origin ${remote}`, { cwd: local, stdio: 'ignore' });
+  execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
+  execSync('git push -u origin HEAD', { cwd: local, stdio: 'ignore' });
+
+  return { local, remote };
+}
+
+function commit(dir: string, message: string): void {
+  writeFileSync(join(dir, `${Date.now()}.txt`), message);
+  execSync('git add .', { cwd: dir, stdio: 'ignore' });
+  execSync(`git commit -m "${message}"`, { cwd: dir, stdio: 'ignore' });
+}
+
+function currentBranch(dir: string): string {
+  return execSync('git rev-parse --abbrev-ref HEAD', { cwd: dir }).toString().trim();
+}
+
+describe(compareRefToRemote, () => {
+  it('returns in-sync when local and remote match', async () => {
+    const { local } = createTempRepoWithRemote();
+    const branch = currentBranch(local);
+
+    const result = await compareRefToRemote(local, branch);
+
+    expect(result.status).toBe('in-sync');
+    if (result.status === 'in-sync') {
+      expect(result.localSha).toBe(result.remoteSha);
+      expect(result.localSha).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it('returns out-of-sync when local is ahead of remote', async () => {
+    const { local } = createTempRepoWithRemote();
+    const branch = currentBranch(local);
+    commit(local, 'local-only');
+
+    const result = await compareRefToRemote(local, branch);
+
+    expect(result.status).toBe('out-of-sync');
+    if (result.status === 'out-of-sync') {
+      expect(result.localSha).not.toBe(result.remoteSha);
+    }
+  });
+
+  it('returns ref-missing when local ref does not exist', async () => {
+    const { local } = createTempRepoWithRemote();
+
+    const result = await compareRefToRemote(local, 'nonexistent-branch');
+
+    expect(result).toEqual({ status: 'ref-missing', ref: 'nonexistent-branch' });
+  });
+
+  it('returns ref-missing when remote ref does not exist', async () => {
+    const { local } = createTempRepoWithRemote();
+    execSync('git checkout -b only-local', { cwd: local, stdio: 'ignore' });
+    execSync('git commit --allow-empty -m "local"', { cwd: local, stdio: 'ignore' });
+
+    const result = await compareRefToRemote(local, 'only-local');
+
+    expect(result).toEqual({ status: 'ref-missing', ref: 'origin/only-local' });
+  });
+
+  it('returns unreachable when the remote cannot be contacted', async () => {
+    const local = mkdtempSync(join(tmpdir(), 'rdy-unreachable-'));
+    execSync('git init', { cwd: local, stdio: 'ignore' });
+    execSync('git remote add origin https://invalid.example.test/repo.git', { cwd: local, stdio: 'ignore' });
+    execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
+    const branch = currentBranch(local);
+
+    const result = await compareRefToRemote(local, branch);
+
+    expect(result.status).toBe('unreachable');
+    if (result.status === 'unreachable') {
+      expect(result.error).toBeInstanceOf(Error);
+    }
+  });
+});

--- a/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
@@ -58,6 +58,27 @@ describe(compareRefToRemote, () => {
     expect(result.aheadBehind).toEqual({ ahead: 1, behind: 0 });
   });
 
+  it('returns out-of-sync when local is behind remote', async () => {
+    const { local, remote } = createTempRepoWithRemote();
+    const branch = currentBranch(local);
+
+    // Advance remote via a second clone without fetching locally.
+    const clone2 = mkdtempSync(join(tmpdir(), 'rdy-clone2-'));
+    execSync(`git clone ${remote} ${clone2}`, { stdio: 'ignore' });
+    commit(clone2, 'remote-advance');
+    execSync('git push', { cwd: clone2, stdio: 'ignore' });
+
+    // Fetch so the local tracking ref sees the remote advance.
+    execSync('git fetch origin', { cwd: local, stdio: 'ignore' });
+
+    const result = await compareRefToRemote(local, branch);
+
+    expect(result.status).toBe('out-of-sync');
+    assert.ok(result.status === 'out-of-sync');
+    expect(result.localSha).not.toBe(result.remoteSha);
+    expect(result.aheadBehind).toEqual({ ahead: 0, behind: 1 });
+  });
+
   it('returns ref-missing when local ref does not exist', async () => {
     const { local } = createTempRepoWithRemote();
 

--- a/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
@@ -4,9 +4,10 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { compareRefToRemote } from '../../../src/check-utils/git/compare-ref-to-remote.ts';
+import * as runGitModule from '../../../src/check-utils/git/run-git.ts';
 
 function createTempRepoWithRemote(): { local: string; remote: string } {
   const remote = mkdtempSync(join(tmpdir(), 'rdy-remote-'));
@@ -73,6 +74,15 @@ describe(compareRefToRemote, () => {
     const result = await compareRefToRemote(local, 'only-local');
 
     expect(result).toEqual({ status: 'ref-missing', ref: 'origin/only-local' });
+  });
+
+  it('rethrows non-ref-missing git errors instead of returning ref-missing', async () => {
+    const gitError = Object.assign(new Error('git failed'), { code: 1, stderr: 'permission denied' });
+    const spy = vi.spyOn(runGitModule, 'runGit').mockRejectedValue(gitError);
+
+    await expect(compareRefToRemote('/tmp', 'main')).rejects.toThrow('git failed');
+
+    spy.mockRestore();
   });
 
   it('returns unreachable when the remote cannot be contacted', async () => {

--- a/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-ref-to-remote.test.ts
@@ -21,15 +21,15 @@ beforeEach(() => {
 
 /** Stub `runGit` to route calls by git subcommand and arguments. */
 function stubRunGit(routes: Record<string, string | Error>): void {
-  runGit.mockImplementation(async (_path: string, ...args: string[]) => {
+  runGit.mockImplementation((_path: string, ...args: string[]) => {
     const key = args.join(' ');
     for (const [pattern, value] of Object.entries(routes)) {
       if (key.includes(pattern)) {
-        if (value instanceof Error) throw value;
-        return value;
+        if (value instanceof Error) return Promise.reject(value);
+        return Promise.resolve(value);
       }
     }
-    throw new Error(`Unexpected runGit call: git ${args.join(' ')}`);
+    return Promise.reject(new Error(`Unexpected runGit call: git ${args.join(' ')}`));
   });
 }
 

--- a/packages/readyup/__tests__/check-utils/git/factories.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/factories.test.ts
@@ -146,6 +146,25 @@ describe(makeRemoteRefSyncCheck, () => {
     expect(result).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('ahead') }));
   });
 
+  it('reports behind detail when local is behind remote', async () => {
+    const { local, remote } = createTempRepoWithRemote();
+    const branch = currentBranch(local);
+
+    // Advance remote via a second clone.
+    const clone2 = mkdtempSync(join(tmpdir(), 'rdy-fac-clone2b-'));
+    execSync(`git clone ${remote} ${clone2}`, { stdio: 'ignore' });
+    commit(clone2, 'remote-advance');
+    execSync('git push', { cwd: clone2, stdio: 'ignore' });
+
+    // Fetch so the local tracking ref sees the remote advance.
+    execSync('git fetch origin', { cwd: local, stdio: 'ignore' });
+
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    const result = await check.check();
+
+    expect(result).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('behind') }));
+  });
+
   it('fails with ref-missing detail when local branch has no upstream', async () => {
     const { local } = createTempRepoWithRemote();
     execSync('git checkout -b only-local', { cwd: local, stdio: 'ignore' });

--- a/packages/readyup/__tests__/check-utils/git/factories.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/factories.test.ts
@@ -3,9 +3,10 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { makeLocalRefSyncCheck, makeRemoteRefSyncCheck } from '../../../src/check-utils/git/factories.ts';
+import * as compareRefToRemoteModule from '../../../src/check-utils/git/compare-ref-to-remote.ts';
 
 function createTempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'rdy-fac-'));
@@ -59,6 +60,32 @@ describe(makeLocalRefSyncCheck, () => {
     expect(result).toEqual(expect.objectContaining({ ok: false }));
   });
 
+  it('fails with ref-missing detail for a nonexistent ref', async () => {
+    const repo = createTempRepo();
+
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: 'nonexistent', refB: 'HEAD' });
+    const result = await check.check();
+
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+    expect(result).toEqual(expect.objectContaining({ detail: expect.stringContaining('nonexistent') }));
+  });
+
+  it('reports diverged detail when both refs have independent commits', async () => {
+    const repo = createTempRepo();
+    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
+    commit(repo, 'main-advance');
+    execSync('git checkout feature', { cwd: repo, stdio: 'ignore' });
+    commit(repo, 'feature-advance');
+    execSync('git checkout -', { cwd: repo, stdio: 'ignore' });
+
+    const branch = currentBranch(repo);
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: branch, refB: 'feature' });
+    const result = await check.check();
+
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+    expect(result).toEqual(expect.objectContaining({ detail: expect.stringContaining('diverged') }));
+  });
+
   it('uses custom fix when provided', () => {
     const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b', fix: 'custom fix' });
 
@@ -69,6 +96,18 @@ describe(makeLocalRefSyncCheck, () => {
     const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b' });
 
     expect(check.fix).toBeUndefined();
+  });
+
+  it('forwards severity to the check', () => {
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b', severity: 'warn' });
+
+    expect(check.severity).toBe('warn');
+  });
+
+  it('omits severity when not provided', () => {
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b' });
+
+    expect(check.severity).toBeUndefined();
   });
 });
 
@@ -96,6 +135,41 @@ describe(makeRemoteRefSyncCheck, () => {
     expect(result).toEqual(expect.objectContaining({ ok: false }));
   });
 
+  it('fails with ref-missing detail when local branch has no upstream', async () => {
+    const { local } = createTempRepoWithRemote();
+    execSync('git checkout -b only-local', { cwd: local, stdio: 'ignore' });
+    execSync('git commit --allow-empty -m "local"', { cwd: local, stdio: 'ignore' });
+
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: 'only-local' });
+    const result = await check.check();
+
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+    expect(result).toEqual(expect.objectContaining({ detail: expect.stringContaining('only-local') }));
+  });
+
+  it('reports diverged detail when local and remote have independent commits', async () => {
+    const { local, remote } = createTempRepoWithRemote();
+    const branch = currentBranch(local);
+
+    // Advance local.
+    commit(local, 'local-advance');
+
+    // Advance remote via a second clone so local and remote diverge.
+    const clone2 = mkdtempSync(join(tmpdir(), 'rdy-fac-clone2-'));
+    execSync(`git clone ${remote} ${clone2}`, { stdio: 'ignore' });
+    commit(clone2, 'remote-advance');
+    execSync('git push', { cwd: clone2, stdio: 'ignore' });
+
+    // Fetch so the local tracking ref is up to date for rev-list.
+    execSync('git fetch origin', { cwd: local, stdio: 'ignore' });
+
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    const result = await check.check();
+
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+    expect(result).toEqual(expect.objectContaining({ detail: expect.stringContaining('diverged') }));
+  });
+
   it('returns skip reason when remote is unreachable', async () => {
     const local = mkdtempSync(join(tmpdir(), 'rdy-fac-unreach-'));
     execSync('git init', { cwd: local, stdio: 'ignore' });
@@ -110,25 +184,48 @@ describe(makeRemoteRefSyncCheck, () => {
     expect(skipResult).toContain('unreachable');
   });
 
-  it('runs the probe at most once when both skip and check are called', async () => {
+  it('returns pass from check() when remote is unreachable', async () => {
+    const local = mkdtempSync(join(tmpdir(), 'rdy-fac-unreach2-'));
+    execSync('git init', { cwd: local, stdio: 'ignore' });
+    execSync('git remote add origin https://invalid.example.test/repo.git', { cwd: local, stdio: 'ignore' });
+    execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
+    const branch = currentBranch(local);
+
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    const result = await check.check();
+
+    expect(result).toBe(true);
+  });
+
+  it('invokes the probe at most once when both skip and check are called', async () => {
     const { local } = createTempRepoWithRemote();
     const branch = currentBranch(local);
 
-    // Create the check and call both skip() and check() — the probe should only run once.
-    // We verify by ensuring both calls return consistent results without error.
+    const spy = vi.spyOn(compareRefToRemoteModule, 'compareRefToRemote');
+
     const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    await check.skip?.();
+    await check.check();
 
-    const skipResult = await check.skip?.();
-    const checkResult = await check.check();
-
-    // Both should succeed: skip returns false (not skipped), check returns true (in sync).
-    expect(skipResult).toBe(false);
-    expect(checkResult).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
   });
 
   it('uses custom fix when provided', () => {
     const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/tmp', ref: 'main', fix: 'run git pull' });
 
     expect(check.fix).toBe('run git pull');
+  });
+
+  it('forwards severity to the check', () => {
+    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/tmp', ref: 'main', severity: 'recommend' });
+
+    expect(check.severity).toBe('recommend');
+  });
+
+  it('omits severity when not provided', () => {
+    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/tmp', ref: 'main' });
+
+    expect(check.severity).toBeUndefined();
   });
 });

--- a/packages/readyup/__tests__/check-utils/git/factories.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/factories.test.ts
@@ -49,7 +49,7 @@ describe(makeLocalRefSyncCheck, () => {
     expect(result).toBe(true);
   });
 
-  it('fails with detail when refs diverge', async () => {
+  it('reports ahead detail when refA is ahead of refB', async () => {
     const repo = createTempRepo();
     execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
     commit(repo, 'main-only');
@@ -57,7 +57,18 @@ describe(makeLocalRefSyncCheck, () => {
     const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: 'HEAD', refB: 'feature' });
     const result = await check.check();
 
-    expect(result).toEqual(expect.objectContaining({ ok: false }));
+    expect(result).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('ahead') }));
+  });
+
+  it('reports behind detail when refA is behind refB', async () => {
+    const repo = createTempRepo();
+    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
+    commit(repo, 'main-advance');
+
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: 'feature', refB: 'HEAD' });
+    const result = await check.check();
+
+    expect(result).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('behind') }));
   });
 
   it('fails with ref-missing detail for a nonexistent ref', async () => {
@@ -124,7 +135,7 @@ describe(makeRemoteRefSyncCheck, () => {
     expect(result).toBe(true);
   });
 
-  it('fails when local is ahead of remote', async () => {
+  it('reports ahead detail when local is ahead of remote', async () => {
     const { local } = createTempRepoWithRemote();
     const branch = currentBranch(local);
     commit(local, 'local-only');
@@ -132,7 +143,7 @@ describe(makeRemoteRefSyncCheck, () => {
     const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
     const result = await check.check();
 
-    expect(result).toEqual(expect.objectContaining({ ok: false }));
+    expect(result).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('ahead') }));
   });
 
   it('fails with ref-missing detail when local branch has no upstream', async () => {

--- a/packages/readyup/__tests__/check-utils/git/factories.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/factories.test.ts
@@ -1,213 +1,199 @@
-import { execSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { makeLocalRefSyncCheck, makeRemoteRefSyncCheck } from '../../../src/check-utils/git/factories.ts';
+import * as compareLocalRefsModule from '../../../src/check-utils/git/compare-local-refs.ts';
 import * as compareRefToRemoteModule from '../../../src/check-utils/git/compare-ref-to-remote.ts';
+import type { LocalRefsCompareResult, RemoteRefCompareResult } from '../../../src/types.ts';
 
-function createTempRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'rdy-fac-'));
-  execSync('git init', { cwd: dir, stdio: 'ignore' });
-  execSync('git commit --allow-empty -m "init"', { cwd: dir, stdio: 'ignore' });
-  return dir;
-}
+vi.mock('../../../src/check-utils/git/compare-local-refs.ts', () => ({
+  compareLocalRefs: vi.fn(),
+}));
 
-function createTempRepoWithRemote(): { local: string; remote: string } {
-  const remote = mkdtempSync(join(tmpdir(), 'rdy-fac-remote-'));
-  execSync('git init --bare', { cwd: remote, stdio: 'ignore' });
+vi.mock('../../../src/check-utils/git/compare-ref-to-remote.ts', () => ({
+  compareRefToRemote: vi.fn(),
+}));
 
-  const local = mkdtempSync(join(tmpdir(), 'rdy-fac-local-'));
-  execSync('git init', { cwd: local, stdio: 'ignore' });
-  execSync(`git remote add origin ${remote}`, { cwd: local, stdio: 'ignore' });
-  execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
-  execSync('git push -u origin HEAD', { cwd: local, stdio: 'ignore' });
+const mockCompareLocalRefs = vi.mocked(compareLocalRefsModule.compareLocalRefs);
+const mockCompareRefToRemote = vi.mocked(compareRefToRemoteModule.compareRefToRemote);
 
-  return { local, remote };
-}
-
-function commit(dir: string, message: string): void {
-  writeFileSync(join(dir, `${Date.now()}.txt`), message);
-  execSync('git add .', { cwd: dir, stdio: 'ignore' });
-  execSync(`git commit -m "${message}"`, { cwd: dir, stdio: 'ignore' });
-}
-
-function currentBranch(dir: string): string {
-  return execSync('git rev-parse --abbrev-ref HEAD', { cwd: dir }).toString().trim();
-}
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe(makeLocalRefSyncCheck, () => {
-  it('passes when refs point to the same commit', async () => {
-    const repo = createTempRepo();
-    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
+  it('passes when refs match', async () => {
+    const result: LocalRefsCompareResult = { status: 'match', shaA: 'aaa', shaB: 'aaa' };
+    mockCompareLocalRefs.mockResolvedValue(result);
 
-    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: 'HEAD', refB: 'feature' });
-    const result = await check.check();
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'main', refB: 'feature' });
 
-    expect(result).toBe(true);
+    expect(await check.check()).toBe(true);
   });
 
-  it('reports ahead detail when refA is ahead of refB', async () => {
-    const repo = createTempRepo();
-    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
-    commit(repo, 'main-only');
+  it('reports ahead detail when refA is ahead', async () => {
+    const result: LocalRefsCompareResult = {
+      status: 'mismatch',
+      shaA: 'aaa',
+      shaB: 'bbb',
+      aheadBehind: { ahead: 3, behind: 0 },
+    };
+    mockCompareLocalRefs.mockResolvedValue(result);
 
-    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: 'HEAD', refB: 'feature' });
-    const result = await check.check();
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'main', refB: 'feature' });
+    const outcome = await check.check();
 
-    expect(result).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('ahead') }));
+    expect(outcome).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('ahead') }));
   });
 
-  it('reports behind detail when refA is behind refB', async () => {
-    const repo = createTempRepo();
-    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
-    commit(repo, 'main-advance');
+  it('reports behind detail when refA is behind', async () => {
+    const result: LocalRefsCompareResult = {
+      status: 'mismatch',
+      shaA: 'aaa',
+      shaB: 'bbb',
+      aheadBehind: { ahead: 0, behind: 2 },
+    };
+    mockCompareLocalRefs.mockResolvedValue(result);
 
-    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: 'feature', refB: 'HEAD' });
-    const result = await check.check();
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'main', refB: 'feature' });
+    const outcome = await check.check();
 
-    expect(result).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('behind') }));
+    expect(outcome).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('behind') }));
+    expect(outcome).toEqual(expect.objectContaining({ detail: expect.stringContaining('git merge') }));
   });
 
-  it('fails with ref-missing detail for a nonexistent ref', async () => {
-    const repo = createTempRepo();
+  it('reports diverged detail when both sides have commits', async () => {
+    const result: LocalRefsCompareResult = {
+      status: 'mismatch',
+      shaA: 'aaa',
+      shaB: 'bbb',
+      aheadBehind: { ahead: 2, behind: 3 },
+    };
+    mockCompareLocalRefs.mockResolvedValue(result);
 
-    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: 'nonexistent', refB: 'HEAD' });
-    const result = await check.check();
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'main', refB: 'feature' });
+    const outcome = await check.check();
 
-    expect(result).toEqual(expect.objectContaining({ ok: false }));
-    expect(result).toEqual(expect.objectContaining({ detail: expect.stringContaining('nonexistent') }));
+    expect(outcome).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('diverged') }));
   });
 
-  it('reports diverged detail when both refs have independent commits', async () => {
-    const repo = createTempRepo();
-    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
-    commit(repo, 'main-advance');
-    execSync('git checkout feature', { cwd: repo, stdio: 'ignore' });
-    commit(repo, 'feature-advance');
-    execSync('git checkout -', { cwd: repo, stdio: 'ignore' });
+  it('reports diverged detail when aheadBehind is unavailable', async () => {
+    const result: LocalRefsCompareResult = { status: 'mismatch', shaA: 'aaa', shaB: 'bbb' };
+    mockCompareLocalRefs.mockResolvedValue(result);
 
-    const branch = currentBranch(repo);
-    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: branch, refB: 'feature' });
-    const result = await check.check();
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'main', refB: 'feature' });
+    const outcome = await check.check();
 
-    expect(result).toEqual(expect.objectContaining({ ok: false }));
-    expect(result).toEqual(expect.objectContaining({ detail: expect.stringContaining('diverged') }));
+    expect(outcome).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('diverged') }));
+  });
+
+  it('reports ref-missing detail for a nonexistent ref', async () => {
+    const result: LocalRefsCompareResult = { status: 'ref-missing', ref: 'nonexistent' };
+    mockCompareLocalRefs.mockResolvedValue(result);
+
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'nonexistent', refB: 'HEAD' });
+    const outcome = await check.check();
+
+    expect(outcome).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('nonexistent') }));
   });
 
   it('uses custom fix when provided', () => {
-    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b', fix: 'custom fix' });
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'a', refB: 'b', fix: 'custom fix' });
 
     expect(check.fix).toBe('custom fix');
   });
 
   it('has no fix when not provided', () => {
-    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b' });
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'a', refB: 'b' });
 
     expect(check.fix).toBeUndefined();
   });
 
   it('forwards severity to the check', () => {
-    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b', severity: 'warn' });
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'a', refB: 'b', severity: 'warn' });
 
     expect(check.severity).toBe('warn');
   });
 
   it('omits severity when not provided', () => {
-    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b' });
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'a', refB: 'b' });
 
     expect(check.severity).toBeUndefined();
   });
 });
 
 describe(makeRemoteRefSyncCheck, () => {
-  it('passes when local and remote match', async () => {
-    const { local } = createTempRepoWithRemote();
-    const branch = currentBranch(local);
+  it('passes when in-sync', async () => {
+    const result: RemoteRefCompareResult = { status: 'in-sync', localSha: 'aaa', remoteSha: 'aaa' };
+    mockCompareRefToRemote.mockResolvedValue(result);
 
-    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'main' });
     const skipResult = await check.skip?.();
     expect(skipResult).toBe(false);
 
-    const result = await check.check();
-    expect(result).toBe(true);
+    expect(await check.check()).toBe(true);
   });
 
-  it('reports ahead detail when local is ahead of remote', async () => {
-    const { local } = createTempRepoWithRemote();
-    const branch = currentBranch(local);
-    commit(local, 'local-only');
+  it('reports ahead detail when local is ahead', async () => {
+    const result: RemoteRefCompareResult = {
+      status: 'out-of-sync',
+      localSha: 'aaa',
+      remoteSha: 'bbb',
+      aheadBehind: { ahead: 1, behind: 0 },
+    };
+    mockCompareRefToRemote.mockResolvedValue(result);
 
-    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
-    const result = await check.check();
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'main' });
+    const outcome = await check.check();
 
-    expect(result).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('ahead') }));
+    expect(outcome).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('ahead') }));
   });
 
-  it('reports behind detail when local is behind remote', async () => {
-    const { local, remote } = createTempRepoWithRemote();
-    const branch = currentBranch(local);
+  it('reports behind detail when local is behind', async () => {
+    const result: RemoteRefCompareResult = {
+      status: 'out-of-sync',
+      localSha: 'aaa',
+      remoteSha: 'bbb',
+      aheadBehind: { ahead: 0, behind: 3 },
+    };
+    mockCompareRefToRemote.mockResolvedValue(result);
 
-    // Advance remote via a second clone.
-    const clone2 = mkdtempSync(join(tmpdir(), 'rdy-fac-clone2b-'));
-    execSync(`git clone ${remote} ${clone2}`, { stdio: 'ignore' });
-    commit(clone2, 'remote-advance');
-    execSync('git push', { cwd: clone2, stdio: 'ignore' });
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'main' });
+    const outcome = await check.check();
 
-    // Fetch so the local tracking ref sees the remote advance.
-    execSync('git fetch origin', { cwd: local, stdio: 'ignore' });
-
-    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
-    const result = await check.check();
-
-    expect(result).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('behind') }));
+    expect(outcome).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('behind') }));
+    expect(outcome).toEqual(expect.objectContaining({ detail: expect.stringContaining('git pull') }));
   });
 
-  it('fails with ref-missing detail when local branch has no upstream', async () => {
-    const { local } = createTempRepoWithRemote();
-    execSync('git checkout -b only-local', { cwd: local, stdio: 'ignore' });
-    execSync('git commit --allow-empty -m "local"', { cwd: local, stdio: 'ignore' });
+  it('reports diverged detail when both sides have commits', async () => {
+    const result: RemoteRefCompareResult = {
+      status: 'out-of-sync',
+      localSha: 'aaa',
+      remoteSha: 'bbb',
+      aheadBehind: { ahead: 2, behind: 5 },
+    };
+    mockCompareRefToRemote.mockResolvedValue(result);
 
-    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: 'only-local' });
-    const result = await check.check();
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'main' });
+    const outcome = await check.check();
 
-    expect(result).toEqual(expect.objectContaining({ ok: false }));
-    expect(result).toEqual(expect.objectContaining({ detail: expect.stringContaining('only-local') }));
+    expect(outcome).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('diverged') }));
   });
 
-  it('reports diverged detail when local and remote have independent commits', async () => {
-    const { local, remote } = createTempRepoWithRemote();
-    const branch = currentBranch(local);
+  it('reports ref-missing detail when remote ref does not exist', async () => {
+    const result: RemoteRefCompareResult = { status: 'ref-missing', ref: 'origin/feature' };
+    mockCompareRefToRemote.mockResolvedValue(result);
 
-    // Advance local.
-    commit(local, 'local-advance');
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'feature' });
+    const outcome = await check.check();
 
-    // Advance remote via a second clone so local and remote diverge.
-    const clone2 = mkdtempSync(join(tmpdir(), 'rdy-fac-clone2-'));
-    execSync(`git clone ${remote} ${clone2}`, { stdio: 'ignore' });
-    commit(clone2, 'remote-advance');
-    execSync('git push', { cwd: clone2, stdio: 'ignore' });
-
-    // Fetch so the local tracking ref is up to date for rev-list.
-    execSync('git fetch origin', { cwd: local, stdio: 'ignore' });
-
-    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
-    const result = await check.check();
-
-    expect(result).toEqual(expect.objectContaining({ ok: false }));
-    expect(result).toEqual(expect.objectContaining({ detail: expect.stringContaining('diverged') }));
+    expect(outcome).toEqual(expect.objectContaining({ ok: false, detail: expect.stringContaining('origin/feature') }));
   });
 
   it('returns skip reason when remote is unreachable', async () => {
-    const local = mkdtempSync(join(tmpdir(), 'rdy-fac-unreach-'));
-    execSync('git init', { cwd: local, stdio: 'ignore' });
-    execSync('git remote add origin https://invalid.example.test/repo.git', { cwd: local, stdio: 'ignore' });
-    execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
-    const branch = currentBranch(local);
+    const result: RemoteRefCompareResult = { status: 'unreachable', error: new Error('network') };
+    mockCompareRefToRemote.mockResolvedValue(result);
 
-    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'main' });
     const skipResult = await check.skip?.();
 
     expect(typeof skipResult).toBe('string');
@@ -215,46 +201,45 @@ describe(makeRemoteRefSyncCheck, () => {
   });
 
   it('returns pass from check() when remote is unreachable', async () => {
-    const local = mkdtempSync(join(tmpdir(), 'rdy-fac-unreach2-'));
-    execSync('git init', { cwd: local, stdio: 'ignore' });
-    execSync('git remote add origin https://invalid.example.test/repo.git', { cwd: local, stdio: 'ignore' });
-    execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
-    const branch = currentBranch(local);
+    const result: RemoteRefCompareResult = { status: 'unreachable', error: new Error('network') };
+    mockCompareRefToRemote.mockResolvedValue(result);
 
-    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
-    const result = await check.check();
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'main' });
 
-    expect(result).toBe(true);
+    expect(await check.check()).toBe(true);
   });
 
   it('invokes the probe at most once when both skip and check are called', async () => {
-    const { local } = createTempRepoWithRemote();
-    const branch = currentBranch(local);
+    const result: RemoteRefCompareResult = { status: 'in-sync', localSha: 'aaa', remoteSha: 'aaa' };
+    mockCompareRefToRemote.mockResolvedValue(result);
 
-    const spy = vi.spyOn(compareRefToRemoteModule, 'compareRefToRemote');
-
-    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'main' });
     await check.skip?.();
     await check.check();
 
-    expect(spy).toHaveBeenCalledTimes(1);
-    spy.mockRestore();
+    expect(mockCompareRefToRemote).toHaveBeenCalledTimes(1);
   });
 
   it('uses custom fix when provided', () => {
-    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/tmp', ref: 'main', fix: 'run git pull' });
+    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/repo', ref: 'main', fix: 'run git pull' });
 
     expect(check.fix).toBe('run git pull');
   });
 
+  it('has no fix when not provided', () => {
+    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/repo', ref: 'main' });
+
+    expect(check.fix).toBeUndefined();
+  });
+
   it('forwards severity to the check', () => {
-    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/tmp', ref: 'main', severity: 'recommend' });
+    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/repo', ref: 'main', severity: 'recommend' });
 
     expect(check.severity).toBe('recommend');
   });
 
   it('omits severity when not provided', () => {
-    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/tmp', ref: 'main' });
+    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/repo', ref: 'main' });
 
     expect(check.severity).toBeUndefined();
   });

--- a/packages/readyup/__tests__/check-utils/git/factories.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/factories.test.ts
@@ -1,0 +1,134 @@
+import { execSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { makeLocalRefSyncCheck, makeRemoteRefSyncCheck } from '../../../src/check-utils/git/factories.ts';
+
+function createTempRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'rdy-fac-'));
+  execSync('git init', { cwd: dir, stdio: 'ignore' });
+  execSync('git commit --allow-empty -m "init"', { cwd: dir, stdio: 'ignore' });
+  return dir;
+}
+
+function createTempRepoWithRemote(): { local: string; remote: string } {
+  const remote = mkdtempSync(join(tmpdir(), 'rdy-fac-remote-'));
+  execSync('git init --bare', { cwd: remote, stdio: 'ignore' });
+
+  const local = mkdtempSync(join(tmpdir(), 'rdy-fac-local-'));
+  execSync('git init', { cwd: local, stdio: 'ignore' });
+  execSync(`git remote add origin ${remote}`, { cwd: local, stdio: 'ignore' });
+  execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
+  execSync('git push -u origin HEAD', { cwd: local, stdio: 'ignore' });
+
+  return { local, remote };
+}
+
+function commit(dir: string, message: string): void {
+  writeFileSync(join(dir, `${Date.now()}.txt`), message);
+  execSync('git add .', { cwd: dir, stdio: 'ignore' });
+  execSync(`git commit -m "${message}"`, { cwd: dir, stdio: 'ignore' });
+}
+
+function currentBranch(dir: string): string {
+  return execSync('git rev-parse --abbrev-ref HEAD', { cwd: dir }).toString().trim();
+}
+
+describe(makeLocalRefSyncCheck, () => {
+  it('passes when refs point to the same commit', async () => {
+    const repo = createTempRepo();
+    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
+
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: 'HEAD', refB: 'feature' });
+    const result = await check.check();
+
+    expect(result).toBe(true);
+  });
+
+  it('fails with detail when refs diverge', async () => {
+    const repo = createTempRepo();
+    execSync('git branch feature', { cwd: repo, stdio: 'ignore' });
+    commit(repo, 'main-only');
+
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: repo, refA: 'HEAD', refB: 'feature' });
+    const result = await check.check();
+
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+  });
+
+  it('uses custom fix when provided', () => {
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b', fix: 'custom fix' });
+
+    expect(check.fix).toBe('custom fix');
+  });
+
+  it('has no fix when not provided', () => {
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/tmp', refA: 'a', refB: 'b' });
+
+    expect(check.fix).toBeUndefined();
+  });
+});
+
+describe(makeRemoteRefSyncCheck, () => {
+  it('passes when local and remote match', async () => {
+    const { local } = createTempRepoWithRemote();
+    const branch = currentBranch(local);
+
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    const skipResult = await check.skip?.();
+    expect(skipResult).toBe(false);
+
+    const result = await check.check();
+    expect(result).toBe(true);
+  });
+
+  it('fails when local is ahead of remote', async () => {
+    const { local } = createTempRepoWithRemote();
+    const branch = currentBranch(local);
+    commit(local, 'local-only');
+
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    const result = await check.check();
+
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+  });
+
+  it('returns skip reason when remote is unreachable', async () => {
+    const local = mkdtempSync(join(tmpdir(), 'rdy-fac-unreach-'));
+    execSync('git init', { cwd: local, stdio: 'ignore' });
+    execSync('git remote add origin https://invalid.example.test/repo.git', { cwd: local, stdio: 'ignore' });
+    execSync('git commit --allow-empty -m "init"', { cwd: local, stdio: 'ignore' });
+    const branch = currentBranch(local);
+
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+    const skipResult = await check.skip?.();
+
+    expect(typeof skipResult).toBe('string');
+    expect(skipResult).toContain('unreachable');
+  });
+
+  it('runs the probe at most once when both skip and check are called', async () => {
+    const { local } = createTempRepoWithRemote();
+    const branch = currentBranch(local);
+
+    // Create the check and call both skip() and check() — the probe should only run once.
+    // We verify by ensuring both calls return consistent results without error.
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: local, ref: branch });
+
+    const skipResult = await check.skip?.();
+    const checkResult = await check.check();
+
+    // Both should succeed: skip returns false (not skipped), check returns true (in sync).
+    expect(skipResult).toBe(false);
+    expect(checkResult).toBe(true);
+  });
+
+  it('uses custom fix when provided', () => {
+    const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/tmp', ref: 'main', fix: 'run git pull' });
+
+    expect(check.fix).toBe('run git pull');
+  });
+});

--- a/packages/readyup/__tests__/check-utils/git/factories.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/factories.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { makeLocalRefSyncCheck, makeRemoteRefSyncCheck } from '../../../src/check-utils/git/factories.ts';
 import * as compareLocalRefsModule from '../../../src/check-utils/git/compare-local-refs.ts';
 import * as compareRefToRemoteModule from '../../../src/check-utils/git/compare-ref-to-remote.ts';
+import { makeLocalRefSyncCheck, makeRemoteRefSyncCheck } from '../../../src/check-utils/git/factories.ts';
 import type { LocalRefsCompareResult, RemoteRefCompareResult } from '../../../src/types.ts';
 
 vi.mock('../../../src/check-utils/git/compare-local-refs.ts', () => ({

--- a/packages/readyup/__tests__/check-utils/git/run-git.int.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/run-git.int.test.ts
@@ -1,8 +1,8 @@
 import { execSync } from 'node:child_process';
 import { mkdtempSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -36,8 +36,12 @@ describe(runGit, () => {
 
     // If home is a git repo, both should succeed with same output.
     // If not, both should fail with the same error.
-    const fromTilde = runGit('~', 'rev-parse', '--git-dir').catch((e: Error) => e.message);
-    const fromHome = runGit(home, 'rev-parse', '--git-dir').catch((e: Error) => e.message);
+    const fromTilde = runGit('~', 'rev-parse', '--git-dir').catch((error: unknown) =>
+      error instanceof Error ? error.message : String(error),
+    );
+    const fromHome = runGit(home, 'rev-parse', '--git-dir').catch((error: unknown) =>
+      error instanceof Error ? error.message : String(error),
+    );
 
     expect(await fromTilde).toBe(await fromHome);
   });
@@ -45,8 +49,12 @@ describe(runGit, () => {
   it('expands ~/ prefix to the home directory', async () => {
     const home = homedir();
 
-    const fromTilde = runGit('~/', 'rev-parse', '--git-dir').catch((e: Error) => e.message);
-    const fromHome = runGit(home, 'rev-parse', '--git-dir').catch((e: Error) => e.message);
+    const fromTilde = runGit('~/', 'rev-parse', '--git-dir').catch((error: unknown) =>
+      error instanceof Error ? error.message : String(error),
+    );
+    const fromHome = runGit(home, 'rev-parse', '--git-dir').catch((error: unknown) =>
+      error instanceof Error ? error.message : String(error),
+    );
 
     expect(await fromTilde).toBe(await fromHome);
   });

--- a/packages/readyup/__tests__/check-utils/git/run-git.int.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/run-git.int.test.ts
@@ -8,10 +8,8 @@ import { describe, expect, it } from 'vitest';
 
 import { isRefMissingError, runGit } from '../../../src/check-utils/git/run-git.ts';
 
-let tempDir: string;
-
 function createTempRepo(): string {
-  tempDir = mkdtempSync(join(tmpdir(), 'rdy-git-'));
+  const tempDir = mkdtempSync(join(tmpdir(), 'rdy-git-'));
   execSync('git init', { cwd: tempDir, stdio: 'ignore' });
   execSync('git commit --allow-empty -m "init"', { cwd: tempDir, stdio: 'ignore' });
   return tempDir;

--- a/packages/readyup/__tests__/check-utils/git/run-git.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/run-git.test.ts
@@ -1,62 +1,69 @@
-import { execSync } from 'node:child_process';
-import { mkdtempSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { promisify } from 'node:util';
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { isRefMissingError, runGit } from '../../../src/check-utils/git/run-git.ts';
 
-function createTempRepo(): string {
-  const tempDir = mkdtempSync(join(tmpdir(), 'rdy-git-'));
-  execSync('git init', { cwd: tempDir, stdio: 'ignore' });
-  execSync('git commit --allow-empty -m "init"', { cwd: tempDir, stdio: 'ignore' });
-  return tempDir;
-}
+const execFileAsync = vi.hoisted(() =>
+  vi.fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr: string }>>(),
+);
+
+vi.mock('node:child_process', () => {
+  const stub = Object.assign(vi.fn(), { [promisify.custom]: execFileAsync });
+  return { execFile: stub };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe(runGit, () => {
   it('returns trimmed stdout for a successful git command', async () => {
-    const repo = createTempRepo();
-    const result = await runGit(repo, 'rev-parse', '--short', 'HEAD');
+    execFileAsync.mockResolvedValue({ stdout: '  abc123\n', stderr: '' });
 
-    expect(result).toMatch(/^[0-9a-f]+$/);
+    const result = await runGit('/repo', 'rev-parse', 'HEAD');
+
+    expect(result).toBe('abc123');
+    expect(execFileAsync).toHaveBeenCalledWith('git', ['-C', '/repo', 'rev-parse', 'HEAD']);
   });
 
   it('throws when git exits with a nonzero code', async () => {
-    const repo = createTempRepo();
+    execFileAsync.mockRejectedValue(Object.assign(new Error('git failed'), { code: 128 }));
 
-    await expect(runGit(repo, 'rev-parse', '--verify', 'nonexistent-ref')).rejects.toThrow();
+    await expect(runGit('/repo', 'rev-parse', 'nonexistent')).rejects.toThrow('git failed');
   });
 
-  it('expands ~ to the home directory', async () => {
-    // Verify tilde expansion produces the same result as homedir()
-    // by running a command that works from any git repo (or fails consistently)
-    const home = homedir();
+  it('expands bare ~ to the home directory', async () => {
+    execFileAsync.mockResolvedValue({ stdout: 'ok\n', stderr: '' });
 
-    // If home is a git repo, both should succeed with same output.
-    // If not, both should fail with the same error.
-    const fromTilde = runGit('~', 'rev-parse', '--git-dir').catch((error: unknown) =>
-      error instanceof Error ? error.message : String(error),
-    );
-    const fromHome = runGit(home, 'rev-parse', '--git-dir').catch((error: unknown) =>
-      error instanceof Error ? error.message : String(error),
-    );
+    await runGit('~', 'status');
 
-    expect(await fromTilde).toBe(await fromHome);
+    expect(execFileAsync).toHaveBeenCalledWith('git', ['-C', homedir(), 'status']);
   });
 
   it('expands ~/ prefix to the home directory', async () => {
-    const home = homedir();
+    execFileAsync.mockResolvedValue({ stdout: 'ok\n', stderr: '' });
 
-    const fromTilde = runGit('~/', 'rev-parse', '--git-dir').catch((error: unknown) =>
-      error instanceof Error ? error.message : String(error),
-    );
-    const fromHome = runGit(home, 'rev-parse', '--git-dir').catch((error: unknown) =>
-      error instanceof Error ? error.message : String(error),
-    );
+    await runGit('~/projects/repo', 'status');
 
-    expect(await fromTilde).toBe(await fromHome);
+    expect(execFileAsync).toHaveBeenCalledWith('git', ['-C', `${homedir()}/projects/repo`, 'status']);
+  });
+
+  it('expands bare ~/ to the home directory', async () => {
+    execFileAsync.mockResolvedValue({ stdout: 'ok\n', stderr: '' });
+
+    await runGit('~/', 'status');
+
+    expect(execFileAsync).toHaveBeenCalledWith('git', ['-C', homedir(), 'status']);
+  });
+
+  it('does not expand ~ in the middle of a path', async () => {
+    execFileAsync.mockResolvedValue({ stdout: 'ok\n', stderr: '' });
+
+    await runGit('/home/~user/repo', 'status');
+
+    expect(execFileAsync).toHaveBeenCalledWith('git', ['-C', '/home/~user/repo', 'status']);
   });
 });
 

--- a/packages/readyup/__tests__/check-utils/git/run-git.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/run-git.test.ts
@@ -1,0 +1,55 @@
+import { execSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it } from 'vitest';
+
+import { runGit } from '../../../src/check-utils/git/run-git.ts';
+
+let tempDir: string;
+
+function createTempRepo(): string {
+  tempDir = mkdtempSync(join(tmpdir(), 'rdy-git-'));
+  execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+  execSync('git commit --allow-empty -m "init"', { cwd: tempDir, stdio: 'ignore' });
+  return tempDir;
+}
+
+describe(runGit, () => {
+  it('returns trimmed stdout for a successful git command', async () => {
+    const repo = createTempRepo();
+    const result = await runGit(repo, 'rev-parse', '--short', 'HEAD');
+
+    expect(result).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('throws when git exits with a nonzero code', async () => {
+    const repo = createTempRepo();
+
+    await expect(runGit(repo, 'rev-parse', '--verify', 'nonexistent-ref')).rejects.toThrow();
+  });
+
+  it('expands ~ to the home directory', async () => {
+    // Verify tilde expansion produces the same result as homedir()
+    // by running a command that works from any git repo (or fails consistently)
+    const home = homedir();
+
+    // If home is a git repo, both should succeed with same output.
+    // If not, both should fail with the same error.
+    const fromTilde = runGit('~', 'rev-parse', '--git-dir').catch((e: Error) => e.message);
+    const fromHome = runGit(home, 'rev-parse', '--git-dir').catch((e: Error) => e.message);
+
+    expect(await fromTilde).toBe(await fromHome);
+  });
+
+  it('expands ~/ prefix to the home directory', async () => {
+    const home = homedir();
+
+    const fromTilde = runGit('~/', 'rev-parse', '--git-dir').catch((e: Error) => e.message);
+    const fromHome = runGit(home, 'rev-parse', '--git-dir').catch((e: Error) => e.message);
+
+    expect(await fromTilde).toBe(await fromHome);
+  });
+});

--- a/packages/readyup/__tests__/check-utils/git/run-git.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/run-git.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 
 import { describe, expect, it } from 'vitest';
 
-import { runGit } from '../../../src/check-utils/git/run-git.ts';
+import { isRefMissingError, runGit } from '../../../src/check-utils/git/run-git.ts';
 
 let tempDir: string;
 
@@ -51,5 +51,54 @@ describe(runGit, () => {
     const fromHome = runGit(home, 'rev-parse', '--git-dir').catch((e: Error) => e.message);
 
     expect(await fromTilde).toBe(await fromHome);
+  });
+});
+
+describe(isRefMissingError, () => {
+  it('returns true for code 128 with "unknown revision" in stderr', () => {
+    const error = Object.assign(new Error('git error'), {
+      code: 128,
+      stderr: "fatal: ambiguous argument 'nonexistent': unknown revision or path not in the working tree.",
+    });
+
+    expect(isRefMissingError(error)).toBe(true);
+  });
+
+  it('returns true for code 128 with "not a valid object name" in stderr', () => {
+    const error = Object.assign(new Error('git error'), {
+      code: 128,
+      stderr: "fatal: Needed a single revision\nerror: not a valid object name: 'nonexistent'",
+    });
+
+    expect(isRefMissingError(error)).toBe(true);
+  });
+
+  it('returns false for code 128 with "not a git repository" in stderr', () => {
+    const error = Object.assign(new Error('git error'), {
+      code: 128,
+      stderr: 'fatal: not a git repository (or any of the parent directories): .git',
+    });
+
+    expect(isRefMissingError(error)).toBe(false);
+  });
+
+  it('returns false for code 128 with "cannot change to" in stderr', () => {
+    const error = Object.assign(new Error('git error'), {
+      code: 128,
+      stderr: "fatal: cannot change to '/nonexistent': No such file or directory",
+    });
+
+    expect(isRefMissingError(error)).toBe(false);
+  });
+
+  it('returns false for non-128 exit codes', () => {
+    const error = Object.assign(new Error('git error'), { code: 1, stderr: 'unknown revision' });
+
+    expect(isRefMissingError(error)).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(isRefMissingError('not an error')).toBe(false);
+    expect(isRefMissingError(null)).toBe(false);
   });
 });

--- a/packages/readyup/src/check-utils/git/compare-local-refs.ts
+++ b/packages/readyup/src/check-utils/git/compare-local-refs.ts
@@ -27,13 +27,14 @@ async function findMissingRef(path: string, refA: string, refB: string): Promise
   return undefined;
 }
 
-/** Check whether a ref exists in the repository. */
+/** Check whether a ref exists in the repository. Rethrow non-ref-missing errors. */
 async function refExists(path: string, ref: string): Promise<boolean> {
   try {
     await runGit(path, 'rev-parse', '--verify', ref);
     return true;
-  } catch {
-    return false;
+  } catch (error: unknown) {
+    if (isRefMissingError(error)) return false;
+    throw error;
   }
 }
 
@@ -46,8 +47,19 @@ async function resolveAheadBehind(
   try {
     const output = await runGit(path, 'rev-list', '--count', '--left-right', `${refA}...${refB}`);
     const [aheadStr, behindStr] = output.split('\t');
-    return { ahead: Number(aheadStr), behind: Number(behindStr) };
+    const ahead = Number(aheadStr);
+    const behind = Number(behindStr);
+    if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return undefined;
+    return { ahead, behind };
   } catch {
     return undefined;
   }
+}
+
+/** Determine whether an error represents a missing ref (git exit code 128). */
+function isRefMissingError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  if (!('code' in error)) return false;
+  const { code } = error;
+  return code === 128;
 }

--- a/packages/readyup/src/check-utils/git/compare-local-refs.ts
+++ b/packages/readyup/src/check-utils/git/compare-local-refs.ts
@@ -1,5 +1,5 @@
 import type { LocalRefsCompareResult } from '../../types.ts';
-import { runGit } from './run-git.ts';
+import { isRefMissingError, runGit } from './run-git.ts';
 
 /** Compare two local git refs and return a discriminated-union result. */
 export async function compareLocalRefs(path: string, refA: string, refB: string): Promise<LocalRefsCompareResult> {
@@ -54,12 +54,4 @@ async function resolveAheadBehind(
   } catch {
     return undefined;
   }
-}
-
-/** Determine whether an error represents a missing ref (git exit code 128). */
-function isRefMissingError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) return false;
-  if (!('code' in error)) return false;
-  const { code } = error;
-  return code === 128;
 }

--- a/packages/readyup/src/check-utils/git/compare-local-refs.ts
+++ b/packages/readyup/src/check-utils/git/compare-local-refs.ts
@@ -1,0 +1,53 @@
+import type { LocalRefsCompareResult } from '../../types.ts';
+import { runGit } from './run-git.ts';
+
+/** Compare two local git refs and return a discriminated-union result. */
+export async function compareLocalRefs(path: string, refA: string, refB: string): Promise<LocalRefsCompareResult> {
+  const missingRef = await findMissingRef(path, refA, refB);
+  if (missingRef !== undefined) {
+    return { status: 'ref-missing', ref: missingRef };
+  }
+
+  const [shaA, shaB] = await Promise.all([runGit(path, 'rev-parse', refA), runGit(path, 'rev-parse', refB)]);
+
+  if (shaA === shaB) {
+    return { status: 'match', shaA, shaB };
+  }
+
+  const aheadBehind = await resolveAheadBehind(path, refA, refB);
+
+  return { status: 'mismatch', shaA, shaB, ...(aheadBehind ? { aheadBehind } : {}) };
+}
+
+/** Return the name of the first ref that does not exist, or undefined if both exist. */
+async function findMissingRef(path: string, refA: string, refB: string): Promise<string | undefined> {
+  const [existsA, existsB] = await Promise.all([refExists(path, refA), refExists(path, refB)]);
+  if (!existsA) return refA;
+  if (!existsB) return refB;
+  return undefined;
+}
+
+/** Check whether a ref exists in the repository. */
+async function refExists(path: string, ref: string): Promise<boolean> {
+  try {
+    await runGit(path, 'rev-parse', '--verify', ref);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Compute ahead/behind counts between two refs. Return undefined on failure. */
+async function resolveAheadBehind(
+  path: string,
+  refA: string,
+  refB: string,
+): Promise<{ ahead: number; behind: number } | undefined> {
+  try {
+    const output = await runGit(path, 'rev-list', '--count', '--left-right', `${refA}...${refB}`);
+    const [aheadStr, behindStr] = output.split('\t');
+    return { ahead: Number(aheadStr), behind: Number(behindStr) };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/readyup/src/check-utils/git/compare-local-refs.ts
+++ b/packages/readyup/src/check-utils/git/compare-local-refs.ts
@@ -46,10 +46,11 @@ async function resolveAheadBehind(
 ): Promise<{ ahead: number; behind: number } | undefined> {
   try {
     const output = await runGit(path, 'rev-list', '--count', '--left-right', `${refA}...${refB}`);
-    const parts = output.split('\t');
-    if (parts.length < 2) return undefined;
-    const ahead = Number(parts[0]);
-    const behind = Number(parts[1]);
+    const aheadStr = output.split('\t')[0];
+    const behindStr = output.split('\t')[1];
+    if (aheadStr === undefined || behindStr === undefined) return undefined;
+    const ahead = Number(aheadStr);
+    const behind = Number(behindStr);
     if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return undefined;
     return { ahead, behind };
   } catch {

--- a/packages/readyup/src/check-utils/git/compare-local-refs.ts
+++ b/packages/readyup/src/check-utils/git/compare-local-refs.ts
@@ -46,9 +46,10 @@ async function resolveAheadBehind(
 ): Promise<{ ahead: number; behind: number } | undefined> {
   try {
     const output = await runGit(path, 'rev-list', '--count', '--left-right', `${refA}...${refB}`);
-    const [aheadStr, behindStr] = output.split('\t');
-    const ahead = Number(aheadStr);
-    const behind = Number(behindStr);
+    const parts = output.split('\t');
+    if (parts.length < 2) return undefined;
+    const ahead = Number(parts[0]);
+    const behind = Number(parts[1]);
     if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return undefined;
     return { ahead, behind };
   } catch {

--- a/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
+++ b/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
@@ -58,9 +58,10 @@ async function resolveAheadBehind(
 ): Promise<{ ahead: number; behind: number } | undefined> {
   try {
     const output = await runGit(path, 'rev-list', '--count', '--left-right', `${ref}...${remote}/${ref}`);
-    const [aheadStr, behindStr] = output.split('\t');
-    const ahead = Number(aheadStr);
-    const behind = Number(behindStr);
+    const parts = output.split('\t');
+    if (parts.length < 2) return undefined;
+    const ahead = Number(parts[0]);
+    const behind = Number(parts[1]);
     if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return undefined;
     return { ahead, behind };
   } catch {

--- a/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
+++ b/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
@@ -1,0 +1,71 @@
+import type { RemoteRefCompareResult } from '../../types.ts';
+import { runGit } from './run-git.ts';
+
+/** Compare a local ref to its counterpart on a remote. Uses `ls-remote` (no fetch). */
+export async function compareRefToRemote(
+  path: string,
+  ref: string,
+  remote = 'origin',
+): Promise<RemoteRefCompareResult> {
+  const localSha = await resolveLocalRef(path, ref);
+  if (localSha === undefined) {
+    return { status: 'ref-missing', ref };
+  }
+
+  let remoteSha: string | undefined;
+  try {
+    remoteSha = await resolveRemoteRef(path, ref, remote);
+  } catch (error: unknown) {
+    return { status: 'unreachable', error: toError(error) };
+  }
+
+  if (remoteSha === undefined) {
+    return { status: 'ref-missing', ref: `${remote}/${ref}` };
+  }
+
+  if (localSha === remoteSha) {
+    return { status: 'in-sync', localSha, remoteSha };
+  }
+
+  const aheadBehind = await resolveAheadBehind(path, ref, remote);
+
+  return { status: 'out-of-sync', localSha, remoteSha, ...(aheadBehind ? { aheadBehind } : {}) };
+}
+
+/** Resolve a local ref to its SHA, or undefined if it doesn't exist. */
+async function resolveLocalRef(path: string, ref: string): Promise<string | undefined> {
+  try {
+    return await runGit(path, 'rev-parse', '--verify', ref);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve a remote ref to its SHA via ls-remote. Return undefined if the ref doesn't exist. Throw on network errors. */
+async function resolveRemoteRef(path: string, ref: string, remote: string): Promise<string | undefined> {
+  const output = await runGit(path, 'ls-remote', remote, ref);
+  if (!output) return undefined;
+  const sha = output.split('\t')[0];
+  return sha;
+}
+
+/** Compute ahead/behind from the local tracking ref. Return undefined on failure. */
+async function resolveAheadBehind(
+  path: string,
+  ref: string,
+  remote: string,
+): Promise<{ ahead: number; behind: number } | undefined> {
+  try {
+    const output = await runGit(path, 'rev-list', '--count', '--left-right', `${ref}...${remote}/${ref}`);
+    const [aheadStr, behindStr] = output.split('\t');
+    return { ahead: Number(aheadStr), behind: Number(behindStr) };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Coerce an unknown value to an Error. */
+function toError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  return new Error(String(value));
+}

--- a/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
+++ b/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
@@ -1,5 +1,5 @@
 import type { RemoteRefCompareResult } from '../../types.ts';
-import { runGit } from './run-git.ts';
+import { isRefMissingError, runGit } from './run-git.ts';
 
 /** Compare a local ref to its counterpart on a remote. Uses `ls-remote` (no fetch). */
 export async function compareRefToRemote(
@@ -66,14 +66,6 @@ async function resolveAheadBehind(
   } catch {
     return undefined;
   }
-}
-
-/** Determine whether an error represents a missing ref (git exit code 128). */
-function isRefMissingError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) return false;
-  if (!('code' in error)) return false;
-  const { code } = error;
-  return code === 128;
 }
 
 /** Coerce an unknown value to an Error. */

--- a/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
+++ b/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
@@ -32,12 +32,13 @@ export async function compareRefToRemote(
   return { status: 'out-of-sync', localSha, remoteSha, ...(aheadBehind ? { aheadBehind } : {}) };
 }
 
-/** Resolve a local ref to its SHA, or undefined if it doesn't exist. */
+/** Resolve a local ref to its SHA, or undefined if it doesn't exist. Rethrow non-ref-missing errors. */
 async function resolveLocalRef(path: string, ref: string): Promise<string | undefined> {
   try {
     return await runGit(path, 'rev-parse', '--verify', ref);
-  } catch {
-    return undefined;
+  } catch (error: unknown) {
+    if (isRefMissingError(error)) return undefined;
+    throw error;
   }
 }
 
@@ -58,10 +59,21 @@ async function resolveAheadBehind(
   try {
     const output = await runGit(path, 'rev-list', '--count', '--left-right', `${ref}...${remote}/${ref}`);
     const [aheadStr, behindStr] = output.split('\t');
-    return { ahead: Number(aheadStr), behind: Number(behindStr) };
+    const ahead = Number(aheadStr);
+    const behind = Number(behindStr);
+    if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return undefined;
+    return { ahead, behind };
   } catch {
     return undefined;
   }
+}
+
+/** Determine whether an error represents a missing ref (git exit code 128). */
+function isRefMissingError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  if (!('code' in error)) return false;
+  const { code } = error;
+  return code === 128;
 }
 
 /** Coerce an unknown value to an Error. */

--- a/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
+++ b/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
@@ -58,10 +58,11 @@ async function resolveAheadBehind(
 ): Promise<{ ahead: number; behind: number } | undefined> {
   try {
     const output = await runGit(path, 'rev-list', '--count', '--left-right', `${ref}...${remote}/${ref}`);
-    const parts = output.split('\t');
-    if (parts.length < 2) return undefined;
-    const ahead = Number(parts[0]);
-    const behind = Number(parts[1]);
+    const aheadStr = output.split('\t')[0];
+    const behindStr = output.split('\t')[1];
+    if (aheadStr === undefined || behindStr === undefined) return undefined;
+    const ahead = Number(aheadStr);
+    const behind = Number(behindStr);
     if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return undefined;
     return { ahead, behind };
   } catch {

--- a/packages/readyup/src/check-utils/git/factories.ts
+++ b/packages/readyup/src/check-utils/git/factories.ts
@@ -1,4 +1,4 @@
-import type { LocalRefsCompareResult, RdyCheck, RemoteRefCompareResult } from '../../types.ts';
+import type { LocalRefsCompareResult, RdyCheck, RemoteRefCompareResult, Severity } from '../../types.ts';
 import { compareLocalRefs } from './compare-local-refs.ts';
 import { compareRefToRemote } from './compare-ref-to-remote.ts';
 
@@ -13,6 +13,8 @@ interface LocalRefSyncCheckOptions {
   refB: string;
   /** Custom remediation message. Overrides the default. */
   fix?: string;
+  /** Severity of the check. When omitted, the kit's default severity applies. */
+  severity?: Severity;
 }
 
 interface RemoteRefSyncCheckOptions {
@@ -26,11 +28,13 @@ interface RemoteRefSyncCheckOptions {
   remote?: string;
   /** Custom remediation message. Overrides the default. */
   fix?: string;
+  /** Severity of the check. When omitted, the kit's default severity applies. */
+  severity?: Severity;
 }
 
 /** Create a check that verifies two local refs point to the same commit. */
 export function makeLocalRefSyncCheck(options: LocalRefSyncCheckOptions): RdyCheck {
-  const { name, path, refA, refB, fix: customFix } = options;
+  const { name, path, refA, refB, fix: customFix, severity } = options;
 
   const check: RdyCheck = {
     name,
@@ -41,12 +45,13 @@ export function makeLocalRefSyncCheck(options: LocalRefSyncCheckOptions): RdyChe
     },
   };
   if (customFix !== undefined) check.fix = customFix;
+  if (severity !== undefined) check.severity = severity;
   return check;
 }
 
 /** Create a check that verifies a local ref matches its remote counterpart. Uses a closure-cached probe so the network call runs at most once. */
 export function makeRemoteRefSyncCheck(options: RemoteRefSyncCheckOptions): RdyCheck {
-  const { name, path, ref, remote = 'origin', fix: customFix } = options;
+  const { name, path, ref, remote = 'origin', fix: customFix, severity } = options;
 
   let probe: Promise<RemoteRefCompareResult> | undefined;
 
@@ -69,10 +74,15 @@ export function makeRemoteRefSyncCheck(options: RemoteRefSyncCheckOptions): RdyC
     async check() {
       const result = await getProbe();
       if (result.status === 'in-sync') return true;
+      // Treat unreachable as passing: skip() is the intended guard for this case.
+      // If a caller invokes check() directly without skip(), the remote cannot be
+      // verified, so failing would be misleading.
+      if (result.status === 'unreachable') return true;
       return { ok: false, detail: formatRemoteResult(result, ref, remote, path) };
     },
   };
   if (customFix !== undefined) rdyCheck.fix = customFix;
+  if (severity !== undefined) rdyCheck.severity = severity;
   return rdyCheck;
 }
 

--- a/packages/readyup/src/check-utils/git/factories.ts
+++ b/packages/readyup/src/check-utils/git/factories.ts
@@ -1,0 +1,132 @@
+import type { LocalRefsCompareResult, RdyCheck, RemoteRefCompareResult } from '../../types.ts';
+import { compareLocalRefs } from './compare-local-refs.ts';
+import { compareRefToRemote } from './compare-ref-to-remote.ts';
+
+interface LocalRefSyncCheckOptions {
+  /** Display name for the check. */
+  name: string;
+  /** Path to the git repository. */
+  path: string;
+  /** First local ref (e.g., a branch name). */
+  refA: string;
+  /** Second local ref to compare against. */
+  refB: string;
+  /** Custom remediation message. Overrides the default. */
+  fix?: string;
+}
+
+interface RemoteRefSyncCheckOptions {
+  /** Display name for the check. */
+  name: string;
+  /** Path to the git repository. */
+  path: string;
+  /** Local ref to compare (e.g., a branch name). */
+  ref: string;
+  /** Remote name. Default: `origin`. */
+  remote?: string;
+  /** Custom remediation message. Overrides the default. */
+  fix?: string;
+}
+
+/** Create a check that verifies two local refs point to the same commit. */
+export function makeLocalRefSyncCheck(options: LocalRefSyncCheckOptions): RdyCheck {
+  const { name, path, refA, refB, fix: customFix } = options;
+
+  const check: RdyCheck = {
+    name,
+    async check() {
+      const result = await compareLocalRefs(path, refA, refB);
+      if (result.status === 'match') return true;
+      return { ok: false, detail: formatLocalResult(result, refA, refB, path) };
+    },
+  };
+  if (customFix !== undefined) check.fix = customFix;
+  return check;
+}
+
+/** Create a check that verifies a local ref matches its remote counterpart. Uses a closure-cached probe so the network call runs at most once. */
+export function makeRemoteRefSyncCheck(options: RemoteRefSyncCheckOptions): RdyCheck {
+  const { name, path, ref, remote = 'origin', fix: customFix } = options;
+
+  let probe: Promise<RemoteRefCompareResult> | undefined;
+
+  function getProbe(): Promise<RemoteRefCompareResult> {
+    if (probe === undefined) {
+      probe = compareRefToRemote(path, ref, remote);
+    }
+    return probe;
+  }
+
+  const rdyCheck: RdyCheck = {
+    name,
+    async skip() {
+      const result = await getProbe();
+      if (result.status === 'unreachable') {
+        return `remote '${remote}' is unreachable — skipping network check`;
+      }
+      return false;
+    },
+    async check() {
+      const result = await getProbe();
+      if (result.status === 'in-sync') return true;
+      return { ok: false, detail: formatRemoteResult(result, ref, remote, path) };
+    },
+  };
+  if (customFix !== undefined) rdyCheck.fix = customFix;
+  return rdyCheck;
+}
+
+/** Format a human-readable detail message for a local ref comparison failure. */
+function formatLocalResult(
+  result: Exclude<LocalRefsCompareResult, { status: 'match' }>,
+  refA: string,
+  refB: string,
+  path: string,
+): string {
+  if (result.status === 'ref-missing') {
+    return `ref '${result.ref}' does not exist in ${path}`;
+  }
+
+  const { aheadBehind } = result;
+  if (aheadBehind === undefined) {
+    return `${refA} and ${refB} have diverged in ${path}`;
+  }
+
+  const { ahead, behind } = aheadBehind;
+  if (ahead > 0 && behind > 0) {
+    return `${refA} and ${refB} have diverged, with ${ahead} and ${behind} different commits each`;
+  }
+  if (behind > 0) {
+    return `${refA} is behind ${refB} by ${behind} commit${behind === 1 ? '' : 's'} — run 'git merge ${refB}' in ${path}`;
+  }
+  return `${refA} is ahead of ${refB} by ${ahead} commit${ahead === 1 ? '' : 's'}`;
+}
+
+/** Format a human-readable detail message for a remote ref comparison failure. */
+function formatRemoteResult(
+  result: Exclude<RemoteRefCompareResult, { status: 'in-sync' }>,
+  ref: string,
+  remote: string,
+  path: string,
+): string {
+  if (result.status === 'ref-missing') {
+    return `ref '${result.ref}' does not exist`;
+  }
+  if (result.status === 'unreachable') {
+    return `remote '${remote}' is unreachable`;
+  }
+
+  const { aheadBehind } = result;
+  if (aheadBehind === undefined) {
+    return `${ref} and ${remote}/${ref} have diverged in ${path}`;
+  }
+
+  const { ahead, behind } = aheadBehind;
+  if (ahead > 0 && behind > 0) {
+    return `${ref} and ${remote}/${ref} have diverged, with ${ahead} and ${behind} different commits each`;
+  }
+  if (behind > 0) {
+    return `${ref} is behind ${remote}/${ref} by ${behind} commit${behind === 1 ? '' : 's'} — run 'git pull' in ${path}`;
+  }
+  return `${ref} is ahead of ${remote}/${ref} by ${ahead} commit${ahead === 1 ? '' : 's'}`;
+}

--- a/packages/readyup/src/check-utils/git/index.ts
+++ b/packages/readyup/src/check-utils/git/index.ts
@@ -1,0 +1,4 @@
+export { compareLocalRefs } from './compare-local-refs.ts';
+export { compareRefToRemote } from './compare-ref-to-remote.ts';
+export { makeLocalRefSyncCheck, makeRemoteRefSyncCheck } from './factories.ts';
+export { runGit } from './run-git.ts';

--- a/packages/readyup/src/check-utils/git/run-git.ts
+++ b/packages/readyup/src/check-utils/git/run-git.ts
@@ -11,6 +11,27 @@ export async function runGit(path: string, ...args: string[]): Promise<string> {
   return stdout.trim();
 }
 
+/**
+ * Determine whether an error from a git command represents a missing ref.
+ * Exit code 128 is ambiguous: git uses it for missing refs, invalid paths,
+ * and "not a git repo". Inspect stderr to distinguish ref-missing from
+ * infrastructure failures.
+ */
+export function isRefMissingError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  if (!('code' in error)) return false;
+  const { code } = error;
+  if (code !== 128) return false;
+  if (!('stderr' in error)) return false;
+  const stderr = String(error.stderr);
+  return (
+    stderr.includes('unknown revision') ||
+    stderr.includes('ambiguous argument') ||
+    stderr.includes('not a valid object name') ||
+    stderr.includes('Needed a single revision')
+  );
+}
+
 /** Expand leading `~` or `~/` to the user's home directory. */
 function expandTilde(path: string): string {
   if (path === '~' || path === '~/') return homedir();

--- a/packages/readyup/src/check-utils/git/run-git.ts
+++ b/packages/readyup/src/check-utils/git/run-git.ts
@@ -1,0 +1,19 @@
+import { execFile } from 'node:child_process';
+import { homedir } from 'node:os';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/** Run a git command in the given directory and return trimmed stdout. */
+export async function runGit(path: string, ...args: string[]): Promise<string> {
+  const resolved = expandTilde(path);
+  const { stdout } = await execFileAsync('git', ['-C', resolved, ...args]);
+  return stdout.trim();
+}
+
+/** Expand leading `~` or `~/` to the user's home directory. */
+function expandTilde(path: string): string {
+  if (path === '~' || path === '~/') return homedir();
+  if (path.startsWith('~/')) return homedir() + path.slice(1);
+  return path;
+}

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -1,9 +1,5 @@
 export { isRecord } from '../isRecord.ts';
 export { commandExists, fileContains, fileDoesNotContain, fileExists, filesExist, readFile } from './filesystem.ts';
-export { computeHash, fileMatchesHash } from './hashing.ts';
-export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json.ts';
-export { getJsonValue, hasJsonValue } from './json-value.ts';
-export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
 export {
   compareLocalRefs,
   compareRefToRemote,
@@ -11,4 +7,8 @@ export {
   makeRemoteRefSyncCheck,
   runGit,
 } from './git/index.ts';
+export { computeHash, fileMatchesHash } from './hashing.ts';
+export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json.ts';
+export { getJsonValue, hasJsonValue } from './json-value.ts';
+export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
 export { compareVersions } from './semver.ts';

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -4,4 +4,11 @@ export { computeHash, fileMatchesHash } from './hashing.ts';
 export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json.ts';
 export { getJsonValue, hasJsonValue } from './json-value.ts';
 export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
+export {
+  compareLocalRefs,
+  compareRefToRemote,
+  makeLocalRefSyncCheck,
+  makeRemoteRefSyncCheck,
+  runGit,
+} from './git/index.ts';
 export { compareVersions } from './semver.ts';

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -1,5 +1,6 @@
 // Types
 export type {
+  AheadBehind,
   ChecklistSummary,
   CheckOutcome,
   CheckReturnValue,
@@ -10,6 +11,7 @@ export type {
   JsonChecklistEntry,
   JsonKitEntry,
   JsonReport,
+  LocalRefsCompareResult,
   PassedResult,
   PercentProgress,
   Progress,
@@ -20,6 +22,7 @@ export type {
   RdyReport,
   RdyResult,
   RdyStagedChecklist,
+  RemoteRefCompareResult,
   ResolvedRdyConfig,
   Severity,
   SkippedResult,
@@ -45,6 +48,8 @@ export { pickJson } from './compile/pickJson.ts';
 // Check utilities
 export {
   commandExists,
+  compareLocalRefs,
+  compareRefToRemote,
   compareVersions,
   computeHash,
   fileContains,
@@ -60,8 +65,11 @@ export {
   hasMinDevDependencyVersion,
   hasPackageJsonField,
   isRecord,
+  makeLocalRefSyncCheck,
+  makeRemoteRefSyncCheck,
   readFile,
   readJsonFile,
   readJsonValue,
   readPackageJson,
+  runGit,
 } from './check-utils/index.ts';

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -1,3 +1,67 @@
+// -- Ahead/behind --
+
+/** Directional commit counts between two refs. */
+export interface AheadBehind {
+  ahead: number;
+  behind: number;
+}
+
+// -- Git comparison results --
+
+/** Result when both local refs point to the same commit. */
+interface LocalRefsMatch {
+  status: 'match';
+  shaA: string;
+  shaB: string;
+}
+
+/** Result when local refs point to different commits. */
+interface LocalRefsMismatch {
+  status: 'mismatch';
+  shaA: string;
+  shaB: string;
+  aheadBehind?: AheadBehind;
+}
+
+/** Result when one of the refs does not exist. */
+interface LocalRefMissing {
+  status: 'ref-missing';
+  ref: string;
+}
+
+/** Discriminated union for a local ref comparison. */
+export type LocalRefsCompareResult = LocalRefsMatch | LocalRefsMismatch | LocalRefMissing;
+
+/** Result when local and remote refs point to the same commit. */
+interface RemoteRefInSync {
+  status: 'in-sync';
+  localSha: string;
+  remoteSha: string;
+}
+
+/** Result when local and remote refs point to different commits. */
+interface RemoteRefOutOfSync {
+  status: 'out-of-sync';
+  localSha: string;
+  remoteSha: string;
+  aheadBehind?: AheadBehind;
+}
+
+/** Result when the remote ref does not exist. */
+interface RemoteRefMissing {
+  status: 'ref-missing';
+  ref: string;
+}
+
+/** Result when the remote cannot be contacted. */
+interface RemoteRefUnreachable {
+  status: 'unreachable';
+  error: Error;
+}
+
+/** Discriminated union for a local-to-remote ref comparison. */
+export type RemoteRefCompareResult = RemoteRefInSync | RemoteRefOutOfSync | RemoteRefMissing | RemoteRefUnreachable;
+
 // -- Severity --
 
 /** Severity levels for assertive checks, ordered from most to least urgent. */


### PR DESCRIPTION
## What

Adds git freshness check utilities to readyup's `check-utils` module, enabling kits to verify branch sync state (local-to-local and local-to-remote) without hand-rolling git subprocess calls. The new utilities return discriminated-union results for type-safe status handling and provide check factories with git-status-style diagnostic messages.

## Why

Kits that verify repo branch state — such as dev-environment staleness checks — had to shell out to git manually and build their own offline-skip and failure-detail logic. This was validated by a real cross-repo kit in `configs/macos` that exercises the exact pattern these utilities now encapsulate.

## Details

### Features

- `runGit(path, ...args)` — async low-level utility wrapping `promisify(execFile)` with tilde expansion (`~`, `~/`) and an `isRefMissingError` predicate that inspects both exit code and stderr to distinguish ref-missing from infrastructure failures (bad paths, non-repos).
- `compareLocalRefs(path, refA, refB)` — returns `match | mismatch | ref-missing` with SHAs and optional ahead/behind counts via `git rev-list --count --left-right`.
- `compareRefToRemote(path, ref, remote?)` — returns `in-sync | out-of-sync | ref-missing | unreachable` using `git ls-remote` (no fetch). Network failures surface as `unreachable` results rather than thrown exceptions.
- `makeLocalRefSyncCheck(options)` and `makeRemoteRefSyncCheck(options)` — check factories wrapping the primitives in `RdyCheck` shapes. The remote factory uses a closure-cached probe shared between `skip()` and `check()` for one network round-trip per check instance. Both produce default fix messages with ahead/behind/diverged directionality. Support optional `severity` and custom `fix` override.
- `AheadBehind`, `LocalRefsCompareResult`, and `RemoteRefCompareResult` discriminated-union types exported from `readyup`.

### Tests

- Comparison primitives and factories tested with mocked `runGit`/comparison calls — no real git processes above the boundary layer.
- `run-git.int.test.ts` retains real git calls as the integration boundary.
- Coverage includes all discriminated-union variants, closure-cache verification via `vi.spyOn`, error rethrow paths, malformed output guards, and directional message formatting.

## Test plan

- [ ] Verify new utilities are importable from `readyup`
- [ ] Verify `runGit` tilde expansion works on target platform
- [ ] Manually test `makeRemoteRefSyncCheck` against a real repo with offline/online scenarios

Closes #15 