### PR TITLE
#109 Adopt nmr devBin to run rdy from source

### DIFF
--- a/.config/nmr.config.ts
+++ b/.config/nmr.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from '@williamthorsen/nmr';
 
 /** nmr configuration for this repo. */
 export default defineConfig({
+  devBin: {
+    // Run the readyup bin from TypeScript source so `build:post` needs no prior build.
+    rdy: 'tsx packages/readyup/src/bin/rdy.ts',
+  },
   rootScripts: {
     'build:post': 'rdy compile',
   },

--- a/packages/readyup/__tests__/resolveHookSpecifier.test.ts
+++ b/packages/readyup/__tests__/resolveHookSpecifier.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveHookSpecifier } from '../src/bin/resolveHookSpecifier.ts';
+
+describe(resolveHookSpecifier, () => {
+  it.each([
+    ['file:///repo/packages/readyup/src/bin/rdy.ts', '../readyupResolverHook.ts'],
+    ['file:///repo/packages/readyup/dist/esm/bin/rdy.js', '../readyupResolverHook.js'],
+    ['file:///repo/packages/readyup/dist/esm/bin/rdy.mjs', '../readyupResolverHook.js'],
+  ])('when the runner URL is %s, resolves %s', (runnerUrl, expected) => {
+    expect(resolveHookSpecifier(runnerUrl)).toBe(expected);
+  });
+});

--- a/packages/readyup/src/bin/rdy.ts
+++ b/packages/readyup/src/bin/rdy.ts
@@ -5,6 +5,7 @@ import module from 'node:module';
 import process from 'node:process';
 
 import { extractMessage } from '../utils/error-handling.ts';
+import { resolveHookSpecifier } from './resolveHookSpecifier.ts';
 import { routeCommand } from './route.ts';
 
 let exitCode: number;
@@ -12,15 +13,16 @@ try {
   // Register the readyup resolver hook before any kit is loaded. Externalized
   // `readyup`/`readyup/*` imports in compiled kits are routed through this hook to
   // the runner's own readyup installation, sidestepping filesystem walk-up from
-  // the kit's location. The hook source lives at `src/readyupResolverHook.ts` and
-  // is emitted to `dist/esm/readyupResolverHook.js`; from `dist/esm/bin/rdy.js`
-  // the runtime path is `'../readyupResolverHook.js'`. Esbuild does not rewrite
-  // string literals inside `module.register()` calls, so the `.js` extension is
-  // written directly in source. Wrapping this call in the runner's error
-  // boundary ensures any registration failure (missing hook file, bad path,
-  // Node rejection) surfaces as `rdy: unexpected error: ...` rather than an
-  // opaque unhandled exception.
-  module.register('../readyupResolverHook.js', {
+  // the kit's location. The hook sits one directory up from this file in both
+  // layouts — `src/readyupResolverHook.ts` under tsx, `dist/esm/readyupResolverHook.js`
+  // in the compiled build — so `resolveHookSpecifier` derives the extension from this
+  // runner's own URL rather than hardcoding one. (nmr-compile rewrites specifiers only
+  // in import/export/`import()` positions, never a `module.register()` argument, so the
+  // extension cannot be deferred to the build.) Wrapping this call in the runner's error
+  // boundary ensures any registration failure (missing hook file, bad path, Node
+  // rejection) surfaces as `rdy: unexpected error: ...` rather than an opaque unhandled
+  // exception.
+  module.register(resolveHookSpecifier(import.meta.url), {
     parentURL: import.meta.url,
     data: { readyupParentURL: import.meta.url },
   });

--- a/packages/readyup/src/bin/resolveHookSpecifier.ts
+++ b/packages/readyup/src/bin/resolveHookSpecifier.ts
@@ -1,0 +1,9 @@
+/**
+ * Resolves the readyup resolver-hook specifier for `module.register`, choosing the extension
+ * from the runner's own URL — `.ts` under tsx, `.js` in the compiled build — so registration
+ * works identically from `src` and from `dist/esm`.
+ */
+export function resolveHookSpecifier(runnerUrl: string): string {
+  const extension = runnerUrl.endsWith('.ts') ? '.ts' : '.js';
+  return `../readyupResolverHook${extension}`;
+}


### PR DESCRIPTION
## What

Developers can now run `rdy`, and the build that relies on it, from a clean checkout: No prior build of the readyup package is required. Previously both failed on a fresh checkout.

## Why

The root `build:post` step (`rdy compile`) only worked when a recursive build had already compiled readyup first — its committed `rdy` stub imports readyup's gitignored `dist`, so on a clean checkout it failed with "build output not found". This made the step fragile and dependent on an implicit build ordering.

## Details

### ♻️ Refactoring

- Resolver-hook registration is now layout-agnostic. A new pure `resolveHookSpecifier` helper selects the hook's extension from the runner's own module URL — `.ts` under tsx, `.js` from the compiled build — replacing the hardcoded `'../readyupResolverHook.js'` specifier in `rdy.ts`. `rdy` can now register its resolver hook whether launched from `src` or `dist/esm`. (The extension cannot be deferred to the build: `nmr-compile` rewrites specifiers only in import/export/`import()` positions, never a `module.register()` argument.)

### 🧪 Tests

- Added `resolveHookSpecifier.test.ts`, covering the `.ts → .ts`, `.js → .js`, and `.mjs → .js` selections.

### ⚙️ Tooling

- `.config/nmr.config.ts` maps `rdy` to `tsx packages/readyup/src/bin/rdy.ts` via nmr's `devBin`, so every nmr-resolved `rdy` command runs from source. `build:post` no longer depends on a prior readyup build.

Closes #109
