### PR TITLE
#44 Add manifest schema and `rdy compile` manifest generation

### DIFF
--- a/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
+++ b/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { validateCompiledOutput } from '../../src/compile/validateCompiledOutput.ts';
+
+/** Create a temporary ESM bundle that exports the given kit fields. */
+function writeTempKit(dir: string, filename: string, kitFields: Record<string, unknown>): string {
+  mkdirSync(dir, { recursive: true });
+  const filePath = join(dir, filename);
+  const serialized = JSON.stringify(kitFields, (_key, value) => {
+    // Functions can't be JSON-serialized; represent checks as plain objects.
+    return value;
+  });
+  writeFileSync(filePath, `export default ${serialized};\n`);
+  return filePath;
+}
+
+describe(validateCompiledOutput, () => {
+  const testDir = join(tmpdir(), `readyup-test-validate-${Date.now()}`);
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('returns description when the kit has one', async () => {
+    const outputPath = writeTempKit(testDir, 'kit-with-desc.mjs', {
+      checklists: [{ name: 'test', checks: [] }],
+      description: 'A kit for testing',
+    });
+
+    const metadata = await validateCompiledOutput(outputPath);
+
+    expect(metadata).toStrictEqual({ description: 'A kit for testing' });
+  });
+
+  it('omits description key when the kit has none', async () => {
+    const outputPath = writeTempKit(testDir, 'kit-no-desc.mjs', {
+      checklists: [{ name: 'test', checks: [] }],
+    });
+
+    const metadata = await validateCompiledOutput(outputPath);
+
+    expect(metadata).toStrictEqual({});
+    expect('description' in metadata).toBe(false);
+  });
+
+  it('deletes the output file and throws when the bundle fails to load', async () => {
+    const filePath = join(testDir, 'bad-bundle.mjs');
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(filePath, 'throw new Error("parse error");\n');
+
+    await expect(validateCompiledOutput(filePath)).rejects.toThrow('Failed to load compiled output for validation');
+  });
+
+  it('deletes the output file and throws when the kit is structurally invalid', async () => {
+    const outputPath = writeTempKit(testDir, 'bad-kit.mjs', {
+      notAKit: true,
+    });
+
+    await expect(validateCompiledOutput(outputPath)).rejects.toThrow();
+  });
+});

--- a/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
+++ b/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { validateCompiledOutput } from '../../src/compile/validateCompiledOutput.ts';

--- a/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
+++ b/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
@@ -9,10 +9,7 @@ import { validateCompiledOutput } from '../../src/compile/validateCompiledOutput
 function writeTempKit(dir: string, filename: string, kitFields: Record<string, unknown>): string {
   mkdirSync(dir, { recursive: true });
   const filePath = join(dir, filename);
-  const serialized = JSON.stringify(kitFields, (_key, value) => {
-    // Functions can't be JSON-serialized; represent checks as plain objects.
-    return value;
-  });
+  const serialized = JSON.stringify(kitFields);
   writeFileSync(filePath, `export default ${serialized};\n`);
   return filePath;
 }
