### PR TITLE
#113 Write an empty manifest for a missing source directory

### DIFF
--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -253,7 +253,7 @@ describe(compileCommand, () => {
     expect(mockCompileConfig).toHaveBeenCalledTimes(2);
   });
 
-  it('returns 1 when srcDir does not exist', async () => {
+  it('writes empty manifest and emits info message when srcDir does not exist', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
     });
@@ -261,8 +261,23 @@ describe(compileCommand, () => {
 
     const exitCode = await compileCommand([]);
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Source directory not found'));
+    expect(exitCode).toBe(0);
+    expect(mockReaddirSync).not.toHaveBeenCalled();
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('treating as empty'));
+  });
+
+  it('returns 0 and skips manifest when --skip-manifest is set and srcDir does not exist', async () => {
+    mockLoadConfig.mockResolvedValue({
+      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+    });
+    mockExistsSync.mockReturnValue(false);
+
+    const exitCode = await compileCommand(['--skip-manifest']);
+
+    expect(exitCode).toBe(0);
+    expect(mockWriteManifest).not.toHaveBeenCalled();
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('treating as empty'));
   });
 
   it('writes empty manifest and emits info message when srcDir has no .ts files', async () => {

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -180,23 +180,27 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
   const srcDir = path.resolve(process.cwd(), config.compile.srcDir);
   const outDir = path.resolve(process.cwd(), config.compile.outDir);
 
-  if (!existsSync(srcDir)) {
-    process.stderr.write(`Error: Source directory not found: ${srcDir}\n`);
-    return 1;
-  }
+  // A missing source directory is treated as an empty one: fall through to the empty-kit-list
+  // manifest write below rather than erroring.
+  const srcDirExists = existsSync(srcDir);
 
-  let tsFiles: string[];
-  try {
-    tsFiles = collectSourceFiles(srcDir, config.compile.include);
-  } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: Failed to read source directory: ${message}\n`);
-    return 1;
+  let tsFiles: string[] = [];
+  if (srcDirExists) {
+    try {
+      tsFiles = collectSourceFiles(srcDir, config.compile.include);
+    } catch (error: unknown) {
+      const message = extractMessage(error);
+      process.stderr.write(`Error: Failed to read source directory: ${message}\n`);
+      return 1;
+    }
   }
 
   if (tsFiles.length === 0) {
     const relSrc = path.relative(process.cwd(), srcDir);
-    process.stdout.write(`No .ts files found in ${relSrc}\n`);
+    const reason = srcDirExists
+      ? `No .ts files found in ${relSrc}`
+      : `Source directory not found: ${relSrc} — treating as empty`;
+    process.stdout.write(`${reason}\n`);
     if (!skipManifest) {
       try {
         writeManifest(manifestPath, { version: 1, kits: [] });


### PR DESCRIPTION
## What

Fixes an issue where `rdy compile` failed when its kit source directory had been removed, such as after deleting all of a project's kits. It now regenerates the manifest with an empty kit list instead of leaving behind one that still lists the removed kits, and recreating the directory as a workaround is no longer required.

## Why

When a project removes its last readyup kit, the configured source directory disappears, and `rdy compile` could no longer regenerate the manifest — it errored with `Source directory not found` and left a stale manifest that still listed the removed kits. Callers legitimately ending up with zero kits had to work around this by recreating an empty source directory before compiling.

## Details

### 🐛 Bug fixes

- `compileBatch` now treats a missing source directory the same as a present-but-empty one: it writes a manifest with an empty `kits` array and exits 0, rather than erroring. The `existsSync` check is retained to gate the directory read (which would otherwise throw `ENOENT`) and reroute the missing-directory case into the existing zero-kits branch — so the manifest write, the `--skip-manifest` short-circuit, present-kit compilation, and the drift-refusal gate are all unchanged. Only the info-line text branches: present-but-empty keeps `No .ts files found in …`, while a missing directory reads `Source directory not found: … — treating as empty`.

### 🧪 Tests

- The removed-error test is rewritten to assert the empty-manifest outcome (exit 0, empty-kit manifest write, and that the directory read is skipped), and a `--skip-manifest` missing-directory case is added, mirroring the existing present-but-empty test pair.

Closes #113
