### PR TITLE
#73 Add `discoverWorkspaces` check-util for monorepo-aware kits

### DIFF
--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -33,18 +33,6 @@ function fileContains(relativePath, pattern) {
   return pattern.test(content);
 }
 
-// packages/readyup/dist/esm/check-utils/git/run-git.js
-import { execFile } from "node:child_process";
-import { homedir } from "node:os";
-import { promisify } from "node:util";
-var execFileAsync = promisify(execFile);
-
-// packages/readyup/dist/esm/check-utils/git/repo-predicates.js
-import { existsSync as existsSync2 } from "node:fs";
-
-// packages/readyup/dist/esm/check-utils/hashing.js
-import { createHash } from "node:crypto";
-
 // packages/readyup/dist/esm/safeJsonParse.js
 function safeJsonParse(content) {
   try {

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -5,7 +5,7 @@
       "name": "demo",
       "path": "kits/demo.js",
       "source": "kits/demo.ts",
-      "targetHash": "eb47f19a"
+      "targetHash": "6ac49c09"
     }
   ]
 }

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -135,25 +135,40 @@ Reusable check functions for common assertions:
 import { fileExists, fileContains, hasPackageJsonField } from 'readyup';
 ```
 
-| Function                                    | Description                                                |
-| ------------------------------------------- | ---------------------------------------------------------- |
-| `fileExists(path)`                          | File exists at path                                        |
-| `fileContains(path, pattern)`               | File matches a string or regex                             |
-| `fileDoesNotContain(path, pattern)`         | File does not match                                        |
-| `readFile(path)`                            | Read file contents (returns `undefined` if missing)        |
-| `hasPackageJsonField(field, value?)`        | package.json has a field (optionally matching a value)     |
-| `hasDevDependency(name)`                    | package.json has a dev dependency                          |
-| `hasMinDevDependencyVersion(name, version)` | Dev dependency meets minimum version                       |
-| `readPackageJson()`                         | Parse package.json                                         |
-| `compareVersions(a, b)`                     | Compare semver strings                                     |
-| `runGit(path, ...args)`                     | Run a git command and return trimmed stdout                |
-| `expandHome(path)`                          | Expand leading `~` or `~/` to the home directory           |
-| `isAtRepoRoot(path)`                        | Path is the top of a git working tree                      |
-| `isGitRepo(path)`                           | Path is inside a git working tree                          |
-| `compareLocalRefs(path, refA, refB)`        | Compare two local refs (discriminated-union result)        |
-| `compareRefToRemote(path, ref, remote?)`    | Compare a local ref to its remote counterpart              |
-| `makeLocalRefSyncCheck(options)`            | Check factory: verify two local refs match                 |
-| `makeRemoteRefSyncCheck(options)`           | Check factory: verify a ref matches its remote counterpart |
+| Function                                    | Description                                                             |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| `fileExists(path)`                          | File exists at path                                                     |
+| `fileContains(path, pattern)`               | File matches a string or regex                                          |
+| `fileDoesNotContain(path, pattern)`         | File does not match                                                     |
+| `readFile(path)`                            | Read file contents (returns `undefined` if missing)                     |
+| `hasPackageJsonField(field, value?)`        | package.json has a field (optionally matching a value)                  |
+| `hasDevDependency(name)`                    | package.json has a dev dependency                                       |
+| `hasMinDevDependencyVersion(name, version)` | Dev dependency meets minimum version                                    |
+| `readPackageJson()`                         | Parse package.json                                                      |
+| `discoverWorkspaces(options?)`              | Enumerate monorepo workspaces (single-workspace repos return one entry) |
+| `compareVersions(a, b)`                     | Compare semver strings                                                  |
+| `runGit(path, ...args)`                     | Run a git command and return trimmed stdout                             |
+| `expandHome(path)`                          | Expand leading `~` or `~/` to the home directory                        |
+| `isAtRepoRoot(path)`                        | Path is the top of a git working tree                                   |
+| `isGitRepo(path)`                           | Path is inside a git working tree                                       |
+| `compareLocalRefs(path, refA, refB)`        | Compare two local refs (discriminated-union result)                     |
+| `compareRefToRemote(path, ref, remote?)`    | Compare a local ref to its remote counterpart                           |
+| `makeLocalRefSyncCheck(options)`            | Check factory: verify two local refs match                              |
+| `makeRemoteRefSyncCheck(options)`           | Check factory: verify a ref matches its remote counterpart              |
+
+### Discovering workspaces
+
+`discoverWorkspaces()` returns a uniform `Workspace[]` that collapses pnpm, npm, and yarn monorepo conventions — and single-workspace repos — into one iteration shape. Every entry includes `dir` (relative to `cwd`; `'.'` for a single-workspace repo), `absolutePath`, `name`, `isPackage` (true when `package.json.private !== true`), and the parsed `packageJson`.
+
+Common filter pattern — get all publishable workspaces:
+
+```ts
+import { discoverWorkspaces } from 'readyup';
+
+const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
+```
+
+Note: `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs using YAML anchors, flow sequences, negation patterns, or other non-trivial features will raise a clear error with a pointer to file an issue.
 
 ## License
 

