### PR TITLE
#67 Allow explicit undefined on optional authoring-type fields

### DIFF
--- a/packages/readyup/__tests__/types.authoring-eop.test.ts
+++ b/packages/readyup/__tests__/types.authoring-eop.test.ts
@@ -1,0 +1,136 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type {
+  CheckOutcome,
+  FixLocation,
+  Progress,
+  RdyCheck,
+  RdyChecklist,
+  RdyConfig,
+  RdyKit,
+  RdyStagedChecklist,
+  Severity,
+  SkipResult,
+} from '../src/types.ts';
+
+// Regression guards for the public authoring surface under
+// `exactOptionalPropertyTypes: true`. Consumer kits use idiomatic factory
+// patterns such as `return { ..., fix: opts.fix }` where `opts.fix?: string`;
+// that pattern only compiles when `RdyCheck.fix` is declared as
+// `string | undefined` rather than bare `string`. If any of the optional
+// fields below is re-tightened, this file will fail to compile. See #67.
+
+describe('public authoring types under exactOptionalPropertyTypes', () => {
+  it('CheckOutcome allows explicit undefined on optional fields', () => {
+    const detail: string | undefined = undefined;
+    const progress: Progress | undefined = undefined;
+    const outcome: CheckOutcome = { ok: true, detail, progress };
+
+    expectTypeOf(outcome).toEqualTypeOf<CheckOutcome>();
+    expectTypeOf<CheckOutcome['detail']>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<CheckOutcome['progress']>().toEqualTypeOf<Progress | undefined>();
+  });
+
+  it('RdyCheck allows explicit undefined on optional fields', () => {
+    function makeCheck(opts: { name: string; fix?: string; severity?: Severity }): RdyCheck {
+      return {
+        name: opts.name,
+        check: () => true,
+        fix: opts.fix,
+        severity: opts.severity,
+      };
+    }
+
+    expectTypeOf(makeCheck).returns.toEqualTypeOf<RdyCheck>();
+    expectTypeOf<RdyCheck['severity']>().toEqualTypeOf<Severity | undefined>();
+    expectTypeOf<RdyCheck['skip']>().toEqualTypeOf<(() => SkipResult | Promise<SkipResult>) | undefined>();
+    expectTypeOf<RdyCheck['fix']>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<RdyCheck['checks']>().toEqualTypeOf<RdyCheck[] | undefined>();
+  });
+
+  it('RdyChecklist allows explicit undefined on optional fields', () => {
+    const preconditions: RdyCheck[] | undefined = undefined;
+    const fixLocation: FixLocation | undefined = undefined;
+    const checklist: RdyChecklist = {
+      name: 'x',
+      preconditions,
+      checks: [{ name: 'c', check: () => true }],
+      fixLocation,
+    };
+
+    expectTypeOf(checklist).toEqualTypeOf<RdyChecklist>();
+    expectTypeOf<RdyChecklist['preconditions']>().toEqualTypeOf<RdyCheck[] | undefined>();
+    expectTypeOf<RdyChecklist['fixLocation']>().toEqualTypeOf<FixLocation | undefined>();
+  });
+
+  it('RdyStagedChecklist allows explicit undefined on optional fields', () => {
+    const preconditions: RdyCheck[] | undefined = undefined;
+    const fixLocation: FixLocation | undefined = undefined;
+    const staged: RdyStagedChecklist = {
+      name: 'x',
+      preconditions,
+      groups: [[{ name: 'c', check: () => true }]],
+      fixLocation,
+    };
+
+    expectTypeOf(staged).toEqualTypeOf<RdyStagedChecklist>();
+    expectTypeOf<RdyStagedChecklist['preconditions']>().toEqualTypeOf<RdyCheck[] | undefined>();
+    expectTypeOf<RdyStagedChecklist['fixLocation']>().toEqualTypeOf<FixLocation | undefined>();
+  });
+
+  it('RdyKit allows explicit undefined on optional fields', () => {
+    function makeKit(opts: {
+      description?: string;
+      defaultSeverity?: Severity;
+      failOn?: Severity;
+      reportOn?: Severity;
+      fixLocation?: FixLocation;
+      suites?: Record<string, string[]>;
+    }): RdyKit {
+      return {
+        checklists: [],
+        description: opts.description,
+        defaultSeverity: opts.defaultSeverity,
+        failOn: opts.failOn,
+        reportOn: opts.reportOn,
+        fixLocation: opts.fixLocation,
+        suites: opts.suites,
+      };
+    }
+
+    expectTypeOf(makeKit).returns.toEqualTypeOf<RdyKit>();
+    expectTypeOf<RdyKit['description']>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<RdyKit['suites']>().toEqualTypeOf<Record<string, string[]> | undefined>();
+    expectTypeOf<RdyKit['defaultSeverity']>().toEqualTypeOf<Severity | undefined>();
+    expectTypeOf<RdyKit['failOn']>().toEqualTypeOf<Severity | undefined>();
+    expectTypeOf<RdyKit['reportOn']>().toEqualTypeOf<Severity | undefined>();
+    expectTypeOf<RdyKit['fixLocation']>().toEqualTypeOf<FixLocation | undefined>();
+  });
+
+  it('RdyConfig allows explicit undefined on optional fields', () => {
+    function makeConfig(opts: {
+      srcDir?: string;
+      outDir?: string;
+      include?: string;
+      dir?: string;
+      infix?: string;
+    }): RdyConfig {
+      return {
+        compile: {
+          srcDir: opts.srcDir,
+          outDir: opts.outDir,
+          include: opts.include,
+        },
+        internal: {
+          dir: opts.dir,
+          infix: opts.infix,
+        },
+      };
+    }
+
+    expectTypeOf(makeConfig).returns.toEqualTypeOf<RdyConfig>();
+
+    const topLevelUndefined: RdyConfig = { compile: undefined, internal: undefined };
+    expectTypeOf(topLevelUndefined).toEqualTypeOf<RdyConfig>();
+  });
+});

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -106,8 +106,8 @@ export function isPercentProgress(progress: Progress): progress is PercentProgre
 /** Structured outcome from a check, carrying diagnostic data alongside the pass/fail status. */
 export interface CheckOutcome {
   ok: boolean;
-  detail?: string;
-  progress?: Progress;
+  detail?: string | undefined;
+  progress?: Progress | undefined;
 }
 
 /** The value a check function may return (or resolve to). */
