### PR TITLE
#78 Add `rdy run --from bitbucket:` private-repo support

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -104,6 +104,15 @@ The `--from` flag accepts these source types:
 
 `@ref` defaults to `main` when omitted. Local repo paths look for kits in `<path>/.readyup/kits/`, while `dir:` paths are used directly.
 
+### Authentication for remote sources
+
+Private repositories are accessed via tokens resolved from ambient sources:
+
+- **GitHub** (`--from github:`): reads `GITHUB_TOKEN`; falls back to `gh auth token` when the env var is unset.
+- **Bitbucket** (`--from bitbucket:`): reads `BITBUCKET_TOKEN`.
+
+When no token is available, requests go anonymous and only public repositories will succeed.
+
 ### List
 
 ```
@@ -111,9 +120,9 @@ rdy list                       List internal and compiled kits (owner view)
 rdy list --from <path>         List compiled kits at a local path
 rdy list --from global         List compiled kits in the global directory
 rdy list --from dir:<path>     List kits in an arbitrary directory
+rdy list --from github:org/repo[@ref]      List kits from a GitHub manifest
+rdy list --from bitbucket:ws/repo[@ref]    List kits from a Bitbucket manifest
 ```
-
-Listing from GitHub/Bitbucket sources is not yet supported.
 
 ## Authoring API
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -12,6 +12,7 @@ const mockFormatCombinedSummary = vi.hoisted(() => vi.fn());
 const mockFormatJsonReport = vi.hoisted(() => vi.fn());
 const mockFormatJsonError = vi.hoisted(() => vi.fn());
 const mockResolveGitHubToken = vi.hoisted(() => vi.fn());
+const mockResolveBitbucketToken = vi.hoisted(() => vi.fn());
 const mockLoadRemoteKit = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/config.ts', () => ({
