### PR TITLE
#59 Prevent authoring deps from being bundled into compiled kits

### DIFF
--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -33,6 +33,12 @@ function fileContains(relativePath, pattern) {
   return pattern.test(content);
 }
 
+// packages/readyup/dist/esm/check-utils/git/run-git.js
+import { execFile } from "node:child_process";
+import { homedir } from "node:os";
+import { promisify } from "node:util";
+var execFileAsync = promisify(execFile);
+
 // packages/readyup/dist/esm/check-utils/hashing.js
 import { createHash } from "node:crypto";
 

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "kits": [
+    {
+      "name": "demo",
+      "path": "kits/demo.js",
+      "source": "kits/demo.ts",
+      "sourceHash": "55151a06"
+    }
+  ]
+}

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -5,8 +5,8 @@ import process from 'node:process';
 import picomatch from 'picomatch';
 
 import { loadConfig } from '../loadConfig.ts';
+import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
-import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestSchema.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { writeManifest } from '../manifest/writeManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -46,8 +46,8 @@ export {
 export { pickJson } from './compile/pickJson.ts';
 
 // Manifest
+export { DEFAULT_MANIFEST_PATH } from './manifest/manifestPath.ts';
 export type { RdyManifest } from './manifest/manifestSchema.ts';
-export { DEFAULT_MANIFEST_PATH } from './manifest/manifestSchema.ts';
 
 // Check utilities
 export {

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import process from 'node:process';
 
 import { loadConfig } from '../loadConfig.ts';
-import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestSchema.ts';
+import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { parseFromValue } from '../parseFromValue.ts';

--- a/packages/readyup/src/manifest/manifestPath.ts
+++ b/packages/readyup/src/manifest/manifestPath.ts
@@ -1,0 +1,7 @@
+// Keep this constant in a zod-free module. Re-exporting it from `src/index.ts`
+// drags the module's transitive graph into every compiled user kit. Colocating
+// it with `manifestSchema.ts` would reintroduce the zod-bloat regression
+// captured in issue #59.
+
+/** Default path for the manifest file, relative to the project root. */
+export const DEFAULT_MANIFEST_PATH = '.readyup/manifest.json';

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -1,8 +1,5 @@
 import { z } from 'zod';
 
-/** Default path for the manifest file, relative to the project root. */
-export const DEFAULT_MANIFEST_PATH = '.readyup/manifest.json';
-
 /** Schema for a single kit entry in the manifest. */
 const ManifestKitSchema = z.object({
   description: z.string().optional(),


### PR DESCRIPTION
## What

Restores compiled kit bundles produced by `rdy compile` to their pre-regression size of ~7 KB, eliminating a 76× bloat (~526 KB) where every compiled kit silently inlined the entire `zod` library and its locale files.

## Why

Commit 4f65f25 added a runtime re-export from the public authoring entrypoint to a module that imports `zod` and declares schemas at module scope. Schema declarations are side-effectful from the bundler's perspective, so esbuild could not tree-shake them — every kit produced by `rdy compile` inflated, harming the cold-start cost and on-disk footprint of any project consuming compiled kits.

## Details

### Fixes

- Move `DEFAULT_MANIFEST_PATH` into a new zod-free module at `packages/readyup/src/manifest/manifestPath.ts`, isolating the constant from the side-effectful zod schemas.
- Re-export `DEFAULT_MANIFEST_PATH` from `packages/readyup/src/index.ts` via the new pure module, so the public authoring entrypoint no longer transitively imports `zod`.
- Update the internal importers `compile/compileCommand.ts` and `list/listCommand.ts` to point at the new module.
- Refresh `.readyup/kits/demo.js` — now byte-identical to the pre-regression baseline.
- Add `.readyup/manifest.json`, generated by `rdy compile` on the refreshed kit.

The `manifest/manifestSchema.ts` module remains in place with its `zod` schemas, but is now reachable only from CLI command code that is not bundled into user kits. A follow-up canary test guarding against future recurrences is tracked under #60.

Closes #59