### PR TITLE
#85 Move check-utils to dedicated subpath export

### DIFF
--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -4,7 +4,8 @@
 
 // .readyup/kits/demo.ts
 import { execFileSync } from "node:child_process";
-import { defineRdyKit, fileContains, fileExists, hasDevDependency, hasPackageJsonField } from "readyup";
+import { defineRdyKit } from "readyup";
+import { fileContains, fileExists, hasDevDependency, hasPackageJsonField } from "readyup/check-utils";
 function commandExists(name) {
   try {
     execFileSync("which", [name], { stdio: "ignore" });

--- a/.readyup/kits/demo.ts
+++ b/.readyup/kits/demo.ts
@@ -8,7 +8,8 @@
  */
 import { execFileSync } from 'node:child_process';
 
-import { defineRdyKit, fileContains, fileExists, hasDevDependency, hasPackageJsonField } from 'readyup';
+import { defineRdyKit } from 'readyup';
+import { fileContains, fileExists, hasDevDependency, hasPackageJsonField } from 'readyup/check-utils';
 
 /** Return true if a CLI command is available on PATH. */
 function commandExists(name: string): boolean {

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -5,7 +5,7 @@
       "name": "demo",
       "path": "kits/demo.js",
       "source": "kits/demo.ts",
-      "targetHash": "6ac8fdc4"
+      "targetHash": "ec1235a9"
     }
   ]
 }

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -141,7 +141,7 @@ All helpers are type-safe identity functions that provide editor autocomplete wi
 Reusable check functions for common assertions:
 
 ```ts
-import { fileExists, fileContains, hasPackageJsonField } from 'readyup';
+import { fileExists, fileContains, hasPackageJsonField } from 'readyup/check-utils';
 ```
 
 | Function                                    | Description                                                             |