@@ -42,8 +39,7 @@ describe(validateCompiledOutput, () => {
 
     const metadata = await validateCompiledOutput(outputPath);
 
-    expect(metadata).toStrictEqual({});
-    expect('description' in metadata).toBe(false);
+    expect(metadata).toStrictEqual({ description: undefined });
   });
 
   it('deletes the output file and throws when the bundle fails to load', async () => {

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -6,6 +6,8 @@ const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockReaddirSync = vi.hoisted(() => vi.fn());
 const mockPicomatch = vi.hoisted(() => vi.fn());
+const mockWriteManifest = vi.hoisted(() => vi.fn());
+const mockReadManifest = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/compile/compileConfig.ts', () => ({
   compileConfig: mockCompileConfig,
@@ -28,6 +30,14 @@ vi.mock('picomatch', () => ({
   default: mockPicomatch,
 }));
 
+vi.mock('../src/manifest/writeManifest.ts', () => ({
+  writeManifest: mockWriteManifest,
+}));
+
+vi.mock('../src/manifest/readManifest.ts', () => ({
+  readManifest: mockReadManifest,
+}));
+
 import { compileCommand } from '../src/compile/compileCommand.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../src/reportRdy.ts';
 
@@ -38,7 +48,7 @@ describe(compileCommand, () => {
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    mockValidateCompiledOutput.mockResolvedValue(undefined);
+    mockValidateCompiledOutput.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -49,6 +59,8 @@ describe(compileCommand, () => {
     mockExistsSync.mockReset();
     mockReaddirSync.mockReset();
     mockPicomatch.mockReset();
+    mockWriteManifest.mockReset();
+    mockReadManifest.mockReset();
   });
 
   // Explicit input file tests
@@ -62,7 +74,7 @@ describe(compileCommand, () => {
     expect(stdoutSpy).toHaveBeenCalledWith('Compiling kit:\n');
   });
 
-  it('shows 📦 indicator for a changed single file', async () => {
+  it('shows compiled indicator for a changed single file', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true });
 
     await compileCommand(['input.ts']);
@@ -71,7 +83,7 @@ describe(compileCommand, () => {
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('→'));
   });
 
-  it('shows 🔍 indicator for an unchanged single file', async () => {
+  it('shows no-changes indicator for an unchanged single file', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: false });
 
     await compileCommand(['input.ts']);
@@ -296,5 +308,137 @@ describe(compileCommand, () => {
 
     expect(exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));
+  });
+
+  // Manifest generation tests
+  it('writes manifest after batch compile with kit entries', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
+    mockCompileConfig
+      .mockResolvedValueOnce({ outputPath: '/abs/alpha.js', changed: true })
+      .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true });
+    mockValidateCompiledOutput.mockResolvedValueOnce({ description: 'Alpha checks' }).mockResolvedValueOnce({});
+
+    await compileCommand([]);
+
+    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
+    const [, manifest] = mockWriteManifest.mock.calls[0] as [
+      string,
+      { version: number; kits: Array<{ name: string; description?: string }> },
+    ];
+    expect(manifest.version).toBe(1);
+    expect(manifest.kits).toStrictEqual([{ name: 'alpha', description: 'Alpha checks' }, { name: 'beta' }]);
+  });
+
+  it('skips manifest generation when --skip-manifest is set', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['a.ts']);
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true });
+
+    await compileCommand(['--skip-manifest']);
+
+    expect(mockWriteManifest).not.toHaveBeenCalled();
+  });
+
+  it('uses custom manifest path from --manifest flag', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['a.ts']);
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true });
+
+    await compileCommand(['--manifest=custom/manifest.json']);
+
+    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
+    const [manifestPath] = mockWriteManifest.mock.calls[0] as [string];
+    expect(manifestPath).toContain('custom/manifest.json');
+  });
+
+  it('upserts manifest entry for single-file compile', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true });
+    mockValidateCompiledOutput.mockResolvedValue({ description: 'Deploy checks' });
+    mockReadManifest.mockReturnValue({
+      version: 1,
+      kits: [{ name: 'default', description: 'Default checks' }],
+    });
+
+    await compileCommand(['deploy.ts']);
+
+    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
+    const [, manifest] = mockWriteManifest.mock.calls[0] as [
+      string,
+      { version: number; kits: Array<{ name: string; description?: string }> },
+    ];
+    expect(manifest.kits).toStrictEqual([
+      { name: 'default', description: 'Default checks' },
+      { name: 'deploy', description: 'Deploy checks' },
+    ]);
+  });
+
+  it('creates new manifest for single-file compile when no manifest exists', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true });
+    mockValidateCompiledOutput.mockResolvedValue({});
+    mockReadManifest.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    await compileCommand(['deploy.ts']);
+
+    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
+    const [, manifest] = mockWriteManifest.mock.calls[0] as [
+      string,
+      { version: number; kits: Array<{ name: string }> },
+    ];
+    expect(manifest.kits).toStrictEqual([{ name: 'deploy' }]);
+  });
+
+  it('replaces existing entry when upserting for single-file compile', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true });
+    mockValidateCompiledOutput.mockResolvedValue({ description: 'Updated' });
+    mockReadManifest.mockReturnValue({
+      version: 1,
+      kits: [{ name: 'deploy', description: 'Old' }],
+    });
+
+    await compileCommand(['deploy.ts']);
+
+    const [, manifest] = mockWriteManifest.mock.calls[0] as [
+      string,
+      { version: number; kits: Array<{ name: string; description?: string }> },
+    ];
+    expect(manifest.kits).toStrictEqual([{ name: 'deploy', description: 'Updated' }]);
+  });
+
+  it('skips manifest for single-file compile when --skip-manifest is set', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true });
+
+    await compileCommand(['input.ts', '--skip-manifest']);
+
+    expect(mockWriteManifest).not.toHaveBeenCalled();
+    expect(mockReadManifest).not.toHaveBeenCalled();
+  });
+
+  it('maintains alphabetical order when upserting manifest entries', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true });
+    mockValidateCompiledOutput.mockResolvedValue({});
+    mockReadManifest.mockReturnValue({
+      version: 1,
+      kits: [{ name: 'charlie' }, { name: 'beta' }],
+    });
+
+    await compileCommand(['alpha.ts']);
+
+    const [, manifest] = mockWriteManifest.mock.calls[0] as [
+      string,
+      { version: number; kits: Array<{ name: string }> },
+    ];
+    expect(manifest.kits.map((k: { name: string }) => k.name)).toStrictEqual(['alpha', 'beta', 'charlie']);
   });
 });

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -324,13 +324,10 @@ describe(compileCommand, () => {
 
     await compileCommand([]);
 
-    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
-    const [, manifest] = mockWriteManifest.mock.calls[0] as [
-      string,
-      { version: number; kits: Array<{ name: string; description?: string }> },
-    ];
-    expect(manifest.version).toBe(1);
-    expect(manifest.kits).toStrictEqual([{ name: 'alpha', description: 'Alpha checks' }, { name: 'beta' }]);
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+      version: 1,
+      kits: [{ name: 'alpha', description: 'Alpha checks' }, { name: 'beta' }],
+    });
   });
 
   it('skips manifest generation when --skip-manifest is set', async () => {
@@ -356,9 +353,7 @@ describe(compileCommand, () => {
 
     await compileCommand(['--manifest=custom/manifest.json']);
 
-    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
-    const [manifestPath] = mockWriteManifest.mock.calls[0] as [string];
-    expect(manifestPath).toContain('custom/manifest.json');
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.stringContaining('custom/manifest.json'), expect.anything());
   });
 
   it('upserts manifest entry for single-file compile', async () => {
@@ -371,15 +366,13 @@ describe(compileCommand, () => {
 
     await compileCommand(['deploy.ts']);
 
-    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
-    const [, manifest] = mockWriteManifest.mock.calls[0] as [
-      string,
-      { version: number; kits: Array<{ name: string; description?: string }> },
-    ];
-    expect(manifest.kits).toStrictEqual([
-      { name: 'default', description: 'Default checks' },
-      { name: 'deploy', description: 'Deploy checks' },
-    ]);
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+      version: 1,
+      kits: [
+        { name: 'default', description: 'Default checks' },
+        { name: 'deploy', description: 'Deploy checks' },
+      ],
+    });
   });
 
   it('creates new manifest for single-file compile when no manifest exists', async () => {
@@ -391,12 +384,10 @@ describe(compileCommand, () => {
 
     await compileCommand(['deploy.ts']);
 
-    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
-    const [, manifest] = mockWriteManifest.mock.calls[0] as [
-      string,
-      { version: number; kits: Array<{ name: string }> },
-    ];
-    expect(manifest.kits).toStrictEqual([{ name: 'deploy' }]);
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+      version: 1,
+      kits: [{ name: 'deploy' }],
+    });
   });
 
   it('replaces existing entry when upserting for single-file compile', async () => {
@@ -409,11 +400,10 @@ describe(compileCommand, () => {
 
     await compileCommand(['deploy.ts']);
 
-    const [, manifest] = mockWriteManifest.mock.calls[0] as [
-      string,
-      { version: number; kits: Array<{ name: string; description?: string }> },
-    ];
-    expect(manifest.kits).toStrictEqual([{ name: 'deploy', description: 'Updated' }]);
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+      version: 1,
+      kits: [{ name: 'deploy', description: 'Updated' }],
+    });
   });
 
   it('skips manifest for single-file compile when --skip-manifest is set', async () => {
@@ -468,8 +458,7 @@ describe(compileCommand, () => {
     await compileCommand(['deploy.ts', '--manifest=custom/manifest.json']);
 
     expect(mockWriteManifest).toHaveBeenCalledTimes(1);
-    const [manifestPath] = mockWriteManifest.mock.calls[0] as [string];
-    expect(manifestPath).toContain('custom/manifest.json');
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.stringContaining('custom/manifest.json'), expect.anything());
   });
 
   it('maintains alphabetical order when upserting manifest entries', async () => {
@@ -482,10 +471,9 @@ describe(compileCommand, () => {
 
     await compileCommand(['alpha.ts']);
 
-    const [, manifest] = mockWriteManifest.mock.calls[0] as [
-      string,
-      { version: number; kits: Array<{ name: string }> },
-    ];
-    expect(manifest.kits.map((k: { name: string }) => k.name)).toStrictEqual(['alpha', 'beta', 'charlie']);
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+      version: 1,
+      kits: [{ name: 'alpha' }, { name: 'beta' }, { name: 'charlie' }],
+    });
   });
 });

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -425,6 +425,53 @@ describe(compileCommand, () => {
     expect(mockReadManifest).not.toHaveBeenCalled();
   });
 