--- a/packages/readyup/__tests__/check-utils/pnpmWorkspaceYaml.test.ts
+++ b/packages/readyup/__tests__/check-utils/pnpmWorkspaceYaml.test.ts
@@ -1,0 +1,200 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readPnpmWorkspacePackages } from '../../src/check-utils/pnpmWorkspaceYaml.ts';
+
+let tempDir: string;
+let yamlPath: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rdy-yaml-'));
+  yamlPath = join(tempDir, 'pnpm-workspace.yaml');
+});
+
+afterEach(() => {
+  // Temp directory is cleaned up by the OS; leaving it in place keeps the test fast.
+});
+
+function writeYaml(content: string): void {
+  writeFileSync(yamlPath, content);
+}
+
+describe(readPnpmWorkspacePackages, () => {
+  it('returns a single unquoted item', () => {
+    writeYaml(['packages:', '  - packages/*', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/*']);
+  });
+
+  it('returns multiple unquoted items in order', () => {
+    writeYaml(['packages:', '  - packages/*', '  - apps/*', '  - tools/*', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/*', 'apps/*', 'tools/*']);
+  });
+
+  it('strips single quotes from items', () => {
+    writeYaml(['packages:', "  - 'apps/*'", ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['apps/*']);
+  });
+
+  it('strips double quotes from items', () => {
+    writeYaml(['packages:', '  - "tools/*"', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['tools/*']);
+  });
+
+  it('handles mixed quoting in one file', () => {
+    writeYaml(['packages:', '  - packages/*', "  - 'apps/*'", '  - "tools/*"', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/*', 'apps/*', 'tools/*']);
+  });
+
+  it('ignores full-line comments', () => {
+    writeYaml(
+      [
+        '# a leading comment',
+        'packages:',
+        '  # commented item',
+        '  - packages/*',
+        '  # another comment',
+        '  - apps/*',
+        '',
+      ].join('\n'),
+    );
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/*', 'apps/*']);
+  });
+
+  it('strips inline trailing comments on items', () => {
+    writeYaml(['packages:', '  - packages/* # primary packages', '  - apps/*    # apps', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/*', 'apps/*']);
+  });
+
+  it('ignores blank lines between items', () => {
+    writeYaml(['packages:', '  - packages/*', '', '  - apps/*', '', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/*', 'apps/*']);
+  });
+
+  it('ignores other top-level keys', () => {
+    writeYaml(
+      [
+        'onlyBuiltDependencies:',
+        '  - esbuild',
+        'packages:',
+        '  - packages/*',
+        'packageExtensions:',
+        '  foo: bar',
+        '',
+      ].join('\n'),
+    );
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/*']);
+  });
+
+  it('returns null when the `packages` key is absent', () => {
+    writeYaml(['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toBeNull();
+  });
+
+  it('returns an empty array when `packages` key has no sequence items', () => {
+    writeYaml(['packages:', 'onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual([]);
+  });
+
+  it('returns an empty array when `packages` is the only key and has no items', () => {
+    writeYaml(['packages:', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual([]);
+  });
+
+  it('throws on a negation pattern with a message naming the pattern and file path', () => {
+    writeYaml(['packages:', '  - packages/*', '  - "!packages/deprecated/*"', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(yamlPath);
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/please open an issue/);
+  });
+
+  it('throws on an unquoted negation pattern', () => {
+    writeYaml(['packages:', '  - !packages/deprecated/*', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
+  });
+
+  it('throws on a flow sequence for `packages`', () => {
+    writeYaml(['packages: [packages/*, apps/*]', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/non-list value/);
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(yamlPath);
+  });
+
+  it('throws on a flow sequence as an item value', () => {
+    writeYaml(['packages:', '  - [a, b]', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/flow sequence or mapping/);
+  });
+
+  it('throws on an anchor (&name) on an item', () => {
+    writeYaml(['packages:', '  - &anchor packages/*', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/anchor/);
+  });
+
+  it('throws on an alias (*name) on an item', () => {
+    writeYaml(['packages:', '  - *alias', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/alias/);
+  });
+
+  it('throws on a multi-document marker', () => {
+    writeYaml(['---', 'packages:', '  - packages/*', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/multi-document/);
+  });
+
+  it('throws on a YAML tag (!!str)', () => {
+    writeYaml(['packages:', '  - !!str packages/*', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/YAML tag/);
+  });
+
+  it('throws on a folded block scalar (>)', () => {
+    writeYaml(['packages:', '  - >', '    packages/*', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/block scalar/);
+  });
+
+  it('throws on a literal block scalar (|)', () => {
+    writeYaml(['packages:', '  - |', '    packages/*', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/block scalar/);
+  });
+
+  it('throws when `packages` is a string instead of a list', () => {
+    writeYaml(['packages: just-a-string', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/non-list value/);
+  });
+
+  it('throws when `packages` value is a mapping', () => {
+    writeYaml(['packages:', '  key: value', ''].join('\n'));
+
+    expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/non-list value/);
+  });
+
+  it('includes the offending line number and line text in the error message', () => {
+    writeYaml(['packages:', '  - packages/*', '  - [flow, sequence]', ''].join('\n'));
+
+    const attempt = (): string[] | null => readPnpmWorkspacePackages(yamlPath);
+    expect(attempt).toThrow(/pnpm-workspace\.yaml:3/);
+    expect(attempt).toThrow(/\[flow, sequence\]/);
+  });
+});

--- a/packages/readyup/__tests__/check-utils/pnpmWorkspaceYaml.test.ts
+++ b/packages/readyup/__tests__/check-utils/pnpmWorkspaceYaml.test.ts
@@ -75,6 +75,18 @@ describe(readPnpmWorkspacePackages, () => {
     expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/*', 'apps/*']);
   });
 
+  it('preserves `#` inside single-quoted items (not treated as an inline comment)', () => {
+    writeYaml(['packages:', "  - 'packages/foo#bar'", ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/foo#bar']);
+  });
+
+  it('preserves `#` inside double-quoted items (not treated as an inline comment)', () => {
+    writeYaml(['packages:', '  - "packages/foo#bar"', ''].join('\n'));
+
+    expect(readPnpmWorkspacePackages(yamlPath)).toEqual(['packages/foo#bar']);
+  });
+
   it('ignores blank lines between items', () => {
     writeYaml(['packages:', '  - packages/*', '', '  - apps/*', '', ''].join('\n'));
 

--- a/packages/readyup/__tests__/check-utils/workspaces.test.ts
+++ b/packages/readyup/__tests__/check-utils/workspaces.test.ts
@@ -1,0 +1,265 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { discoverWorkspaces } from '../../src/check-utils/workspaces.ts';
+
+let tempDir: string;
+let cwdSpy: MockInstance;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rdy-ws-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+});
+
+function writeRootPackageJson(content: Record<string, unknown>): void {
+  writeFileSync(join(tempDir, 'package.json'), JSON.stringify(content));
+}
+
+function writeWorkspacePackage(relDir: string, content: Record<string, unknown>): void {
+  mkdirSync(join(tempDir, relDir), { recursive: true });
+  writeFileSync(join(tempDir, relDir, 'package.json'), JSON.stringify(content));
+}
+
+function writePnpmWorkspaceYaml(content: string): void {
+  writeFileSync(join(tempDir, 'pnpm-workspace.yaml'), content);
+}
+
+describe(discoverWorkspaces, () => {
+  describe('pnpm workspaces', () => {
+    it('discovers workspaces listed via `packages` block sequence', () => {
+      writeRootPackageJson({ name: 'root', private: true });
+      writePnpmWorkspaceYaml(['packages:', '  - packages/*', '  - apps/**', ''].join('\n'));
+      writeWorkspacePackage('packages/alpha', { name: 'alpha', version: '1.0.0' });
+      writeWorkspacePackage('packages/beta', { name: 'beta', version: '1.0.0' });
+      writeWorkspacePackage('apps/web', { name: 'web', version: '1.0.0' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.dir)).toEqual(['apps/web', 'packages/alpha', 'packages/beta']);
+      expect(workspaces.map((w) => w.name)).toEqual(['web', 'alpha', 'beta']);
+    });
+
+    it('returns an empty array when a pattern expands to zero directories', () => {
+      writeRootPackageJson({ name: 'root', private: true });
+      writePnpmWorkspaceYaml(['packages:', '  - packages/*', ''].join('\n'));
+
+      expect(discoverWorkspaces()).toEqual([]);
+    });
+
+    it('falls through to npm/single detection when `packages` key is absent', () => {
+      writeRootPackageJson({ name: 'root', version: '1.0.0' });
+      writePnpmWorkspaceYaml(['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces).toEqual([
+        {
+          dir: '.',
+          absolutePath: tempDir,
+          name: 'root',
+          isPackage: true,
+          packageJson: { name: 'root', version: '1.0.0' },
+        },
+      ]);
+    });
+
+    it('propagates errors from the YAML reader for unsupported features', () => {
+      writeRootPackageJson({ name: 'root', private: true });
+      writePnpmWorkspaceYaml(['packages:', '  - &anchor packages/*', ''].join('\n'));
+
+      expect(() => discoverWorkspaces()).toThrow(/anchor/);
+    });
+  });
+
+  describe('npm/yarn workspaces', () => {
+    it('discovers workspaces when `workspaces` is a string array', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('packages/beta', { name: 'beta' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.dir)).toEqual(['packages/alpha', 'packages/beta']);
+    });
+
+    it('discovers workspaces when `workspaces.packages` is a string array', () => {
+      writeRootPackageJson({
+        name: 'root',
+        private: true,
+        workspaces: { packages: ['packages/*', 'apps/*'] },
+      });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('apps/web', { name: 'web' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.dir)).toEqual(['apps/web', 'packages/alpha']);
+    });
+  });
+
+  describe('single-workspace repo', () => {
+    it('returns a single entry with dir: "." when no workspace config is present', () => {
+      writeRootPackageJson({ name: 'solo', version: '1.0.0' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces).toEqual([
+        {
+          dir: '.',
+          absolutePath: tempDir,
+          name: 'solo',
+          isPackage: true,
+          packageJson: { name: 'solo', version: '1.0.0' },
+        },
+      ]);
+    });
+
+    it('returns isPackage: false when `private: true`', () => {
+      writeRootPackageJson({ name: 'solo', private: true });
+
+      expect(discoverWorkspaces()[0]?.isPackage).toBe(false);
+    });
+
+    it('returns isPackage: true when `private` is absent', () => {
+      writeRootPackageJson({ name: 'solo' });
+
+      expect(discoverWorkspaces()[0]?.isPackage).toBe(true);
+    });
+
+    it('returns isPackage: true when `private: false`', () => {
+      writeRootPackageJson({ name: 'solo', private: false });
+
+      expect(discoverWorkspaces()[0]?.isPackage).toBe(true);
+    });
+
+    it('returns isPackage: true when `private` is a non-true value like the string "false"', () => {
+      writeRootPackageJson({ name: 'solo', private: 'false' });
+
+      expect(discoverWorkspaces()[0]?.isPackage).toBe(true);
+    });
+
+    it('returns `name: undefined` when root package.json has no `name` field', () => {
+      writeRootPackageJson({ version: '1.0.0' });
+
+      expect(discoverWorkspaces()[0]?.name).toBeUndefined();
+    });
+  });
+
+  describe('filter option', () => {
+    it('excludes workspaces for which the filter returns false', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('packages/beta', { name: 'beta', private: true });
+
+      const workspaces = discoverWorkspaces({ filter: (w) => w.isPackage });
+
+      expect(workspaces.map((w) => w.name)).toEqual(['alpha']);
+    });
+  });
+
+  describe('skipping non-workspace matched directories', () => {
+    it('skips a matched directory without a package.json', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      mkdirSync(join(tempDir, 'packages/empty'), { recursive: true });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.dir)).toEqual(['packages/alpha']);
+    });
+
+    it('skips a matched directory with an unparseable package.json', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      mkdirSync(join(tempDir, 'packages/broken'), { recursive: true });
+      writeFileSync(join(tempDir, 'packages/broken/package.json'), '{ not valid json');
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.dir)).toEqual(['packages/alpha']);
+    });
+
+    it('does not traverse into node_modules', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['**/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      // A fake workspace hiding inside node_modules — must not appear in results.
+      writeWorkspacePackage('node_modules/sneaky', { name: 'sneaky' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.name)).not.toContain('sneaky');
+    });
+
+    it('does not traverse into .git', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['**/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('.git/fake', { name: 'fake' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.name)).not.toContain('fake');
+    });
+  });
+
+  describe('error: missing root package.json', () => {
+    it('throws with a message that includes the resolved path', () => {
+      expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
+      expect(() => discoverWorkspaces()).toThrow(tempDir);
+    });
+
+    it('throws even when pnpm-workspace.yaml is present', () => {
+      writePnpmWorkspaceYaml(['packages:', '  - packages/*', ''].join('\n'));
+
+      expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
+    });
+  });
+
+  describe('sorting', () => {
+    it('sorts results by dir ascending', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/zeta', { name: 'zeta' });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('packages/mu', { name: 'mu' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.dir)).toEqual(['packages/alpha', 'packages/mu', 'packages/zeta']);
+    });
+  });
+
+  describe('Workspace shape', () => {
+    it('includes absolutePath, name, isPackage, and packageJson for a monorepo workspace', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha', version: '1.2.3' });
+
+      const [workspace] = discoverWorkspaces();
+
+      expect(workspace).toEqual({
+        dir: 'packages/alpha',
+        absolutePath: join(tempDir, 'packages/alpha'),
+        name: 'alpha',
+        isPackage: true,
+        packageJson: { name: 'alpha', version: '1.2.3' },
+      });
+    });
+  });
+
+  describe('negation patterns in npm workspaces', () => {
+    it('throws when `workspaces` contains a negation pattern', () => {
+      writeRootPackageJson({
+        name: 'root',
+        private: true,
+        workspaces: ['packages/*', '!packages/deprecated/*'],
+      });
+
+      expect(() => discoverWorkspaces()).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
+    });
+  });
+});