@@ -127,19 +127,19 @@ export interface RdyCheck {
    * Severity of this check. Determines failure and reporting behavior.
    * Default: kit's `defaultSeverity`, falling back to 'error'.
    */
-  severity?: Severity;
+  severity?: Severity | undefined;
 
   /**
    * Skip condition. When provided, evaluated before the check runs.
    * Return `false` to run the check, or a reason string to skip it.
    */
-  skip?: () => SkipResult | Promise<SkipResult>;
+  skip?: (() => SkipResult | Promise<SkipResult>) | undefined;
 
   /** Remediation message shown when the check fails. */
-  fix?: string;
+  fix?: string | undefined;
 
   /** Dependent checks that run only if this check passes. */
-  checks?: RdyCheck[];
+  checks?: RdyCheck[] | undefined;
 }
 
 // -- Results --
@@ -255,19 +255,19 @@ export interface RdyChecklist {
    * Each dependent check's own severity determines whether its skipped entry
    * is shown.
    */
-  preconditions?: RdyCheck[];
+  preconditions?: RdyCheck[] | undefined;
 
   checks: RdyCheck[];
 
-  fixLocation?: FixLocation;
+  fixLocation?: FixLocation | undefined;
 }
 
 /** A staged checklist where groups run sequentially; checks within each group run concurrently. */
 export interface RdyStagedChecklist {
   name: string;
-  preconditions?: RdyCheck[];
+  preconditions?: RdyCheck[] | undefined;
   groups: RdyCheck[][];
-  fixLocation?: FixLocation;
+  fixLocation?: FixLocation | undefined;
 }
 
 /** Distinguish a flat checklist from a staged checklist by the presence of `checks`. */