+  it('returns 1 when writeManifest throws during batch compile', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['a.ts']);
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true });
+    mockWriteManifest.mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const exitCode = await compileCommand([]);
+
+    expect(exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error writing manifest'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('EACCES'));
+  });
+
+  it('writes warning to stderr when upsert encounters non-missing-file error', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true });
+    mockValidateCompiledOutput.mockResolvedValue({});
+    mockReadManifest.mockImplementation(() => {
+      throw new Error('Invalid manifest schema in .readyup/manifest.json: bad data');
+    });
+
+    await compileCommand(['deploy.ts']);
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Warning:'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid manifest schema'));
+    // Still writes the manifest despite the warning
+    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses custom manifest path from --manifest flag for single-file compile', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true });
+    mockValidateCompiledOutput.mockResolvedValue({});
+    mockReadManifest.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    await compileCommand(['deploy.ts', '--manifest=custom/manifest.json']);
+
+    expect(mockWriteManifest).toHaveBeenCalledTimes(1);
+    const [manifestPath] = mockWriteManifest.mock.calls[0] as [string];
+    expect(manifestPath).toContain('custom/manifest.json');
+  });
+
   it('maintains alphabetical order when upserting manifest entries', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true });
     mockValidateCompiledOutput.mockResolvedValue({});

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatConsumerView, formatEmpty, formatOwnerView } from '../../src/list/formatList.ts';
+import { formatConsumerView, formatEmpty, formatManifestView, formatOwnerView } from '../../src/list/formatList.ts';
 
 describe(formatOwnerView, () => {
   it('renders only the Internal section when compiled kits are empty', () => {
@@ -191,6 +191,48 @@ describe(formatConsumerView, () => {
     });
 
     expect(result).toBe('No compiled kits found at /custom/path.');
+  });
+});
+
+describe(formatManifestView, () => {
+  it('renders kit names with the compiled icon', () => {
+    const result = formatManifestView({
+      kits: [{ name: 'deploy' }, { name: 'monitor' }],
+      manifestPath: '.readyup/manifest.json',
+    });
+
+    expect(result).toContain('Manifest: .readyup/manifest.json');
+    expect(result).toContain('📦 deploy');
+    expect(result).toContain('📦 monitor');
+  });
+
+  it('renders description inline after kit name when present', () => {
+    const result = formatManifestView({
+      kits: [{ name: 'default', description: 'General project health checks' }],
+      manifestPath: '.readyup/manifest.json',
+    });
+
+    expect(result).toContain('📦 default — General project health checks');
+  });
+
+  it('omits description suffix when description is absent', () => {
+    const result = formatManifestView({
+      kits: [{ name: 'deploy' }],
+      manifestPath: '.readyup/manifest.json',
+    });
+
+    const lines = result.split('\n');
+    const kitLine = lines.find((l) => l.includes('deploy'));
+    expect(kitLine).toBe('  📦 deploy');
+  });
+
+  it('returns empty-manifest message when kits array is empty', () => {
+    const result = formatManifestView({
+      kits: [],
+      manifestPath: '.readyup/manifest.json',
+    });
+
+    expect(result).toBe('No kits found in manifest: .readyup/manifest.json');
   });
 });
 

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockEnumerateKits = vi.hoisted(() => vi.fn());
+const mockReadManifest = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/loadConfig.ts', () => ({
   loadConfig: mockLoadConfig,
@@ -9,6 +10,10 @@ vi.mock('../src/loadConfig.ts', () => ({
 
 vi.mock('../src/list/enumerateKits.ts', () => ({
   enumerateKits: mockEnumerateKits,
+}));
+
+vi.mock('../src/manifest/readManifest.ts', () => ({
+  readManifest: mockReadManifest,
 }));
 
 import { listCommand } from '../src/list/listCommand.ts';
@@ -31,6 +36,7 @@ describe(listCommand, () => {
     vi.restoreAllMocks();
     mockLoadConfig.mockReset();
     mockEnumerateKits.mockReset();
+    mockReadManifest.mockReset();
   });
 
   describe('owner mode', () => {
@@ -180,6 +186,43 @@ describe(listCommand, () => {
 
       expect(exitCode).toBe(1);
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('not yet supported'));
+    });
+  });
+
+  describe('manifest mode', () => {
+    it('displays kits from the manifest file', async () => {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'default', description: 'Health checks' }, { name: 'deploy' }],
+      });
+
+      const exitCode = await listCommand(['--manifest', '.readyup/manifest.json']);
+
+      expect(exitCode).toBe(0);
+      expect(mockLoadConfig).not.toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('Manifest:');
+      expect(output).toContain('default');
+      expect(output).toContain('Health checks');
+      expect(output).toContain('deploy');
+    });
+
+    it('returns 1 when manifest file cannot be read', async () => {
+      mockReadManifest.mockImplementation(() => {
+        throw new Error('Manifest file not found: /missing/manifest.json');
+      });
+
+      const exitCode = await listCommand(['--manifest', '/missing/manifest.json']);
+
+      expect(exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Manifest file not found'));
+    });
+
+    it('returns 1 when --from and --manifest are both provided', async () => {
+      const exitCode = await listCommand(['--from', '.', '--manifest', '.readyup/manifest.json']);
+
+      expect(exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
     });
   });
 

