### PR TITLE
#52 Enable cross-directory kit discovery via manifest

### DIFF
--- a/packages/readyup/__tests__/compile/hashSourceFile.test.ts
+++ b/packages/readyup/__tests__/compile/hashSourceFile.test.ts
@@ -1,0 +1,51 @@
+import { writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { hashSourceFile } from '../../src/compile/hashSourceFile.ts';
+
+describe(hashSourceFile, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'hash-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns an 8-character hex string', () => {
+    const filePath = path.join(tempDir, 'test.ts');
+    writeFileSync(filePath, 'export default {};\n', 'utf8');
+
+    const result = hashSourceFile(filePath);
+
+    expect(result).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('returns the same hash for identical content', () => {
+    const file1 = path.join(tempDir, 'a.ts');
+    const file2 = path.join(tempDir, 'b.ts');
+    writeFileSync(file1, 'hello world', 'utf8');
+    writeFileSync(file2, 'hello world', 'utf8');
+
+    expect(hashSourceFile(file1)).toBe(hashSourceFile(file2));
+  });
+
+  it('returns different hashes for different content', () => {
+    const file1 = path.join(tempDir, 'a.ts');
+    const file2 = path.join(tempDir, 'b.ts');
+    writeFileSync(file1, 'content A', 'utf8');
+    writeFileSync(file2, 'content B', 'utf8');
+
+    expect(hashSourceFile(file1)).not.toBe(hashSourceFile(file2));
+  });
+
+  it('throws when the file does not exist', () => {
+    expect(() => hashSourceFile(path.join(tempDir, 'missing.ts'))).toThrow();
+  });
+});

--- a/packages/readyup/__tests__/compile/hashSourceFile.test.ts
+++ b/packages/readyup/__tests__/compile/hashSourceFile.test.ts
@@ -1,5 +1,4 @@
-import { writeFileSync } from 'node:fs';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -8,6 +8,7 @@ const mockReaddirSync = vi.hoisted(() => vi.fn());
 const mockPicomatch = vi.hoisted(() => vi.fn());
 const mockWriteManifest = vi.hoisted(() => vi.fn());
 const mockReadManifest = vi.hoisted(() => vi.fn());
+const mockHashSourceFile = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/compile/compileConfig.ts', () => ({
   compileConfig: mockCompileConfig,
@@ -38,6 +39,10 @@ vi.mock('../src/manifest/readManifest.ts', () => ({
   readManifest: mockReadManifest,
 }));
 
+vi.mock('../src/compile/hashSourceFile.ts', () => ({
+  hashSourceFile: mockHashSourceFile,
+}));
+
 import { compileCommand } from '../src/compile/compileCommand.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../src/reportRdy.ts';
 
@@ -49,6 +54,7 @@ describe(compileCommand, () => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockValidateCompiledOutput.mockResolvedValue({});
+    mockHashSourceFile.mockReturnValue('abcd1234');
   });
 
   afterEach(() => {
@@ -61,6 +67,7 @@ describe(compileCommand, () => {
     mockPicomatch.mockReset();
     mockWriteManifest.mockReset();
     mockReadManifest.mockReset();
+    mockHashSourceFile.mockReset();
   });
 
   // Explicit input file tests
@@ -241,7 +248,7 @@ describe(compileCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Source directory not found'));
   });
 
-  it('returns 1 when srcDir has no .ts files', async () => {
+  it('writes empty manifest and returns 0 when srcDir has no .ts files', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
     });
@@ -250,8 +257,8 @@ describe(compileCommand, () => {
 
     const exitCode = await compileCommand([]);
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));
+    expect(exitCode).toBe(0);
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
   });
 
   // Post-compile validation tests
@@ -296,7 +303,7 @@ describe(compileCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('EACCES'));
   });
 
-  it('returns 1 when glob matches only non-.ts files during batch compile', async () => {
+  it('writes empty manifest when glob matches only non-.ts files during batch compile', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: 'data/*' },
     });
@@ -306,12 +313,12 @@ describe(compileCommand, () => {
 
     const exitCode = await compileCommand([]);
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));
+    expect(exitCode).toBe(0);
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
   });
 
   // Manifest generation tests
-  it('writes manifest after batch compile with kit entries', async () => {
+  it('writes manifest after batch compile with kit entries including location fields', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
     });
@@ -321,12 +328,27 @@ describe(compileCommand, () => {
       .mockResolvedValueOnce({ outputPath: '/abs/alpha.js', changed: true })
       .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true });
     mockValidateCompiledOutput.mockResolvedValueOnce({ description: 'Alpha checks' }).mockResolvedValueOnce({});
+    mockHashSourceFile.mockReturnValueOnce('aaaa1111').mockReturnValueOnce('bbbb2222');
 
     await compileCommand([]);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
-      kits: [{ name: 'alpha', description: 'Alpha checks' }, { name: 'beta' }],
+      kits: [
+        {
+          name: 'alpha',
+          description: 'Alpha checks',
+          path: expect.stringContaining('alpha.js'),
+          source: expect.stringContaining('alpha.ts'),
+          sourceHash: 'aaaa1111',
+        },
+        {
+          name: 'beta',
+          path: expect.stringContaining('beta.js'),
+          source: expect.stringContaining('beta.ts'),
+          sourceHash: 'bbbb2222',
+        },
+      ],
     });
   });
 
