### PR TITLE
#86 Embed compile-time readyup version and warn on runtime skew

### DIFF
--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -1,5 +1,6 @@
 /** @noformat — @generated. Do not edit. Compiled by rdy. */
 /* eslint-disable */
+export const __readyupVersion = "0.20.0";
 
 
 // .readyup/kits/demo.ts

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -4,8 +4,9 @@
     {
       "name": "demo",
       "path": "kits/demo.js",
+      "readyupVersion": "0.20.0",
       "source": "kits/demo.ts",
-      "targetHash": "ec1235a9"
+      "targetHash": "7a100ea0"
     }
   ]
 }

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -770,7 +770,7 @@ describe(runCommand, () => {
 
   it('runs all checklists when no checklist filter is given', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     const exitCode = await runCommand({
@@ -784,7 +784,7 @@ describe(runCommand, () => {
 
   it('filters to named checklists only', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     const exitCode = await runCommand({
@@ -802,7 +802,7 @@ describe(runCommand, () => {
 
   it('errors when an unknown checklist name is given', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
 
     const exitCode = await runCommand({
       kitEntries: singleKitEntry(['nonexistent']),
@@ -815,7 +815,7 @@ describe(runCommand, () => {
 
   it('returns exit code 1 when any checklist fails', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy
       .mockResolvedValueOnce({ results: [], passed: true, durationMs: 0 })
       .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
@@ -830,7 +830,7 @@ describe(runCommand, () => {
 
   it('passes kit path to local kit loader', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -843,7 +843,7 @@ describe(runCommand, () => {
 
   it('shows checklist headers when running multiple checklists in a single kit', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -858,7 +858,7 @@ describe(runCommand, () => {
 
   it('does not show checklist headers for a single checklist', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -874,7 +874,7 @@ describe(runCommand, () => {
     const kit = makeKit({
       checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
     });
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -892,7 +892,7 @@ describe(runCommand, () => {
 
   it('does not print combined summary when running multiple kits', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -911,7 +911,7 @@ describe(runCommand, () => {
       fixLocation: 'end',
       checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }], fixLocation: 'inline' }],
     });
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -927,7 +927,7 @@ describe(runCommand, () => {
       fixLocation: 'end',
       checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
     });
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -952,7 +952,7 @@ describe(runCommand, () => {
 
   it('prints combined summary for a single kit with multiple checklists', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
     mockFormatCombinedSummary.mockReturnValue('Combined summary');
 
@@ -969,7 +969,7 @@ describe(runCommand, () => {
 
   it('does not print combined summary for a single checklist', async () => {
     const kit = makeKit();
-    mockLoadRdyKit.mockResolvedValue(kit);
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -1020,7 +1020,7 @@ describe(runCommand, () => {
   describe('threshold cascade', () => {
     it('uses CLI --fail-on flag over kit default', async () => {
       const kit = makeKit({ failOn: 'error' });
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
@@ -1034,7 +1034,7 @@ describe(runCommand, () => {
 
     it('falls back to kit failOn when CLI flag is absent', async () => {
       const kit = makeKit({ failOn: 'recommend' });
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
@@ -1047,7 +1047,7 @@ describe(runCommand, () => {
 
     it('falls back to kit reportOn when CLI flag is absent', async () => {
       const kit = makeKit({ reportOn: 'warn' });
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
@@ -1060,7 +1060,7 @@ describe(runCommand, () => {
 
     it('passes reportOn to reportRdy', async () => {
       const kit = makeKit();
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
@@ -1074,7 +1074,7 @@ describe(runCommand, () => {
 
     it('passes reportOn to formatJsonReport', async () => {
       const kit = makeKit();
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
       mockFormatJsonReport.mockReturnValue('{"worstSeverity":null}');
 
@@ -1099,7 +1099,7 @@ describe(runCommand, () => {
 
     it('emits JSON output and no human-readable text', async () => {
       const kit = makeKit();
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       const exitCode = await runCommand({
@@ -1116,7 +1116,7 @@ describe(runCommand, () => {
 
     it('returns exit code 1 when any checklist fails in JSON mode', async () => {
       const kit = makeKit();
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy
         .mockResolvedValueOnce({ results: [], passed: true, durationMs: 0 })
         .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
@@ -1145,7 +1145,7 @@ describe(runCommand, () => {
 
     it('emits JSON error to stdout for unknown checklist names', async () => {
       const kit = makeKit();
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
 
       const exitCode = await runCommand({
         kitEntries: singleKitEntry(['nonexistent']),
@@ -1159,7 +1159,7 @@ describe(runCommand, () => {
 
     it('passes kit-grouped entries to formatJsonReport', async () => {
       const kit = makeKit();
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       const report1 = { results: [], passed: true, durationMs: 10 };
       const report2 = { results: [], passed: true, durationMs: 20 };
       mockRunRdy.mockResolvedValueOnce(report1).mockResolvedValueOnce(report2);
@@ -1186,7 +1186,7 @@ describe(runCommand, () => {
 
     it('emits JSON error to stdout when runRdy throws', async () => {
       const kit = makeKit();
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockRejectedValue(new Error('runner crashed'));
 
       const exitCode = await runCommand({
@@ -1201,7 +1201,7 @@ describe(runCommand, () => {
 
     it('does not write headers in JSON mode', async () => {
       const kit = makeKit();
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       await runCommand({
@@ -1217,7 +1217,7 @@ describe(runCommand, () => {
       const kit = makeKit({
         checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
       });
-      mockLoadRdyKit.mockResolvedValue(kit);
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
       const exitCode = await runCommand({
@@ -1241,7 +1241,7 @@ describe(runCommand, () => {
   it('resolves token for GitHub raw URLs', async () => {
     const kit = makeKit();
     mockResolveGitHubToken.mockReturnValue('token-abc');
-    mockLoadRemoteKit.mockResolvedValue(kit);
+    mockLoadRemoteKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     const exitCode = await runCommand({
@@ -1266,7 +1266,7 @@ describe(runCommand, () => {
   it('omits token when resolveGitHubToken returns undefined for GitHub URLs', async () => {
     const kit = makeKit();
     mockResolveGitHubToken.mockReturnValue(undefined);
-    mockLoadRemoteKit.mockResolvedValue(kit);
+    mockLoadRemoteKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -1290,7 +1290,7 @@ describe(runCommand, () => {
   it('forwards Bitbucket token as Bearer Authorization for Bitbucket Cloud API URLs', async () => {
     const kit = makeKit();
     mockResolveBitbucketToken.mockReturnValue('bb-token-xyz');
-    mockLoadRemoteKit.mockResolvedValue(kit);
+    mockLoadRemoteKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     const exitCode = await runCommand({
@@ -1315,7 +1315,7 @@ describe(runCommand, () => {
   it('omits Authorization when resolveBitbucketToken returns undefined for Bitbucket URLs', async () => {
     const kit = makeKit();
     mockResolveBitbucketToken.mockReturnValue(undefined);
-    mockLoadRemoteKit.mockResolvedValue(kit);
+    mockLoadRemoteKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     await runCommand({
@@ -1367,7 +1367,7 @@ describe(runCommand, () => {
   // URL source tests
   it('fetches directly for non-GitHub URL source without token resolution', async () => {
     const kit = makeKit();
-    mockLoadRemoteKit.mockResolvedValue(kit);
+    mockLoadRemoteKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
     const exitCode = await runCommand({

--- a/packages/readyup/__tests__/compareVersionsForSkew.test.ts
+++ b/packages/readyup/__tests__/compareVersionsForSkew.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareVersionsForSkew } from '../src/versionSkew/compareVersionsForSkew.ts';
+
+describe(compareVersionsForSkew, () => {
+  // Threshold table from the ticket
+  it.each([
+    ['0.20.0', '0.21.0', 'runner-newer'],
+    ['0.20.0', '0.19.0', 'runner-older'],
+    ['1.2.0', '2.0.0', 'runner-newer'],
+    ['1.2.0', '0.9.0', 'runner-older'],
+  ] as const)('reports skew above the leftmost-non-zero boundary: %s vs %s', (compileTime, runtime, direction) => {
+    expect(compareVersionsForSkew(compileTime, runtime)).toStrictEqual({ kind: 'skew', direction });
+  });
+
+  it.each([
+    ['0.20.0', '0.20.5'],
+    ['0.20.3', '0.20.0'],
+    ['1.2.0', '1.3.0'],
+    ['1.5.7', '1.4.0'],
+  ])('reports no-skew below the leftmost-non-zero boundary: %s vs %s', (compileTime, runtime) => {
+    expect(compareVersionsForSkew(compileTime, runtime)).toStrictEqual({ kind: 'no-skew' });
+  });
+
+  it('reports no-skew when versions are identical', () => {
+    expect(compareVersionsForSkew('0.20.0', '0.20.0')).toStrictEqual({ kind: 'no-skew' });
+  });
+
+  it('reports no-skew when compile-time version is all-zero (no leftmost non-zero segment)', () => {
+    expect(compareVersionsForSkew('0.0.0', '0.0.1')).toStrictEqual({ kind: 'no-skew' });
+  });
+
+  it('reports skew with runner-newer when runtime is newer at the patch-segment boundary', () => {
+    // Compile-time leftmost non-zero is patch (0.0.5); runtime patch differs.
+    expect(compareVersionsForSkew('0.0.5', '0.0.6')).toStrictEqual({ kind: 'skew', direction: 'runner-newer' });
+  });
+
+  it('reports skew with runner-older when runtime is older at the patch-segment boundary', () => {
+    expect(compareVersionsForSkew('0.0.5', '0.0.4')).toStrictEqual({ kind: 'skew', direction: 'runner-older' });
+  });
+
+  it.each([
+    ['invalid', '1.2.3'],
+    ['1.2.3', 'invalid'],
+    ['1.2', '1.2.3'],
+    ['', '1.2.3'],
+    ['1.2.3', ''],
+  ])('reports no-skew for unparseable inputs: %s vs %s', (compileTime, runtime) => {
+    expect(compareVersionsForSkew(compileTime, runtime)).toStrictEqual({ kind: 'no-skew' });
+  });
+
+  it('ignores pre-release suffixes when parsing', () => {
+    // `0.20.0-beta` parses as `0.20.0`; identical to `0.20.0` → no-skew.
+    expect(compareVersionsForSkew('0.20.0-beta.1', '0.20.0')).toStrictEqual({ kind: 'no-skew' });
+  });
+
+  it('ignores build metadata suffixes when parsing', () => {
+    expect(compareVersionsForSkew('1.2.3+sha.abc', '1.2.3')).toStrictEqual({ kind: 'no-skew' });
+  });
+});

--- a/packages/readyup/__tests__/compareVersionsForSkew.test.ts
+++ b/packages/readyup/__tests__/compareVersionsForSkew.test.ts
@@ -57,4 +57,23 @@ describe(compareVersionsForSkew, () => {
   it('ignores build metadata suffixes when parsing', () => {
     expect(compareVersionsForSkew('1.2.3+sha.abc', '1.2.3')).toStrictEqual({ kind: 'no-skew' });
   });
+
+  // Cross-major regression: when majors differ, direction must be decided by the major comparison
+  // alone, not by the boundary-index segment. Otherwise `0.20.0 → 1.0.0` would mis-report as
+  // `runner-older` because runtime.minor (0) < compileTime.minor (20).
+  it('reports runner-newer when runtime crosses the major boundary from 0.x.y to 1.y.z', () => {
+    expect(compareVersionsForSkew('0.20.0', '1.0.0')).toStrictEqual({ kind: 'skew', direction: 'runner-newer' });
+  });
+
+  it('reports runner-older when runtime is 0.x.y and compile-time is 1.y.z', () => {
+    expect(compareVersionsForSkew('1.0.0', '0.20.0')).toStrictEqual({ kind: 'skew', direction: 'runner-older' });
+  });
+
+  it('reports runner-newer when runtime crosses multiple majors upward', () => {
+    expect(compareVersionsForSkew('1.5.0', '3.0.0')).toStrictEqual({ kind: 'skew', direction: 'runner-newer' });
+  });
+
+  it('reports runner-older when runtime is multiple majors behind', () => {
+    expect(compareVersionsForSkew('3.0.0', '1.5.0')).toStrictEqual({ kind: 'skew', direction: 'runner-older' });
+  });
 });

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -716,4 +716,37 @@ describe(compileCommand, () => {
 
     expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('skipped due to drift'));
   });
+
+  it('warns on stderr when the existing manifest is unreadable during batch compile', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['alpha.ts']);
+    mockReadManifest.mockImplementation(() => {
+      throw new Error('Unexpected token in JSON at position 0');
+    });
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' });
+
+    await compileCommand([]);
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Unexpected token in JSON'));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('drift gate skipped'));
+  });
+
+  it('is silent when the manifest is missing during batch compile', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['alpha.ts']);
+    mockReadManifest.mockImplementation(() => {
+      throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
+    });
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' });
+
+    await compileCommand([]);
+
+    expect(stderrSpy).not.toHaveBeenCalledWith(expect.stringContaining('drift gate skipped'));
+  });
 });

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -54,6 +54,7 @@ vi.mock('../src/verify/checkDrift.ts', () => ({
 import { compileCommand } from '../src/compile/compileCommand.ts';
 import { ManifestNotFoundError } from '../src/manifest/readManifest.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../src/reportRdy.ts';
+import { VERSION } from '../src/version.ts';
 
 describe(compileCommand, () => {
   let stdoutSpy: MockInstance;
@@ -362,12 +363,14 @@ describe(compileCommand, () => {
           name: 'alpha',
           description: 'Alpha checks',
           path: expect.stringContaining('alpha.js'),
+          readyupVersion: VERSION,
           source: expect.stringContaining('alpha.ts'),
           targetHash: 'aaaa1111',
         },
         {
           name: 'beta',
           path: expect.stringContaining('beta.js'),
+          readyupVersion: VERSION,
           source: expect.stringContaining('beta.ts'),
           targetHash: 'bbbb2222',
         },
@@ -428,6 +431,7 @@ describe(compileCommand, () => {
           name: 'deploy',
           description: 'Deploy checks',
           path: expect.stringContaining('deploy.js'),
+          readyupVersion: VERSION,
           source: expect.stringContaining('deploy.ts'),
           targetHash: 'deadbeef',
         },
@@ -450,6 +454,7 @@ describe(compileCommand, () => {
         {
           name: 'deploy',
           path: expect.stringContaining('deploy.js'),
+          readyupVersion: VERSION,
           source: expect.stringContaining('deploy.ts'),
           targetHash: 'deadbeef',
         },
@@ -474,6 +479,7 @@ describe(compileCommand, () => {
           name: 'deploy',
           description: 'Updated',
           path: expect.stringContaining('deploy.js'),
+          readyupVersion: VERSION,
           source: expect.stringContaining('deploy.ts'),
           targetHash: 'deadbeef',
         },
@@ -534,6 +540,39 @@ describe(compileCommand, () => {
 
     expect(mockWriteManifest).toHaveBeenCalledTimes(1);
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.stringContaining('custom/manifest.json'), expect.anything());
+  });
+
+  it('populates readyupVersion from the runner version on every batch-compile entry', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
+    mockCompileConfig
+      .mockResolvedValueOnce({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' })
+      .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
+
+    await compileCommand([]);
+
+    const writtenManifest: RdyManifest = mockWriteManifest.mock.calls[0][1];
+    for (const kit of writtenManifest.kits) {
+      expect(kit.readyupVersion).toBe(VERSION);
+    }
+  });
+
+  it('populates readyupVersion when upserting a single-file compile entry', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
+    mockValidateCompiledOutput.mockResolvedValue({});
+    mockReadManifest.mockImplementation(() => {
+      throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
+    });
+
+    await compileCommand(['deploy.ts']);
+
+    const writtenManifest: RdyManifest = mockWriteManifest.mock.calls[0][1];
+    const deployEntry = writtenManifest.kits.find((k) => k.name === 'deploy');
+    assert.ok(deployEntry, 'Expected deploy entry to be present');
+    expect(deployEntry.readyupVersion).toBe(VERSION);
   });
 
   it('maintains alphabetical order when upserting manifest entries', async () => {

--- a/packages/readyup/__tests__/compileConfig.test.ts
+++ b/packages/readyup/__tests__/compileConfig.test.ts
@@ -20,6 +20,7 @@ vi.mock(import('node:fs'), () => ({
 }));
 
 import { compileConfig } from '../src/compile/compileConfig.ts';
+import { VERSION } from '../src/version.ts';
 
 /** Build a mock esbuild result with the given output text. */
 function buildResult(text: string) {
@@ -52,6 +53,19 @@ describe(compileConfig, () => {
       banner: { js: expect.stringContaining('@generated') },
       write: false,
     });
+  });
+
+  it('embeds an export of __readyupVersion in the banner', async () => {
+    mockBuild.mockResolvedValue(buildResult('compiled'));
+    mockExistsSync.mockReturnValue(false);
+
+    await compileConfig('config/readyup.config.ts');
+
+    expect(mockBuild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        banner: { js: expect.stringContaining(`export const __readyupVersion = ${JSON.stringify(VERSION)};`) },
+      }),
+    );
   });
 
   it('returns the resolved output path', async () => {

--- a/packages/readyup/__tests__/config.test.ts
+++ b/packages/readyup/__tests__/config.test.ts
@@ -121,7 +121,7 @@ describe(loadRdyKit, () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ default: { checklists: validChecklists } });
 
-    const kit = await loadRdyKit(KIT_PATH);
+    const { kit } = await loadRdyKit(KIT_PATH);
 
     expect(kit.checklists).toHaveLength(1);
     expect(kit.checklists[0]?.name).toBe('test');
@@ -132,7 +132,7 @@ describe(loadRdyKit, () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ default: { checklists: validChecklists, fixLocation: 'inline' } });
 
-    const kit = await loadRdyKit(KIT_PATH);
+    const { kit } = await loadRdyKit(KIT_PATH);
 
     expect(kit.fixLocation).toBe('inline');
   });
@@ -142,7 +142,7 @@ describe(loadRdyKit, () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ checklists: validChecklists });
 
-    const kit = await loadRdyKit(KIT_PATH);
+    const { kit } = await loadRdyKit(KIT_PATH);
 
     expect(kit.checklists).toHaveLength(1);
     expect(kit.checklists[0]?.name).toBe('test');
@@ -153,7 +153,7 @@ describe(loadRdyKit, () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ checklists: validChecklists, fixLocation: 'inline' });
 
-    const kit = await loadRdyKit(KIT_PATH);
+    const { kit } = await loadRdyKit(KIT_PATH);
 
     expect(kit.fixLocation).toBe('inline');
   });
@@ -163,8 +163,38 @@ describe(loadRdyKit, () => {
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ checklists: validChecklists });
 
-    const kit = await loadRdyKit(KIT_PATH);
+    const { kit } = await loadRdyKit(KIT_PATH);
 
     expect(kit.fixLocation).toBeUndefined();
+  });
+
+  it('returns compileTimeVersion when __readyupVersion is exported as a string', async () => {
+    const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ checklists: validChecklists, __readyupVersion: '0.19.2' });
+
+    const { compileTimeVersion } = await loadRdyKit(KIT_PATH);
+
+    expect(compileTimeVersion).toBe('0.19.2');
+  });
+
+  it('returns undefined compileTimeVersion when __readyupVersion is absent', async () => {
+    const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ checklists: validChecklists });
+
+    const { compileTimeVersion } = await loadRdyKit(KIT_PATH);
+
+    expect(compileTimeVersion).toBeUndefined();
+  });
+
+  it('returns undefined compileTimeVersion when __readyupVersion is not a string', async () => {
+    const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({ checklists: validChecklists, __readyupVersion: 42 });
+
+    const { compileTimeVersion } = await loadRdyKit(KIT_PATH);
+
+    expect(compileTimeVersion).toBeUndefined();
   });
 });

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -234,6 +234,47 @@ describe(formatManifestView, () => {
 
     expect(result).toBe('No kits found in manifest: .readyup/manifest.json');
   });
+
+  it('renders readyup version as a parenthetical between name and description', () => {
+    const result = formatManifestView({
+      kits: [{ name: 'default', description: 'General project health checks', readyupVersion: '0.20.0' }],
+      manifestPath: '.readyup/manifest.json',
+    });
+
+    expect(result).toContain('📦 default (readyup v0.20.0) — General project health checks');
+  });
+
+  it('renders version-only parenthetical when description is absent', () => {
+    const result = formatManifestView({
+      kits: [{ name: 'deploy', readyupVersion: '0.19.2' }],
+      manifestPath: '.readyup/manifest.json',
+    });
+
+    const lines = result.split('\n');
+    const kitLine = lines.find((l) => l.includes('deploy'));
+    expect(kitLine).toBe('  📦 deploy (readyup v0.19.2)');
+  });
+
+  it('omits the version parenthetical entirely when readyupVersion is absent', () => {
+    const result = formatManifestView({
+      kits: [{ name: 'legacy', description: 'Older kit' }],
+      manifestPath: '.readyup/manifest.json',
+    });
+
+    expect(result).toContain('📦 legacy — Older kit');
+    expect(result).not.toContain('readyup v');
+  });
+
+  it('omits both segments when both version and description are absent', () => {
+    const result = formatManifestView({
+      kits: [{ name: 'bare' }],
+      manifestPath: '.readyup/manifest.json',
+    });
+
+    const lines = result.split('\n');
+    const kitLine = lines.find((l) => l.includes('bare'));
+    expect(kitLine).toBe('  📦 bare');
+  });
 });
 
 describe(formatEmpty, () => {

--- a/packages/readyup/__tests__/loadRemoteKit.validation.test.ts
+++ b/packages/readyup/__tests__/loadRemoteKit.validation.test.ts
@@ -32,7 +32,7 @@ describe('loadRemoteKit validation', () => {
     `;
     mockFetch.mockResolvedValue(mockResponse(jsBody));
 
-    const kit = await loadRemoteKit({ url: 'https://example.com/config.js' });
+    const { kit } = await loadRemoteKit({ url: 'https://example.com/config.js' });
 
     expect(kit.checklists).toHaveLength(1);
     expect(kit.checklists[0].name).toBe('test');
@@ -56,7 +56,7 @@ describe('loadRemoteKit validation', () => {
     `;
     mockFetch.mockResolvedValue(mockResponse(jsBody));
 
-    const kit = await loadRemoteKit({ url: 'https://example.com/config.js' });
+    const { kit } = await loadRemoteKit({ url: 'https://example.com/config.js' });
 
     expect(kit.fixLocation).toBe('inline');
   });
@@ -69,8 +69,49 @@ describe('loadRemoteKit validation', () => {
     `;
     mockFetch.mockResolvedValue(mockResponse(jsBody));
 
-    const kit = await loadRemoteKit({ url: 'https://example.com/config.js' });
+    const { kit } = await loadRemoteKit({ url: 'https://example.com/config.js' });
 
     expect(kit.fixLocation).toBeUndefined();
+  });
+
+  it('returns compileTimeVersion when __readyupVersion is exported as a string', async () => {
+    const jsBody = `
+      export const __readyupVersion = '0.19.2';
+      export const checklists = [
+        { name: 'test', checks: [{ name: 'check-a', check: () => true }] },
+      ];
+    `;
+    mockFetch.mockResolvedValue(mockResponse(jsBody));
+
+    const { compileTimeVersion } = await loadRemoteKit({ url: 'https://example.com/config.js' });
+
+    expect(compileTimeVersion).toBe('0.19.2');
+  });
+
+  it('returns undefined compileTimeVersion when __readyupVersion is absent', async () => {
+    const jsBody = `
+      export const checklists = [
+        { name: 'test', checks: [{ name: 'check-a', check: () => true }] },
+      ];
+    `;
+    mockFetch.mockResolvedValue(mockResponse(jsBody));
+
+    const { compileTimeVersion } = await loadRemoteKit({ url: 'https://example.com/config.js' });
+
+    expect(compileTimeVersion).toBeUndefined();
+  });
+
+  it('returns undefined compileTimeVersion when __readyupVersion is not a string', async () => {
+    const jsBody = `
+      export const __readyupVersion = 42;
+      export const checklists = [
+        { name: 'test', checks: [{ name: 'check-a', check: () => true }] },
+      ];
+    `;
+    mockFetch.mockResolvedValue(mockResponse(jsBody));
+
+    const { compileTimeVersion } = await loadRemoteKit({ url: 'https://example.com/config.js' });
+
+    expect(compileTimeVersion).toBeUndefined();
   });
 });

--- a/packages/readyup/__tests__/manifest/manifestSchema.test.ts
+++ b/packages/readyup/__tests__/manifest/manifestSchema.test.ts
@@ -103,6 +103,51 @@ describe(ManifestSchema, () => {
     expect(result.data.kits[0].targetHash).toBe('e5f6a7b8');
   });
 
+  it('accepts a manifest with readyupVersion as an optional string and preserves it on parse', () => {
+    const input = {
+      version: 1,
+      kits: [
+        {
+          name: 'deploy',
+          path: 'kits/deploy.js',
+          source: 'kits/deploy.ts',
+          targetHash: 'a1b2c3d4',
+          readyupVersion: '0.20.0',
+        },
+      ],
+    };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+    assert.ok(result.success);
+    expect(result.data.kits[0]?.readyupVersion).toBe('0.20.0');
+  });
+
+  it('accepts a manifest where readyupVersion is omitted', () => {
+    const input = {
+      version: 1,
+      kits: [{ name: 'deploy' }],
+    };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+    assert.ok(result.success);
+    expect(result.data.kits[0]?.readyupVersion).toBeUndefined();
+  });
+
+  it('rejects a manifest where readyupVersion is a non-string value', () => {
+    const input = {
+      version: 1,
+      kits: [{ name: 'deploy', readyupVersion: 42 }],
+    };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
   it('rejects a kit with an empty name', () => {
     const input = { version: 1, kits: [{ name: '' }] };
 

--- a/packages/readyup/__tests__/versionSkewWarning.test.ts
+++ b/packages/readyup/__tests__/versionSkewWarning.test.ts
@@ -210,6 +210,44 @@ describe('version-skew warning', () => {
     expect(stderrText()).not.toContain('Warning:');
   });
 
+  it('scopes the warning to the skewing kit when running multiple kits in human mode', async () => {
+    // First kit has skew (compile-time 0.20.0 vs runner 0.21.0); second kit has no compile-time version.
+    mockLoadRdyKit
+      .mockResolvedValueOnce({ kit: makeKit(), compileTimeVersion: '0.20.0' })
+      .mockResolvedValueOnce({ kit: makeKit(), compileTimeVersion: undefined });
+
+    await runCommand({
+      kitEntries: [
+        { name: 'alpha', source: { path: '.readyup/kits/alpha.js' }, checklists: [] },
+        { name: 'beta', source: { path: '.readyup/kits/beta.js' }, checklists: [] },
+      ],
+      json: false,
+    });
+
+    const stderr = stderrText();
+    expect(stderr).toContain('Warning: kit "alpha" was compiled against readyup 0.20.0');
+    expect(stderr).not.toContain('kit "beta"');
+  });
+
+  it('scopes the warning to the skewing kit when running multiple kits in JSON mode', async () => {
+    mockLoadRdyKit
+      .mockResolvedValueOnce({ kit: makeKit(), compileTimeVersion: '0.20.0' })
+      .mockResolvedValueOnce({ kit: makeKit(), compileTimeVersion: undefined });
+    mockFormatJsonReport.mockReturnValue('{"kits":[]}');
+
+    await runCommand({
+      kitEntries: [
+        { name: 'alpha', source: { path: '.readyup/kits/alpha.js' }, checklists: [] },
+        { name: 'beta', source: { path: '.readyup/kits/beta.js' }, checklists: [] },
+      ],
+      json: true,
+    });
+
+    const stderr = stderrText();
+    expect(stderr).toContain('Warning: kit "alpha" was compiled against readyup 0.20.0');
+    expect(stderr).not.toContain('kit "beta"');
+  });
+
   it('emits the warning before any checklist runs', async () => {
     mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: '0.20.0' });
     const order: string[] = [];

--- a/packages/readyup/__tests__/versionSkewWarning.test.ts
+++ b/packages/readyup/__tests__/versionSkewWarning.test.ts
@@ -1,0 +1,231 @@
+import process from 'node:process';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import type { RdyKit } from '../src/types.ts';
+
+const { RUNNER_VERSION } = vi.hoisted(() => ({ RUNNER_VERSION: '0.21.0' }));
+
+const mockLoadRdyKit = vi.hoisted(() => vi.fn());
+const mockRunRdy = vi.hoisted(() => vi.fn());
+const mockReportRdy = vi.hoisted(() => vi.fn());
+const mockFormatCombinedSummary = vi.hoisted(() => vi.fn());
+const mockFormatJsonReport = vi.hoisted(() => vi.fn());
+const mockFormatJsonError = vi.hoisted(() => vi.fn());
+const mockResolveGitHubToken = vi.hoisted(() => vi.fn());
+const mockResolveBitbucketToken = vi.hoisted(() => vi.fn());
+const mockLoadRemoteKit = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/config.ts', () => ({
+  loadRdyKit: mockLoadRdyKit,
+}));
+
+vi.mock('../src/runRdy.ts', () => ({
+  meetsThreshold: () => true,
+  runRdy: mockRunRdy,
+}));
+
+vi.mock('../src/reportRdy.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/reportRdy.ts')>('../src/reportRdy.ts');
+  return {
+    ...actual,
+    reportRdy: mockReportRdy,
+  };
+});
+
+vi.mock('../src/formatCombinedSummary.ts', () => ({
+  formatCombinedSummary: mockFormatCombinedSummary,
+}));
+
+vi.mock('../src/formatJsonReport.ts', () => ({
+  formatJsonReport: mockFormatJsonReport,
+}));
+
+vi.mock('../src/formatJsonError.ts', () => ({
+  formatJsonError: mockFormatJsonError,
+}));
+
+vi.mock('../src/resolveGitHubToken.ts', () => ({
+  resolveGitHubToken: mockResolveGitHubToken,
+}));
+
+vi.mock('../src/resolveBitbucketToken.ts', () => ({
+  resolveBitbucketToken: mockResolveBitbucketToken,
+}));
+
+vi.mock('../src/loadRemoteKit.ts', () => ({
+  loadRemoteKit: mockLoadRemoteKit,
+}));
+
+vi.mock('../src/version.ts', () => ({
+  VERSION: RUNNER_VERSION,
+}));
+
+import { runCommand } from '../src/cli.ts';
+
+/** Build a minimal kit with one passing checklist. */
+function makeKit(): RdyKit {
+  return {
+    checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
+  };
+}
+
+/** Build a single-kit entry pointing at a fixture-style local path. */
+function singleKitEntry(name = 'default') {
+  return [{ name, source: { path: '.readyup/kits/default.js' }, checklists: [] }];
+}
+
+describe('version-skew warning', () => {
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockReportRdy.mockReturnValue('report output');
+    mockFormatCombinedSummary.mockReturnValue('');
+    mockFormatJsonReport.mockReturnValue('{}');
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockLoadRdyKit.mockReset();
+    mockRunRdy.mockReset();
+    mockReportRdy.mockReset();
+    mockFormatCombinedSummary.mockReset();
+    mockFormatJsonReport.mockReset();
+    mockFormatJsonError.mockReset();
+    mockResolveGitHubToken.mockReset();
+    mockResolveBitbucketToken.mockReset();
+    mockLoadRemoteKit.mockReset();
+  });
+
+  /** Concatenate every stderr write into a single string for substring assertions. */
+  function stderrText(): string {
+    return stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+  }
+
+  /** Concatenate every stdout write into a single string for substring assertions. */
+  function stdoutText(): string {
+    return stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+  }
+
+  it('emits "rdy compile" advice on stderr when runner is newer above the boundary', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: '0.20.0' });
+
+    const exitCode = await runCommand({ kitEntries: singleKitEntry('default'), json: false });
+
+    expect(exitCode).toBe(0);
+    const stderr = stderrText();
+    expect(stderr).toContain('Warning: kit "default" was compiled against readyup 0.20.0; runner is 0.21.0.');
+    expect(stderr).toContain('Run `rdy compile` to refresh.');
+  });
+
+  it('emits "upgrade readyup" advice on stderr when runner is older above the boundary', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: '0.22.0' });
+
+    const exitCode = await runCommand({ kitEntries: singleKitEntry('default'), json: false });
+
+    expect(exitCode).toBe(0);
+    const stderr = stderrText();
+    expect(stderr).toContain('Warning: kit "default" was compiled against readyup 0.22.0; runner is 0.21.0.');
+    expect(stderr).toContain('Upgrade readyup to match.');
+  });
+
+  it('stays silent when versions differ only below the leftmost-non-zero boundary', async () => {
+    // RUNNER_VERSION is 0.21.0; compile-time 0.21.5 has same boundary segment.
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: '0.21.5' });
+
+    await runCommand({ kitEntries: singleKitEntry('default'), json: false });
+
+    expect(stderrText()).not.toContain('Warning:');
+  });
+
+  it('stays silent when compile-time and runner versions are identical', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: RUNNER_VERSION });
+
+    await runCommand({ kitEntries: singleKitEntry('default'), json: false });
+
+    expect(stderrText()).not.toContain('Warning:');
+  });
+
+  it('stays silent when compile-time version is absent (back-compat)', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
+
+    await runCommand({ kitEntries: singleKitEntry('default'), json: false });
+
+    expect(stderrText()).not.toContain('Warning:');
+  });
+
+  it('stays silent when compile-time version is unparseable (defensive)', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: 'not-a-version' });
+
+    await runCommand({ kitEntries: singleKitEntry('default'), json: false });
+
+    expect(stderrText()).not.toContain('Warning:');
+  });
+
+  it('does not alter the exit code regardless of skew direction', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: '0.20.0' });
+
+    const exitCode = await runCommand({ kitEntries: singleKitEntry('default'), json: false });
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('emits the warning to stderr in JSON mode without polluting stdout JSON', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: '0.20.0' });
+    mockFormatJsonReport.mockReturnValue('{"kits":[]}');
+
+    await runCommand({ kitEntries: singleKitEntry('default'), json: true });
+
+    expect(stderrText()).toContain('Warning:');
+    // stdout should contain only the JSON report (and a trailing newline).
+    expect(stdoutText()).toBe('{"kits":[]}\n');
+  });
+
+  it('uses the entry display name (URL) in the warning for --url sources', async () => {
+    mockLoadRemoteKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: '0.20.0' });
+    const url = 'https://example.com/kits/deploy.js';
+
+    await runCommand({
+      kitEntries: [{ name: url, source: { url }, checklists: [] }],
+      json: false,
+    });
+
+    expect(stderrText()).toContain(`Warning: kit "${url}" was compiled against readyup 0.20.0`);
+  });
+
+  it('stays silent when --url kit omits __readyupVersion (third-party tolerance)', async () => {
+    mockLoadRemoteKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
+
+    await runCommand({
+      kitEntries: [
+        { name: 'https://example.com/kits/x.js', source: { url: 'https://example.com/kits/x.js' }, checklists: [] },
+      ],
+      json: false,
+    });
+
+    expect(stderrText()).not.toContain('Warning:');
+  });
+
+  it('emits the warning before any checklist runs', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: '0.20.0' });
+    const order: string[] = [];
+    stderrSpy.mockImplementation((chunk: unknown) => {
+      const text = String(chunk);
+      if (text.includes('Warning:')) order.push('warning');
+      return true;
+    });
+    mockRunRdy.mockImplementation(() => {
+      order.push('run');
+      return Promise.resolve({ results: [], passed: true, durationMs: 0 });
+    });
+
+    await runCommand({ kitEntries: singleKitEntry('default'), json: false });
+
+    expect(order[0]).toBe('warning');
+    expect(order).toContain('run');
+  });
+});

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import process from 'node:process';
 
 import { buildKitFilename } from './buildKitFilename.ts';
-import { loadRdyKit } from './config.ts';
+import { type LoadedRdyKit, loadRdyKit } from './config.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonError } from './formatJsonError.ts';
 import { formatJsonReport } from './formatJsonReport.ts';
@@ -26,6 +26,8 @@ import type {
   SummaryCounts,
 } from './types.ts';
 import { extractMessage } from './utils/error-handling.ts';
+import { VERSION } from './version.ts';
+import { compareVersionsForSkew } from './versionSkew/compareVersionsForSkew.ts';
 
 /** Valid severity values for CLI flag validation. */
 const VALID_SEVERITIES = new Set<string>(['error', 'warn', 'recommend']);
@@ -333,7 +335,7 @@ interface RunCommandOptions {
 }
 
 /** Load a rdy kit from a path or URL source. */
-async function loadKit(source: KitSource, isJit: boolean): Promise<RdyKit> {
+async function loadKit(source: KitSource, isJit: boolean): Promise<LoadedRdyKit> {
   if ('url' in source) {
     const options: LoadRemoteKitOptions = { url: source.url };
     if (source.url.includes('raw.githubusercontent.com')) {
@@ -366,6 +368,23 @@ async function loadKit(source: KitSource, isJit: boolean): Promise<RdyKit> {
     }
     throw error;
   }
+}
+
+/**
+ * Emit a directional, advisory stderr warning when a kit's compile-time readyup version skews
+ * from the runner's version above the leftmost-non-zero boundary.
+ *
+ * Silent when the compile-time version is absent (older kit, third-party `--url` source, or
+ * uncompiled `.ts` source via `--jit`) and when the comparator returns no-skew.
+ */
+function warnOnVersionSkew(kitName: string, compileTimeVersion: string | undefined): void {
+  if (compileTimeVersion === undefined) return;
+  const result = compareVersionsForSkew(compileTimeVersion, VERSION);
+  if (result.kind === 'no-skew') return;
+  const remedy = result.direction === 'runner-newer' ? 'Run `rdy compile` to refresh.' : 'Upgrade readyup to match.';
+  process.stderr.write(
+    `Warning: kit "${kitName}" was compiled against readyup ${compileTimeVersion}; runner is ${VERSION}. ${remedy}\n`,
+  );
 }
 
 /** Detect module-not-found errors that mention a specific package name. */
@@ -402,13 +421,16 @@ async function runMultiKitJsonMode(
 
   for (const entry of kitEntries) {
     let kit: RdyKit;
+    let compileTimeVersion: string | undefined;
     try {
-      kit = await loadKit(entry.source, isJit);
+      ({ kit, compileTimeVersion } = await loadKit(entry.source, isJit));
     } catch (error: unknown) {
       const message = extractMessage(error);
       process.stdout.write(formatJsonError(message) + '\n');
       return 1;
     }
+
+    warnOnVersionSkew(entry.name, compileTimeVersion);
 
     const thresholds = resolveThresholds(kit, failOn, reportOn);
     let resolvedNames: string[];
@@ -464,13 +486,16 @@ async function runMultiKitHumanMode(
   let allPassed = true;
   for (const entry of kitEntries) {
     let kit: RdyKit;
+    let compileTimeVersion: string | undefined;
     try {
-      kit = await loadKit(entry.source, isJit);
+      ({ kit, compileTimeVersion } = await loadKit(entry.source, isJit));
     } catch (error: unknown) {
       const message = extractMessage(error);
       process.stderr.write(`Error: ${message}\n`);
       return 1;
     }
+
+    warnOnVersionSkew(entry.name, compileTimeVersion);
 
     if (showKitHeader) {
       process.stdout.write(`\n=== ${entry.name} ===\n`);

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -14,6 +14,7 @@ import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../reportRdy.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import type { DriftStatus } from '../verify/checkDrift.ts';
 import { checkDrift } from '../verify/checkDrift.ts';
+import { VERSION } from '../version.ts';
 import { compileConfig } from './compileConfig.ts';
 import type { KitMetadata } from './validateCompiledOutput.ts';
 import { validateCompiledOutput } from './validateCompiledOutput.ts';
@@ -234,6 +235,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
       kitEntries.push({
         name: kitName,
         path: relOutputPath,
+        readyupVersion: VERSION,
         source: relSourcePath,
         targetHash: result.targetHash,
         ...(metadata.description !== undefined && { description: metadata.description }),
@@ -295,6 +297,7 @@ function upsertManifest(
   const entry: RdyManifestKit = {
     name: kitName,
     path: location.path,
+    readyupVersion: VERSION,
     source: location.source,
     targetHash: location.targetHash,
     ...(metadata.description !== undefined && { description: metadata.description }),

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -311,7 +311,7 @@ function upsertManifest(
   writeManifest(manifestPath, { version: 1, kits });
 }
 
-/** Read the manifest and index its kits by name, returning an empty map on any read failure. */
+/** Read the manifest and index its kits by name. Missing manifest is expected (first compile); other failures are surfaced on stderr and treated as a no-op drift gate. */
 function loadExistingKitsByName(manifestPath: string): Map<string, RdyManifestKit> {
   const map = new Map<string, RdyManifestKit>();
   try {
@@ -319,8 +319,11 @@ function loadExistingKitsByName(manifestPath: string): Map<string, RdyManifestKi
     for (const kit of manifest.kits) {
       map.set(kit.name, kit);
     }
-  } catch {
-    // Missing or unreadable manifest — drift gate becomes a no-op for this run.
+  } catch (error: unknown) {
+    if (!(error instanceof ManifestNotFoundError)) {
+      const message = extractMessage(error);
+      process.stderr.write(`Warning: ${message} — drift gate skipped\n`);
+    }
   }
   return map;
 }

--- a/packages/readyup/src/compile/compileConfig.ts
+++ b/packages/readyup/src/compile/compileConfig.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { hashBytes } from '../verify/targetHash.ts';
+import { VERSION } from '../version.ts';
 import { pickJsonPlugin } from './pickJsonPlugin.ts';
 
 /** Result of a successful compilation. */
@@ -11,10 +12,16 @@ export interface CompileResult {
   targetHash: string;
 }
 
-/** Generated-file header prepended to compiled output. */
+/**
+ * Generated-file header prepended to compiled output.
+ *
+ * Includes an exported `__readyupVersion` constant so the runner can detect skew between the
+ * readyup version a kit was compiled against and the runner's own version at execution time.
+ */
 const GENERATED_HEADER = [
   '/** @noformat — @generated. Do not edit. Compiled by rdy. */',
   '/* eslint-disable */',
+  `export const __readyupVersion = ${JSON.stringify(VERSION)};`,
   '',
 ].join('\n');
 

--- a/packages/readyup/src/config.ts
+++ b/packages/readyup/src/config.ts
@@ -7,12 +7,21 @@ import { resolveKitExports } from './resolveKitExports.ts';
 import type { RdyKit } from './types.ts';
 import { validateKit } from './validateKit.ts';
 
+/** Result of loading a rdy kit: the validated kit plus the compile-time readyup version, if embedded. */
+export interface LoadedRdyKit {
+  kit: RdyKit;
+  compileTimeVersion: string | undefined;
+}
+
 /**
  * Load and validate a rdy kit file.
  *
- * Uses jiti to load TypeScript config files at runtime.
+ * Uses jiti to load TypeScript config files at runtime. Returns the validated kit and the
+ * embedded `__readyupVersion` from the imported module namespace when present, or `undefined`
+ * for kits compiled before that field was introduced (and for `.ts` sources, which have no
+ * generated banner).
  */
-export async function loadRdyKit(kitPath: string): Promise<RdyKit> {
+export async function loadRdyKit(kitPath: string): Promise<LoadedRdyKit> {
   const resolvedPath = path.resolve(process.cwd(), kitPath);
 
   if (!existsSync(resolvedPath)) {
@@ -30,8 +39,17 @@ export async function loadRdyKit(kitPath: string): Promise<RdyKit> {
     'Kit file',
   );
 
+  // Extract __readyupVersion from the raw module namespace before `resolveKitExports` strips it.
+  const compileTimeVersion = readCompileTimeVersion(imported);
+
   const resolved = resolveKitExports(imported);
   assertIsRdyKit(resolved);
   validateKit(resolved);
-  return resolved;
+  return { kit: resolved, compileTimeVersion };
+}
+
+/** Narrow `__readyupVersion` from an imported module namespace to a string, or undefined. */
+function readCompileTimeVersion(moduleRecord: Record<string, unknown>): string | undefined {
+  const value = moduleRecord.__readyupVersion;
+  return typeof value === 'string' ? value : undefined;
 }

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -93,14 +93,17 @@ export function formatEmpty(mode: 'owner' | 'consumer', kitsDir?: string): strin
 // -- Manifest view --
 
 interface ManifestViewOptions {
-  kits: Array<{ name: string; description?: string | undefined }>;
+  kits: Array<{ name: string; description?: string | undefined; readyupVersion?: string | undefined }>;
   manifestPath: string;
 }
 
 /**
  * Format a view of kits loaded from a manifest file.
  *
- * Kit names are displayed with the compiled icon; descriptions appear inline when present.
+ * Kit names are displayed with the compiled icon. When a kit's `readyupVersion` is present, it
+ * appears as a parenthetical between the name and the description — `📦 <name> (readyup v<X>) — <description>`.
+ * The literal `readyup` label is load-bearing: it disambiguates the version from a hypothetical
+ * kit-own version. Descriptions appear inline when present; both fields are omitted independently.
  */
 export function formatManifestView({ kits, manifestPath }: ManifestViewOptions): string {
   if (kits.length === 0) {
@@ -108,8 +111,9 @@ export function formatManifestView({ kits, manifestPath }: ManifestViewOptions):
   }
 
   const items = kits.map((kit) => {
-    const suffix = kit.description !== undefined ? ` — ${kit.description}` : '';
-    return `  ${ICON_COMPILED} ${kit.name}${suffix}`;
+    const versionSegment = kit.readyupVersion !== undefined ? ` (readyup v${kit.readyupVersion})` : '';
+    const descriptionSegment = kit.description !== undefined ? ` — ${kit.description}` : '';
+    return `  ${ICON_COMPILED} ${kit.name}${versionSegment}${descriptionSegment}`;
   });
 
   return `Manifest: ${manifestPath}\n${items.join('\n')}`;

--- a/packages/readyup/src/loadRemoteKit.ts
+++ b/packages/readyup/src/loadRemoteKit.ts
@@ -4,9 +4,9 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { assertIsRdyKit } from './assertIsRdyKit.ts';
+import type { LoadedRdyKit } from './config.ts';
 import { isRecord } from './isRecord.ts';
 import { resolveKitExports } from './resolveKitExports.ts';
-import type { RdyKit } from './types.ts';
 import { validateKit } from './validateKit.ts';
 
 export interface LoadRemoteKitOptions {
@@ -19,9 +19,11 @@ export interface LoadRemoteKitOptions {
  *
  * Sends the supplied headers (if any) with the request; the helper has no auth-scheme knowledge —
  * callers pre-format `Authorization` and any other headers (e.g., proxy/telemetry in corporate environments).
- * Writes the fetched content to a temp file for dynamic import, then cleans up.
+ * Writes the fetched content to a temp file for dynamic import, then cleans up. Returns the kit
+ * alongside the embedded `__readyupVersion` (undefined for kits compiled before that field existed
+ * or fetched from third-party sources that omit it).
  */
-export async function loadRemoteKit({ url, headers = {} }: LoadRemoteKitOptions): Promise<RdyKit> {
+export async function loadRemoteKit({ url, headers = {} }: LoadRemoteKitOptions): Promise<LoadedRdyKit> {
   const response = await fetch(url, { headers });
 
   if (!response.ok) {
@@ -47,10 +49,13 @@ export async function loadRemoteKit({ url, headers = {} }: LoadRemoteKitOptions)
     // Narrow the module namespace to access exports. `import()` always returns an object,
     // but TypeScript types it as `any`; narrowing avoids unsafe-member-access lint errors.
     const moduleRecord = isRecord(imported) ? imported : {};
+    // Read __readyupVersion from the raw namespace before resolveKitExports drops unknown fields.
+    const versionValue = moduleRecord.__readyupVersion;
+    const compileTimeVersion = typeof versionValue === 'string' ? versionValue : undefined;
     const resolved = resolveKitExports(moduleRecord);
     assertIsRdyKit(resolved);
     validateKit(resolved);
-    return resolved;
+    return { kit: resolved, compileTimeVersion };
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -5,6 +5,7 @@ const ManifestKitSchema = z.object({
   description: z.string().optional(),
   name: z.string().min(1),
   path: z.string().optional(),
+  readyupVersion: z.string().optional(),
   source: z.string().optional(),
   targetHash: z.string().optional(),
 });

--- a/packages/readyup/src/versionSkew/compareVersionsForSkew.ts
+++ b/packages/readyup/src/versionSkew/compareVersionsForSkew.ts
@@ -56,11 +56,26 @@ function leftmostNonZeroIndex(version: ParsedVersion): 0 | 1 | 2 | undefined {
  *
  * Returns `no-skew` for identical versions, sub-boundary differences, all-zero compile-time
  * versions, and unparseable inputs.
+ *
+ * When the two versions have different major numbers, direction is determined by the major
+ * comparison alone — the boundary-index logic only applies to within-major comparisons, since
+ * a lower-segment value in a higher-major version (e.g. `1.0.0` vs `0.20.0`) is semantically
+ * newer despite having a numerically smaller minor.
  */
 export function compareVersionsForSkew(compileTime: string, runtime: string): SkewResult {
   const compileTimeParsed = parseSemverTriple(compileTime);
   const runtimeParsed = parseSemverTriple(runtime);
   if (compileTimeParsed === undefined || runtimeParsed === undefined) return { kind: 'no-skew' };
+
+  // When majors differ, the major comparison alone determines direction.
+  // This guards against the cross-boundary inversion that would otherwise occur when
+  // the compile-time boundary index points at a non-major segment.
+  if (runtimeParsed.major !== compileTimeParsed.major) {
+    return {
+      kind: 'skew',
+      direction: runtimeParsed.major > compileTimeParsed.major ? 'runner-newer' : 'runner-older',
+    };
+  }
 
   const boundaryIndex = leftmostNonZeroIndex(compileTimeParsed);
   if (boundaryIndex === undefined) return { kind: 'no-skew' };

--- a/packages/readyup/src/versionSkew/compareVersionsForSkew.ts
+++ b/packages/readyup/src/versionSkew/compareVersionsForSkew.ts
@@ -23,13 +23,9 @@ interface ParsedVersion {
 function parseSemverTriple(version: string): ParsedVersion | undefined {
   const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
   if (match === null) return undefined;
-  const [majorRaw, minorRaw, patchRaw] = [match[1], match[2], match[3]];
+  const [, majorRaw, minorRaw, patchRaw] = match;
   if (majorRaw === undefined || minorRaw === undefined || patchRaw === undefined) return undefined;
-  const major = Number(majorRaw);
-  const minor = Number(minorRaw);
-  const patch = Number(patchRaw);
-  if (!Number.isFinite(major) || !Number.isFinite(minor) || !Number.isFinite(patch)) return undefined;
-  return { major, minor, patch };
+  return { major: Number(majorRaw), minor: Number(minorRaw), patch: Number(patchRaw) };
 }
 
 /** Look up a numeric segment by its leftmost-non-zero index (0=major, 1=minor, 2=patch). */

--- a/packages/readyup/src/versionSkew/compareVersionsForSkew.ts
+++ b/packages/readyup/src/versionSkew/compareVersionsForSkew.ts
@@ -1,0 +1,76 @@
+/**
+ * Result of comparing a compile-time version against a runtime version.
+ *
+ * `no-skew` covers identical versions, sub-boundary differences, all-zero
+ * compile-time versions, and unparseable inputs (forgiving — matches the
+ * absent-field policy used by the warning emitter).
+ */
+export type SkewResult = { kind: 'no-skew' } | { kind: 'skew'; direction: 'runner-newer' | 'runner-older' };
+
+/** Parsed `MAJOR.MINOR.PATCH` triple (numeric segments only; pre-release suffixes are ignored). */
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/**
+ * Parse the leading `MAJOR.MINOR.PATCH` of a version string into a numeric triple.
+ *
+ * Strips any pre-release or build suffix (`-beta`, `+sha`). Returns `undefined` when
+ * the string does not begin with three dot-separated non-negative integers.
+ */
+function parseSemverTriple(version: string): ParsedVersion | undefined {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (match === null) return undefined;
+  const [majorRaw, minorRaw, patchRaw] = [match[1], match[2], match[3]];
+  if (majorRaw === undefined || minorRaw === undefined || patchRaw === undefined) return undefined;
+  const major = Number(majorRaw);
+  const minor = Number(minorRaw);
+  const patch = Number(patchRaw);
+  if (!Number.isFinite(major) || !Number.isFinite(minor) || !Number.isFinite(patch)) return undefined;
+  return { major, minor, patch };
+}
+
+/** Look up a numeric segment by its leftmost-non-zero index (0=major, 1=minor, 2=patch). */
+function segmentAt(version: ParsedVersion, index: 0 | 1 | 2): number {
+  if (index === 0) return version.major;
+  if (index === 1) return version.minor;
+  return version.patch;
+}
+
+/** Find the leftmost non-zero segment of a parsed version, or `undefined` when all segments are zero. */
+function leftmostNonZeroIndex(version: ParsedVersion): 0 | 1 | 2 | undefined {
+  if (version.major !== 0) return 0;
+  if (version.minor !== 0) return 1;
+  if (version.patch !== 0) return 2;
+  return undefined;
+}
+
+/**
+ * Compare a compile-time version against a runtime version using the leftmost-non-zero rule.
+ *
+ * Matches npm's `^` operator: the leftmost non-zero segment of the compile-time version is the
+ * breaking boundary. When that segment differs between the two versions, there is skew; the
+ * direction reflects whether the runtime is newer or older.
+ *
+ * Returns `no-skew` for identical versions, sub-boundary differences, all-zero compile-time
+ * versions, and unparseable inputs.
+ */
+export function compareVersionsForSkew(compileTime: string, runtime: string): SkewResult {
+  const compileTimeParsed = parseSemverTriple(compileTime);
+  const runtimeParsed = parseSemverTriple(runtime);
+  if (compileTimeParsed === undefined || runtimeParsed === undefined) return { kind: 'no-skew' };
+
+  const boundaryIndex = leftmostNonZeroIndex(compileTimeParsed);
+  if (boundaryIndex === undefined) return { kind: 'no-skew' };
+
+  const compileTimeSegment = segmentAt(compileTimeParsed, boundaryIndex);
+  const runtimeSegment = segmentAt(runtimeParsed, boundaryIndex);
+  if (runtimeSegment === compileTimeSegment) return { kind: 'no-skew' };
+
+  return {
+    kind: 'skew',
+    direction: runtimeSegment > compileTimeSegment ? 'runner-newer' : 'runner-older',
+  };
+}


### PR DESCRIPTION
## What

The `rdy` runner now prints an advisory when a compiled kit was built against a different readyup version than the one running it. `rdy list` displays the readyup version against which each kit was compiled.

When `rdy compile`'s batch mode encounters an unreadable manifest, it now surfaces the error and proceeds as if the manifest were absent. Previously these failures were swallowed silently.

## Why

After externalization (#84), a compiled kit imports `readyup` from the runner's installation rather than its own bundled copy. A kit built against an older readyup with a different API could diverge from runner behavior with no signal to the user — this change makes the version difference observable so the user knows when to recompile or upgrade.

## Details

### 🎉 Features

- The `rdy` runner detects compile-time/runtime readyup version skew and emits a directional stderr advisory before each kit runs. Silent when the kit's compile-time version is unknown (kits compiled before this change, third-party kits loaded via `--url`, `.ts` sources loaded via `--jit`) and when the version difference is below the leftmost-non-zero boundary.
- `rdy list` renders the readyup version each kit was compiled against when the manifest records it, with a `readyup` label that disambiguates the runner version from any kit-specific version.

### 🐛 Bug fixes

- `rdy compile`'s batch mode now surfaces non-missing manifest read failures on stderr (corrupt JSON, permission errors, schema mismatches). Missing manifests remain silent — the expected first-compile case.

### 🧪 Tests

- New tests cover the version-skew comparator's full threshold table including cross-major boundaries and unparseable inputs, the runner's directional warning across both human and JSON output modes including multi-kit scoping, the manifest schema's optional version field, and the unreadable-manifest stderr surfacing.


Closes #86