@@ -283,44 +283,48 @@ export interface RdyKit {
   checklists: Array<RdyChecklist | RdyStagedChecklist>;
 
   /** Human-readable summary of what the kit checks. */
-  description?: string;
+  description?: string | undefined;
 
   /** Named subsets of checklists. */
-  suites?: Record<string, string[]>;
+  suites?: Record<string, string[]> | undefined;
 
   /**
    * Default severity for checks that don't declare one.
    * Default: 'error'.
    */
-  defaultSeverity?: Severity;
+  defaultSeverity?: Severity | undefined;
 
   /**
    * Minimum severity at which a failed check causes the run to fail.
    * Default: 'error'.
    */
-  failOn?: Severity;
+  failOn?: Severity | undefined;
 
   /**
    * Minimum severity at which results appear in output.
    * Default: 'recommend' (show all assertive results).
    */
-  reportOn?: Severity;
+  reportOn?: Severity | undefined;
 
   /** Default placement of fix messages across all checklists. */
-  fixLocation?: FixLocation;
+  fixLocation?: FixLocation | undefined;
 }
 
 /** Repo-level settings for the rdy CLI (user-facing, all fields optional). */
 export interface RdyConfig {
-  compile?: {
-    srcDir?: string;
-    outDir?: string;
-    include?: string;
-  };
-  internal?: {
-    dir?: string;
-    infix?: string;
-  };
+  compile?:
+    | {
+        srcDir?: string | undefined;
+        outDir?: string | undefined;
+        include?: string | undefined;
+      }
+    | undefined;
+  internal?:
+    | {
+        dir?: string | undefined;
+        infix?: string | undefined;
+      }
+    | undefined;
 }
 
 /** Fully-resolved config with defaults applied, returned by `loadConfig`. */


### PR DESCRIPTION
## What

Fixes an issue where TypeScript consumers of `readyup` with `exactOptionalPropertyTypes: true` could not use idiomatic factory patterns to construct public authoring types. Writing `return { name, check, fix: opts.fix }` — where `opts.fix?: string` — now compiles cleanly against `RdyCheck`; previously it produced a `TS2375` "not assignable" error, forcing consumers to fall back on awkward conditional-assignment workarounds.

No runtime behavior changes. All internal readers already treated missing and explicitly-undefined values identically.

## Why

`exactOptionalPropertyTypes: true` is the current TypeScript recommendation (and the setting used by `readyup`'s own monorepo). Under this setting, declaring an optional field as `fix?: string` forbids explicit-undefined assignment, which is exactly the pattern kit authors hit the moment they write a factory function over optional inputs. The result was a poor first-run experience for anyone adopting `readyup` on a modern TS project.

## Details

### Fixes

Every optional field on the public authoring surface now explicitly accepts `undefined`:

- `CheckOutcome`: `detail`, `progress`
- `RdyCheck`: `severity`, `skip`, `fix`, `checks`
- `RdyChecklist`: `preconditions`, `fixLocation`
- `RdyStagedChecklist`: `preconditions`, `fixLocation`
- `RdyKit`: `description`, `suites`, `defaultSeverity`, `failOn`, `reportOn`, `fixLocation`
- `RdyConfig`: `compile` (plus nested `srcDir`, `outDir`, `include`), `internal` (plus nested `dir`, `infix`)

Result types (`RdyResult`, `RdyReport`, `JsonReport`, `ResolvedRdyConfig`, etc.) and the internal discriminated-union variants keep their strict declarations — they are `readyup`-produced and continue to benefit from the stricter form.

### Tests

Adds a compile-time regression guard at `packages/readyup/__tests__/types.authoring-eop.test.ts`. Each loosened interface is exercised via a factory function that uses the idiomatic `fix: opts.fix` pattern plus `expectTypeOf` assertions on the field types. If any optional field is re-tightened to bare `T`, the factory bodies will fail to compile and the build will break.

Closes #67