@@ -356,9 +378,10 @@ describe(compileCommand, () => {
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.stringContaining('custom/manifest.json'), expect.anything());
   });
 
-  it('upserts manifest entry for single-file compile', async () => {
+  it('upserts manifest entry for single-file compile with location fields', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true });
     mockValidateCompiledOutput.mockResolvedValue({ description: 'Deploy checks' });
+    mockHashSourceFile.mockReturnValue('deadbeef');
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [{ name: 'default', description: 'Default checks' }],
@@ -370,7 +393,13 @@ describe(compileCommand, () => {
       version: 1,
       kits: [
         { name: 'default', description: 'Default checks' },
-        { name: 'deploy', description: 'Deploy checks' },
+        {
+          name: 'deploy',
+          description: 'Deploy checks',
+          path: expect.stringContaining('deploy.js'),
+          source: expect.stringContaining('deploy.ts'),
+          sourceHash: 'deadbeef',
+        },
       ],
     });
   });
@@ -378,6 +407,7 @@ describe(compileCommand, () => {
   it('creates new manifest for single-file compile when no manifest exists', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true });
     mockValidateCompiledOutput.mockResolvedValue({});
+    mockHashSourceFile.mockReturnValue('abcd1234');
     mockReadManifest.mockImplementation(() => {
       throw new Error('not found');
     });
@@ -386,13 +416,21 @@ describe(compileCommand, () => {
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
-      kits: [{ name: 'deploy' }],
+      kits: [
+        {
+          name: 'deploy',
+          path: expect.stringContaining('deploy.js'),
+          source: expect.stringContaining('deploy.ts'),
+          sourceHash: 'abcd1234',
+        },
+      ],
     });
   });
 
   it('replaces existing entry when upserting for single-file compile', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true });
     mockValidateCompiledOutput.mockResolvedValue({ description: 'Updated' });
+    mockHashSourceFile.mockReturnValue('newh4sh0');
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [{ name: 'deploy', description: 'Old' }],
@@ -402,7 +440,15 @@ describe(compileCommand, () => {
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
-      kits: [{ name: 'deploy', description: 'Updated' }],
+      kits: [
+        {
+          name: 'deploy',
+          description: 'Updated',
+          path: expect.stringContaining('deploy.js'),
+          source: expect.stringContaining('deploy.ts'),
+          sourceHash: 'newh4sh0',
+        },
+      ],
     });
   });
 
@@ -464,6 +510,7 @@ describe(compileCommand, () => {
   it('maintains alphabetical order when upserting manifest entries', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true });
     mockValidateCompiledOutput.mockResolvedValue({});
+    mockHashSourceFile.mockReturnValue('abcd1234');
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [{ name: 'charlie' }, { name: 'beta' }],
@@ -473,7 +520,7 @@ describe(compileCommand, () => {
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
-      kits: [{ name: 'alpha' }, { name: 'beta' }, { name: 'charlie' }],
+      kits: [expect.objectContaining({ name: 'alpha', sourceHash: 'abcd1234' }), { name: 'beta' }, { name: 'charlie' }],
     });
   });
 });

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -1,4 +1,8 @@
+import assert from 'node:assert';
+
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import type { RdyManifest } from '../src/manifest/manifestSchema.ts';
 
 const mockCompileConfig = vi.hoisted(() => vi.fn());
 const mockValidateCompiledOutput = vi.hoisted(() => vi.fn());
@@ -35,15 +39,20 @@ vi.mock('../src/manifest/writeManifest.ts', () => ({
   writeManifest: mockWriteManifest,
 }));
 
-vi.mock('../src/manifest/readManifest.ts', () => ({
-  readManifest: mockReadManifest,
-}));
+vi.mock('../src/manifest/readManifest.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/manifest/readManifest.ts')>();
+  return {
+    ManifestNotFoundError: actual.ManifestNotFoundError,
+    readManifest: mockReadManifest,
+  };
+});
 
 vi.mock('../src/compile/hashSourceFile.ts', () => ({
   hashSourceFile: mockHashSourceFile,
 }));
 
 import { compileCommand } from '../src/compile/compileCommand.ts';
+import { ManifestNotFoundError } from '../src/manifest/readManifest.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../src/reportRdy.ts';
 
 describe(compileCommand, () => {
@@ -248,7 +257,7 @@ describe(compileCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Source directory not found'));
   });
 
-  it('writes empty manifest and returns 0 when srcDir has no .ts files', async () => {
+  it('writes empty manifest and emits info message when srcDir has no .ts files', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
     });
@@ -259,6 +268,21 @@ describe(compileCommand, () => {
 
     expect(exitCode).toBe(0);
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));
+  });
+
+  it('returns 0 and skips manifest when --skip-manifest is set and srcDir has no .ts files', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['readme.md']);
+
+    const exitCode = await compileCommand(['--skip-manifest']);
+
+    expect(exitCode).toBe(0);
+    expect(mockWriteManifest).not.toHaveBeenCalled();
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));
   });
 
   // Post-compile validation tests
@@ -350,6 +374,15 @@ describe(compileCommand, () => {
         },
       ],
     });