--- a/packages/readyup/__tests__/manifest/manifestSchema.test.ts
+++ b/packages/readyup/__tests__/manifest/manifestSchema.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { ManifestSchema } from '../../src/manifest/manifestSchema.ts';
+
+describe(ManifestSchema, () => {
+  it('accepts a valid manifest with descriptions', () => {
+    const input = {
+      version: 1,
+      kits: [{ name: 'default', description: 'General health checks' }, { name: 'deploy' }],
+    };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a manifest with an empty kits array', () => {
+    const input = { version: 1, kits: [] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a manifest with wrong version', () => {
+    const input = { version: 2, kits: [] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a manifest missing version', () => {
+    const input = { kits: [] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a manifest missing kits', () => {
+    const input = { version: 1 };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a kit with an empty name', () => {
+    const input = { version: 1, kits: [{ name: '' }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a kit missing the name field', () => {
+    const input = { version: 1, kits: [{ description: 'orphan' }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/readyup/__tests__/manifest/readManifest.test.ts
+++ b/packages/readyup/__tests__/manifest/readManifest.test.ts
@@ -29,10 +29,22 @@ describe(readManifest, () => {
 
   it('throws when the file does not exist', () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error('ENOENT');
+      const error = new Error("ENOENT: no such file or directory, open '/missing/manifest.json'");
+      (error as NodeJS.ErrnoException).code = 'ENOENT';
+      throw error;
     });
 
     expect(() => readManifest('/missing/manifest.json')).toThrow('Manifest file not found');
+  });
+
+  it('throws with detail when the file is unreadable', () => {
+    mockReadFileSync.mockImplementation(() => {
+      const error = new Error("EACCES: permission denied, open '/locked/manifest.json'");
+      (error as NodeJS.ErrnoException).code = 'EACCES';
+      throw error;
+    });
+
+    expect(() => readManifest('/locked/manifest.json')).toThrow('Failed to read manifest file');
   });
 
   it('throws when the file contains invalid JSON', () => {

--- a/packages/readyup/__tests__/manifest/readManifest.test.ts
+++ b/packages/readyup/__tests__/manifest/readManifest.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+import { readManifest } from '../../src/manifest/readManifest.ts';
+
+describe(readManifest, () => {
+  it('returns a typed manifest for valid content', () => {
+    const manifest = { version: 1, kits: [{ name: 'deploy', description: 'Deploy checks' }] };
+    mockReadFileSync.mockReturnValue(JSON.stringify(manifest));
+
+    const result = readManifest('/project/.readyup/manifest.json');
+
+    expect(result).toStrictEqual(manifest);
+  });
+
+  it('returns a manifest without descriptions when they are absent', () => {
+    const manifest = { version: 1, kits: [{ name: 'deploy' }] };
+    mockReadFileSync.mockReturnValue(JSON.stringify(manifest));
+
+    const result = readManifest('/project/.readyup/manifest.json');
+
+    expect(result).toStrictEqual(manifest);
+  });
+
+  it('throws when the file does not exist', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(() => readManifest('/missing/manifest.json')).toThrow('Manifest file not found');
+  });
+
+  it('throws when the file contains invalid JSON', () => {
+    mockReadFileSync.mockReturnValue('not json');
+
+    expect(() => readManifest('/bad/manifest.json')).toThrow('invalid JSON');
+  });
+
+  it('throws when the manifest has an invalid schema', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ version: 2, kits: [] }));
+
+    expect(() => readManifest('/bad/manifest.json')).toThrow('Invalid manifest schema');
+  });
+});

--- a/packages/readyup/__tests__/manifest/readManifest.test.ts
+++ b/packages/readyup/__tests__/manifest/readManifest.test.ts
@@ -29,9 +29,9 @@ describe(readManifest, () => {
 
   it('throws when the file does not exist', () => {
     mockReadFileSync.mockImplementation(() => {
-      const error = new Error("ENOENT: no such file or directory, open '/missing/manifest.json'");
-      (error as NodeJS.ErrnoException).code = 'ENOENT';
-      throw error;
+      throw Object.assign(new Error("ENOENT: no such file or directory, open '/missing/manifest.json'"), {
+        code: 'ENOENT',
+      });
     });
 
     expect(() => readManifest('/missing/manifest.json')).toThrow('Manifest file not found');
@@ -39,9 +39,9 @@ describe(readManifest, () => {
 
   it('throws with detail when the file is unreadable', () => {
     mockReadFileSync.mockImplementation(() => {
-      const error = new Error("EACCES: permission denied, open '/locked/manifest.json'");
-      (error as NodeJS.ErrnoException).code = 'EACCES';
-      throw error;
+      throw Object.assign(new Error("EACCES: permission denied, open '/locked/manifest.json'"), {
+        code: 'EACCES',
+      });
     });
 
     expect(() => readManifest('/locked/manifest.json')).toThrow('Failed to read manifest file');

--- a/packages/readyup/__tests__/manifest/writeManifest.test.ts
+++ b/packages/readyup/__tests__/manifest/writeManifest.test.ts
@@ -31,11 +31,4 @@ describe(writeManifest, () => {
 
     expect(mockMkdirSync).toHaveBeenCalledWith('/project/.readyup', { recursive: true });
   });
-
-  it('throws when manifest data fails schema validation', () => {
-    // Deliberately invalid: version must be 1 per ManifestSchema.
-    const invalid = { version: 2, kits: [] } as unknown as RdyManifest;
-
-    expect(() => writeManifest('/project/.readyup/manifest.json', invalid)).toThrow('Invalid manifest data');
-  });
 });

--- a/packages/readyup/__tests__/manifest/writeManifest.test.ts
+++ b/packages/readyup/__tests__/manifest/writeManifest.test.ts
@@ -8,8 +8,8 @@ vi.mock(import('node:fs'), () => ({
   writeFileSync: mockWriteFileSync,
 }));
 
-import { writeManifest } from '../../src/manifest/writeManifest.ts';
 import type { RdyManifest } from '../../src/manifest/manifestSchema.ts';
+import { writeManifest } from '../../src/manifest/writeManifest.ts';
 
 describe(writeManifest, () => {
   it('writes formatted JSON with a trailing newline', () => {
@@ -30,5 +30,12 @@ describe(writeManifest, () => {
     writeManifest('/project/.readyup/manifest.json', manifest);
 
     expect(mockMkdirSync).toHaveBeenCalledWith('/project/.readyup', { recursive: true });
+  });
+
+  it('throws when manifest data fails schema validation', () => {
+    // Deliberately invalid: version must be 1 per ManifestSchema.
+    const invalid = { version: 2, kits: [] } as unknown as RdyManifest;
+
+    expect(() => writeManifest('/project/.readyup/manifest.json', invalid)).toThrow('Invalid manifest data');
   });
 });

--- a/packages/readyup/__tests__/manifest/writeManifest.test.ts
+++ b/packages/readyup/__tests__/manifest/writeManifest.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  mkdirSync: mockMkdirSync,
+  writeFileSync: mockWriteFileSync,
+}));
+
+import { writeManifest } from '../../src/manifest/writeManifest.ts';
+import type { RdyManifest } from '../../src/manifest/manifestSchema.ts';
+
+describe(writeManifest, () => {
+  it('writes formatted JSON with a trailing newline', () => {
+    const manifest: RdyManifest = { version: 1, kits: [{ name: 'deploy' }] };
+
+    writeManifest('/project/.readyup/manifest.json', manifest);
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      '/project/.readyup/manifest.json',
+      JSON.stringify(manifest, null, 2) + '\n',
+      'utf8',
+    );
+  });
+
+  it('creates parent directories before writing', () => {
+    const manifest: RdyManifest = { version: 1, kits: [] };
+
+    writeManifest('/project/.readyup/manifest.json', manifest);
+
+    expect(mockMkdirSync).toHaveBeenCalledWith('/project/.readyup', { recursive: true });
+  });
+});

--- a/packages/readyup/__tests__/resolveKitExports.test.ts
+++ b/packages/readyup/__tests__/resolveKitExports.test.ts
@@ -46,6 +46,20 @@ describe(resolveKitExports, () => {
     expect(result).not.toHaveProperty('suites');
   });
 
+  it('forwards description when defined', () => {
+    const checklists = [{ name: 'a', checks: [] }];
+    const result = resolveKitExports({ checklists, description: 'Health checks' });
+
+    expect(result).toStrictEqual({ checklists, description: 'Health checks' });
+  });
+
+  it('omits description when undefined', () => {
+    const checklists = [{ name: 'a', checks: [] }];
+    const result = resolveKitExports({ checklists });
+
+    expect(result).not.toHaveProperty('description');
+  });
+
   it('forwards both fixLocation and suites from a default export', () => {
     const checklists = [{ name: 'a', checks: [] }];
     const suites = { ci: ['a'] };

--- a/packages/readyup/src/assertIsRdyKit.ts
+++ b/packages/readyup/src/assertIsRdyKit.ts
@@ -27,6 +27,7 @@ const ChecklistSchema = z
 const RdyKitSchema = z.looseObject({
   checklists: z.array(ChecklistSchema),
   defaultSeverity: SeveritySchema.optional(),
+  description: z.string().optional(),
   failOn: SeveritySchema.optional(),
   fixLocation: z.enum(['inline', 'end']).optional(),
   reportOn: SeveritySchema.optional(),

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -88,10 +88,7 @@ export async function compileCommand(args: string[]): Promise<number> {
 
 /** Resolve the manifest output path from the optional `--manifest` flag. */
 function resolveManifestPath(flagValue: string | undefined): string {
-  if (flagValue !== undefined) {
-    return path.resolve(process.cwd(), flagValue);
-  }
-  return path.resolve(process.cwd(), DEFAULT_MANIFEST_PATH);
+  return path.resolve(process.cwd(), flagValue ?? DEFAULT_MANIFEST_PATH);
 }
 
 /** Collect `.ts` files matching the optional `include` glob, falling back to all `.ts` files. */
@@ -166,8 +163,8 @@ async function compileBatch(skipManifest: boolean, manifestPath: string): Promis
 
   if (!skipManifest) {
     try {
-      const sorted = kitEntries.sort((a, b) => a.name.localeCompare(b.name));
-      writeManifest(manifestPath, { version: 1, kits: sorted });
+      kitEntries.sort((a, b) => a.name.localeCompare(b.name));
+      writeManifest(manifestPath, { version: 1, kits: kitEntries });
     } catch (error: unknown) {
       const message = extractMessage(error);
       process.stderr.write(`Error writing manifest: ${message}\n`);

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -205,6 +205,7 @@ function upsertManifest(manifestPath: string, kitName: string, metadata: KitMeta
 
   // Replace existing entry for this kit name, or append.
   const filtered = existingKits.filter((k) => k.name !== kitName);
+  // eslint-disable-next-line unicorn/no-array-sort -- toSorted() requires es2023 lib
   const kits = [...filtered, entry].sort((a, b) => a.name.localeCompare(b.name));
 
   writeManifest(manifestPath, { version: 1, kits });

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -165,8 +165,14 @@ async function compileBatch(skipManifest: boolean, manifestPath: string): Promis
   }
 
   if (!skipManifest) {
-    const sorted = kitEntries.sort((a, b) => a.name.localeCompare(b.name));
-    writeManifest(manifestPath, { version: 1, kits: sorted });
+    try {
+      const sorted = kitEntries.sort((a, b) => a.name.localeCompare(b.name));
+      writeManifest(manifestPath, { version: 1, kits: sorted });
+    } catch (error: unknown) {
+      const message = extractMessage(error);
+      process.stderr.write(`Error writing manifest: ${message}\n`);
+      return 1;
+    }
   }
 
   return 0;
@@ -178,8 +184,12 @@ function upsertManifest(manifestPath: string, kitName: string, metadata: KitMeta
   try {
     const existing = readManifest(manifestPath);
     existingKits = existing.kits;
-  } catch {
-    // No existing manifest or invalid -- start fresh.
+  } catch (error: unknown) {
+    const message = extractMessage(error);
+    // Missing manifest is expected for first compile; other failures should surface.
+    if (!message.includes('not found')) {
+      process.stderr.write(`Warning: ${message} — starting with empty manifest\n`);
+    }
   }
 
   const entry: RdyManifestKit = {

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -5,8 +5,8 @@ import process from 'node:process';
 import picomatch from 'picomatch';
 
 import { loadConfig } from '../loadConfig.ts';
-import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestSchema.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
+import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestSchema.ts';
 import { readManifest } from '../manifest/readManifest.ts';
 import { writeManifest } from '../manifest/writeManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
@@ -56,25 +56,34 @@ export async function compileCommand(args: string[]): Promise<number> {
 
   // Explicit input file -- compile just that one
   if (inputPath !== undefined) {
+    let result;
+    let metadata: KitMetadata;
     try {
-      const result = await compileConfig(inputPath, outputPath);
-      const metadata = await validateCompiledOutput(result.outputPath);
-      const relInput = path.relative(process.cwd(), path.resolve(inputPath));
-      const relOutput = path.relative(process.cwd(), result.outputPath);
-      process.stdout.write('Compiling kit:\n');
-      process.stdout.write(formatResultLine(relInput, relOutput, result.changed));
-
-      if (!skipManifest) {
-        const kitName = path.basename(result.outputPath, '.js');
-        upsertManifest(manifestPath, kitName, metadata);
-      }
-
-      return 0;
+      result = await compileConfig(inputPath, outputPath);
+      metadata = await validateCompiledOutput(result.outputPath);
     } catch (error: unknown) {
       const message = extractMessage(error);
       process.stderr.write(`Error: ${message}\n`);
       return 1;
     }
+
+    const relInput = path.relative(process.cwd(), path.resolve(inputPath));
+    const relOutput = path.relative(process.cwd(), result.outputPath);
+    process.stdout.write('Compiling kit:\n');
+    process.stdout.write(formatResultLine(relInput, relOutput, result.changed));
+
+    if (!skipManifest) {
+      try {
+        const kitName = path.basename(result.outputPath, '.js');
+        upsertManifest(manifestPath, kitName, metadata);
+      } catch (error: unknown) {
+        const message = extractMessage(error);
+        process.stderr.write(`Error writing manifest: ${message}\n`);
+        return 1;
+      }
+    }
+
+    return 0;
   }
 
   // No input file -- compile all sources from config

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -5,14 +5,21 @@ import process from 'node:process';
 import picomatch from 'picomatch';
 
 import { loadConfig } from '../loadConfig.ts';
+import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestSchema.ts';
+import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
+import { readManifest } from '../manifest/readManifest.ts';
+import { writeManifest } from '../manifest/writeManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../reportRdy.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { compileConfig } from './compileConfig.ts';
+import type { KitMetadata } from './validateCompiledOutput.ts';
 import { validateCompiledOutput } from './validateCompiledOutput.ts';
 
 const compileFlagSchema = {
+  manifest: { long: '--manifest', type: 'string' as const },
   output: { long: '--output', type: 'string' as const, short: '-o' },
+  skipManifest: { long: '--skip-manifest', type: 'boolean' as const },
 };
 
 /**
@@ -37,6 +44,8 @@ export async function compileCommand(args: string[]): Promise<number> {
 
   const outputPath = parsed.flags.output;
   const positionals = parsed.positionals;
+  const skipManifest = parsed.flags.skipManifest;
+  const manifestPath = resolveManifestPath(parsed.flags.manifest);
 
   if (positionals.length > 1) {
     process.stderr.write('Error: Too many arguments. Expected a single input file.\n');
@@ -49,11 +58,17 @@ export async function compileCommand(args: string[]): Promise<number> {
   if (inputPath !== undefined) {
     try {
       const result = await compileConfig(inputPath, outputPath);
-      await validateCompiledOutput(result.outputPath);
+      const metadata = await validateCompiledOutput(result.outputPath);
       const relInput = path.relative(process.cwd(), path.resolve(inputPath));
       const relOutput = path.relative(process.cwd(), result.outputPath);
       process.stdout.write('Compiling kit:\n');
       process.stdout.write(formatResultLine(relInput, relOutput, result.changed));
+
+      if (!skipManifest) {
+        const kitName = path.basename(result.outputPath, '.js');
+        upsertManifest(manifestPath, kitName, metadata);
+      }
+
       return 0;
     } catch (error: unknown) {
       const message = extractMessage(error);
@@ -68,7 +83,15 @@ export async function compileCommand(args: string[]): Promise<number> {
     return 1;
   }
 
-  return compileBatch();
+  return compileBatch(skipManifest, manifestPath);
+}
+
+/** Resolve the manifest output path from the optional `--manifest` flag. */
+function resolveManifestPath(flagValue: string | undefined): string {
+  if (flagValue !== undefined) {
+    return path.resolve(process.cwd(), flagValue);
+  }
+  return path.resolve(process.cwd(), DEFAULT_MANIFEST_PATH);
 }
 
 /** Collect `.ts` files matching the optional `include` glob, falling back to all `.ts` files. */
@@ -80,7 +103,7 @@ function collectSourceFiles(srcDir: string, includeGlob: string | undefined): st
 }
 
 /** Compile all matching `.ts` files from the config-driven source directory. */
-async function compileBatch(): Promise<number> {
+async function compileBatch(skipManifest: boolean, manifestPath: string): Promise<number> {
   let config;
   try {
     config = await loadConfig();
@@ -118,14 +141,22 @@ async function compileBatch(): Promise<number> {
     srcDir === outDir ? `Compiling kits in ${relSrcDir}:\n` : `Compiling kits from ${relSrcDir} to ${relOutDir}:\n`;
   process.stdout.write(header);
 
+  const kitEntries: RdyManifestKit[] = [];
+
   for (const fileName of tsFiles) {
     const srcFile = path.join(srcDir, fileName);
     const outFile = path.join(outDir, fileName.replace(/\.ts$/, '.js'));
     try {
       const result = await compileConfig(srcFile, outFile);
-      await validateCompiledOutput(result.outputPath);
+      const metadata = await validateCompiledOutput(result.outputPath);
       const outName = fileName.replace(/\.ts$/, '.js');
       process.stdout.write(formatResultLine(fileName, outName, result.changed));
+
+      const kitName = path.basename(result.outputPath, '.js');
+      kitEntries.push({
+        name: kitName,
+        ...(metadata.description !== undefined && { description: metadata.description }),
+      });
     } catch (error: unknown) {
       const message = extractMessage(error);
       process.stderr.write(`Error compiling ${fileName}: ${message}\n`);
@@ -133,7 +164,34 @@ async function compileBatch(): Promise<number> {
     }
   }
 
+  if (!skipManifest) {
+    const sorted = kitEntries.sort((a, b) => a.name.localeCompare(b.name));
+    writeManifest(manifestPath, { version: 1, kits: sorted });
+  }
+
   return 0;
+}
+
+/** Read an existing manifest (if any), upsert a kit entry, and write back. */
+function upsertManifest(manifestPath: string, kitName: string, metadata: KitMetadata): void {
+  let existingKits: RdyManifestKit[] = [];
+  try {
+    const existing = readManifest(manifestPath);
+    existingKits = existing.kits;
+  } catch {
+    // No existing manifest or invalid -- start fresh.
+  }
+
+  const entry: RdyManifestKit = {
+    name: kitName,
+    ...(metadata.description !== undefined && { description: metadata.description }),
+  };
+
+  // Replace existing entry for this kit name, or append.
+  const filtered = existingKits.filter((k) => k.name !== kitName);
+  const kits = [...filtered, entry].sort((a, b) => a.name.localeCompare(b.name));
+
+  writeManifest(manifestPath, { version: 1, kits });
 }
 
 /** Format a single compile-result line with a change indicator. */

--- a/packages/readyup/src/compile/validateCompiledOutput.ts
+++ b/packages/readyup/src/compile/validateCompiledOutput.ts
@@ -44,6 +44,6 @@ export async function validateCompiledOutput(outputPath: string): Promise<KitMet
   }
 
   return {
-    ...(kit.description !== undefined && { description: kit.description }),
+    description: kit.description,
   };
 }

--- a/packages/readyup/src/compile/validateCompiledOutput.ts
+++ b/packages/readyup/src/compile/validateCompiledOutput.ts
@@ -4,15 +4,22 @@ import { pathToFileURL } from 'node:url';
 import { assertIsRdyKit } from '../assertIsRdyKit.ts';
 import { isRecord } from '../isRecord.ts';
 import { resolveKitExports } from '../resolveKitExports.ts';
+import type { RdyKit } from '../types.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { validateKit } from '../validateKit.ts';
+
+/** Lightweight metadata extracted from a validated kit. */
+export interface KitMetadata {
+  description?: string;
+}
 
 /**
  * Import a compiled kit bundle and run semantic validation.
  *
- * Deletes the output file when validation fails so the user isn't left with an invalid bundle.
+ * Returns metadata extracted from the validated kit. Deletes the output file when validation
+ * fails so the user isn't left with an invalid bundle.
  */
-export async function validateCompiledOutput(outputPath: string): Promise<void> {
+export async function validateCompiledOutput(outputPath: string): Promise<KitMetadata> {
   const fileUrl = `${pathToFileURL(outputPath).href}?t=${Date.now()}`;
   let imported: unknown;
   try {
@@ -25,12 +32,18 @@ export async function validateCompiledOutput(outputPath: string): Promise<void> 
 
   const moduleRecord = isRecord(imported) ? imported : {};
 
+  let kit: RdyKit;
   try {
     const resolved = resolveKitExports(moduleRecord);
     assertIsRdyKit(resolved);
     validateKit(resolved);
+    kit = resolved;
   } catch (error: unknown) {
     rmSync(outputPath, { force: true });
     throw error;
   }
+
+  return {
+    ...(kit.description !== undefined && { description: kit.description }),
+  };
 }

--- a/packages/readyup/src/compile/validateCompiledOutput.ts
+++ b/packages/readyup/src/compile/validateCompiledOutput.ts
@@ -10,7 +10,7 @@ import { validateKit } from '../validateKit.ts';
 
 /** Lightweight metadata extracted from a validated kit. */
 export interface KitMetadata {
-  description?: string;
+  description?: string | undefined;
 }
 
 /**

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -45,6 +45,10 @@ export {
 // Compile utilities
 export { pickJson } from './compile/pickJson.ts';
 
+// Manifest
+export type { RdyManifest } from './manifest/manifestSchema.ts';
+export { DEFAULT_MANIFEST_PATH } from './manifest/manifestSchema.ts';
+
 // Check utilities
 export {
   commandExists,

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -93,7 +93,7 @@ export function formatEmpty(mode: 'owner' | 'consumer', kitsDir?: string): strin
 // -- Manifest view --
 
 interface ManifestViewOptions {
-  kits: Array<{ name: string; description?: string }>;
+  kits: Array<{ name: string; description?: string | undefined }>;
   manifestPath: string;
 }
 

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -90,6 +90,31 @@ export function formatEmpty(mode: 'owner' | 'consumer', kitsDir?: string): strin
   return 'No kits found.\nRun `rdy init` to scaffold an internal kit or `rdy compile` to compile a kit from source.';
 }
 
+// -- Manifest view --
+
+interface ManifestViewOptions {
+  kits: Array<{ name: string; description?: string }>;
+  manifestPath: string;
+}
+
+/**
+ * Format a view of kits loaded from a manifest file.
+ *
+ * Kit names are displayed with the compiled icon; descriptions appear inline when present.
+ */
+export function formatManifestView({ kits, manifestPath }: ManifestViewOptions): string {
+  if (kits.length === 0) {
+    return `No kits found in manifest: ${manifestPath}`;
+  }
+
+  const items = kits.map((kit) => {
+    const suffix = kit.description !== undefined ? ` — ${kit.description}` : '';
+    return `  ${ICON_COMPILED} ${kit.name}${suffix}`;
+  });
+
+  return `Manifest: ${manifestPath}\n${items.join('\n')}`;
+}
+
 // -- Helpers --
 
 /** Build a titled section with a usage hint and indented item list. */

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -2,15 +2,17 @@ import path from 'node:path';
 import process from 'node:process';
 
 import { loadConfig } from '../loadConfig.ts';
+import { readManifest } from '../manifest/readManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { parseFromValue } from '../parseFromValue.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { enumerateKits } from './enumerateKits.ts';
 import type { CompiledStyle } from './formatList.ts';
-import { formatConsumerView, formatOwnerView } from './formatList.ts';
+import { formatConsumerView, formatManifestView, formatOwnerView } from './formatList.ts';
 
 const listFlagSchema = {
   from: { long: '--from', type: 'string' as const },
+  manifest: { long: '--manifest', type: 'string' as const },
 };
 
 /**
@@ -28,12 +30,41 @@ export async function listCommand(args: string[]): Promise<number> {
   }
 
   const fromArg = parsed.flags.from;
+  const manifestArg = parsed.flags.manifest;
+
+  if (fromArg !== undefined && manifestArg !== undefined) {
+    process.stderr.write('Error: --from and --manifest are mutually exclusive\n');
+    return 1;
+  }
+
+  if (manifestArg !== undefined) {
+    return runManifestMode(manifestArg);
+  }
 
   if (fromArg !== undefined) {
     return runFromMode(fromArg);
   }
 
   return runOwnerMode();
+}
+
+/** Display kits from a manifest file. */
+function runManifestMode(manifestArg: string): number {
+  const manifestPath = path.resolve(process.cwd(), manifestArg);
+
+  let manifest;
+  try {
+    manifest = readManifest(manifestPath);
+  } catch (error: unknown) {
+    const message = extractMessage(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
+  }
+
+  const relPath = path.relative(process.cwd(), manifestPath);
+  const output = formatManifestView({ kits: manifest.kits, manifestPath: relPath });
+  process.stdout.write(output + '\n');
+  return 0;
 }
 
 /** Enumerate kits from a `--from` source. */

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/** Default path for the manifest file, relative to the project root. */
+export const DEFAULT_MANIFEST_PATH = '.readyup/manifest.json';
+
+/** Schema for a single kit entry in the manifest. */
+const ManifestKitSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+});
+
+/** Schema for the readyup manifest file. */
+export const ManifestSchema = z.object({
+  version: z.literal(1),
+  kits: z.array(ManifestKitSchema),
+});
+
+/** Typed manifest produced by parsing with `ManifestSchema`. */
+export type RdyManifest = z.infer<typeof ManifestSchema>;
+
+/** Typed manifest kit entry. */
+export type RdyManifestKit = z.infer<typeof ManifestKitSchema>;

--- a/packages/readyup/src/manifest/readManifest.ts
+++ b/packages/readyup/src/manifest/readManifest.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 
-import { ManifestSchema } from './manifestSchema.ts';
 import type { RdyManifest } from './manifestSchema.ts';
+import { ManifestSchema } from './manifestSchema.ts';
 
 /**
  * Read and validate a manifest file from disk.
@@ -12,8 +12,13 @@ export function readManifest(manifestPath: string): RdyManifest {
   let raw: string;
   try {
     raw = readFileSync(manifestPath, 'utf8');
-  } catch {
-    throw new Error(`Manifest file not found: ${manifestPath}`);
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      throw new Error(`Manifest file not found: ${manifestPath}`);
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read manifest file ${manifestPath}: ${detail}`);
   }
 
   let parsed: unknown;

--- a/packages/readyup/src/manifest/readManifest.ts
+++ b/packages/readyup/src/manifest/readManifest.ts
@@ -13,8 +13,7 @@ export function readManifest(manifestPath: string): RdyManifest {
   try {
     raw = readFileSync(manifestPath, 'utf8');
   } catch (error: unknown) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT') {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       throw new Error(`Manifest file not found: ${manifestPath}`);
     }
     const detail = error instanceof Error ? error.message : String(error);

--- a/packages/readyup/src/manifest/readManifest.ts
+++ b/packages/readyup/src/manifest/readManifest.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+
+import { ManifestSchema } from './manifestSchema.ts';
+import type { RdyManifest } from './manifestSchema.ts';
+
+/**
+ * Read and validate a manifest file from disk.
+ *
+ * Throws on missing file, invalid JSON, or schema-invalid content.
+ */
+export function readManifest(manifestPath: string): RdyManifest {
+  let raw: string;
+  try {
+    raw = readFileSync(manifestPath, 'utf8');
+  } catch {
+    throw new Error(`Manifest file not found: ${manifestPath}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Manifest file contains invalid JSON: ${manifestPath}`);
+  }
+
+  const result = ManifestSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`Invalid manifest schema in ${manifestPath}: ${result.error.message}`);
+  }
+
+  return result.data;
+}

--- a/packages/readyup/src/manifest/writeManifest.ts
+++ b/packages/readyup/src/manifest/writeManifest.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-import { ManifestSchema } from './manifestSchema.ts';
 import type { RdyManifest } from './manifestSchema.ts';
+import { ManifestSchema } from './manifestSchema.ts';
 
 /**
  * Validate and write a manifest to disk as formatted JSON.

--- a/packages/readyup/src/manifest/writeManifest.ts
+++ b/packages/readyup/src/manifest/writeManifest.ts
@@ -1,0 +1,20 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { ManifestSchema } from './manifestSchema.ts';
+import type { RdyManifest } from './manifestSchema.ts';
+
+/**
+ * Validate and write a manifest to disk as formatted JSON.
+ *
+ * Creates parent directories as needed. Throws on invalid manifest data.
+ */
+export function writeManifest(manifestPath: string, manifest: RdyManifest): void {
+  const result = ManifestSchema.safeParse(manifest);
+  if (!result.success) {
+    throw new Error(`Invalid manifest data: ${result.error.message}`);
+  }
+
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  writeFileSync(manifestPath, JSON.stringify(result.data, null, 2) + '\n', 'utf8');
+}

--- a/packages/readyup/src/resolveKitExports.ts
+++ b/packages/readyup/src/resolveKitExports.ts
@@ -20,6 +20,7 @@ export function resolveKitExports(moduleRecord: Record<string, unknown>): Record
   return {
     checklists: source.checklists,
     ...(source.defaultSeverity !== undefined && { defaultSeverity: source.defaultSeverity }),
+    ...(source.description !== undefined && { description: source.description }),
     ...(source.failOn !== undefined && { failOn: source.failOn }),
     ...(source.fixLocation !== undefined && { fixLocation: source.fixLocation }),
     ...(source.reportOn !== undefined && { reportOn: source.reportOn }),

--- a/packages/readyup/src/resolveKitExports.ts
+++ b/packages/readyup/src/resolveKitExports.ts
@@ -1,11 +1,12 @@
 import { isRecord } from './isRecord.ts';
 
 /**
- * Extract `checklists`, `fixLocation`, and `suites` from an imported module namespace.
+ * Extract all recognized kit fields from an imported module namespace.
  *
- * Supports both `export default defineRdyKit({...})` and the named-export
- * convention (`export const checklists = ...`). Returns a plain record suitable for passing
- * to `assertIsRdyKit`.
+ * Extracts `checklists` (required), and optionally `defaultSeverity`, `description`, `failOn`,
+ * `fixLocation`, `reportOn`, and `suites`. Supports both `export default defineRdyKit({...})`
+ * and the named-export convention (`export const checklists = ...`). Returns a plain record
+ * suitable for passing to `assertIsRdyKit`.
  */
 export function resolveKitExports(moduleRecord: Record<string, unknown>): Record<string, unknown> {
   // Unwrap default export when present (e.g., `export default defineRdyKit({...})`)

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -282,6 +282,9 @@ export interface RdyKit {
   /** Checklists in this kit. */
   checklists: Array<RdyChecklist | RdyStagedChecklist>;
 
+  /** Human-readable summary of what the kit checks. */
+  description?: string;
+
   /** Named subsets of checklists. */
   suites?: Record<string, string[]>;
 


### PR DESCRIPTION
## What

Adds a `.readyup/manifest.json` file that is automatically generated on every `rdy compile` invocation, providing machine-readable kit discovery for external consumers. Batch mode writes the full manifest; single-file mode upserts a single entry. A new `rdy list --manifest` flag reads and displays manifest contents. Kit authors can now supply an optional `description` that flows through to the manifest.

## Why

External consumers had no machine-readable way to discover what kits a project provides. Discovery required filesystem scanning via `enumerateKits`, which doesn't work across repo boundaries or for remote consumers. The manifest is a foundation for future work on non-standard kit locations (#52) and orphan cleanup (#53).

## Details

### Features

- Manifest schema (`version: 1`, `kits: [{ name, description? }]`) validated with zod on both read and write
- `rdy compile` generates `.readyup/manifest.json` after successful compilation
  - Batch mode: writes full manifest from all compiled kits
  - Single-file mode: upserts only the targeted kit entry, preserving others
  - Kit array maintained in alphabetical order for deterministic output
- `--manifest=<path>` overrides the default manifest location in both `compile` and `list`
- `--skip-manifest` suppresses manifest generation entirely
- `rdy list --manifest=<path>` displays kits from a manifest file (mutually exclusive with `--from`)
- Optional `description` field on `RdyKit`, forwarded through `resolveKitExports` and `validateCompiledOutput`
- `RdyManifest` type and `DEFAULT_MANIFEST_PATH` exported from the package entry point

### Fixes

- `readManifest` distinguishes ENOENT from other filesystem errors (EACCES, etc.) for accurate error messages
- Single-file compile path separates compile errors from manifest write errors into distinct try/catch blocks
- `KitMetadata` and `ManifestViewOptions` interfaces use `string | undefined` for optional properties to satisfy `exactOptionalPropertyTypes`

### Tests

- 8 new/modified test files; 792 tests passing
- Coverage includes: schema validation, manifest read/write, `validateCompiledOutput` metadata extraction (end-to-end with real ESM bundles), compile command manifest generation (batch, single-file, upsert, flags, error paths), list command manifest display, and `resolveKitExports` description forwarding

Closes #44