### PR TITLE
#46 Add `rdy list --from bitbucket:` remote kit listing

### DIFF
--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 const mockEnumerateKits = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockReadManifest = vi.hoisted(() => vi.fn());
+const mockResolveBitbucketToken = vi.hoisted(() => vi.fn());
 const mockResolveGitHubToken = vi.hoisted(() => vi.fn());
 const mockFetch = vi.hoisted(() => vi.fn());
 
@@ -24,6 +25,10 @@ vi.mock('../../src/manifest/readManifest.ts', async (importOriginal) => {
     readManifest: mockReadManifest,
   };
 });
+
+vi.mock('../../src/resolveBitbucketToken.ts', () => ({
+  resolveBitbucketToken: mockResolveBitbucketToken,
+}));
 
 vi.mock('../../src/resolveGitHubToken.ts', () => ({
   resolveGitHubToken: mockResolveGitHubToken,
@@ -48,6 +53,7 @@ describe(listCommand, () => {
     stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     mockEnumerateKits.mockReturnValue([]);
     mockReadManifest.mockReturnValue({ version: 1, kits: [] });
+    mockResolveBitbucketToken.mockReturnValue(undefined);
     mockResolveGitHubToken.mockReturnValue(undefined);
   });
 
@@ -56,6 +62,7 @@ describe(listCommand, () => {
     mockEnumerateKits.mockReset();
     mockLoadConfig.mockReset();
     mockReadManifest.mockReset();
+    mockResolveBitbucketToken.mockReset();
     mockResolveGitHubToken.mockReset();
     mockFetch.mockReset();
   });
@@ -234,6 +241,128 @@ describe(listCommand, () => {
     const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
     expect(stderrCalls).toContain(
       'Failed to reach https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json',
+    );
+    expect(stderrCalls).toContain('ECONNREFUSED');
+  });
+
+  it('with --from bitbucket:ws/repo, fetches and renders the remote manifest', async () => {
+    mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
+
+    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+
+    expect(exitCode).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json',
+      { headers: {} },
+    );
+    expect(mockReadManifest).not.toHaveBeenCalled();
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+
+    const stdoutCalls = stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stdoutCalls).toContain(
+      'Manifest: https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json',
+    );
+    expect(stdoutCalls).toContain('default — General project health checks');
+    expect(stdoutCalls).toContain('deploy');
+  });
+
+  it('with --from bitbucket:ws/repo@ref, builds the URL using the supplied ref', async () => {
+    mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
+
+    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo@develop']);
+
+    expect(exitCode).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/develop/.readyup/manifest.json',
+      { headers: {} },
+    );
+  });
+
+  it('with --from bitbucket:..., forwards the Bitbucket token as a Bearer Authorization header when available', async () => {
+    mockResolveBitbucketToken.mockReturnValue('bb-token');
+    mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
+
+    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+
+    expect(exitCode).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json',
+      { headers: { Authorization: 'Bearer bb-token' } },
+    );
+  });
+
+  it('with --from bitbucket:... and no token, the request goes anonymous', async () => {
+    mockResolveBitbucketToken.mockReturnValue(undefined);
+    mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
+
+    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+
+    expect(exitCode).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json',
+      { headers: {} },
+    );
+  });
+
+  it('with --from bitbucket:... and a 404 response, writes a stderr message naming the URL', async () => {
+    mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
+
+    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Error: No manifest found at https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json.',
+    );
+  });
+
+  it('with --from bitbucket:... and a malformed manifest, writes a stderr message including the URL and "malformed"', async () => {
+    mockFetch.mockResolvedValue(mockResponse('{ not valid json'));
+
+    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Manifest at https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json is malformed:',
+    );
+  });
+
+  it('with --from bitbucket:... and a schema-invalid manifest, writes a stderr message including the URL and "malformed"', async () => {
+    mockFetch.mockResolvedValue(mockResponse(JSON.stringify({ version: 1, kits: 'not-an-array' })));
+
+    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Manifest at https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json is malformed:',
+    );
+  });
+
+  it('with --from bitbucket:... and a 500 response, writes a stderr message including the URL and status', async () => {
+    mockFetch.mockResolvedValue(
+      mockResponse('Internal Server Error', { status: 500, statusText: 'Internal Server Error' }),
+    );
+
+    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Failed to fetch manifest from https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json: 500 Internal Server Error',
+    );
+  });
+
+  it('with --from bitbucket:... and a network failure, writes a stderr message including the URL', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+
+    expect(exitCode).toBe(1);
+    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderrCalls).toContain(
+      'Failed to reach https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json',
     );
     expect(stderrCalls).toContain('ECONNREFUSED');
   });

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -291,7 +291,7 @@ describe(listCommand, () => {
     );
   });
 