+
+    // Verify paths are relative (not absolute).
+    const writtenManifest: RdyManifest = mockWriteManifest.mock.calls[0][1];
+    for (const kit of writtenManifest.kits) {
+      assert.ok(kit.path, 'Expected kit.path to be defined');
+      assert.ok(kit.source, 'Expected kit.source to be defined');
+      expect(kit.path).not.toMatch(/^\//);
+      expect(kit.source).not.toMatch(/^\//);
+    }
   });
 
   it('skips manifest generation when --skip-manifest is set', async () => {
@@ -409,7 +442,7 @@ describe(compileCommand, () => {
     mockValidateCompiledOutput.mockResolvedValue({});
     mockHashSourceFile.mockReturnValue('abcd1234');
     mockReadManifest.mockImplementation(() => {
-      throw new Error('not found');
+      throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
 
     await compileCommand(['deploy.ts']);
@@ -498,7 +531,7 @@ describe(compileCommand, () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true });
     mockValidateCompiledOutput.mockResolvedValue({});
     mockReadManifest.mockImplementation(() => {
-      throw new Error('not found');
+      throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
 
     await compileCommand(['deploy.ts', '--manifest=custom/manifest.json']);

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -1,14 +1,13 @@
 import assert from 'node:assert';
 import path from 'node:path';
-import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import type { enumerateKits } from '../../src/list/enumerateKits.ts';
 import { listCommand } from '../../src/list/listCommand.ts';
 
-const mockEnumerateKits = vi.hoisted(() => vi.fn<typeof enumerateKits>());
+const mockEnumerateKits = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
+const mockReadManifest = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/list/enumerateKits.ts', () => ({
   enumerateKits: mockEnumerateKits,
@@ -16,6 +15,10 @@ vi.mock('../../src/list/enumerateKits.ts', () => ({
 
 vi.mock('../../src/loadConfig.ts', () => ({
   loadConfig: mockLoadConfig,
+}));
+
+vi.mock('../../src/manifest/readManifest.ts', () => ({
+  readManifest: mockReadManifest,
 }));
 
 describe(listCommand, () => {
@@ -26,51 +29,62 @@ describe(listCommand, () => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     mockEnumerateKits.mockReturnValue([]);
+    mockReadManifest.mockReturnValue({ version: 1, kits: [] });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     mockEnumerateKits.mockReset();
     mockLoadConfig.mockReset();
+    mockReadManifest.mockReset();
   });
 
-  it('with --from global, enumerates kits from the home-based .readyup/kits directory', async () => {
-    mockEnumerateKits.mockReturnValue(['default']);
+  it('with --from global, reads manifest from the home-based .readyup directory', async () => {
+    mockReadManifest.mockReturnValue({
+      version: 1,
+      kits: [{ name: 'default' }],
+    });
 
     const exitCode = await listCommand(['--from', 'global']);
 
     expect(exitCode).toBe(0);
-    const firstCall = mockEnumerateKits.mock.calls[0];
-    assert.ok(firstCall, 'expected enumerateKits to have been called');
-    const calledDir = firstCall[0].dir;
-    expect(calledDir).toMatch(/\/.readyup\/kits$/);
+    const firstCall = mockReadManifest.mock.calls[0];
+    assert.ok(firstCall, 'expected readManifest to have been called');
+    const calledPath = String(firstCall[0]);
+    expect(calledPath).toMatch(/\/.readyup\/manifest\.json$/);
     expect(stdoutSpy).toHaveBeenCalled();
   });
 
-  it('with --from dir:/some/path, enumerates kits from the resolved absolute path', async () => {
-    mockEnumerateKits.mockReturnValue(['my-kit']);
+  it('with --from dir:/some/path, reads manifest from the resolved directory', async () => {
+    mockReadManifest.mockReturnValue({
+      version: 1,
+      kits: [{ name: 'my-kit' }],
+    });
 
     const exitCode = await listCommand(['--from', 'dir:/some/path']);
 
     expect(exitCode).toBe(0);
-    const firstCall = mockEnumerateKits.mock.calls[0];
-    assert.ok(firstCall, 'expected enumerateKits to have been called');
-    const calledDir = firstCall[0].dir;
-    expect(calledDir).toBe(path.resolve('/some/path'));
-    // Directory source does not append .readyup/kits.
-    expect(calledDir).not.toContain('.readyup/kits');
+    const firstCall = mockReadManifest.mock.calls[0];
+    assert.ok(firstCall, 'expected readManifest to have been called');
+    const calledPath = String(firstCall[0]);
+    expect(calledPath).toBe(path.join(path.resolve('/some/path'), 'manifest.json'));
+    // Directory source does not append .readyup.
+    expect(calledPath).not.toContain('.readyup');
   });
 
-  it('with --from <local-path>, enumerates kits from .readyup/kits under the local path', async () => {
-    mockEnumerateKits.mockReturnValue(['default']);
+  it('with --from <local-path>, reads manifest from .readyup under the local path', async () => {
+    mockReadManifest.mockReturnValue({
+      version: 1,
+      kits: [{ name: 'default' }],
+    });
 
     const exitCode = await listCommand(['--from', '/some/repo']);
 
     expect(exitCode).toBe(0);
-    const firstCall = mockEnumerateKits.mock.calls[0];
-    assert.ok(firstCall, 'expected enumerateKits to have been called');
-    const calledDir = firstCall[0].dir;
-    expect(calledDir).toBe(path.join(path.resolve('/some/repo'), '.readyup/kits'));
+    const firstCall = mockReadManifest.mock.calls[0];
+    assert.ok(firstCall, 'expected readManifest to have been called');
+    const calledPath = String(firstCall[0]);
+    expect(calledPath).toBe(path.join(path.resolve('/some/repo'), '.readyup/manifest.json'));
   });
 
   it('returns exit code 1 with a user-readable error for malformed --from values', async () => {
@@ -79,6 +93,6 @@ describe(listCommand, () => {
     expect(exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error:'));
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('URLs are not accepted by --from'));
-    expect(mockEnumerateKits).not.toHaveBeenCalled();
+    expect(mockReadManifest).not.toHaveBeenCalled();
   });
 });

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -17,9 +17,13 @@ vi.mock('../../src/loadConfig.ts', () => ({
   loadConfig: mockLoadConfig,
 }));
 
-vi.mock('../../src/manifest/readManifest.ts', () => ({
-  readManifest: mockReadManifest,
-}));
+vi.mock('../../src/manifest/readManifest.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/manifest/readManifest.ts')>();
+  return {
+    ManifestNotFoundError: actual.ManifestNotFoundError,
+    readManifest: mockReadManifest,
+  };
+});
 
 describe(listCommand, () => {
   let stdoutSpy: MockInstance;

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -30,6 +30,7 @@ describe(listCommand, () => {
       internal: { dir: '.', infix: undefined },
     });
     mockEnumerateKits.mockReturnValue([]);
+    mockReadManifest.mockReturnValue({ version: 1, kits: [] });
   });
 
   afterEach(() => {
@@ -40,19 +41,22 @@ describe(listCommand, () => {
   });
 
   describe('owner mode', () => {
-    it('loads config and enumerates both internal and compiled kits', async () => {
-      mockEnumerateKits.mockReturnValueOnce(['default']).mockReturnValueOnce(['deploy']);
+    it('loads config and reads manifest for compiled kits', async () => {
+      mockEnumerateKits.mockReturnValue(['default']);
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'deploy' }],
+      });
 
       const exitCode = await listCommand([]);
 
       expect(exitCode).toBe(0);
       expect(mockLoadConfig).toHaveBeenCalled();
-      expect(mockEnumerateKits).toHaveBeenCalledTimes(2);
+      expect(mockReadManifest).toHaveBeenCalled();
+      // enumerateKits is only called for internal kits
+      expect(mockEnumerateKits).toHaveBeenCalledTimes(1);
       expect(mockEnumerateKits).toHaveBeenCalledWith(
         expect.objectContaining({ dir: expect.stringContaining('.readyup/kits'), extension: '.ts' }),
-      );
-      expect(mockEnumerateKits).toHaveBeenCalledWith(
-        expect.objectContaining({ dir: expect.stringContaining('.readyup/kits'), extension: '.js' }),
       );
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(output).toContain('Internal:');
@@ -64,7 +68,7 @@ describe(listCommand, () => {
         compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
         internal: { dir: '.', infix: 'int' },
       });
-      mockEnumerateKits.mockReturnValueOnce(['default']).mockReturnValueOnce([]);
+      mockEnumerateKits.mockReturnValue(['default']);
 
       const exitCode = await listCommand([]);
 
@@ -72,8 +76,9 @@ describe(listCommand, () => {
       expect(mockEnumerateKits).toHaveBeenCalledWith(expect.objectContaining({ extension: '.int.ts' }));
     });
 
-    it('renders only Internal section when no compiled kits exist', async () => {
-      mockEnumerateKits.mockReturnValueOnce(['default']).mockReturnValueOnce([]);
+    it('renders only Internal section when manifest has no compiled kits', async () => {
+      mockEnumerateKits.mockReturnValue(['default']);
+      mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
       const exitCode = await listCommand([]);
 
@@ -88,7 +93,11 @@ describe(listCommand, () => {
         compile: { srcDir: 'src/kits', outDir: 'dist/kits', include: undefined },
         internal: { dir: '.', infix: undefined },
       });
-      mockEnumerateKits.mockReturnValueOnce([]).mockReturnValueOnce(['deploy']);
+      mockEnumerateKits.mockReturnValue([]);
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'deploy' }],
+      });
 
       const exitCode = await listCommand([]);
 
@@ -99,6 +108,10 @@ describe(listCommand, () => {
     });
 
     it('prints empty-owner message when no kits exist', async () => {
+      mockReadManifest.mockImplementation(() => {
+        throw new Error('not found');
+      });
+
       const exitCode = await listCommand([]);
 
       expect(exitCode).toBe(0);
@@ -130,7 +143,7 @@ describe(listCommand, () => {
 
   describe('from mode', () => {
     it('does not load config when --from is given', async () => {
-      mockEnumerateKits.mockReturnValue([]);
+      mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
       const exitCode = await listCommand(['--from', '.']);
 
@@ -138,40 +151,30 @@ describe(listCommand, () => {
       expect(mockLoadConfig).not.toHaveBeenCalled();
     });
 
-    it('enumerates compiled kits from a local path', async () => {
-      mockEnumerateKits.mockReturnValue(['deploy']);
+    it('reads manifest from a local path and displays compiled kits', async () => {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'deploy' }],
+      });
 
       const exitCode = await listCommand(['--from', '.']);
 
       expect(exitCode).toBe(0);
-      expect(mockEnumerateKits).toHaveBeenCalledWith(
-        expect.objectContaining({ dir: expect.stringContaining('.readyup/kits'), extension: '.js' }),
-      );
+      expect(mockReadManifest).toHaveBeenCalledWith(expect.stringContaining('.readyup/manifest.json'));
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(output).toContain('Compiled:');
       expect(output).toContain('deploy');
     });
 
-    it('prints empty-consumer message when no kits exist at the local path', async () => {
-      mockEnumerateKits.mockReturnValue([]);
+    it('returns 1 when manifest is not found at --from path', async () => {
+      mockReadManifest.mockImplementation(() => {
+        throw new Error('Manifest file not found: /nonexistent/.readyup/manifest.json');
+      });
 
       const exitCode = await listCommand(['--from', '/nonexistent']);
 
-      expect(exitCode).toBe(0);
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('No compiled kits found at /nonexistent/.readyup/kits.');
-    });
-
-    it('returns 1 and writes to stderr when enumerateKits throws', async () => {
-      const permError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
-      mockEnumerateKits.mockImplementation(() => {
-        throw permError;
-      });
-
-      const exitCode = await listCommand(['--from', '.']);
-
       expect(exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Manifest file not found'));
     });
 
     it('returns 1 for github: scheme with not-yet-supported message', async () => {

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -12,11 +12,16 @@ vi.mock('../src/list/enumerateKits.ts', () => ({
   enumerateKits: mockEnumerateKits,
 }));
 
-vi.mock('../src/manifest/readManifest.ts', () => ({
-  readManifest: mockReadManifest,
-}));
+vi.mock('../src/manifest/readManifest.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/manifest/readManifest.ts')>();
+  return {
+    ManifestNotFoundError: actual.ManifestNotFoundError,
+    readManifest: mockReadManifest,
+  };
+});
 
 import { listCommand } from '../src/list/listCommand.ts';
+import { ManifestNotFoundError } from '../src/manifest/readManifest.ts';
 
 describe(listCommand, () => {
   let stdoutSpy: MockInstance;
@@ -109,7 +114,7 @@ describe(listCommand, () => {
 
     it('prints empty-owner message when no kits exist', async () => {
       mockReadManifest.mockImplementation(() => {
-        throw new Error('not found');
+        throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
       });
 
       const exitCode = await listCommand([]);
@@ -139,6 +144,37 @@ describe(listCommand, () => {
       expect(exitCode).toBe(1);
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
     });
+
+    it('renders Internal section without Compiled when manifest file is missing and internal kits exist', async () => {
+      mockEnumerateKits.mockReturnValue(['default']);
+      mockReadManifest.mockImplementation(() => {
+        throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
+      });
+
+      const exitCode = await listCommand([]);
+
+      expect(exitCode).toBe(0);
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('Internal:');
+      expect(output).not.toContain('Compiled:');
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it('writes warning to stderr when manifest read fails with non-missing-file error and internal kits exist', async () => {
+      mockEnumerateKits.mockReturnValue(['default']);
+      mockReadManifest.mockImplementation(() => {
+        throw new Error('Manifest file contains invalid JSON: .readyup/manifest.json');
+      });
+
+      const exitCode = await listCommand([]);
+
+      expect(exitCode).toBe(0);
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('Internal:');
+      expect(output).not.toContain('Compiled:');
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Warning:'));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'));
+    });
   });
 
   describe('from mode', () => {
@@ -164,6 +200,16 @@ describe(listCommand, () => {
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(output).toContain('Compiled:');
       expect(output).toContain('deploy');
+    });
+
+    it('prints empty-consumer message when manifest contains no kits', async () => {
+      mockReadManifest.mockReturnValue({ version: 1, kits: [] });
+
+      const exitCode = await listCommand(['--from', '.']);
+
+      expect(exitCode).toBe(0);
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('No compiled kits found');
     });
 
     it('returns 1 when manifest is not found at --from path', async () => {

--- a/packages/readyup/__tests__/manifest/manifestSchema.test.ts
+++ b/packages/readyup/__tests__/manifest/manifestSchema.test.ts
@@ -46,6 +46,39 @@ describe(ManifestSchema, () => {
     expect(result.success).toBe(false);
   });
 
+  it('accepts a manifest with path, source, and sourceHash fields', () => {
+    const input = {
+      version: 1,
+      kits: [
+        {
+          name: 'deploy',
+          description: 'Deploy checks',
+          path: 'kits/deploy.js',
+          source: 'kits/deploy.ts',
+          sourceHash: 'a1b2c3d4',
+        },
+      ],
+    };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a manifest mixing entries with and without location fields', () => {
+    const input = {
+      version: 1,
+      kits: [
+        { name: 'default', description: 'General health checks' },
+        { name: 'deploy', path: 'kits/deploy.js', source: 'kits/deploy.ts', sourceHash: 'abcd1234' },
+      ],
+    };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+  });
+
   it('rejects a kit with an empty name', () => {
     const input = { version: 1, kits: [{ name: '' }] };
 

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -78,8 +78,9 @@ export async function compileCommand(args: string[]): Promise<number> {
         const kitName = path.basename(result.outputPath, '.js');
         const manifestDir = path.dirname(manifestPath);
         const relOutputPath = path.relative(manifestDir, path.resolve(result.outputPath));
-        const relSourcePath = path.relative(manifestDir, path.resolve(inputPath));
-        const sourceHash = hashSourceFile(path.resolve(inputPath));
+        const resolvedInputPath = path.resolve(inputPath);
+        const relSourcePath = path.relative(manifestDir, resolvedInputPath);
+        const sourceHash = hashSourceFile(resolvedInputPath);
         upsertManifest(manifestPath, kitName, metadata, {
           path: relOutputPath,
           source: relSourcePath,

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -13,6 +13,7 @@ import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../reportRdy.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { compileConfig } from './compileConfig.ts';
+import { hashSourceFile } from './hashSourceFile.ts';
 import type { KitMetadata } from './validateCompiledOutput.ts';
 import { validateCompiledOutput } from './validateCompiledOutput.ts';
 
@@ -75,7 +76,15 @@ export async function compileCommand(args: string[]): Promise<number> {
     if (!skipManifest) {
       try {
         const kitName = path.basename(result.outputPath, '.js');
-        upsertManifest(manifestPath, kitName, metadata);
+        const manifestDir = path.dirname(manifestPath);
+        const relOutputPath = path.relative(manifestDir, path.resolve(result.outputPath));
+        const relSourcePath = path.relative(manifestDir, path.resolve(inputPath));
+        const sourceHash = hashSourceFile(path.resolve(inputPath));
+        upsertManifest(manifestPath, kitName, metadata, {
+          path: relOutputPath,
+          source: relSourcePath,
+          sourceHash,
+        });
       } catch (error: unknown) {
         const message = extractMessage(error);
         process.stderr.write(`Error writing manifest: ${message}\n`);
@@ -137,8 +146,16 @@ async function compileBatch(skipManifest: boolean, manifestPath: string): Promis
   }
 
   if (tsFiles.length === 0) {
-    process.stderr.write(`Error: No .ts files found in ${srcDir}\n`);
-    return 1;
+    if (!skipManifest) {
+      try {
+        writeManifest(manifestPath, { version: 1, kits: [] });
+      } catch (error: unknown) {
+        const message = extractMessage(error);
+        process.stderr.write(`Error writing manifest: ${message}\n`);
+        return 1;
+      }
+    }
+    return 0;
   }
 
   const relSrcDir = path.relative(process.cwd(), srcDir);
@@ -147,6 +164,7 @@ async function compileBatch(skipManifest: boolean, manifestPath: string): Promis
     srcDir === outDir ? `Compiling kits in ${relSrcDir}:\n` : `Compiling kits from ${relSrcDir} to ${relOutDir}:\n`;
   process.stdout.write(header);
 
+  const manifestDir = path.dirname(manifestPath);
   const kitEntries: RdyManifestKit[] = [];
 
   for (const fileName of tsFiles) {
@@ -159,8 +177,14 @@ async function compileBatch(skipManifest: boolean, manifestPath: string): Promis
       process.stdout.write(formatResultLine(fileName, outName, result.changed));
 
       const kitName = path.basename(result.outputPath, '.js');
+      const relOutputPath = path.relative(manifestDir, path.resolve(result.outputPath));
+      const relSourcePath = path.relative(manifestDir, srcFile);
+      const sourceHash = hashSourceFile(srcFile);
       kitEntries.push({
         name: kitName,
+        path: relOutputPath,
+        source: relSourcePath,
+        sourceHash,
         ...(metadata.description !== undefined && { description: metadata.description }),
       });
     } catch (error: unknown) {
@@ -184,8 +208,20 @@ async function compileBatch(skipManifest: boolean, manifestPath: string): Promis
   return 0;
 }
 
+/** Location fields for a manifest kit entry. */
+interface KitLocationFields {
+  path: string;
+  source: string;
+  sourceHash: string;
+}
+
 /** Read an existing manifest (if any), upsert a kit entry, and write back. */
-function upsertManifest(manifestPath: string, kitName: string, metadata: KitMetadata): void {
+function upsertManifest(
+  manifestPath: string,
+  kitName: string,
+  metadata: KitMetadata,
+  location: KitLocationFields,
+): void {
   let existingKits: RdyManifestKit[] = [];
   try {
     const existing = readManifest(manifestPath);
@@ -200,6 +236,9 @@ function upsertManifest(manifestPath: string, kitName: string, metadata: KitMeta
 
   const entry: RdyManifestKit = {
     name: kitName,
+    path: location.path,
+    source: location.source,
+    sourceHash: location.sourceHash,
     ...(metadata.description !== undefined && { description: metadata.description }),
   };
 

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -7,7 +7,7 @@ import picomatch from 'picomatch';
 import { loadConfig } from '../loadConfig.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestSchema.ts';
-import { readManifest } from '../manifest/readManifest.ts';
+import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { writeManifest } from '../manifest/writeManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../reportRdy.ts';
@@ -146,6 +146,8 @@ async function compileBatch(skipManifest: boolean, manifestPath: string): Promis
   }
 
   if (tsFiles.length === 0) {
+    const relSrc = path.relative(process.cwd(), srcDir);
+    process.stdout.write(`No .ts files found in ${relSrc}\n`);
     if (!skipManifest) {
       try {
         writeManifest(manifestPath, { version: 1, kits: [] });
@@ -227,9 +229,9 @@ function upsertManifest(
     const existing = readManifest(manifestPath);
     existingKits = existing.kits;
   } catch (error: unknown) {
-    const message = extractMessage(error);
     // Missing manifest is expected for first compile; other failures should surface.
-    if (!message.includes('not found')) {
+    if (!(error instanceof ManifestNotFoundError)) {
+      const message = extractMessage(error);
       process.stderr.write(`Warning: ${message} — starting with empty manifest\n`);
     }
   }

--- a/packages/readyup/src/compile/hashSourceFile.ts
+++ b/packages/readyup/src/compile/hashSourceFile.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'node:fs';
+
+import { computeHash } from '../check-utils/hashing.ts';
+
+/** Return the first 8 characters of the SHA-256 hex digest of a file's content. */
+export function hashSourceFile(filePath: string): string {
+  const content = readFileSync(filePath, 'utf8');
+  return computeHash(content).slice(0, 8);
+}

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -3,7 +3,7 @@ import process from 'node:process';
 
 import { loadConfig } from '../loadConfig.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestSchema.ts';
-import { readManifest } from '../manifest/readManifest.ts';
+import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { parseFromValue } from '../parseFromValue.ts';
 import { extractMessage } from '../utils/error-handling.ts';
@@ -131,13 +131,19 @@ async function runOwnerMode(): Promise<number> {
   try {
     const manifest = readManifest(manifestPath);
     compiledKits = manifest.kits.map((kit) => kit.name);
-  } catch {
-    // Missing or invalid manifest — show hint only when no internal kits exist either.
-    if (internalKits.length === 0) {
-      process.stdout.write(
-        'No kits found.\nRun `rdy init` to scaffold an internal kit or `rdy compile` to compile a kit from source.\n',
-      );
-      return 0;
+  } catch (error: unknown) {
+    if (error instanceof ManifestNotFoundError) {
+      // Missing manifest — show hint only when no internal kits exist either.
+      if (internalKits.length === 0) {
+        process.stdout.write(
+          'No kits found.\nRun `rdy init` to scaffold an internal kit or `rdy compile` to compile a kit from source.\n',
+        );
+        return 0;
+      }
+    } else {
+      // Corrupt or unreadable manifest — warn and continue with empty compiled list.
+      const message = extractMessage(error);
+      process.stderr.write(`Warning: ${message}\n`);
     }
   }
 

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import process from 'node:process';
 
 import { loadConfig } from '../loadConfig.ts';
+import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestSchema.ts';
 import { readManifest } from '../manifest/readManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { parseFromValue } from '../parseFromValue.ts';
@@ -16,7 +17,7 @@ const listFlagSchema = {
 };
 
 /**
- * Handle the `list` subcommand: enumerate kits from the filesystem and print their names.
+ * Handle the `list` subcommand: enumerate kits from the manifest and filesystem, then print their names.
  *
  * Returns a numeric exit code.
  */
@@ -67,7 +68,7 @@ function runManifestMode(manifestArg: string): number {
   return 0;
 }
 
-/** Enumerate kits from a `--from` source. */
+/** Resolve the manifest path for a `--from` source and display its kits. */
 function runFromMode(fromArg: string): number {
   let source;
   try {
@@ -83,27 +84,19 @@ function runFromMode(fromArg: string): number {
     return 1;
   }
 
-  let kitsDir: string;
-  if (source.type === 'global') {
-    const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '~';
-    kitsDir = path.join(homeDir, '.readyup/kits');
-  } else if (source.type === 'directory') {
-    kitsDir = path.resolve(source.path);
-  } else {
-    // local path
-    kitsDir = path.join(path.resolve(source.path), '.readyup/kits');
-  }
+  const manifestPath = resolveFromManifestPath(source);
 
-  let compiledKits;
+  let manifest;
   try {
-    compiledKits = enumerateKits({ dir: kitsDir, extension: '.js' });
+    manifest = readManifest(manifestPath);
   } catch (error: unknown) {
     const message = extractMessage(error);
     process.stderr.write(`Error: ${message}\n`);
     return 1;
   }
 
-  const output = formatConsumerView({ compiledKits, fromArg, kitsDir });
+  const kitNames = manifest.kits.map((kit) => kit.name);
+  const output = formatConsumerView({ compiledKits: kitNames, fromArg, kitsDir: path.dirname(manifestPath) });
   process.stdout.write(output + '\n');
   return 0;
 }
@@ -122,25 +115,53 @@ async function runOwnerMode(): Promise<number> {
   }
 
   const internalDir = path.join(cwd, '.readyup/kits', config.internal.dir);
-  const compiledDir = path.resolve(cwd, config.compile.outDir);
-
   const internalExtension = config.internal.infix !== undefined ? `.${config.internal.infix}.ts` : '.ts';
 
   let internalKits;
-  let compiledKits;
   try {
     internalKits = enumerateKits({ dir: internalDir, extension: internalExtension });
-    compiledKits = enumerateKits({ dir: compiledDir, extension: '.js' });
   } catch (error: unknown) {
     const message = extractMessage(error);
     process.stderr.write(`Error: ${message}\n`);
     return 1;
   }
 
+  const manifestPath = path.resolve(cwd, DEFAULT_MANIFEST_PATH);
+  let compiledKits: string[] = [];
+  try {
+    const manifest = readManifest(manifestPath);
+    compiledKits = manifest.kits.map((kit) => kit.name);
+  } catch {
+    // Missing or invalid manifest — show hint only when no internal kits exist either.
+    if (internalKits.length === 0) {
+      process.stdout.write(
+        'No kits found.\nRun `rdy init` to scaffold an internal kit or `rdy compile` to compile a kit from source.\n',
+      );
+      return 0;
+    }
+  }
+
   const compiledStyle = resolveCompiledStyle(cwd, config.compile.outDir);
   const output = formatOwnerView({ internalKits, compiledKits, compiledStyle });
   process.stdout.write(output + '\n');
   return 0;
+}
+
+/** Resolve the manifest path for a parsed `--from` source. */
+function resolveFromManifestPath(
+  source: { type: 'global' } | { type: 'directory'; path: string } | { type: 'local'; path: string },
+): string {
+  if (source.type === 'global') {
+    const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '~';
+    return path.join(homeDir, '.readyup/manifest.json');
+  }
+
+  if (source.type === 'directory') {
+    return path.join(path.resolve(source.path), 'manifest.json');
+  }
+
+  // local path
+  return path.join(path.resolve(source.path), '.readyup/manifest.json');
 }
 
 /** Determine the compiled-section display style based on the outDir setting. */

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -5,8 +5,11 @@ export const DEFAULT_MANIFEST_PATH = '.readyup/manifest.json';
 
 /** Schema for a single kit entry in the manifest. */
 const ManifestKitSchema = z.object({
-  name: z.string().min(1),
   description: z.string().optional(),
+  name: z.string().min(1),
+  path: z.string().optional(),
+  source: z.string().optional(),
+  sourceHash: z.string().optional(),
 });
 
 /** Schema for the readyup manifest file. */

--- a/packages/readyup/src/manifest/readManifest.ts
+++ b/packages/readyup/src/manifest/readManifest.ts
@@ -3,10 +3,18 @@ import { readFileSync } from 'node:fs';
 import type { RdyManifest } from './manifestSchema.ts';
 import { ManifestSchema } from './manifestSchema.ts';
 
+/** Thrown when the manifest file does not exist on disk. */
+export class ManifestNotFoundError extends Error {
+  constructor(manifestPath: string) {
+    super(`Manifest file not found: ${manifestPath}`);
+    this.name = 'ManifestNotFoundError';
+  }
+}
+
 /**
  * Read and validate a manifest file from disk.
  *
- * Throws on missing file, invalid JSON, or schema-invalid content.
+ * Throws `ManifestNotFoundError` for missing files, or a plain `Error` for invalid JSON / schema failures.
  */
 export function readManifest(manifestPath: string): RdyManifest {
   let raw: string;
@@ -14,7 +22,7 @@ export function readManifest(manifestPath: string): RdyManifest {
     raw = readFileSync(manifestPath, 'utf8');
   } catch (error: unknown) {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-      throw new Error(`Manifest file not found: ${manifestPath}`);
+      throw new ManifestNotFoundError(manifestPath);
     }
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to read manifest file ${manifestPath}: ${detail}`);


### PR DESCRIPTION
## What

Enables `rdy list` to discover compiled kits across directory boundaries by reading location data from the manifest instead of scanning the filesystem. `rdy compile` now records each kit's compiled path, source path, and a content hash in the manifest, making cross-directory resolution possible without filesystem traversal.

## Why

Kits placed in monorepo packages or non-standard locations were invisible to `rdy list`, which only scanned a single directory. The manifest already existed but carried only names and descriptions — not enough to locate kits outside the default output directory.

## Details

### Features

- Added optional `path`, `source`, and `sourceHash` fields to `ManifestKitSchema`. All paths are relative to the manifest file's directory. `sourceHash` is the first 8 hex characters of the source file's SHA-256 digest, sufficient for staleness detection.
- `rdy compile` populates all three fields in both batch and single-file modes.
- `rdy compile` with no source files now writes an empty manifest (`{ version: 1, kits: [] }`) and returns exit code 0, aligning with the "manifest always exists after compile" design.
- `rdy list` owner mode reads `.readyup/manifest.json` for compiled kits instead of scanning `.js` files. Shows a hint to run `rdy compile` when no manifest exists.
- `rdy list --from` resolves the manifest path per source type: `global` → `~/.readyup/manifest.json`, `dir:<path>` → `<path>/manifest.json`, local → `<path>/.readyup/manifest.json`.

### Fixes

- Introduced `ManifestNotFoundError` class for proper error discrimination. Owner mode silently handles missing manifests (expected state) but warns on stderr for unexpected errors. Replaced fragile `message.includes('not found')` string matching in `upsertManifest` with `instanceof` checks.

### Refactoring

- Extracted `resolveFromManifestPath` helper for source-type-to-path mapping in `listCommand`.
- Removed duplicate `path.resolve` call in single-file compile path.

### Tests

- Schema validation tests for mixed old/new manifest entries.
- Compile tests for location fields in batch and single-file modes, empty manifest write, `--skip-manifest` with no source files, and relative-path assertions.
- List tests for all three modes (owner, from, manifest), missing manifest hint, corrupt manifest warning, and empty-kits handling.

Closes #52