### PR TITLE
#95 Stabilize compileConfig esbuild-import-failure test

### DIFF
--- a/packages/readyup/__tests__/compileConfig.test.ts
+++ b/packages/readyup/__tests__/compileConfig.test.ts
@@ -1,15 +1,16 @@
 import path from 'node:path';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockBuild = vi.hoisted(() => vi.fn());
+const mockLoadEsbuild = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockMkdirSync = vi.hoisted(() => vi.fn());
 const mockReadFileSync = vi.hoisted(() => vi.fn());
 const mockWriteFileSync = vi.hoisted(() => vi.fn());
 
-vi.mock('esbuild', () => ({
-  build: mockBuild,
+vi.mock('../src/compile/loadEsbuild.ts', () => ({
+  loadEsbuild: mockLoadEsbuild,
 }));
 
 vi.mock(import('node:fs'), () => ({
@@ -22,14 +23,16 @@ vi.mock(import('node:fs'), () => ({
 import { compileConfig } from '../src/compile/compileConfig.ts';
 import { VERSION } from '../src/version.ts';
 
-/** Build a mock esbuild result with the given output text. */
-function buildResult(text: string) {
-  return { outputFiles: [{ contents: new TextEncoder().encode(text) }] };
-}
-
 describe(compileConfig, () => {
+  beforeEach(() => {
+    // Default: The esbuild import succeeds and exposes the mocked `build`.
+    // Failure-path tests override this with `mockRejectedValue`.
+    mockLoadEsbuild.mockResolvedValue({ build: mockBuild });
+  });
+
   afterEach(() => {
     mockBuild.mockReset();
+    mockLoadEsbuild.mockReset();
     mockExistsSync.mockReset();
     mockMkdirSync.mockReset();
     mockReadFileSync.mockReset();
@@ -141,36 +144,24 @@ describe(compileConfig, () => {
   });
 
   it('throws a clear error when esbuild is not installed', async () => {
-    vi.doMock('esbuild', () => {
-      throw new Error('Cannot find module esbuild');
-    });
-    vi.resetModules();
+    mockLoadEsbuild.mockRejectedValue(new Error('Cannot find module esbuild'));
 
-    const { compileConfig: freshCompile } = await import('../src/compile/compileConfig.ts');
-
-    await expect(freshCompile('input.ts')).rejects.toThrow('esbuild is required');
-
-    // Restore the mock for subsequent tests
-    vi.doMock('esbuild', () => ({ build: mockBuild }));
-    vi.resetModules();
+    await expect(compileConfig('input.ts')).rejects.toThrow('esbuild is required');
   });
 
   it('chains the original error as cause when esbuild import fails', async () => {
-    vi.doMock('esbuild', () => {
-      throw new Error('Cannot find module esbuild');
-    });
-    vi.resetModules();
+    const importError = new Error('Cannot find module esbuild');
+    mockLoadEsbuild.mockRejectedValue(importError);
 
-    const { compileConfig: freshCompile } = await import('../src/compile/compileConfig.ts');
-
-    const thrownError = await freshCompile('input.ts').catch((error: unknown) => error);
+    const thrownError = await compileConfig('input.ts').catch((error: unknown) => error);
     expect(thrownError).toBeInstanceOf(Error);
     if (thrownError instanceof Error) {
-      expect(thrownError.cause).toBeInstanceOf(Error);
+      expect(thrownError.cause).toBe(importError);
     }
-
-    // Restore the mock for subsequent tests
-    vi.doMock('esbuild', () => ({ build: mockBuild }));
-    vi.resetModules();
   });
 });
+
+/** Builds a mock esbuild result with the given output text. */
+function buildResult(text: string) {
+  return { outputFiles: [{ contents: new TextEncoder().encode(text) }] };
+}

--- a/packages/readyup/src/compile/compileConfig.ts
+++ b/packages/readyup/src/compile/compileConfig.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { hashBytes } from '../verify/targetHash.ts';
 import { VERSION } from '../version.ts';
+import { loadEsbuild } from './loadEsbuild.ts';
 import { pickJsonPlugin } from './pickJsonPlugin.ts';
 
 /** Result of a successful compilation. */
@@ -25,17 +26,8 @@ const GENERATED_HEADER = [
   '',
 ].join('\n');
 
-/** Derive the default output path by replacing the `.ts` extension with `.js`. */
-function deriveOutputPath(inputPath: string): string {
-  const ext = path.extname(inputPath);
-  if (ext === '.ts' || ext === '.mts' || ext === '.cts') {
-    return inputPath.slice(0, -ext.length) + '.js';
-  }
-  return `${inputPath}.js`;
-}
-
 /**
- * Bundle a TypeScript checklist file into a self-contained ESM bundle using esbuild.
+ * Bundles a TypeScript checklist file into a self-contained ESM bundle using esbuild.
  *
  * Node built-in modules and the `readyup` package (including `readyup/*` subpaths) are
  * kept external; all other imports are inlined. The externalized `readyup` specifiers
@@ -49,7 +41,7 @@ export async function compileConfig(inputPath: string, outputPath?: string): Pro
 
   let esbuild: typeof import('esbuild');
   try {
-    esbuild = await import('esbuild');
+    esbuild = await loadEsbuild();
   } catch (error: unknown) {
     throw new Error(
       'esbuild is required for the compile command but is not installed. Install it with: pnpm add --save-dev esbuild',
@@ -84,4 +76,13 @@ export async function compileConfig(inputPath: string, outputPath?: string): Pro
   }
 
   return { outputPath: resolvedOutput, changed, targetHash: hashBytes(compiled) };
+}
+
+/** Derives the default output path by replacing the `.ts` extension with `.js`. */
+function deriveOutputPath(inputPath: string): string {
+  const ext = path.extname(inputPath);
+  if (ext === '.ts' || ext === '.mts' || ext === '.cts') {
+    return inputPath.slice(0, -ext.length) + '.js';
+  }
+  return `${inputPath}.js`;
 }

--- a/packages/readyup/src/compile/loadEsbuild.ts
+++ b/packages/readyup/src/compile/loadEsbuild.ts
@@ -1,0 +1,9 @@
+/**
+ * Loads the esbuild module via dynamic import.
+ *
+ * Isolated behind a named function so tests can replace the esbuild boundary with an ordinary mock,
+ * rather than mocking the module and forcing the import to fail through module-cache resets.
+ */
+export async function loadEsbuild(): Promise<typeof import('esbuild')> {
+  return import('esbuild');
+}


### PR DESCRIPTION
## What

Fixes intermittent failures in the readyup test suite, where a set of test cases failed roughly one run in twelve regardless of the code under test. The suite now passes reliably, so a green branch no longer fails the gate on an unlucky run.

## Why

The flaky test eroded trust in the readyup gate: a branch with no real defect could fail `nmr ci` on an unlucky run, which can block merges even though production behavior was always correct.

## Details

### ♻️ Refactoring

- Extracted the esbuild dynamic import into a dedicated `loadEsbuild` seam so the import boundary can be replaced by an ordinary mock instead of by mocking the module itself.

### 🧪 Tests

- The two esbuild-import-failure cases now drive the failure through a plain function mock and assert the chained cause directly, replacing the `vi.doMock`/`vi.resetModules` choreography that raced with the assertion and caused the flake.

Closes #95
