### PR TITLE
#106 Use the skip emoji for skipped compilations and checks

### DIFF
--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -882,3 +882,9 @@ describe(tallyResult, () => {
     expect(counts.optional).toBe(1);
   });
 });
+
+describe('status icons', () => {
+  it('marks skipped-N/A outcomes with the skip-forward emoji, not the magnifying glass', () => {
+    expect(ICON_SKIPPED_NA).toBe('\u{23ED}\u{FE0F}');
+  });
+});

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -8,7 +8,7 @@ export const ICON_PASSED = '\u{1F7E2}';
 export const ICON_ERROR_FAILED = '\u{1F534}';
 export const ICON_WARN_FAILED = '\u{1F7E0}';
 export const ICON_RECOMMEND_FAILED = '\u{1F7E1}';
-export const ICON_SKIPPED_NA = '\u{1F50D}';
+export const ICON_SKIPPED_NA = '\u{23ED}\u{FE0F}';
 export const ICON_SKIPPED_PRECONDITION = '\u{1F6AB}';
 export const ICON_FIX = '\u{1F48A}';
 


### PR DESCRIPTION
## What

Changes the icon for a skipped kit compilation, and for a check skipped as optional, from a magnifying glass (🔍) to a skip-forward symbol (⏭️).

## Why

The magnifying-glass glyph reads as "searching" or "inspecting," not "skipped," so a skipped compilation or an optional check that was skipped was easy to misread in ReadyUp's output. A skip-forward symbol conveys the outcome directly.

## Details

### 🎉 Features

- Skipped kit compilations and checks skipped as optional now display the skip-forward emoji (⏭️) in place of the magnifying glass (🔍), across both the compile output and the run report.

Closes #106
