### PR TITLE
#111 Upgrade pnpm to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
     "vitest": "4.1.10",
     "zod": "4.4.3"
   },
-  "packageManager": "pnpm@10.34.5"
+  "packageManager": "pnpm@11.15.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,14 @@
 packages:
   - packages/*
 
-onlyBuiltDependencies:
-  - esbuild
-  - lefthook
+allowBuilds:
+  esbuild: true
+  lefthook: true
+
+savePrefix: ''
+
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@williamthorsen/*'
+  - readyup
+  - v11y-check


### PR DESCRIPTION
## What

Upgrades pnpm from 10 to 11. Newly published dependency versions are now held for 24 hours before Workshop will adopt them — a supply-chain safeguard against compromised releases — while the project's own packages are exempt, so publishing a first-party package and consuming it in the same repo is not delayed.

## Why

Workshop was the last active repo in the template fleet still on pnpm 10. Standardizing on pnpm 11 aligns the repo with the rest of the fleet and adds pnpm 11's supply-chain protections against compromised dependency releases.

## Details

### 📦 Dependencies

- Pins the package manager to `pnpm@11.15.0` (from `pnpm@10.34.5`).
- Consolidates all pnpm configuration into `pnpm-workspace.yaml`: the build-script allowlist, exact-version saving, and a 24-hour minimum-release-age soak with `@williamthorsen/*`, `readyup`, and `v11y-check` carved out.
- Removes `.npmrc`; its `save-exact` setting now lives in `pnpm-workspace.yaml`.
- Leaves `pnpm-lock.yaml` untouched — no dependency versions change.

Closes #111
