### PR TITLE
#77 Generalize `loadRemoteKit` to headers-based auth

### DIFF
--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -1250,7 +1250,7 @@ describe(runCommand, () => {
     expect(mockResolveGitHubToken).toHaveBeenCalled();
     expect(mockLoadRemoteKit).toHaveBeenCalledWith({
       url: 'https://raw.githubusercontent.com/org/repo/main/.readyup/kits/nmr.js',
-      token: 'token-abc',
+      headers: { Authorization: 'token token-abc' },
     });
     expect(exitCode).toBe(0);
   });
@@ -1275,7 +1275,7 @@ describe(runCommand, () => {
     expect(mockLoadRemoteKit).toHaveBeenCalledWith({
       url: 'https://raw.githubusercontent.com/org/repo/v2/.readyup/kits/nmr.js',
     });
-    expect(mockLoadRemoteKit.mock.calls[0][0]).not.toHaveProperty('token');
+    expect(mockLoadRemoteKit.mock.calls[0][0]).not.toHaveProperty('headers');
   });
 
   // URL source tests

--- a/packages/readyup/__tests__/loadRemoteKit.test.ts
+++ b/packages/readyup/__tests__/loadRemoteKit.test.ts
@@ -14,20 +14,7 @@ const mockFetch = vi.hoisted(() => vi.fn());
 vi.stubGlobal('fetch', mockFetch);
 
 import { loadRemoteKit } from '../src/loadRemoteKit.ts';
-
-/** Build a minimal mock Response with the given body and status. */
-function mockResponse(
-  body: string,
-  init?: { status?: number; statusText?: string },
-): Pick<Response, 'ok' | 'status' | 'statusText' | 'text' | 'headers'> {
-  return {
-    ok: (init?.status ?? 200) >= 200 && (init?.status ?? 200) < 300,
-    status: init?.status ?? 200,
-    statusText: init?.statusText ?? 'OK',
-    text: () => Promise.resolve(body),
-    headers: new Headers(),
-  };
-}
+import { mockResponse } from './helpers/mockResponse.ts';
 
 describe(loadRemoteKit, () => {
   afterEach(() => {
@@ -61,19 +48,22 @@ describe(loadRemoteKit, () => {
     );
   });
 
-  it('sends authorization header when token is provided', async () => {
+  it('forwards supplied headers to fetch', async () => {
     mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
 
-    await loadRemoteKit({ url: 'https://example.com/config.js', token: 'my-token' }).catch(() => {
+    await loadRemoteKit({
+      url: 'https://example.com/config.js',
+      headers: { Authorization: 'Bearer my-token', 'X-Custom': 'value' },
+    }).catch(() => {
       // Expected to throw due to 404
     });
 
     expect(mockFetch).toHaveBeenCalledWith('https://example.com/config.js', {
-      headers: { Authorization: 'token my-token' },
+      headers: { Authorization: 'Bearer my-token', 'X-Custom': 'value' },
     });
   });
 
-  it('does not send authorization header when no token is provided', async () => {
+  it('calls fetch with empty headers when none are provided', async () => {
     mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
 
     await loadRemoteKit({ url: 'https://example.com/config.js' }).catch(() => {

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -338,7 +338,7 @@ async function loadKit(source: KitSource, isJit: boolean): Promise<RdyKit> {
     if (source.url.includes('raw.githubusercontent.com')) {
       const token = resolveGitHubToken();
       if (token !== undefined) {
-        options.token = token;
+        options.headers = { Authorization: `token ${token}` };
       }
     }
     return loadRemoteKit(options);

--- a/packages/readyup/src/loadRemoteKit.ts
+++ b/packages/readyup/src/loadRemoteKit.ts
@@ -11,20 +11,17 @@ import { validateKit } from './validateKit.ts';
 
 export interface LoadRemoteKitOptions {
   url: string;
-  token?: string;
+  headers?: Record<string, string> | undefined;
 }
 
 /**
  * Fetch a remote `.js` kit bundle, evaluate it, and return a validated RdyKit.
  *
+ * Sends the supplied headers (if any) with the request; the helper has no auth-scheme knowledge —
+ * callers pre-format `Authorization` and any other headers (e.g., proxy/telemetry in corporate environments).
  * Writes the fetched content to a temp file for dynamic import, then cleans up.
  */
-export async function loadRemoteKit({ url, token }: LoadRemoteKitOptions): Promise<RdyKit> {
-  const headers: Record<string, string> = {};
-  if (token !== undefined) {
-    headers.Authorization = `token ${token}`;
-  }
-
+export async function loadRemoteKit({ url, headers = {} }: LoadRemoteKitOptions): Promise<RdyKit> {
   const response = await fetch(url, { headers });
 
   if (!response.ok) {


### PR DESCRIPTION
## What

Generalizes the `loadRemoteKit` helper used by `rdy run` to fetch remote kit files: the GitHub-specific `token?: string` option is replaced with a scheme-agnostic `headers?: Record<string, string> | undefined`. Callers now pre-format their own `Authorization` header (and can add proxy or telemetry headers as needed). Behavior for `rdy run --from github:org/repo` is unchanged.

## Why

The previous `token?: string` option hardcoded `Authorization: token {token}` (GitHub-style), preventing Bitbucket consumers from sending `Authorization: Bearer {token}`. The sibling helper `loadRemoteManifest` was already generalized in #45; this change keeps the two helpers consistent and unblocks Bitbucket private-repo support for `rdy run` (tracked separately as #78).

## Details

### Refactoring

- `LoadRemoteKitOptions` now exposes `headers?: Record<string, string> | undefined` (replacing `token?: string`); the helper passes the supplied headers verbatim to `fetch` and has no auth-scheme knowledge of its own.
- The JSDoc on `loadRemoteKit` is rewritten to mirror `loadRemoteManifest`, documenting that callers pre-format `Authorization` and any other headers (e.g., proxy or telemetry in corporate environments).
- The single GitHub call site in `cli.ts` (`loadKit`) builds `{ Authorization: \`token ${token}\` }` inline when `resolveGitHubToken` returns a value, preserving the existing outbound request.

### Tests

- `loadRemoteKit.test.ts` swaps the two token-specific cases for header-shape cases — one asserting that a multi-header object (including a custom `X-Custom` value) is forwarded verbatim, and one asserting empty headers when none are supplied. The multi-header assertion implicitly verifies the helper does not mutate, filter, or rename headers, which is the property `rdy run --from bitbucket:` will rely on for `Authorization: Bearer …`.
- `cli.test.ts` updates the two assertions in the GitHub-source `runCommand` cases to expect the new `headers` shape passed to the mocked `loadRemoteKit`.
- The test file also adopts the shared `mockResponse` helper (already used by `loadRemoteManifest.test.ts`) in place of an inline copy.

Closes #77