### PR TITLE
#45 Add `rdy list --from github:` remote kit listing

### DIFF
--- a/packages/readyup/__tests__/helpers/mockResponse.ts
+++ b/packages/readyup/__tests__/helpers/mockResponse.ts
@@ -1,0 +1,13 @@
+/** Build a minimal mock Response with the given body and status. */
+export function mockResponse(
+  body: string,
+  init?: { status?: number; statusText?: string },
+): Pick<Response, 'ok' | 'status' | 'statusText' | 'text' | 'headers'> {
+  return {
+    ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+    text: () => Promise.resolve(body),
+    headers: new Headers(),
+  };
+}

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -3,11 +3,11 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import { listCommand } from '../../src/list/listCommand.ts';
-
 const mockEnumerateKits = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockReadManifest = vi.hoisted(() => vi.fn());
+const mockResolveGitHubToken = vi.hoisted(() => vi.fn());
+const mockFetch = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/list/enumerateKits.ts', () => ({
   enumerateKits: mockEnumerateKits,
@@ -25,6 +25,33 @@ vi.mock('../../src/manifest/readManifest.ts', async (importOriginal) => {
   };
 });
 
+vi.mock('../../src/resolveGitHubToken.ts', () => ({
+  resolveGitHubToken: mockResolveGitHubToken,
+}));
+
+vi.stubGlobal('fetch', mockFetch);
+
+import { listCommand } from '../../src/list/listCommand.ts';
+
+/** Build a minimal mock Response with the given body and status. */
+function mockResponse(
+  body: string,
+  init?: { status?: number; statusText?: string },
+): Pick<Response, 'ok' | 'status' | 'statusText' | 'text' | 'headers'> {
+  return {
+    ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+    text: () => Promise.resolve(body),
+    headers: new Headers(),
+  };
+}
+
+const validRemoteManifestBody = JSON.stringify({
+  version: 1,
+  kits: [{ name: 'default', description: 'General project health checks' }, { name: 'deploy' }],
+});
+
 describe(listCommand, () => {
   let stdoutSpy: MockInstance;
   let stderrSpy: MockInstance;
@@ -34,6 +61,7 @@ describe(listCommand, () => {
     stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     mockEnumerateKits.mockReturnValue([]);
     mockReadManifest.mockReturnValue({ version: 1, kits: [] });
+    mockResolveGitHubToken.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -41,6 +69,8 @@ describe(listCommand, () => {
     mockEnumerateKits.mockReset();
     mockLoadConfig.mockReset();
     mockReadManifest.mockReset();
+    mockResolveGitHubToken.mockReset();
+    mockFetch.mockReset();
   });
 
   it('with --from global, reads manifest from the home-based .readyup directory', async () => {
@@ -98,5 +128,87 @@ describe(listCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error:'));
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('URLs are not accepted by --from'));
     expect(mockReadManifest).not.toHaveBeenCalled();
+  });
+
+  it('with --from github:org/repo, fetches and renders the remote manifest', async () => {
+    mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
+
+    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+
+    expect(exitCode).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json',
+      { headers: {} },
+    );
+    expect(mockReadManifest).not.toHaveBeenCalled();
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+
+    const stdoutCalls = stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stdoutCalls).toContain(
+      'Manifest: https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json',
+    );
+    expect(stdoutCalls).toContain('default — General project health checks');
+    expect(stdoutCalls).toContain('deploy');
+  });
+
+  it('with --from github:org/repo@ref, builds the URL using the supplied ref', async () => {
+    mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
+
+    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop@develop']);
+
+    expect(exitCode).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/williamthorsen/workshop/develop/.readyup/manifest.json',
+      { headers: {} },
+    );
+  });
+
+  it('with --from github:..., forwards the GitHub token as an Authorization header when available', async () => {
+    mockResolveGitHubToken.mockReturnValue('my-token');
+    mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
+
+    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+
+    expect(exitCode).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json',
+      { headers: { Authorization: 'token my-token' } },
+    );
+  });
+
+  it('with --from github:... and a 404 response, writes an actionable stderr message', async () => {
+    mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
+
+    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Error: No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json. Has `rdy compile --with-manifest` been run?',
+    );
+  });
+
+  it('with --from github:... and an HTML soft-404 body, writes an actionable stderr message', async () => {
+    mockFetch.mockResolvedValue(mockResponse('<!DOCTYPE html><html><body>Not Found</body></html>'));
+
+    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Error: No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json. Has `rdy compile --with-manifest` been run?',
+    );
+  });
+
+  it('with --from github:... and a malformed manifest, writes a stderr message including the URL and "malformed"', async () => {
+    mockFetch.mockResolvedValue(mockResponse('{ not valid json'));
+
+    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Manifest at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json is malformed:',
+    );
   });
 });

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -32,20 +32,7 @@ vi.mock('../../src/resolveGitHubToken.ts', () => ({
 vi.stubGlobal('fetch', mockFetch);
 
 import { listCommand } from '../../src/list/listCommand.ts';
-
-/** Build a minimal mock Response with the given body and status. */
-function mockResponse(
-  body: string,
-  init?: { status?: number; statusText?: string },
-): Pick<Response, 'ok' | 'status' | 'statusText' | 'text' | 'headers'> {
-  return {
-    ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
-    status: init?.status ?? 200,
-    statusText: init?.statusText ?? 'OK',
-    text: () => Promise.resolve(body),
-    headers: new Headers(),
-  };
-}
+import { mockResponse } from '../helpers/mockResponse.ts';
 
 const validRemoteManifestBody = JSON.stringify({
   version: 1,

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -163,7 +163,7 @@ describe(listCommand, () => {
     );
   });
 
-  it('with --from github:... and a 404 response, writes an actionable stderr message', async () => {
+  it('with --from github:... and a 404 response, writes a stderr message naming the URL', async () => {
     mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
 
     const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
@@ -171,11 +171,11 @@ describe(listCommand, () => {
     expect(exitCode).toBe(1);
     const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
     expect(stderrCalls).toContain(
-      'Error: No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json. Has `rdy compile --with-manifest` been run?',
+      'Error: No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json.',
     );
   });
 
-  it('with --from github:... and an HTML soft-404 body, writes an actionable stderr message', async () => {
+  it('with --from github:... and an HTML soft-404 body, writes a stderr message naming the URL', async () => {
     mockFetch.mockResolvedValue(mockResponse('<!DOCTYPE html><html><body>Not Found</body></html>'));
 
     const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
@@ -183,7 +183,7 @@ describe(listCommand, () => {
     expect(exitCode).toBe(1);
     const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
     expect(stderrCalls).toContain(
-      'Error: No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json. Has `rdy compile --with-manifest` been run?',
+      'Error: No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json.',
     );
   });
 

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -198,4 +198,43 @@ describe(listCommand, () => {
       'Manifest at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json is malformed:',
     );
   });
+
+  it('with --from github:... and a schema-invalid manifest, writes a stderr message including the URL and "malformed"', async () => {
+    mockFetch.mockResolvedValue(mockResponse(JSON.stringify({ version: 1, kits: 'not-an-array' })));
+
+    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Manifest at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json is malformed:',
+    );
+  });
+
+  it('with --from github:... and a 500 response, writes a stderr message including the URL and status', async () => {
+    mockFetch.mockResolvedValue(
+      mockResponse('Internal Server Error', { status: 500, statusText: 'Internal Server Error' }),
+    );
+
+    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Failed to fetch manifest from https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json: 500 Internal Server Error',
+    );
+  });
+
+  it('with --from github:... and a network failure, writes a stderr message including the URL', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Failed to reach https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json',
+    );
+    expect(stderrCalls).toContain('ECONNREFUSED');
+  });
 });

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -223,13 +223,6 @@ describe(listCommand, () => {
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Manifest file not found'));
     });
 
-    it('returns 1 for github: scheme with not-yet-supported message', async () => {
-      const exitCode = await listCommand(['--from', 'github:org/repo']);
-
-      expect(exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('not yet supported'));
-    });
-
     it('returns 1 for bitbucket: scheme with not-yet-supported message', async () => {
       const exitCode = await listCommand(['--from', 'bitbucket:team/repo']);
 

--- a/packages/readyup/__tests__/loadRemoteManifest.test.ts
+++ b/packages/readyup/__tests__/loadRemoteManifest.test.ts
@@ -4,20 +4,7 @@ const mockFetch = vi.hoisted(() => vi.fn());
 vi.stubGlobal('fetch', mockFetch);
 
 import { loadRemoteManifest, RemoteManifestNotFoundError } from '../src/loadRemoteManifest.ts';
-
-/** Build a minimal mock Response with the given body and status. */
-function mockResponse(
-  body: string,
-  init?: { status?: number; statusText?: string },
-): Pick<Response, 'ok' | 'status' | 'statusText' | 'text' | 'headers'> {
-  return {
-    ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
-    status: init?.status ?? 200,
-    statusText: init?.statusText ?? 'OK',
-    text: () => Promise.resolve(body),
-    headers: new Headers(),
-  };
-}
+import { mockResponse } from './helpers/mockResponse.ts';
 
 const validManifestBody = JSON.stringify({
   version: 1,

--- a/packages/readyup/__tests__/loadRemoteManifest.test.ts
+++ b/packages/readyup/__tests__/loadRemoteManifest.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.hoisted(() => vi.fn());
+vi.stubGlobal('fetch', mockFetch);
+
+import { loadRemoteManifest, RemoteManifestNotFoundError } from '../src/loadRemoteManifest.ts';
+
+/** Build a minimal mock Response with the given body and status. */
+function mockResponse(
+  body: string,
+  init?: { status?: number; statusText?: string },
+): Pick<Response, 'ok' | 'status' | 'statusText' | 'text' | 'headers'> {
+  return {
+    ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+    text: () => Promise.resolve(body),
+    headers: new Headers(),
+  };
+}
+
+const validManifestBody = JSON.stringify({
+  version: 1,
+  kits: [{ name: 'default', description: 'General project health checks' }, { name: 'deploy' }],
+});
+
+describe(loadRemoteManifest, () => {
+  afterEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('returns parsed manifest on 200 with a valid body', async () => {
+    mockFetch.mockResolvedValue(mockResponse(validManifestBody));
+
+    const manifest = await loadRemoteManifest({ url: 'https://example.com/manifest.json' });
+
+    expect(manifest.version).toBe(1);
+    expect(manifest.kits).toHaveLength(2);
+    expect(manifest.kits[0]?.name).toBe('default');
+    expect(manifest.kits[0]?.description).toBe('General project health checks');
+    expect(manifest.kits[1]?.name).toBe('deploy');
+  });
+
+  it('throws RemoteManifestNotFoundError on 404', async () => {
+    mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
+
+    await expect(loadRemoteManifest({ url: 'https://example.com/manifest.json' })).rejects.toBeInstanceOf(
+      RemoteManifestNotFoundError,
+    );
+  });
+
+  it('throws RemoteManifestNotFoundError when response body is an HTML page with <!doctype', async () => {
+    mockFetch.mockResolvedValue(mockResponse('<!DOCTYPE html><html><body>Not Found</body></html>'));
+
+    await expect(loadRemoteManifest({ url: 'https://example.com/manifest.json' })).rejects.toBeInstanceOf(
+      RemoteManifestNotFoundError,
+    );
+  });
+
+  it('throws RemoteManifestNotFoundError when response body starts with <html', async () => {
+    mockFetch.mockResolvedValue(mockResponse('<html><body>Not Found</body></html>'));
+
+    await expect(loadRemoteManifest({ url: 'https://example.com/manifest.json' })).rejects.toBeInstanceOf(
+      RemoteManifestNotFoundError,
+    );
+  });
+
+  it('throws plain Error containing URL and status for non-404 non-2xx responses', async () => {
+    mockFetch.mockResolvedValue(mockResponse('boom', { status: 500, statusText: 'Internal Server Error' }));
+
+    await expect(loadRemoteManifest({ url: 'https://example.com/manifest.json' })).rejects.toThrow(
+      'Failed to fetch manifest from https://example.com/manifest.json: 500 Internal Server Error',
+    );
+  });
+
+  it('throws Error containing URL and "malformed" for invalid JSON', async () => {
+    mockFetch.mockResolvedValue(mockResponse('{ not valid json'));
+
+    await expect(loadRemoteManifest({ url: 'https://example.com/manifest.json' })).rejects.toThrow(
+      /Manifest at https:\/\/example\.com\/manifest\.json is malformed:/,
+    );
+  });
+
+  it('throws Error containing URL and "malformed" for schema-invalid JSON', async () => {
+    mockFetch.mockResolvedValue(mockResponse(JSON.stringify({ version: 2, kits: [] })));
+
+    await expect(loadRemoteManifest({ url: 'https://example.com/manifest.json' })).rejects.toThrow(
+      /Manifest at https:\/\/example\.com\/manifest\.json is malformed:/,
+    );
+  });
+
+  it('sends Authorization header when token is provided', async () => {
+    mockFetch.mockResolvedValue(mockResponse(validManifestBody));
+
+    await loadRemoteManifest({ url: 'https://example.com/manifest.json', token: 'my-token' });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/manifest.json', {
+      headers: { Authorization: 'token my-token' },
+    });
+  });
+
+  it('omits Authorization header when no token is provided', async () => {
+    mockFetch.mockResolvedValue(mockResponse(validManifestBody));
+
+    await loadRemoteManifest({ url: 'https://example.com/manifest.json' });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/manifest.json', {
+      headers: {},
+    });
+  });
+
+  it('propagates network errors from fetch', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(loadRemoteManifest({ url: 'https://example.com/manifest.json' })).rejects.toThrow('ECONNREFUSED');
+  });
+});

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -124,19 +124,21 @@ Usage: rdy list [options]
 List available kits without running them.
 
 Modes:
-  rdy list                       List internal and compiled kits (owner view)
-  rdy list --from <path>         List compiled kits at a local path (consumer view)
-  rdy list --from global         List compiled kits in the global directory
-  rdy list --from dir:<path>     List kits in an arbitrary directory
+  rdy list                                List internal and compiled kits (owner view)
+  rdy list --from <path>                  List compiled kits at a local path (consumer view)
+  rdy list --from global                  List compiled kits in the global directory
+  rdy list --from dir:<path>              List kits in an arbitrary directory
+  rdy list --from github:org/repo[@ref]   List kits in a remote GitHub repository
 
 Options:
-  --from <source>  Kit source (local path, global, or dir:path)
+  --from <source>  Kit source (github:org/repo[@ref], global, dir:path, or local path)
   --help, -h       Show this help message
 
 Examples:
-  rdy list                Show kits in the current project
-  rdy list --from .       Show compiled kits in the current directory
-  rdy list --from global  Show kits in the global directory
+  rdy list                                       Show kits in the current project
+  rdy list --from .                              Show compiled kits in the current directory
+  rdy list --from global                         Show kits in the global directory
+  rdy list --from github:williamthorsen/workshop Show kits in a remote GitHub repository
 `);
 }
 

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -113,7 +113,7 @@ async function runFromMode(fromArg: string): Promise<number> {
 async function runRemoteFromMode({ url, token }: { url: string; token: string | undefined }): Promise<number> {
   let manifest;
   try {
-    manifest = await loadRemoteManifest(token !== undefined ? { url, token } : { url });
+    manifest = await loadRemoteManifest({ url, token });
   } catch (error: unknown) {
     if (error instanceof RemoteManifestNotFoundError) {
       process.stderr.write(`Error: No manifest found at ${url}. Has \`rdy compile --with-manifest\` been run?\n`);

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -116,7 +116,7 @@ async function runRemoteFromMode({ url, token }: { url: string; token: string | 
     manifest = await loadRemoteManifest({ url, token });
   } catch (error: unknown) {
     if (error instanceof RemoteManifestNotFoundError) {
-      process.stderr.write(`Error: No manifest found at ${url}. Has \`rdy compile --with-manifest\` been run?\n`);
+      process.stderr.write(`Error: No manifest found at ${url}.\n`);
       return 1;
     }
     const message = extractMessage(error);

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -2,10 +2,12 @@ import path from 'node:path';
 import process from 'node:process';
 
 import { loadConfig } from '../loadConfig.ts';
+import { loadRemoteManifest, RemoteManifestNotFoundError } from '../loadRemoteManifest.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { parseFromValue } from '../parseFromValue.ts';
+import { resolveGitHubToken } from '../resolveGitHubToken.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { enumerateKits } from './enumerateKits.ts';
 import type { CompiledStyle } from './formatList.ts';
@@ -69,7 +71,7 @@ function runManifestMode(manifestArg: string): number {
 }
 
 /** Resolve the manifest path for a `--from` source and display its kits. */
-function runFromMode(fromArg: string): number {
+async function runFromMode(fromArg: string): Promise<number> {
   let source;
   try {
     source = parseFromValue(fromArg);
@@ -79,7 +81,13 @@ function runFromMode(fromArg: string): number {
     return 1;
   }
 
-  if (source.type === 'github' || source.type === 'bitbucket') {
+  if (source.type === 'github') {
+    const url = `https://raw.githubusercontent.com/${source.org}/${source.repo}/${source.ref}/.readyup/manifest.json`;
+    const token = resolveGitHubToken();
+    return runRemoteFromMode({ url, token });
+  }
+
+  if (source.type === 'bitbucket') {
     process.stderr.write(`Error: Listing kits from ${source.type} repositories is not yet supported.\n`);
     return 1;
   }
@@ -97,6 +105,26 @@ function runFromMode(fromArg: string): number {
 
   const kitNames = manifest.kits.map((kit) => kit.name);
   const output = formatConsumerView({ compiledKits: kitNames, fromArg, kitsDir: path.dirname(manifestPath) });
+  process.stdout.write(output + '\n');
+  return 0;
+}
+
+/** Fetch and display kits from a remote manifest URL. */
+async function runRemoteFromMode({ url, token }: { url: string; token: string | undefined }): Promise<number> {
+  let manifest;
+  try {
+    manifest = await loadRemoteManifest(token !== undefined ? { url, token } : { url });
+  } catch (error: unknown) {
+    if (error instanceof RemoteManifestNotFoundError) {
+      process.stderr.write(`Error: No manifest found at ${url}. Has \`rdy compile --with-manifest\` been run?\n`);
+      return 1;
+    }
+    const message = extractMessage(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return 1;
+  }
+
+  const output = formatManifestView({ kits: manifest.kits, manifestPath: url });
   process.stdout.write(output + '\n');
   return 0;
 }

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -120,7 +120,9 @@ async function runRemoteFromMode({ url, token }: { url: string; token: string | 
       return 1;
     }
     const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
+    // Network failures (raw `fetch` rejections) carry no URL context; thrown errors from `loadRemoteManifest` already include the URL.
+    const detail = message.includes(url) ? message : `Failed to reach ${url}: ${message}`;
+    process.stderr.write(`Error: ${detail}\n`);
     return 1;
   }
 

--- a/packages/readyup/src/loadRemoteManifest.ts
+++ b/packages/readyup/src/loadRemoteManifest.ts
@@ -11,7 +11,7 @@ export class RemoteManifestNotFoundError extends Error {
 
 export interface LoadRemoteManifestOptions {
   url: string;
-  token?: string;
+  token?: string | undefined;
 }
 
 /**

--- a/packages/readyup/src/loadRemoteManifest.ts
+++ b/packages/readyup/src/loadRemoteManifest.ts
@@ -1,0 +1,62 @@
+import type { RdyManifest } from './manifest/manifestSchema.ts';
+import { ManifestSchema } from './manifest/manifestSchema.ts';
+
+/** Thrown when a remote manifest URL responds with 404 or an HTML soft-404. */
+export class RemoteManifestNotFoundError extends Error {
+  constructor(url: string) {
+    super(`No manifest found at ${url}`);
+    this.name = 'RemoteManifestNotFoundError';
+  }
+}
+
+export interface LoadRemoteManifestOptions {
+  url: string;
+  token?: string;
+}
+
+/**
+ * Fetch, parse, and schema-validate a manifest from a URL.
+ *
+ * Sends `Authorization: token {token}` (GitHub-style) when a token is provided.
+ * Throws `RemoteManifestNotFoundError` for 404 and HTML soft-404 responses,
+ * and a plain `Error` for other non-2xx responses, malformed JSON, and schema-invalid bodies.
+ */
+export async function loadRemoteManifest({ url, token }: LoadRemoteManifestOptions): Promise<RdyManifest> {
+  const headers: Record<string, string> = {};
+  if (token !== undefined) {
+    headers.Authorization = `token ${token}`;
+  }
+
+  const response = await fetch(url, { headers });
+
+  if (response.status === 404) {
+    throw new RemoteManifestNotFoundError(url);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch manifest from ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  const body = await response.text();
+
+  // Detect HTML error pages (e.g., GitHub 404 pages that return 200)
+  const trimmedBody = body.trimStart().toLowerCase();
+  if (trimmedBody.startsWith('<html') || trimmedBody.startsWith('<!doctype')) {
+    throw new RemoteManifestNotFoundError(url);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Manifest at ${url} is malformed: ${detail}`);
+  }
+
+  const result = ManifestSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(`Manifest at ${url} is malformed: ${result.error.message}`);
+  }
+
+  return result.data;
+}


### PR DESCRIPTION
## What

Adds support for listing kits from a remote GitHub repository via `rdy list --from github:org/repo[@ref]`. The command fetches the manifest from `raw.githubusercontent.com`, validates it against the manifest schema, and renders the kit list in the same format as the local `--from` modes. A `GITHUB_TOKEN` (when present) is forwarded as `Authorization: token …` so private and rate-limited public repos work without extra configuration. Missing manifests, malformed responses, and network failures all produce actionable error messages with the URL in context.

## Why

Until now, anyone wanting to discover what kits a workshop repository exposed had to clone the repository first. With `compile --with-manifest` already producing `.readyup/manifest.json` in remote repos, the discovery half of the round trip was missing. This change closes that loop and is the first half of the broader remote-listing capability planned across #45 (GitHub) and #46 (Bitbucket).

## Details

### Features

- **`loadRemoteManifest` helper (`packages/readyup/src/loadRemoteManifest.ts`).** Provider-agnostic — fetches a URL, optionally forwards an `Authorization` header, parses the body as JSON, and validates through `ManifestSchema`. Detects HTML soft-404s (GitHub's 200-with-HTML response for missing files) using the same trim-and-prefix-check pattern already used in `loadRemoteKit`. Throws the typed `RemoteManifestNotFoundError` for both real 404s and soft-404s; throws plain `Error`s with URL-contextual messages for other failures.
- **GitHub branch in `runFromMode` (`packages/readyup/src/list/listCommand.ts`).** Replaces the previous "not yet supported" stub for `source.type === 'github'`. Builds the `raw.githubusercontent.com` URL inline, resolves a token via `resolveGitHubToken`, and delegates to a small `runRemoteFromMode` inner helper that maps known errors to actionable stderr messages. The Bitbucket arm is left intact verbatim so #46 can be applied as a near copy-paste. `runFromMode` becomes async; the lone caller already awaits it, so the surface change is contained.
- **`rdy list --help` updated (`packages/readyup/src/bin/route.ts`).** Documents the new mode in the modes section, extends the `--from <source>` description, and adds an example.

### Refactoring

- **Helper-call simplification.** Flattened a redundant `token !== undefined ? { url, token } : { url }` ternary at the helper call site into a single `loadRemoteManifest({ url, token })`, after widening `LoadRemoteManifestOptions.token` to explicitly accept `string | undefined` under `exactOptionalPropertyTypes`.
- **Shared test fixture.** Extracted the duplicated `mockResponse` helper from two test files into `packages/readyup/__tests__/helpers/mockResponse.ts`.
- **Network-error URL context.** Wrapped the network-error catch arm with `Failed to reach ${url}: …` when the underlying error doesn't already include the URL — thrown errors from `loadRemoteManifest` already carry it.

### Tests

- New unit suite (`packages/readyup/__tests__/loadRemoteManifest.test.ts`): success, real 404, HTML soft-404 (both `<html` and `<!doctype` variants), other non-2xx, malformed JSON, schema-invalid JSON, and `Authorization` header forwarding/absence.
- New integration cases in `packages/readyup/__tests__/list/listCommand.test.ts`: success, ref selection, auth forwarding, 404 stderr, soft-404 stderr, malformed manifest, schema-invalid manifest, 500 response, network failure, and an explicit assertion that `loadConfig` is not invoked for GitHub sources.
- Total: 985 tests passing on the readyup package (+16 new behavioral tests over the merge base).

## Test plan

- [x] Smoke-test against a real public repository: `node packages/readyup/dist/esm/cli.js list --from github:williamthorsen/workshop` renders kits with the expected `📦 name — description` format.
- [x] Smoke-test ref selection: `... list --from github:williamthorsen/workshop@<sha>` builds the correct URL.
- [ ] Smoke-test missing manifest: pointing at a repo without `.readyup/manifest.json` produces the actionable "No manifest found at … Has `rdy compile --with-manifest` been run?" message.
- [ ] Smoke-test private-repo access: with `GITHUB_TOKEN` set in the environment, listing from a private workshop repository succeeds.
- [ ] Verify `rdy list --help` displays the new mode keyword, option text, and example.

## Follow-ups

- **#75** — Extract a shared `isHtmlBody` helper from the duplicated soft-404 detection in `loadRemoteKit.ts` and `loadRemoteManifest.ts`. Best done before #46 lands and triples the duplication.
- **#46** — Bitbucket symmetry. The `runFromMode` skeleton is already async-shaped to accommodate it; see the comment posted on #46 for the three deltas (URL builder, token resolver, auth-header scheme).

Closes #45