### PR TITLE
#100 Enable public npm publishing for the scoped package

### DIFF
--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -42,5 +42,8 @@
   },
   "engines": {
     "node": ">=20.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## What

Releases of `@williamthorsen/overlay` now publish publicly to npm instead of as a restricted, private package.

## Why

`@williamthorsen/overlay` is a scoped package, and npm publishes scoped packages with restricted (private) access unless told otherwise. Without an explicit public-access declaration, the automated tag-triggered release would fail or ship the package privately. This change satisfies the manifest prerequisite for the package's one-time trusted-publishing bootstrap.

## Details

### ⚙️ Tooling

- Set public publish access for `@williamthorsen/overlay` in `packages/overlay/package.json`, so the OIDC tag-triggered publish workflow ships each tagged version publicly.

Closes #100