@@ -172,12 +172,18 @@ import { fileExists, fileContains, hasPackageJsonField } from 'readyup';
 Common filter pattern — get all publishable workspaces:
 
 ```ts
-import { discoverWorkspaces } from 'readyup';
+import { discoverWorkspaces } from 'readyup/check-utils';
 
 const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
 ```
 
 Note: `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs using YAML anchors, flow sequences, negation patterns, or other non-trivial features will raise a clear error with a pointer to file an issue.
+
+## Compatibility
+
+`readyup/check-utils` is the stable, versioned surface for kit-author imports of check utilities. It follows semver: no breaking changes within a major version.
+
+Compiled kits embed nothing of readyup itself — the runner satisfies `readyup` and `readyup/*` imports at runtime via its module-resolution hook. Kits are therefore version-coupled to the runner across breaking boundaries: when you upgrade readyup across a major, recompile your kits with `rdy compile` so any newly-shipped or changed check utilities are picked up.
 
 ## License
 

--- a/packages/readyup/__tests__/compile/externalReadyup.integration.test.ts
+++ b/packages/readyup/__tests__/compile/externalReadyup.integration.test.ts
@@ -77,8 +77,9 @@ describe('readyup externalization + resolver-hook integration', () => {
     await rm(outputDir, { recursive: true, force: true });
   });
 
-  it("preserves the bare 'readyup' import as a live specifier in the compiled output", () => {
+  it('preserves readyup specifiers as live imports in the compiled output', () => {
     expect(compiledSource).toMatch(/from\s+["']readyup["']/);
+    expect(compiledSource).toMatch(/from\s+["']readyup\/check-utils["']/);
   });
 
   it('compiles the fixture below the 2KB regression threshold', () => {

--- a/packages/readyup/__tests__/compile/fixtures/discoverWorkspaces-fixture.ts
+++ b/packages/readyup/__tests__/compile/fixtures/discoverWorkspaces-fixture.ts
@@ -1,4 +1,5 @@
-import { defineRdyKit, discoverWorkspaces } from 'readyup';
+import { defineRdyKit } from 'readyup';
+import { discoverWorkspaces } from 'readyup/check-utils';
 
 export default defineRdyKit({
   description: 'Minimal fixture that exercises a runtime `readyup` import.',

--- a/packages/readyup/__tests__/readyupResolverHook.test.ts
+++ b/packages/readyup/__tests__/readyupResolverHook.test.ts
@@ -39,12 +39,7 @@ describe('readyupResolverHook', () => {
       });
     });
 
-    it("rewrites parentURL for 'readyup/<subpath>' specifiers in isolation (end-to-end resolution lands with subpath exports in PR #85)", () => {
-      // This verifies the hook's pass-through-with-rewritten-parentURL behavior
-      // in isolation — `nextResolve` is stubbed. End-to-end resolution of
-      // `readyup/check-utils` against the real Node resolver also requires the
-      // package `exports` map to declare the subpath (currently it does not;
-      // PR #85 adds those entries). The hook is forward-compatible.
+    it("rewrites parentURL for 'readyup/<subpath>' specifiers", () => {
       const nextResolve = buildNextResolve();
       const context = buildContext({ parentURL: KIT_PARENT_URL });
 

--- a/packages/readyup/package.json
+++ b/packages/readyup/package.json
@@ -29,6 +29,10 @@
       "import": "./dist/esm/index.js",
       "types": "./dist/esm/index.d.ts"
     },
+    "./check-utils": {
+      "import": "./dist/esm/check-utils/index.js",
+      "types": "./dist/esm/check-utils/index.d.ts"
+    },
     "./readyupResolverHook": {
       "import": "./dist/esm/readyupResolverHook.js",
       "types": "./dist/esm/readyupResolverHook.d.ts"

--- a/packages/readyup/src/compile/compileConfig.ts
+++ b/packages/readyup/src/compile/compileConfig.ts
@@ -35,12 +35,6 @@ function deriveOutputPath(inputPath: string): string {
  * are resolved at runtime by the `rdy` runner's module-resolution hook
  * (`readyupResolverHook.ts`), which routes them to the runner's own readyup
  * installation. Prepends a generated-file header comment to the output.
- *
- * Note: `readyup/<subpath>` specifiers are listed external so that the bundler
- * leaves them as live imports, and the hook routes them correctly at runtime.
- * However, the `readyup` package's `exports` map only declares `"."` at present;
- * subpath exports (e.g., `readyup/check-utils`) ship in PR #85. Until then,
- * compiled kits should import from `readyup` only.
  */
 export async function compileConfig(inputPath: string, outputPath?: string): Promise<CompileResult> {
   const resolvedInput = path.resolve(inputPath);

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -48,37 +48,3 @@ export { pickJson } from './compile/pickJson.ts';
 // Manifest
 export { DEFAULT_MANIFEST_PATH } from './manifest/manifestPath.ts';
 export type { RdyManifest } from './manifest/manifestSchema.ts';
-
-// Check utilities
-export type { DiscoverWorkspacesOptions, Workspace } from './check-utils/index.ts';
-export {
-  commandExists,
-  compareLocalRefs,
-  compareRefToRemote,
-  compareVersions,
-  computeHash,
-  discoverWorkspaces,
-  expandHome,
-  fileContains,
-  fileDoesNotContain,
-  fileExists,
-  fileMatchesHash,
-  filesExist,
-  getJsonValue,
-  hasDevDependency,
-  hasJsonField,
-  hasJsonFields,
-  hasJsonValue,
-  hasMinDevDependencyVersion,
-  hasPackageJsonField,
-  isAtRepoRoot,
-  isGitRepo,
-  isRecord,
-  makeLocalRefSyncCheck,
-  makeRemoteRefSyncCheck,
-  readFile,
-  readJsonFile,
-  readJsonValue,
-  readPackageJson,
-  runGit,
-} from './check-utils/index.ts';

--- a/packages/readyup/src/readyupResolverHook.ts
+++ b/packages/readyup/src/readyupResolverHook.ts
@@ -14,15 +14,6 @@
  * intercepted. All other specifiers pass through unchanged. If a third bare
  * specifier ever needs interception, design that case explicitly rather than
  * generalizing this hook.
- *
- * **Subpath status (PR #84):** This hook routes any `readyup/<subpath>` specifier
- * correctly, but the `readyup` package `exports` map currently only declares `"."`
- * and `"./readyupResolverHook"`. A kit importing `readyup/check-utils` (or any
- * other subpath) today would receive `ERR_PACKAGE_PATH_NOT_EXPORTED` from Node's
- * exports enforcement — even though the hook rewrites `parentURL` correctly. The
- * hook is forward-compatible: PR #85 adds the `readyup/check-utils` subpath
- * export (and any others), at which point `readyup/<subpath>` imports from
- * compiled kits will work end-to-end without further hook changes.
  */
 
 /** Data passed from `module.register()` to `initialize()`. */


### PR DESCRIPTION
## What

Check utilities now import from a dedicated `readyup/check-utils` subpath rather than the `readyup` package root. Kit authors must split imports: authoring helpers stay on `readyup`; check utilities like `fileExists` and `discoverWorkspaces` move to `readyup/check-utils`.

`readyup/check-utils` is the stable surface for these imports. After upgrading readyup across a major boundary, recompile kits with `rdy compile` so newly-shipped or changed check utilities are picked up.

## Why

The dual-surface exposure — check utilities reachable from both the `readyup` package root and the implicit `./check-utils` path — was destined for cleanup before 1.0 anyway. Consolidating to a single declared subpath now, paired with the externalization that shipped in v0.20.0, locks in a clean post-1.0 contract where compiled kits commit to a versioned `readyup/<subpath>` shape that semver can defend.

## Details

### 🎉 Features

- 🚨 **Breaking:** check utilities are no longer importable from `readyup` — update kit imports to `readyup/check-utils`. The `readyup` package root now exposes only authoring helpers, types, manifest entries, and compile primitives.
- New "Compatibility" section in the README names `readyup/check-utils` as the stable, versioned surface for kit-author imports and documents the version-coupling contract (recompile kits after upgrading readyup across a major).

### 🧪 Tests

- Tightened the externalization integration test to assert both the bare `'readyup'` and `'readyup/check-utils'` specifiers survive bundling, so a future regression that inlines one but not the other gets caught.

Closes #85