--- a/packages/readyup/__tests__/check-utils/workspaces.test.ts
+++ b/packages/readyup/__tests__/check-utils/workspaces.test.ts
@@ -102,6 +102,17 @@ describe(discoverWorkspaces, () => {
 
       expect(workspaces.map((w) => w.dir)).toEqual(['apps/web', 'packages/alpha']);
     });
+
+    it('returns isPackage: false for a discovered workspace with `private: true`', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('packages/internal', { name: 'internal', private: true });
+
+      const workspaces = discoverWorkspaces();
+      const byDir = Object.fromEntries(workspaces.map((w) => [w.dir, w.isPackage]));
+
+      expect(byDir).toEqual({ 'packages/alpha': true, 'packages/internal': false });
+    });
   });
 
   describe('single-workspace repo', () => {
@@ -257,6 +268,16 @@ describe(discoverWorkspaces, () => {
         name: 'root',
         private: true,
         workspaces: ['packages/*', '!packages/deprecated/*'],
+      });
+
+      expect(() => discoverWorkspaces()).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
+    });
+
+    it('throws when `workspaces.packages` contains a negation pattern', () => {
+      writeRootPackageJson({
+        name: 'root',
+        private: true,
+        workspaces: { packages: ['packages/*', '!packages/deprecated/*'] },
       });
 
       expect(() => discoverWorkspaces()).toThrow(/negation pattern "!packages\/deprecated\/\*"/);

--- a/packages/readyup/__tests__/sideEffectFreeSrc.test.ts
+++ b/packages/readyup/__tests__/sideEffectFreeSrc.test.ts
@@ -1,0 +1,109 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+import { isRecord } from '../src/isRecord.ts';
+
+const thisFileDir = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = join(thisFileDir, '..', 'src');
+const PACKAGE_JSON_PATH = join(thisFileDir, '..', 'package.json');
+
+/**
+ * Files in `src/` that intentionally carry top-level side effects (CLI entry points, etc.).
+ * Each entry is a src-relative POSIX path. The corresponding compiled output MUST appear in
+ * package.json's `sideEffects` array so bundlers don't tree-shake it.
+ */
+const INTENTIONAL_SIDE_EFFECT_FILES = new Set<string>(['bin/rdy.ts']);
+
+/** TypeScript AST kinds that represent purely declarative top-level statements. */
+const DECLARATIVE_KINDS = new Set<ts.SyntaxKind>([
+  ts.SyntaxKind.ImportDeclaration,
+  ts.SyntaxKind.ImportEqualsDeclaration,
+  ts.SyntaxKind.ExportDeclaration,
+  ts.SyntaxKind.ExportAssignment,
+  ts.SyntaxKind.VariableStatement,
+  ts.SyntaxKind.FunctionDeclaration,
+  ts.SyntaxKind.ClassDeclaration,
+  ts.SyntaxKind.InterfaceDeclaration,
+  ts.SyntaxKind.TypeAliasDeclaration,
+  ts.SyntaxKind.EnumDeclaration,
+  ts.SyntaxKind.ModuleDeclaration,
+]);
+
+interface Offender {
+  line: number;
+  kind: string;
+  snippet: string;
+}
+
+describe('readyup source tree is side-effect-free', () => {
+  const files = collectSrcFiles(SRC_ROOT);
+  const checked = files
+    .filter((file) => !INTENTIONAL_SIDE_EFFECT_FILES.has(toSrcRelative(file)))
+    .map((file): [string, string] => [toSrcRelative(file), file]);
+
+  it.each(checked)('%s contains only declarative top-level statements', (_rel, absolutePath) => {
+    const offenders = findTopLevelSideEffects(absolutePath);
+    const formatted = offenders.map((o) => `  line ${o.line}: ${o.kind} — ${o.snippet}`).join('\n');
+    expect(offenders, `Found non-declarative top-level statements:\n${formatted}`).toEqual([]);
+  });
+
+  it('intentional side-effect files have matching entries in package.json sideEffects', () => {
+    const packageJsonText = readFileSync(PACKAGE_JSON_PATH, 'utf8');
+    const parsed: unknown = JSON.parse(packageJsonText);
+    const listed = extractSideEffectsArray(parsed);
+    const missing: string[] = [];
+    for (const srcPath of INTENTIONAL_SIDE_EFFECT_FILES) {
+      const expectedCompiled = `./dist/esm/${srcPath.replace(/\.ts$/, '.js')}`;
+      if (!listed.has(expectedCompiled)) missing.push(expectedCompiled);
+    }
+    expect(missing, 'Missing from package.json sideEffects:\n  ' + missing.join('\n  ')).toEqual([]);
+  });
+});
+
+// region | Helpers
+
+function toSrcRelative(absolutePath: string): string {
+  return relative(SRC_ROOT, absolutePath).split('\\').join('/');
+}
+
+function collectSrcFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectSrcFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function findTopLevelSideEffects(absolutePath: string): Offender[] {
+  const text = readFileSync(absolutePath, 'utf8');
+  const source = ts.createSourceFile(absolutePath, text, ts.ScriptTarget.Latest, true);
+  const offenders: Offender[] = [];
+  for (const statement of source.statements) {
+    if (DECLARATIVE_KINDS.has(statement.kind)) continue;
+    const start = statement.getStart(source);
+    const line = source.getLineAndCharacterOfPosition(start).line + 1;
+    const fullText = statement.getText(source);
+    const firstLineRaw = fullText.split('\n')[0] ?? '';
+    const snippet = firstLineRaw.length > 100 ? `${firstLineRaw.slice(0, 97)}...` : firstLineRaw;
+    offenders.push({ line, kind: ts.SyntaxKind[statement.kind], snippet });
+  }
+  return offenders;
+}
+
+function extractSideEffectsArray(parsed: unknown): Set<string> {
+  if (!isRecord(parsed)) return new Set();
+  const value = parsed.sideEffects;
+  if (!Array.isArray(value)) return new Set();
+  return new Set(value.filter((entry): entry is string => typeof entry === 'string'));
+}
+
+// endregion | Helpers

--- a/packages/readyup/package.json
+++ b/packages/readyup/package.json
@@ -20,6 +20,9 @@
   },
   "license": "MIT",
   "author": "William Thorsen <william@thorsen.dev> (https://github.com/williamthorsen)",
+  "sideEffects": [
+    "./dist/esm/bin/rdy.js"
+  ],
   "type": "module",
   "exports": {
     ".": {

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -15,3 +15,5 @@ export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json
 export { getJsonValue, hasJsonValue } from './json-value.ts';
 export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
 export { compareVersions } from './semver.ts';
+export type { DiscoverWorkspacesOptions, Workspace } from './workspaces.ts';
+export { discoverWorkspaces } from './workspaces.ts';

--- a/packages/readyup/src/check-utils/pnpmWorkspaceYaml.ts
+++ b/packages/readyup/src/check-utils/pnpmWorkspaceYaml.ts
@@ -1,0 +1,224 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Read the `packages` block-sequence from a `pnpm-workspace.yaml` file.
+ * Returns the list of pattern strings, or `null` when the `packages` key is absent.
+ * Throws on YAML features outside the supported subset (anchors, flow sequences,
+ * tags, negation patterns, etc.) with a pathful, line-pointing error.
+ */
+export function readPnpmWorkspacePackages(absolutePath: string): string[] | null {
+  const content = readFileSync(absolutePath, 'utf8');
+  const lines = content.split(/\r?\n/);
+
+  rejectGlobalUnsupportedFeatures(absolutePath, lines);
+
+  const packagesLineIndex = findPackagesKeyLine(lines);
+  if (packagesLineIndex === -1) return null;
+
+  const packagesLine = lines[packagesLineIndex] ?? '';
+  const inlineValue = extractInlineValue(packagesLine);
+
+  if (inlineValue !== null && inlineValue.length > 0) {
+    throwUnsupported(absolutePath, packagesLineIndex, packagesLine, 'non-list value for `packages:`');
+  }
+
+  return collectSequenceItems(absolutePath, lines, packagesLineIndex);
+}
+
+// region | Helpers
+
+/** Reject whole-file features (multi-document streams, anchors/aliases/tags appearing anywhere). */
+function rejectGlobalUnsupportedFeatures(absolutePath: string, lines: string[]): void {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const trimmed = line.trim();
+    if (trimmed === '---' || trimmed === '...') {
+      throwUnsupported(absolutePath, index, line, 'multi-document stream marker');
+    }
+  }
+}
+
+/** Find the line containing the top-level `packages:` key. Returns -1 if absent. */
+function findPackagesKeyLine(lines: string[]): number {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    if (isBlankOrComment(line)) continue;
+    // Top-level keys start at column 0 (no leading whitespace).
+    if (/^\s/.test(line)) continue;
+    const match = /^([A-Za-z_][\w-]*)\s*:(.*)$/.exec(line);
+    if (match === null) continue;
+    if (match[1] === 'packages') return index;
+  }
+  return -1;
+}
+
+/** Return the trimmed value after a `key:` on the same line, or null if there's no inline value. */
+function extractInlineValue(line: string): string | null {
+  const colonIndex = line.indexOf(':');
+  if (colonIndex === -1) return null;
+  const rest = line.slice(colonIndex + 1);
+  const commentStripped = stripInlineComment(rest);
+  const trimmed = commentStripped.trim();
+  return trimmed;
+}
+
+/** Collect block-sequence items below the `packages:` line. */
+function collectSequenceItems(absolutePath: string, lines: string[], packagesLineIndex: number): string[] {
+  const items: string[] = [];
+  let sequenceIndent: number | null = null;
+
+  for (let index = packagesLineIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    if (isBlankOrComment(line)) continue;
+
+    const leadingSpaces = countLeadingSpaces(line);
+
+    // A new top-level key (no leading whitespace) ends the sequence.
+    if (leadingSpaces === 0) break;
+
+    // Lines inside the sequence must be list items (start with `-`).
+    const trimmed = line.slice(leadingSpaces);
+    if (!trimmed.startsWith('-')) {
+      throwUnsupported(absolutePath, index, line, 'non-list value for `packages:`');
+    }
+
+    if (sequenceIndent === null) {
+      sequenceIndent = leadingSpaces;
+    } else if (leadingSpaces !== sequenceIndent) {
+      throwUnsupported(absolutePath, index, line, 'inconsistent indentation in `packages:` sequence');
+    }
+
+    const afterDash = trimmed.slice(1);
+    rejectItemLevelUnsupportedFeatures(absolutePath, index, line, afterDash);
+
+    const rawValue = afterDash.replace(/^\s*/, '');
+    const withoutComment = stripInlineComment(rawValue).trimEnd();
+
+    if (withoutComment === '') {
+      throwUnsupported(absolutePath, index, line, 'empty sequence item or nested structure');
+    }
+
+    const value = unquote(withoutComment, absolutePath, index, line);
+
+    if (value.startsWith('!')) {
+      throwNegationUnsupported(absolutePath, index, line, value);
+    }
+
+    items.push(value);
+  }
+
+  return items;
+}
+
+/** Reject per-item unsupported YAML features before quote-stripping. */
+function rejectItemLevelUnsupportedFeatures(
+  absolutePath: string,
+  lineIndex: number,
+  line: string,
+  after: string,
+): void {
+  const trimmed = after.replace(/^\s*/, '');
+  if (trimmed === '') return;
+
+  const firstChar = trimmed[0];
+
+  if (firstChar === '&') {
+    throwUnsupported(absolutePath, lineIndex, line, 'anchor (&name)');
+  }
+  if (firstChar === '*') {
+    throwUnsupported(absolutePath, lineIndex, line, 'alias (*name)');
+  }
+  if (firstChar === '[' || firstChar === '{') {
+    throwUnsupported(absolutePath, lineIndex, line, 'flow sequence or mapping');
+  }
+  if (firstChar === '|' || firstChar === '>') {
+    throwUnsupported(absolutePath, lineIndex, line, 'block scalar (| or >)');
+  }
+  // `!!tag` (e.g., `!!str`) is a YAML verbatim tag; always unsupported.
+  // A single-`!` prefix on a plain (unquoted) scalar is treated as a negation pattern
+  // (e.g., `!packages/deprecated/*`) and is handled downstream after unquoting.
+  if (trimmed.startsWith('!!')) {
+    throwUnsupported(absolutePath, lineIndex, line, 'YAML tag');
+  }
+}
+
+/** Strip outer quotes from a sequence-item value. Does not interpret escapes. */
+function unquote(value: string, absolutePath: string, lineIndex: number, line: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value.at(-1);
+    if (first === "'" && last === "'") {
+      return value.slice(1, -1);
+    }
+    if (first === '"' && last === '"') {
+      return value.slice(1, -1);
+    }
+  }
+  if (value.startsWith("'") || value.startsWith('"')) {
+    // Unterminated quoted scalar.
+    throwUnsupported(absolutePath, lineIndex, line, 'unterminated quoted scalar');
+  }
+  return value;
+}
+
+/**
+ * Strip an inline `#` comment, respecting single- and double-quoted scalars so a `#`
+ * inside quotes is treated as part of the value.
+ */
+function stripInlineComment(text: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (!inDouble && char === "'") {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (!inSingle && char === '"') {
+      inDouble = !inDouble;
+      continue;
+    }
+    // A comment must be preceded by whitespace (or be at column 0 of the input slice).
+    if (!inSingle && !inDouble && char === '#' && (index === 0 || /\s/.test(text[index - 1] ?? ''))) {
+      return text.slice(0, index);
+    }
+  }
+  return text;
+}
+
+/** True if a line is blank or a full-line comment. */
+function isBlankOrComment(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed === '' || trimmed.startsWith('#');
+}
+
+/** Count leading space characters on a line. */
+function countLeadingSpaces(line: string): number {
+  let count = 0;
+  while (count < line.length && line[count] === ' ') count += 1;
+  return count;
+}
+
+/** Throw a pathful, line-pointing error for an unsupported YAML feature. */
+function throwUnsupported(absolutePath: string, lineIndex: number, line: string, feature: string): never {
+  const lineNumber = lineIndex + 1;
+  const message =
+    `pnpm-workspace.yaml: unsupported YAML feature (${feature}) at ${absolutePath}:${lineNumber}\n` +
+    `  ${line}\n` +
+    "readyup's workspace discovery handles the common block-sequence form for `packages:`.\n" +
+    'If you need broader YAML support, please open an issue.';
+  throw new Error(message);
+}
+
+/** Throw a pathful, line-pointing error for a negation pattern. */
+function throwNegationUnsupported(absolutePath: string, lineIndex: number, line: string, pattern: string): never {
+  const lineNumber = lineIndex + 1;
+  const message =
+    `pnpm-workspace.yaml: negation pattern "${pattern}" is not supported at ${absolutePath}:${lineNumber}\n` +
+    `  ${line}\n` +
+    "Negation patterns are not supported in this release of readyup's workspace discovery.\n" +
+    'If you need negation support, please open an issue.';
+  throw new Error(message);
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -1,0 +1,223 @@
+import { type Dirent, existsSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import picomatch from 'picomatch';
+
+import { isRecord } from '../isRecord.ts';
+import { readJsonFile } from './json.ts';
+import { readPnpmWorkspacePackages } from './pnpmWorkspaceYaml.ts';
+
+/** A monorepo workspace, or the single workspace of a single-workspace repo. */
+export interface Workspace {
+  /** Workspace directory, relative to `cwd`. `'.'` for a single-workspace repo. */
+  dir: string;
+  /** Absolute filesystem path to the workspace directory. */
+  absolutePath: string;
+  /** `name` from the workspace's `package.json`; `undefined` if absent. */
+  name: string | undefined;
+  /** True iff `package.json.private !== true`. (Equivalently: "this workspace is a package".) */
+  isPackage: boolean;
+  /** Parsed `package.json` contents, validated to be a record. */
+  packageJson: Record<string, unknown>;
+}
+
+/** Options for `discoverWorkspaces`. */
+export interface DiscoverWorkspacesOptions {
+  /** Optional predicate. Workspaces returning false are omitted. */
+  filter?: (workspace: Workspace) => boolean;
+}
+
+type WorkspacePatternSource = 'pnpm-workspace.yaml' | 'package.json';
+
+/** Maximum recursion depth for the glob walk. */
+const MAX_WALK_DEPTH = 10;
+
+/** Directory names that are never traversed. */
+const PRUNED_NAMES = new Set(['node_modules', '.git']);
+
+/**
+ * Discover the workspaces of the current repo.
+ * Detects pnpm (`pnpm-workspace.yaml`), then npm/yarn (`package.json.workspaces`),
+ * and falls back to a single-workspace repo using the root `package.json`.
+ */
+export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspace[] {
+  const cwd = process.cwd();
+  const rootPackageJsonPath = join(cwd, 'package.json');
+
+  const patternResult = resolveWorkspacePatterns(cwd);
+
+  if (patternResult === null) {
+    // Single-workspace fallback uses the root package.json, which MUST exist.
+    const rootPackageJson = readJsonFile('package.json');
+    if (rootPackageJson === undefined) {
+      throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
+    }
+    const workspace = buildWorkspaceFromPackageJson('.', cwd, rootPackageJson);
+    return applyFilter([workspace], options?.filter);
+  }
+
+  // Monorepo path: still require a root package.json (both pnpm and npm workspaces do).
+  if (!existsSync(rootPackageJsonPath)) {
+    throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
+  }
+
+  const matchedDirs = expandPatterns(cwd, patternResult.patterns, patternResult.source);
+  const workspaces: Workspace[] = [];
+  for (const relDir of matchedDirs) {
+    const workspace = buildWorkspace(cwd, relDir);
+    if (workspace !== undefined) {
+      workspaces.push(workspace);
+    }
+  }
+
+  // eslint-disable-next-line unicorn/no-array-sort -- `toSorted` requires Node 20; this package supports Node 18.17+.
+  const sortedWorkspaces = [...workspaces].sort((a, b) => compareDirs(a.dir, b.dir));
+  return applyFilter(sortedWorkspaces, options?.filter);
+}
+
+// region | Helpers
+
+/** Apply the optional filter to a workspace list. */
+function applyFilter(workspaces: Workspace[], filter: DiscoverWorkspacesOptions['filter']): Workspace[] {
+  if (filter === undefined) return workspaces;
+  return workspaces.filter(filter);
+}
+
+/**
+ * Resolve the workspace pattern list for the repo at `cwd`.
+ * Returns `null` to signal single-workspace fallback, or `{ patterns, source }` for a monorepo.
+ */
+function resolveWorkspacePatterns(cwd: string): { patterns: string[]; source: WorkspacePatternSource } | null {
+  const pnpmWorkspacePath = join(cwd, 'pnpm-workspace.yaml');
+  if (existsSync(pnpmWorkspacePath)) {
+    const patterns = readPnpmWorkspacePackages(pnpmWorkspacePath);
+    if (patterns !== null) {
+      return { patterns, source: 'pnpm-workspace.yaml' };
+    }
+    // `packages` key absent — fall through to npm/single detection.
+  }
+
+  const rootPackageJson = readJsonFile('package.json');
+  if (rootPackageJson !== undefined) {
+    const workspaces = rootPackageJson.workspaces;
+    const npmPatterns = extractNpmWorkspacePatterns(workspaces);
+    if (npmPatterns !== null) {
+      return { patterns: npmPatterns, source: 'package.json' };
+    }
+  }
+
+  return null;
+}
+
+/** Extract workspace patterns from the `workspaces` field of a root `package.json`. */
+function extractNpmWorkspacePatterns(workspaces: unknown): string[] | null {
+  if (Array.isArray(workspaces)) {
+    const strings = workspaces.filter((entry): entry is string => typeof entry === 'string');
+    if (strings.length !== workspaces.length) return null;
+    return strings;
+  }
+  if (isRecord(workspaces)) {
+    const nested = workspaces.packages;
+    if (Array.isArray(nested)) {
+      const strings = nested.filter((entry): entry is string => typeof entry === 'string');
+      if (strings.length !== nested.length) return null;
+      return strings;
+    }
+  }
+  return null;
+}
+
+/**
+ * Expand each pattern against a pruned recursive directory walk, returning relative
+ * dir paths (forward-slash style) sorted and deduplicated.
+ */
+function expandPatterns(cwd: string, patterns: string[], source: WorkspacePatternSource): string[] {
+  if (patterns.length === 0) return [];
+
+  // Check for negation patterns up front — the pnpm reader already rejects these in YAML,
+  // but npm `workspaces` entries come through untouched.
+  for (const pattern of patterns) {
+    if (pattern.startsWith('!')) {
+      throw new Error(
+        `Workspace discovery: negation pattern "${pattern}" in ${source} is not supported.\n` +
+          'Negation patterns are not supported in this release of readyup.\n' +
+          'If you need negation support, please open an issue.',
+      );
+    }
+  }
+
+  const matchers = patterns.map((pattern) => picomatch(normalizePattern(pattern)));
+  const matched = new Set<string>();
+
+  walk(cwd, '.', 0, (relDir) => {
+    if (relDir === '.') return;
+    if (matchers.some((isMatch) => isMatch(relDir))) {
+      matched.add(relDir);
+    }
+  });
+
+  // eslint-disable-next-line unicorn/no-array-sort -- toSorted() requires es2023 lib / Node 20+; this package supports Node 18.17+.
+  return [...matched].sort();
+}
+
+/** Ascending lexicographic comparator for workspace dir strings. */
+function compareDirs(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/**
+ * Normalize a workspace pattern.
+ * Strips a trailing `/` because picomatch's `**` matches paths, not directories-with-slash.
+ */
+function normalizePattern(pattern: string): string {
+  if (pattern.endsWith('/')) return pattern.slice(0, -1);
+  return pattern;
+}
+
+/** Recursively walk `cwd` starting at `relDir`, calling `visit` for each directory. */
+function walk(cwd: string, relDir: string, depth: number, visit: (relDir: string) => void): void {
+  visit(relDir);
+  if (depth >= MAX_WALK_DEPTH) return;
+
+  const absDir = relDir === '.' ? cwd : join(cwd, relDir);
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(absDir, { withFileTypes: true, encoding: 'utf8' });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const name = entry.name;
+    if (PRUNED_NAMES.has(name)) continue;
+    if (name.startsWith('.')) continue;
+    const childRel = relDir === '.' ? name : `${relDir}/${name}`;
+    walk(cwd, childRel, depth + 1, visit);
+  }
+}
+
+/** Build a `Workspace` for a relative directory; returns undefined if its `package.json` is missing or malformed. */
+function buildWorkspace(cwd: string, relDir: string): Workspace | undefined {
+  const absoluteDir = resolve(cwd, relDir);
+  const packageJsonRelativePath = relDir === '.' ? 'package.json' : `${relDir}/package.json`;
+  const packageJson = readJsonFile(packageJsonRelativePath);
+  if (packageJson === undefined) return undefined;
+  return buildWorkspaceFromPackageJson(relDir, absoluteDir, packageJson);
+}
+
+/** Build a `Workspace` from a relative dir, absolute path, and a parsed `package.json`. */
+function buildWorkspaceFromPackageJson(
+  relDir: string,
+  absolutePath: string,
+  packageJson: Record<string, unknown>,
+): Workspace {
+  const nameValue = packageJson.name;
+  const name = typeof nameValue === 'string' ? nameValue : undefined;
+  const isPackage = packageJson.private !== true;
+  return { dir: relDir, absolutePath, name, isPackage, packageJson };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -181,8 +181,12 @@ function walk(cwd: string, relDir: string, depth: number, visit: (relDir: string
   let entries: Dirent[];
   try {
     entries = readdirSync(absDir, { withFileTypes: true, encoding: 'utf8' });
-  } catch {
-    return;
+  } catch (error) {
+    // Skip directories we can't read for benign reasons (missing, permission-denied).
+    // Rethrow systemic failures (e.g. EMFILE, EIO) so an incomplete walk isn't masked.
+    const code = isRecord(error) && typeof error.code === 'string' ? error.code : undefined;
+    if (code === 'ENOENT' || code === 'EACCES' || code === 'EPERM') return;
+    throw error;
   }
 
   for (const entry of entries) {

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -32,8 +32,11 @@ type WorkspacePatternSource = 'pnpm-workspace.yaml' | 'package.json';
 /** Maximum recursion depth for the glob walk. */
 const MAX_WALK_DEPTH = 10;
 
-/** Directory names that are never traversed. */
-const PRUNED_NAMES = new Set(['node_modules', '.git']);
+/**
+ * Directory names that are never traversed. Only `node_modules` is listed here;
+ * dot-prefixed directories (including `.git`) are pruned separately in `walk`.
+ */
+const PRUNED_NAMES = new Set(['node_modules']);
 
 /**
  * Discover the workspaces of the current repo.
@@ -61,6 +64,8 @@ export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspa
     throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
   }
 
+  // `matchedDirs` is already sorted ascending by `expandPatterns`, and each workspace's
+  // `dir` equals its entry in that list, so the result is sorted without an extra pass.
   const matchedDirs = expandPatterns(cwd, patternResult.patterns, patternResult.source);
   const workspaces: Workspace[] = [];
   for (const relDir of matchedDirs) {
@@ -70,9 +75,7 @@ export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspa
     }
   }
 
-  // eslint-disable-next-line unicorn/no-array-sort -- `toSorted` requires Node 20; this package supports Node 18.17+.
-  const sortedWorkspaces = [...workspaces].sort((a, b) => compareDirs(a.dir, b.dir));
-  return applyFilter(sortedWorkspaces, options?.filter);
+  return applyFilter(workspaces, options?.filter);
 }
 
 // region | Helpers
@@ -158,13 +161,6 @@ function expandPatterns(cwd: string, patterns: string[], source: WorkspacePatter
 
   // eslint-disable-next-line unicorn/no-array-sort -- toSorted() requires es2023 lib / Node 20+; this package supports Node 18.17+.
   return [...matched].sort();
-}
-
-/** Ascending lexicographic comparator for workspace dir strings. */
-function compareDirs(a: string, b: string): number {
-  if (a < b) return -1;
-  if (a > b) return 1;
-  return 0;
 }
 
 /**

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -50,12 +50,14 @@ export { DEFAULT_MANIFEST_PATH } from './manifest/manifestPath.ts';
 export type { RdyManifest } from './manifest/manifestSchema.ts';
 
 // Check utilities
+export type { DiscoverWorkspacesOptions, Workspace } from './check-utils/index.ts';
 export {
   commandExists,
   compareLocalRefs,
   compareRefToRemote,
   compareVersions,
   computeHash,
+  discoverWorkspaces,
   expandHome,
   fileContains,
   fileDoesNotContain,


### PR DESCRIPTION
## What

Adds `discoverWorkspaces()` to readyup's `check-utils`, a single helper that enumerates a repo's workspaces across pnpm, npm/yarn, and single-workspace layouts with a uniform return shape. Consumer kits can now answer workspace-iteration questions — including "does this repo have anything publishable?" as `discoverWorkspaces({ filter: (w) => w.isPackage }).length > 0` — without bundling their own `glob` + YAML-parser combination.

Also declares readyup side-effect-free at the package level (`"sideEffects": ["./dist/esm/bin/rdy.js"]`), so consumer kit bundles no longer inherit `readyup` modules they don't import. For the included demo kit, the declaration removes 12 lines of previously-leaked imports from modules `demo.ts` never referenced (git helpers, hashing).

## Why

Every readyup kit that needed workspace awareness was reinventing the same primitive. `release-kit` grew 25× (387 → 9592 LOC) after three workspace-aware checks were added, driven almost entirely by two transitive deps (`glob` + a YAML parser). Three readyup kits in `node-monorepo-tools` hardcoded `packages/*` and silently missed `apps/*` layouts, and `node-monorepo-tools#307` needs the same primitive for a publish-gate predicate. Without a shared helper, every future monorepo-aware kit hits the same wall.

The obvious "just take a YAML dep" shortcut doesn't work: compiled kits are self-contained bundles loaded from `/tmp/` in remote-kit mode, so the optional-peer-dep pattern can't resolve a YAML package at runtime. A purpose-built subset reader sidesteps the problem entirely without adding any runtime dep.

## Details

### Features

- **`discoverWorkspaces()`** in `packages/readyup/src/check-utils/workspaces.ts`. Detects workspace convention in probe order: `pnpm-workspace.yaml` (with a `packages:` key) → `package.json.workspaces` (array or `{ packages: string[] }` object form) → single-workspace fallback using the root `package.json`. Returns a uniform `Workspace[]`: `{ dir, absolutePath, name, isPackage, packageJson }`. `isPackage` is strictly `private !== true`. Single-workspace fallback returns one entry with `dir: '.'` so callers never branch on repo type.
- **Glob expansion** uses the existing `picomatch` dependency against a manually driven recursive `readdirSync` walk that prunes `node_modules` and dot-prefixed directories and caps depth at 10. Matched directories without a `package.json` or with unparseable JSON are skipped silently, matching the existing `node-monorepo-tools` convention.
- **Minimal `pnpm-workspace.yaml` reader** in `pnpmWorkspaceYaml.ts`. A ~190-LOC subset parser that handles the block-sequence form the format uses in practice: unquoted/single-quoted/double-quoted items, full-line and inline `#` comments, blank lines, arbitrary block indentation, other top-level keys skipped. Throws pathful, line-pointing errors with a "please open an issue" pointer for flow sequences, anchors/aliases, multi-document streams, tags, folded/literal scalars, non-list values, and negation patterns. `packages:` key absent returns `null` so the caller falls through to npm/single-workspace detection (legitimate in pnpm 10+, which uses the file for non-workspace settings).
- **Optional `filter` callback** on `discoverWorkspaces`. Default returns all discovered workspaces.
- **Uniform negation rejection** across both `pnpm-workspace.yaml` and `package.json.workspaces` (array and object forms). Negation semantics in pnpm are set subtraction, which `picomatch`'s inverted-single-matcher semantics don't replicate — rather than ship a partial implementation, the helper rejects `!`-prefixed patterns with an actionable error and defers real negation support until a consumer demonstrates need.

### Fixes

- **Narrowed error handling** in the directory walk: the `readdirSync` catch discriminates on `error.code` and accepts `ENOENT`/`EACCES`/`EPERM` silently while rethrowing anything else, so systemic failures (`EMFILE`, `EIO`) surface instead of silently truncating the walk result.
- **Package-level `sideEffects` declaration.** `packages/readyup/package.json` now declares `"sideEffects": ["./dist/esm/bin/rdy.js"]`, telling bundlers every non-CLI module in readyup is tree-shakable. Without this hint, esbuild preserved every reached module's top-level external imports on the conservative assumption that modules might carry side effects — inflating every downstream kit bundle with imports it didn't use.

### Refactoring

- **Removed redundant work in `discoverWorkspaces`.** Dropped a second `[...workspaces].sort()` pass (the upstream `expandPatterns` already returns a sorted list) and its now-unused `compareDirs` helper. Also removed `.git` from `PRUNED_NAMES` since the existing `name.startsWith('.')` guard in the walk already subsumes it.

### Tests

- **47 new behavioral tests** covering every acceptance criterion: `pnpmWorkspaceYaml.test.ts` (25 cases) exercises each supported YAML form and each unsupported-feature error path; `workspaces.test.ts` (22 cases) covers monorepo detection across all three conventions, single-workspace fallback, filter composition, `isPackage` across all `private` value shapes (absent, `false`, `true`, non-boolean), negation rejection in both array and object forms of `workspaces`, silent-skip behavior for matched directories without valid `package.json`, and `node_modules`/`.git` prune guarantees.
- **AST-based side-effect-free invariant** in `sideEffectFreeSrc.test.ts`. Walks every `src/**/*.ts` file using TypeScript's compiler API and asserts each top-level statement is purely declarative (import, export, variable declaration, function/class declaration, or type construct). Anything else — bare expression statements, control-flow, IIFEs — fails the test with a file-relative line number, AST kind, and snippet. A companion assertion enforces that every file on the intentional-side-effects allowlist has a matching entry in `package.json`'s `sideEffects` array, so neither side of the contract can drift without the test catching it.

### Dependencies

- **No new entries** in `dependencies`, `devDependencies`, or `peerDependencies`. The `sideEffects` declaration is a tree-shaking hint, not a dep. The minimal YAML reader was a deliberate design choice specifically to avoid taking a runtime YAML parser.

Closes #73 