-  it('with --from bitbucket:... and no token, the request goes anonymous', async () => {
+  it('with --from bitbucket:... and BITBUCKET_TOKEN unset, omits the Authorization header', async () => {
     mockResolveBitbucketToken.mockReturnValue(undefined);
     mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
 

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -222,13 +222,6 @@ describe(listCommand, () => {
       expect(exitCode).toBe(1);
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Manifest file not found'));
     });
-
-    it('returns 1 for bitbucket: scheme with not-yet-supported message', async () => {
-      const exitCode = await listCommand(['--from', 'bitbucket:team/repo']);
-
-      expect(exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('not yet supported'));
-    });
   });
 
   describe('manifest mode', () => {

--- a/packages/readyup/__tests__/loadRemoteManifest.test.ts
+++ b/packages/readyup/__tests__/loadRemoteManifest.test.ts
@@ -76,17 +76,20 @@ describe(loadRemoteManifest, () => {
     );
   });
 
-  it('sends Authorization header when token is provided', async () => {
+  it('forwards supplied headers to fetch', async () => {
     mockFetch.mockResolvedValue(mockResponse(validManifestBody));
 
-    await loadRemoteManifest({ url: 'https://example.com/manifest.json', token: 'my-token' });
+    await loadRemoteManifest({
+      url: 'https://example.com/manifest.json',
+      headers: { Authorization: 'Bearer my-token', 'X-Custom': 'value' },
+    });
 
     expect(mockFetch).toHaveBeenCalledWith('https://example.com/manifest.json', {
-      headers: { Authorization: 'token my-token' },
+      headers: { Authorization: 'Bearer my-token', 'X-Custom': 'value' },
     });
   });
 
-  it('omits Authorization header when no token is provided', async () => {
+  it('calls fetch with empty headers when none are provided', async () => {
     mockFetch.mockResolvedValue(mockResponse(validManifestBody));
 
     await loadRemoteManifest({ url: 'https://example.com/manifest.json' });

--- a/packages/readyup/__tests__/resolveBitbucketToken.test.ts
+++ b/packages/readyup/__tests__/resolveBitbucketToken.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveBitbucketToken } from '../src/resolveBitbucketToken.ts';
+
+describe(resolveBitbucketToken, () => {
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    originalToken = process.env.BITBUCKET_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env.BITBUCKET_TOKEN;
+    } else {
+      process.env.BITBUCKET_TOKEN = originalToken;
+    }
+  });
+
+  it('returns the env value when BITBUCKET_TOKEN is set and non-empty', () => {
+    process.env.BITBUCKET_TOKEN = 'bb-secret-123';
+
+    expect(resolveBitbucketToken()).toBe('bb-secret-123');
+  });
+
+  it('returns undefined when BITBUCKET_TOKEN is unset', () => {
+    delete process.env.BITBUCKET_TOKEN;
+
+    expect(resolveBitbucketToken()).toBeUndefined();
+  });
+
+  it('returns undefined when BITBUCKET_TOKEN is the empty string', () => {
+    process.env.BITBUCKET_TOKEN = '';
+
+    expect(resolveBitbucketToken()).toBeUndefined();
+  });
+});

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -124,21 +124,23 @@ Usage: rdy list [options]
 List available kits without running them.
 
 Modes:
-  rdy list                                List internal and compiled kits (owner view)
-  rdy list --from <path>                  List compiled kits at a local path (consumer view)
-  rdy list --from global                  List compiled kits in the global directory
-  rdy list --from dir:<path>              List kits in an arbitrary directory
-  rdy list --from github:org/repo[@ref]   List kits in a remote GitHub repository
+  rdy list                                  List internal and compiled kits (owner view)
+  rdy list --from <path>                    List compiled kits at a local path (consumer view)
+  rdy list --from global                    List compiled kits in the global directory
+  rdy list --from dir:<path>                List kits in an arbitrary directory
+  rdy list --from github:org/repo[@ref]     List kits in a remote GitHub repository
+  rdy list --from bitbucket:ws/repo[@ref]   List kits in a remote Bitbucket repository
 
 Options:
-  --from <source>  Kit source (github:org/repo[@ref], global, dir:path, or local path)
+  --from <source>  Kit source (github:org/repo[@ref], bitbucket:ws/repo[@ref], global, dir:path, or local path)
   --help, -h       Show this help message
 
 Examples:
-  rdy list                                       Show kits in the current project
-  rdy list --from .                              Show compiled kits in the current directory
-  rdy list --from global                         Show kits in the global directory
-  rdy list --from github:williamthorsen/workshop Show kits in a remote GitHub repository
+  rdy list                                         Show kits in the current project
+  rdy list --from .                                Show compiled kits in the current directory
+  rdy list --from global                           Show kits in the global directory
+  rdy list --from github:williamthorsen/workshop   Show kits in a remote GitHub repository
+  rdy list --from bitbucket:tutorials/markdowndemo Show kits in a remote Bitbucket repository
 `);
 }
 

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -140,7 +140,7 @@ Examples:
   rdy list --from .                                Show compiled kits in the current directory
   rdy list --from global                           Show kits in the global directory
   rdy list --from github:williamthorsen/workshop   Show kits in a remote GitHub repository
-  rdy list --from bitbucket:tutorials/markdowndemo Show kits in a remote Bitbucket repository
+  rdy list --from bitbucket:tutorials/markdowndemo@master Show kits in a remote Bitbucket repository
 `);
 }
 

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -7,6 +7,7 @@ import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { parseArgs, translateParseError } from '../parseArgs.ts';
 import { parseFromValue } from '../parseFromValue.ts';
+import { resolveBitbucketToken } from '../resolveBitbucketToken.ts';
 import { resolveGitHubToken } from '../resolveGitHubToken.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { enumerateKits } from './enumerateKits.ts';
@@ -84,12 +85,15 @@ async function runFromMode(fromArg: string): Promise<number> {
   if (source.type === 'github') {
     const url = `https://raw.githubusercontent.com/${source.org}/${source.repo}/${source.ref}/.readyup/manifest.json`;
     const token = resolveGitHubToken();
-    return runRemoteFromMode({ url, token });
+    const headers = token !== undefined ? { Authorization: `token ${token}` } : undefined;
+    return runRemoteFromMode({ url, headers });
   }
 
   if (source.type === 'bitbucket') {
-    process.stderr.write(`Error: Listing kits from ${source.type} repositories is not yet supported.\n`);
-    return 1;
+    const url = `https://api.bitbucket.org/2.0/repositories/${source.workspace}/${source.repo}/src/${source.ref}/.readyup/manifest.json`;
+    const token = resolveBitbucketToken();
+    const headers = token !== undefined ? { Authorization: `Bearer ${token}` } : undefined;
+    return runRemoteFromMode({ url, headers });
   }
 
   const manifestPath = resolveFromManifestPath(source);
@@ -110,10 +114,16 @@ async function runFromMode(fromArg: string): Promise<number> {
 }
 
 /** Fetch and display kits from a remote manifest URL. */
-async function runRemoteFromMode({ url, token }: { url: string; token: string | undefined }): Promise<number> {
+async function runRemoteFromMode({
+  url,
+  headers,
+}: {
+  url: string;
+  headers: Record<string, string> | undefined;
+}): Promise<number> {
   let manifest;
   try {
-    manifest = await loadRemoteManifest({ url, token });
+    manifest = await loadRemoteManifest({ url, headers });
   } catch (error: unknown) {
     if (error instanceof RemoteManifestNotFoundError) {
       process.stderr.write(`Error: No manifest found at ${url}.\n`);

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -119,7 +119,7 @@ async function runRemoteFromMode({
   headers,
 }: {
   url: string;
-  headers: Record<string, string> | undefined;
+  headers?: Record<string, string> | undefined;
 }): Promise<number> {
   let manifest;
   try {

--- a/packages/readyup/src/loadRemoteManifest.ts
+++ b/packages/readyup/src/loadRemoteManifest.ts
@@ -11,22 +11,18 @@ export class RemoteManifestNotFoundError extends Error {
 
 export interface LoadRemoteManifestOptions {
   url: string;
-  token?: string | undefined;
+  headers?: Record<string, string> | undefined;
 }
 
 /**
  * Fetch, parse, and schema-validate a manifest from a URL.
  *
- * Sends `Authorization: token {token}` (GitHub-style) when a token is provided.
+ * Sends the supplied headers (if any) with the request; the helper has no auth-scheme knowledge —
+ * callers pre-format `Authorization` and any other headers (e.g., proxy/telemetry in corporate environments).
  * Throws `RemoteManifestNotFoundError` for 404 and HTML soft-404 responses,
  * and a plain `Error` for other non-2xx responses, malformed JSON, and schema-invalid bodies.
  */
-export async function loadRemoteManifest({ url, token }: LoadRemoteManifestOptions): Promise<RdyManifest> {
-  const headers: Record<string, string> = {};
-  if (token !== undefined) {
-    headers.Authorization = `token ${token}`;
-  }
-
+export async function loadRemoteManifest({ url, headers = {} }: LoadRemoteManifestOptions): Promise<RdyManifest> {
   const response = await fetch(url, { headers });
 
   if (response.status === 404) {

--- a/packages/readyup/src/resolveBitbucketToken.ts
+++ b/packages/readyup/src/resolveBitbucketToken.ts
@@ -1,0 +1,14 @@
+/**
+ * Resolve a Bitbucket token from ambient sources for authenticating private repo fetches.
+ *
+ * Checks the `BITBUCKET_TOKEN` env var only — there is no widely-deployed Bitbucket CLI
+ * with a stable `auth token` equivalent (Atlassian's `acli` is Jira/Confluence-centric).
+ * Returns `undefined` when the env var is unset or empty.
+ */
+export function resolveBitbucketToken(): string | undefined {
+  const envToken = process.env.BITBUCKET_TOKEN;
+  if (envToken !== undefined && envToken !== '') {
+    return envToken;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What

Adds support for listing kits from a remote Bitbucket Cloud repository via `rdy list --from bitbucket:workspace/repo[@ref]`. The command fetches the manifest from Bitbucket's documented file-source API endpoint, validates it against the manifest schema, and renders the kit list in the same format as the `--from github:` and local modes. When `BITBUCKET_TOKEN` is set, the request is authenticated as `Authorization: Bearer …` so private and rate-limited public repos work without extra configuration; without a token, public repos still work anonymously. Missing manifests, malformed responses, and network failures produce actionable error messages with the URL in context.

## Why

`rdy list` already supported GitHub-hosted workshop repos via `--from github:` (#76), but Bitbucket-hosted workshops still required cloning before users could discover what kits the repo exposed. Closing that loop on Bitbucket completes the discovery half of the round trip with `rdy compile --with-manifest`, and unblocks consumers of Bitbucket-hosted workshops from running anything other than the local-path flow.

## Details

### Features

- **`bitbucket:` arm in `runFromMode` (`packages/readyup/src/list/listCommand.ts`).** Replaces the previous "not yet supported" stub. Builds the API URL `https://api.bitbucket.org/2.0/repositories/{workspace}/{repo}/src/{ref}/.readyup/manifest.json` inline, resolves a token via `resolveBitbucketToken`, and delegates to the existing `runRemoteFromMode` helper. The Bitbucket arm is structurally identical to the GitHub arm — only URL construction and the `Authorization` scheme differ.
- **`resolveBitbucketToken` (`packages/readyup/src/resolveBitbucketToken.ts`).** Reads `BITBUCKET_TOKEN` from the environment; returns `undefined` when unset or empty. No CLI fallback — Atlassian's `acli` is Jira/Confluence-centric and there is no widely-deployed Bitbucket CLI with a stable `auth token` equivalent.
- **`rdy list --help` updated (`packages/readyup/src/bin/route.ts`).** Adds `bitbucket:ws/repo[@ref]` to the Modes section, extends the `--from <source>` description, and adds a `bitbucket:tutorials/markdowndemo@master` example. The example pins `@master` because that repo's default branch is `master` and the parser otherwise defaults to `main`, so a literal copy-paste resolves a real ref instead of 404'ing on a missing branch.

### Refactoring

- **`loadRemoteManifest` headers generalization (`packages/readyup/src/loadRemoteManifest.ts`).** Replaces the GitHub-coupled `token?: string` option with a provider-agnostic `headers?: Record<string, string>`. The helper merges the supplied headers into the outbound `fetch` call without owning any auth-scheme knowledge — callers pre-format their own `Authorization` value (and corporate environments can add proxy or telemetry headers when needed). The GitHub call site builds `{ Authorization: \`token ${token}\` }`; the Bitbucket call site builds `{ Authorization: \`Bearer ${token}\` }`.
- **`runRemoteFromMode` signature aligned.** The shared inner helper's `headers` parameter is `headers?: Record<string, string> | undefined` (optional-and-undefined), matching `LoadRemoteManifestOptions` so a future call site that omits the property compiles cleanly.

### Tests

- New `packages/readyup/__tests__/resolveBitbucketToken.test.ts`: env-set, env-unset, env-empty-string.
- New bitbucket cases in `packages/readyup/__tests__/list/listCommand.test.ts` mirroring the GitHub block: success, ref selection, auth forwarding (Bearer), `BITBUCKET_TOKEN`-unset omits the `Authorization` header, 404 stderr, malformed JSON, schema-invalid manifest, 500 response, network failure, and an explicit assertion that `loadConfig` is not invoked for bitbucket sources.
- `loadRemoteManifest.test.ts` updated for the new `headers` shape: forwards arbitrary headers to fetch and calls fetch with empty headers when none are supplied.
- Removes the obsolete "not yet supported" bitbucket assertion from the legacy `__tests__/listCommand.test.ts`, mirroring the same removal #76 did for the GitHub equivalent.

## Test plan

- [x] Smoke-test against a real public Bitbucket repository: `rdy list --from bitbucket:<workspace>/<repo>@<ref>` renders kits in the standard `📦 name — description` format.
- [x] Smoke-test ref selection: `... list --from bitbucket:<ws>/<repo>@<ref>` builds the correct URL.
- [x] Smoke-test missing manifest: pointing at a repo without `.readyup/manifest.json` produces the actionable "No manifest found at … Has `rdy compile --with-manifest` been run?" message.
- [ ] Smoke-test private-repo access: with `BITBUCKET_TOKEN` set, listing from a private workshop repository succeeds.
- [ ] Verify `rdy list --help` shows the `bitbucket:` mode keyword, the option text, and the example.

## Follow-ups

- **#77** — Generalize `loadRemoteKit` to headers-based auth (mirror of the `loadRemoteManifest` change in this PR).
- **#78** — Add `rdy run --from bitbucket:` private-repo support via the API endpoint (consumes #77).
- **#79** — Surface env-var hint on 401/403 from remote kit listing/fetching, for both providers.

Closes #46