@@ -53,6 +54,10 @@ vi.mock('../src/formatJsonError.ts', () => ({
 
 vi.mock('../src/resolveGitHubToken.ts', () => ({
   resolveGitHubToken: mockResolveGitHubToken,
+}));
+
+vi.mock('../src/resolveBitbucketToken.ts', () => ({
+  resolveBitbucketToken: mockResolveBitbucketToken,
 }));
 
 vi.mock('../src/loadRemoteKit.ts', () => ({
@@ -603,13 +608,15 @@ describe(resolveKitSources, () => {
 
   // -- --from bitbucket: --
 
-  it('resolves --from bitbucket: to a Bitbucket raw URL', () => {
+  it('resolves --from bitbucket: to a Bitbucket Cloud API source URL', () => {
     expect(
       resolve({ fromValue: 'bitbucket:myteam/deploy-checks', kitSpecifiers: [{ kitName: 'deploy', checklists: [] }] }),
     ).toStrictEqual([
       {
         name: 'deploy',
-        source: { url: 'https://bitbucket.org/myteam/deploy-checks/raw/main/.readyup/kits/deploy.js' },
+        source: {
+          url: 'https://api.bitbucket.org/2.0/repositories/myteam/deploy-checks/src/main/.readyup/kits/deploy.js',
+        },
         checklists: [],
       },
     ]);
@@ -619,7 +626,7 @@ describe(resolveKitSources, () => {
     expect(resolve({ fromValue: 'bitbucket:myteam/repo@v2' })).toStrictEqual([
       {
         name: 'default',
-        source: { url: 'https://bitbucket.org/myteam/repo/raw/v2/.readyup/kits/default.js' },
+        source: { url: 'https://api.bitbucket.org/2.0/repositories/myteam/repo/src/v2/.readyup/kits/default.js' },
         checklists: [],
       },
     ]);
@@ -752,6 +759,7 @@ describe(runCommand, () => {
     mockFormatJsonReport.mockReset();
     mockFormatJsonError.mockReset();
     mockResolveGitHubToken.mockReset();
+    mockResolveBitbucketToken.mockReset();
     mockLoadRemoteKit.mockReset();
   });
 
@@ -1278,6 +1286,84 @@ describe(runCommand, () => {
     expect(mockLoadRemoteKit.mock.calls[0][0]).not.toHaveProperty('headers');
   });
 
+  // Bitbucket source tests (via URL with api.bitbucket.org)
+  it('forwards Bitbucket token as Bearer Authorization for Bitbucket Cloud API URLs', async () => {
+    const kit = makeKit();
+    mockResolveBitbucketToken.mockReturnValue('bb-token-xyz');
+    mockLoadRemoteKit.mockResolvedValue(kit);
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    const exitCode = await runCommand({
+      kitEntries: [
+        {
+          name: 'deploy',
+          source: { url: 'https://api.bitbucket.org/2.0/repositories/myteam/repo/src/main/.readyup/kits/deploy.js' },
+          checklists: [],
+        },
+      ],
+      json: false,
+    });
+
+    expect(mockResolveBitbucketToken).toHaveBeenCalled();
+    expect(mockLoadRemoteKit).toHaveBeenCalledWith({
+      url: 'https://api.bitbucket.org/2.0/repositories/myteam/repo/src/main/.readyup/kits/deploy.js',
+      headers: { Authorization: 'Bearer bb-token-xyz' },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it('omits Authorization when resolveBitbucketToken returns undefined for Bitbucket URLs', async () => {
+    const kit = makeKit();
+    mockResolveBitbucketToken.mockReturnValue(undefined);
+    mockLoadRemoteKit.mockResolvedValue(kit);
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runCommand({
+      kitEntries: [
+        {
+          name: 'deploy',
+          source: { url: 'https://api.bitbucket.org/2.0/repositories/myteam/repo/src/v2/.readyup/kits/deploy.js' },
+          checklists: [],
+        },
+      ],
+      json: false,
+    });
+
+    expect(mockLoadRemoteKit).toHaveBeenCalledWith({
+      url: 'https://api.bitbucket.org/2.0/repositories/myteam/repo/src/v2/.readyup/kits/deploy.js',
+    });
+    expect(mockLoadRemoteKit.mock.calls[0][0]).not.toHaveProperty('headers');
+  });
+
+  it('reports a 404 for a Bitbucket URL with the URL in stderr', async () => {
+    const url = 'https://api.bitbucket.org/2.0/repositories/myteam/repo/src/main/.readyup/kits/missing.js';
+    mockResolveBitbucketToken.mockReturnValue(undefined);
+    mockLoadRemoteKit.mockRejectedValue(new Error(`Failed to fetch remote kit from ${url}: 404 Not Found`));
+
+    const exitCode = await runCommand({
+      kitEntries: [{ name: 'missing', source: { url }, checklists: [] }],
+      json: false,
+    });
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(url));
+    expect(exitCode).toBe(1);
+  });
+
+  it('reports a network failure for a Bitbucket URL with the URL in stderr', async () => {
+    const url = 'https://api.bitbucket.org/2.0/repositories/myteam/repo/src/main/.readyup/kits/deploy.js';
+    mockResolveBitbucketToken.mockReturnValue(undefined);
+    // Raw fetch rejection — no URL in the error message; loadKit must inject it.
+    mockLoadRemoteKit.mockRejectedValue(new TypeError('fetch failed'));
+
+    const exitCode = await runCommand({
+      kitEntries: [{ name: 'deploy', source: { url }, checklists: [] }],
+      json: false,
+    });
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(url));
+    expect(exitCode).toBe(1);
+  });
+
   // URL source tests
   it('fetches directly for non-GitHub URL source without token resolution', async () => {
     const kit = makeKit();
@@ -1290,21 +1376,23 @@ describe(runCommand, () => {
     });
 
     expect(mockResolveGitHubToken).not.toHaveBeenCalled();
+    expect(mockResolveBitbucketToken).not.toHaveBeenCalled();
     expect(mockLoadRemoteKit).toHaveBeenCalledWith({
       url: 'https://example.com/config.js',
     });
     expect(exitCode).toBe(0);
   });
 
-  it('reports remote kit loading errors to stderr', async () => {
+  it('reports remote kit loading errors to stderr, prepending the URL when missing from the message', async () => {
+    const url = 'https://example.com/config.js';
     mockLoadRemoteKit.mockRejectedValue(new Error('Failed to fetch remote kit'));
 
     const exitCode = await runCommand({
-      kitEntries: [{ name: 'config', source: { url: 'https://example.com/config.js' }, checklists: [] }],
+      kitEntries: [{ name: 'config', source: { url }, checklists: [] }],
       json: false,
     });
 
-    expect(stderrSpy).toHaveBeenCalledWith('Error: Failed to fetch remote kit\n');
+    expect(stderrSpy).toHaveBeenCalledWith(`Error: Failed to reach ${url}: Failed to fetch remote kit\n`);
     expect(exitCode).toBe(1);
   });
 });

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -11,6 +11,7 @@ import { parseArgs } from './parseArgs.ts';
 import { type FromSource, parseFromValue } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
 import { reportRdy, tallyResult } from './reportRdy.ts';
+import { resolveBitbucketToken } from './resolveBitbucketToken.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
 import { resolveRequestedNames } from './resolveRequestedNames.ts';
 import { meetsThreshold, runRdy } from './runRdy.ts';
@@ -82,9 +83,9 @@ function buildGitHubKitUrl(org: string, repo: string, ref: string, kit: string, 
   return `https://raw.githubusercontent.com/${org}/${repo}/${ref}/${KITS_DIR}/${kit}${extension}`;
 }
 
-/** Build the Bitbucket raw content URL for a kit. */
+/** Build the Bitbucket Cloud API source URL for a kit. */
 function buildBitbucketKitUrl(workspace: string, repo: string, ref: string, kit: string, extension: string): string {
-  return `https://bitbucket.org/${workspace}/${repo}/raw/${ref}/${KITS_DIR}/${kit}${extension}`;
+  return `https://api.bitbucket.org/2.0/repositories/${workspace}/${repo}/src/${ref}/${KITS_DIR}/${kit}${extension}`;
 }
 
 /** Map generic "requires a value" errors to domain-specific hints for run-subcommand flags. */
@@ -340,8 +341,21 @@ async function loadKit(source: KitSource, isJit: boolean): Promise<RdyKit> {
       if (token !== undefined) {
         options.headers = { Authorization: `token ${token}` };
       }
+    } else if (source.url.includes('api.bitbucket.org')) {
+      const token = resolveBitbucketToken();
+      if (token !== undefined) {
+        options.headers = { Authorization: `Bearer ${token}` };
+      }
     }
-    return loadRemoteKit(options);
+
+    try {
+      return await loadRemoteKit(options);
+    } catch (error: unknown) {
+      const message = extractMessage(error);
+      // Network failures (raw `fetch` rejections) carry no URL context; thrown errors from `loadRemoteKit` already include the URL.
+      if (message.includes(source.url)) throw error;
+      throw new Error(`Failed to reach ${source.url}: ${message}`);
+    }
   }
 
   try {


### PR DESCRIPTION
## What

Adds support for fetching kits from private Bitbucket repositories with `rdy run --from bitbucket:`. When `BITBUCKET_TOKEN` is set, the request authenticates as that token; when unset, requests go anonymous and continue to work for public repos as before.

Improves error reporting for all remote kit sources by always including the source URL in stderr, even when the underlying failure (such as a network rejection) carries no URL of its own. This brings `rdy run` to parity with `rdy list`.

## Why

After `rdy list --from bitbucket:` shipped in #46/#80, users who tried the same source with `rdy run` could still only reach **public** Bitbucket repositories. The kit-fetching path used Bitbucket's web `bitbucket.org/.../raw/...` endpoint, which has no `Authorization: Bearer` route from a CLI no matter how the env var was set. The asymmetry was user-visible: list advertised private-repo support; run silently lacked it.

Once `loadRemoteKit` was generalized to accept arbitrary headers in #77/#81, the remaining work was to switch the URL builder to Bitbucket Cloud's API endpoint and plumb `BITBUCKET_TOKEN` through.

## Details

### Features

- Switches `buildBitbucketKitUrl` to Bitbucket Cloud's API source endpoint: `https://api.bitbucket.org/2.0/repositories/{ws}/{repo}/src/{ref}/{path}`. This endpoint accepts `Authorization: Bearer {token}`, unlike the previous web raw URL.
- Adds a Bitbucket branch in `loadKit` (`packages/readyup/src/cli.ts`) alongside the existing GitHub branch: when the URL targets `api.bitbucket.org`, the helper resolves a token via `resolveBitbucketToken` and, when defined, attaches `Authorization: Bearer ${token}` to the outgoing request.
- Wraps the `loadRemoteKit` call in `loadKit` so that thrown errors always include the source URL in their message, including raw `fetch` rejections that previously surfaced as bare `TypeError: fetch failed`. The wrapper applies uniformly to all remote sources (GitHub, Bitbucket, arbitrary URLs).

### Tests

- `cli.test.ts` covers token forwarding, anonymous fallback, missing-kit (404), and network-failure paths for the Bitbucket arm, mirroring the existing GitHub test cases.
- The `resolveKitSources` Bitbucket cases are updated to expect the new API endpoint URL.

### Documentation

- README's stale "Listing from GitHub/Bitbucket sources is not yet supported" line is replaced with explicit `--from github:` / `--from bitbucket:` examples in the List section, matching the support shipped in #45/#46/#76/#80.
- A new Authentication subsection documents `GITHUB_TOKEN` (with `gh auth token` fallback) and `BITBUCKET_TOKEN` for private-repo fetches.

Closes #78
