### PR TITLE
#118 Correct n/a semantics, thrown severity, and counts

### DIFF
--- a/packages/readyup/__tests__/countAgreement.test.ts
+++ b/packages/readyup/__tests__/countAgreement.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCombinedSummary } from '../src/formatCombinedSummary.ts';
+import { formatJsonReport } from '../src/formatJsonReport.ts';
+import { countResults, formatSummaryCounts, formatSummaryCountsPlain, reportRdy } from '../src/reportRdy.ts';
+import { runRdy } from '../src/runRdy.ts';
+import type { RdyChecklist, SummaryCounts } from '../src/types.ts';
+
+/**
+ * A checklist exercising every count-divergence hazard at once: a nested n/a parent, an
+ * n/a precondition, a failed gate with dependents, and a failure below the reporting threshold.
+ */
+const checklist: RdyChecklist = {
+  name: 'deploy',
+  preconditions: [{ name: 'pre-na', check: () => true, skip: () => 'not applicable' }],
+  checks: [
+    {
+      name: 'na-parent',
+      check: () => true,
+      skip: () => 'not applicable',
+      checks: [
+        {
+          name: 'na-child',
+          check: () => true,
+          checks: [{ name: 'na-grandchild', check: () => true }],
+        },
+      ],
+    },
+    {
+      name: 'gate-fails',
+      check: () => false,
+      checks: [{ name: 'blocked-child', check: () => true }],
+    },
+    { name: 'warn-fail', check: () => false, severity: 'warn' },
+    { name: 'passes', check: () => true },
+  ],
+};
+
+const expectedCounts: SummaryCounts = {
+  passed: 1,
+  errors: 1,
+  warnings: 1,
+  recommendations: 0,
+  blocked: 1,
+  optional: 2,
+  worstSeverity: 'error',
+};
+
+describe('count agreement across views', () => {
+  it('tallies the same counts for every view when the reporting threshold prunes results', async () => {
+    const report = await runRdy(checklist);
+    const counts = countResults(report.results);
+
+    expect(counts).toStrictEqual(expectedCounts);
+
+    // Human tail line.
+    const human = reportRdy(report, { reportOn: 'error' });
+    expect(human).toContain(formatSummaryCounts(expectedCounts));
+
+    // Combined-summary table row.
+    const table = formatCombinedSummary([{ name: 'deploy', ...counts, durationMs: report.durationMs }]);
+    expect(table).toContain(formatSummaryCountsPlain(expectedCounts));
+
+    // JSON payload.
+    const parsed: unknown = JSON.parse(
+      formatJsonReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }], { reportOn: 'error' }),
+    );
+    expect(parsed).toMatchObject(expectedCounts);
+  });
+
+  it('prunes below-threshold results from the detail tree without altering the counts', async () => {
+    const report = await runRdy(checklist);
+
+    const human = reportRdy(report, { reportOn: 'error' });
+    const json = formatJsonReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }], { reportOn: 'error' });
+
+    expect(human).not.toContain('warn-fail');
+    expect(json).not.toContain('warn-fail');
+    expect(human).toContain('gate-fails');
+    expect(json).toContain('gate-fails');
+  });
+
+  it('emits no descendants of an n/a result in any view', async () => {
+    const report = await runRdy(checklist);
+
+    const human = reportRdy(report);
+    const json = formatJsonReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }]);
+
+    for (const name of ['na-child', 'na-grandchild']) {
+      expect(human).not.toContain(name);
+      expect(json).not.toContain(name);
+    }
+    expect(human).toContain('na-parent');
+    expect(json).toContain('na-parent');
+  });
+});

--- a/packages/readyup/__tests__/formatJsonReport.test.ts
+++ b/packages/readyup/__tests__/formatJsonReport.test.ts
@@ -613,7 +613,7 @@ describe(formatJsonReport, () => {
       });
     });
 
-    it('counts only visible results in granular buckets', () => {
+    it('counts every result in granular buckets, including results pruned from the tree', () => {
       const report = makeReport({
         results: [
           makePassedResult({ name: 'a', severity: 'error' }),
@@ -629,11 +629,31 @@ describe(formatJsonReport, () => {
         passed: 1,
         errors: 0,
         warnings: 0,
-        recommendations: 0,
+        recommendations: 1,
         blocked: 0,
         optional: 0,
-        worstSeverity: null,
+        worstSeverity: 'recommend',
       });
+    });
+
+    it('reports a below-threshold failure in the counts while omitting it from the detail tree', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'error-pass', severity: 'error' }),
+          makeFailedResult({ name: 'warn-fail', severity: 'warn' }),
+        ],
+        passed: false,
+        durationMs: 15,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report), { reportOn: 'error' }));
+
+      expect(parsed).toMatchObject({
+        warnings: 1,
+        worstSeverity: 'warn',
+        kits: [{ warnings: 1, checklists: [{ warnings: 1, checks: [{ name: 'error-pass' }] }] }],
+      });
+      expect(JSON.stringify(parsed)).not.toContain('warn-fail');
     });
   });
 });

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -386,11 +386,10 @@ describe(reportRdy, () => {
       expect(lines[0]).toBe(`${ICON_PASSED} top-check (7ms)`);
     });
 
-    it('shows n/a parent but suppresses descendants', () => {
+    it('renders an n/a result and the results that follow it', () => {
       const report = makeReport({
         results: [
           makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
-          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 1 }),
           makePassedResult({ name: 'next-sibling', depth: 0, durationMs: 10 }),
         ],
       });
@@ -398,7 +397,6 @@ describe(reportRdy, () => {
       const output = reportRdy(report);
 
       expect(output).toContain('na-parent');
-      expect(output).not.toContain('na-child');
       expect(output).toContain('next-sibling');
     });
 
@@ -466,11 +464,10 @@ describe(reportRdy, () => {
       expect(output).toContain(`${ICON_PASSED} 2 passed. Failed: ${ICON_ERROR_FAILED} 1 error`);
     });
 
-    it('counts n/a parent as optional skip and excludes suppressed descendants from summary', () => {
+    it('counts an n/a result as an optional skip', () => {
       const report = makeReport({
         results: [
           makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
-          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 1 }),
           makePassedResult({ name: 'sibling', depth: 0, durationMs: 10 }),
         ],
         durationMs: 50,
@@ -478,18 +475,17 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      // na-parent counts as optional skip; na-child is suppressed; sibling counts as passed.
       expect(output).toContain(`${ICON_PASSED} 1 passed`);
       expect(output).toContain(`${ICON_SKIPPED_NA} 1 optional`);
-      expect(output).toContain('na-parent');
-      expect(output).not.toContain('na-child');
     });
 
-    it('resumes output after n/a subtree at same depth', () => {
+    it('renders every result it is given, applying no suppression of its own', () => {
+      // `runRdy` no longer emits descendants of an n/a result, so the renderer must not
+      // second-guess its input: whatever arrives is displayed and counted.
       const report = makeReport({
         results: [
           makeSkippedResult({ name: 'na-check', skipReason: 'n/a', depth: 1 }),
-          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 2 }),
+          makeSkippedResult({ name: 'deeper', skipReason: 'precondition', depth: 2 }),
           makePassedResult({ name: 'sibling', depth: 1, durationMs: 5 }),
         ],
       });
@@ -497,8 +493,9 @@ describe(reportRdy, () => {
       const output = reportRdy(report);
 
       expect(output).toContain('na-check');
-      expect(output).not.toContain('na-child');
+      expect(output).toContain('deeper');
       expect(output).toContain('sibling');
+      expect(output).toContain(`${ICON_SKIPPED_PRECONDITION} 1 blocked`);
     });
   });
 

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -515,7 +515,7 @@ describe(reportRdy, () => {
       expect(output).not.toContain('recommend-check');
     });
 
-    it('counts only visible results in the summary', () => {
+    it('counts every result in the summary, including results pruned from the tree', () => {
       const report = makeReport({
         results: [
           makePassedResult({ name: 'error-pass', severity: 'error' }),
@@ -525,8 +525,23 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report, { reportOn: 'error' });
 
-      expect(output).toContain(`${ICON_PASSED} 1 passed`);
-      expect(output).not.toContain('2 passed');
+      expect(output).toContain(`${ICON_PASSED} 2 passed`);
+      expect(output).not.toContain('recommend-pass');
+    });
+
+    it('reports a below-threshold failure in the counts and worst severity', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'error-pass', severity: 'error' }),
+          makeFailedResult({ name: 'warn-fail', severity: 'warn' }),
+        ],
+        passed: false,
+      });
+
+      const output = reportRdy(report, { reportOn: 'error' });
+
+      expect(output).toContain(`${ICON_WARN_FAILED} 1 warning`);
+      expect(output).not.toContain('warn-fail');
     });
 
     it('hides precondition result when its severity is below the reporting threshold', () => {

--- a/packages/readyup/__tests__/runRdy.test.ts
+++ b/packages/readyup/__tests__/runRdy.test.ts
@@ -187,6 +187,167 @@ describe(runRdy, () => {
       expect(report.results[0]?.status).toBe('passed');
       expect(report.results[1]?.status).toBe('passed');
     });
+
+    it('runs checks when a precondition is skipped n/a', async () => {
+      const checklist: RdyChecklist = {
+        name: 'gated',
+        preconditions: [{ name: 'pre-na', check: () => true, skip: () => 'not applicable here' }],
+        checks: [{ name: 'runs-anyway', check: () => true }],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.passed).toBe(true);
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.status).toBe('skipped');
+      expect(report.results[1]?.name).toBe('runs-anyway');
+      expect(report.results[1]?.status).toBe('passed');
+    });
+
+    it('runs the checklist when one precondition is n/a and the rest pass', async () => {
+      const checklist: RdyChecklist = {
+        name: 'gated',
+        preconditions: [
+          { name: 'pre-na', check: () => true, skip: () => 'not applicable here' },
+          { name: 'pre-pass', check: () => true },
+        ],
+        checks: [{ name: 'runs-anyway', check: () => false }],
+      };
+
+      const report = await runRdy(checklist);
+
+      const target = report.results.find((r) => r.name === 'runs-anyway');
+      expect(target?.status).toBe('failed');
+    });
+
+    it('still skips the checklist when one precondition is n/a and another fails', async () => {
+      const checklist: RdyChecklist = {
+        name: 'gated',
+        preconditions: [
+          { name: 'pre-na', check: () => true, skip: () => 'not applicable here' },
+          { name: 'pre-fail', check: () => false },
+        ],
+        checks: [{ name: 'should-skip', check: () => true }],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.passed).toBe(false);
+      const target = report.results.find((r) => r.name === 'should-skip');
+      assert.ok(target?.status === 'skipped');
+      expect(target.skipReason).toBe('precondition');
+    });
+  });
+
+  describe('thrown checks', () => {
+    it('reports a thrown check at error severity regardless of its declared severity', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'recommend-throws',
+            severity: 'recommend',
+            check: () => {
+              throw new Error('boom');
+            },
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.severity).toBe('error');
+      expect(report.results[0]?.error?.message).toBe('boom');
+    });
+
+    it('reports a thrown skip function at error severity regardless of declared severity', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'recommend-skip-throws',
+            severity: 'recommend',
+            check: () => true,
+            skip: () => {
+              throw new Error('skip boom');
+            },
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.severity).toBe('error');
+      expect(report.results[0]?.error?.message).toBe('skip boom');
+    });
+
+    it('fails the run when a recommend-severity check throws under the default failOn', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'recommend-throws',
+            severity: 'recommend',
+            check: () => {
+              throw new Error('boom');
+            },
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.passed).toBe(false);
+    });
+
+    it('leaves sibling results intact when one check throws', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'throws',
+            check: () => {
+              throw new Error('boom');
+            },
+          },
+          { name: 'sibling-passes', check: () => true },
+          { name: 'sibling-fails', check: () => false },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results.map((r) => ({ name: r.name, status: r.status }))).toStrictEqual([
+        { name: 'throws', status: 'failed' },
+        { name: 'sibling-passes', status: 'passed' },
+        { name: 'sibling-fails', status: 'failed' },
+      ]);
+    });
+
+    it('escalates only the thrown check, leaving descendant severities untouched', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'parent-throws',
+            severity: 'recommend',
+            check: () => {
+              throw new Error('boom');
+            },
+            checks: [{ name: 'child', check: () => true, severity: 'warn' }],
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.severity).toBe('error');
+      expect(report.results[1]?.name).toBe('child');
+      expect(report.results[1]?.status).toBe('skipped');
+      expect(report.results[1]?.severity).toBe('warn');
+    });
   });
 
   describe('staged checklists', () => {
@@ -665,7 +826,7 @@ describe(runRdy, () => {
       expect(child.depth).toBe(1);
     });
 
-    it('skips children of an n/a-skipped check with n/a reason', async () => {
+    it('emits no results for descendants of an n/a-skipped check', async () => {
       const checklist: RdyChecklist = {
         name: 'nested',
         checks: [
@@ -680,12 +841,96 @@ describe(runRdy, () => {
 
       const report = await runRdy(checklist);
 
-      expect(report.results).toHaveLength(2);
-      expect(report.results[0]?.status).toBe('skipped');
-      expect(report.results[1]?.name).toBe('child');
-      const child = report.results[1];
-      assert.ok(child?.status === 'skipped');
-      expect(child.skipReason).toBe('n/a');
+      expect(report.results).toHaveLength(1);
+      const parent = report.results[0];
+      assert.ok(parent?.status === 'skipped');
+      expect(parent.skipReason).toBe('n/a');
+    });
+
+    it('emits exactly one result for an n/a-skipped check with a multi-level subtree', async () => {
+      const checklist: RdyChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'na-parent',
+            check: () => true,
+            skip: () => 'not applicable',
+            checks: [
+              {
+                name: 'child-a',
+                check: () => true,
+                checks: [{ name: 'grandchild-a', check: () => true }],
+              },
+              {
+                name: 'child-b',
+                check: () => true,
+                checks: [{ name: 'grandchild-b', check: () => true }],
+              },
+            ],
+          },
+          { name: 'next-sibling', check: () => true },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results.map((r) => r.name)).toStrictEqual(['na-parent', 'next-sibling']);
+    });
+
+    it('does not run descendants of an n/a-skipped check', async () => {
+      let childCalled = false;
+      const checklist: RdyChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'na-parent',
+            check: () => true,
+            skip: () => 'not applicable',
+            checks: [
+              {
+                name: 'child',
+                check: () => {
+                  childCalled = true;
+                  return true;
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      await runRdy(checklist);
+
+      expect(childCalled).toBe(false);
+    });
+
+    it('emits one result per descendant of a precondition-skipped check', async () => {
+      const checklist: RdyChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'failing-parent',
+            check: () => false,
+            checks: [
+              {
+                name: 'child-a',
+                check: () => true,
+                checks: [{ name: 'grandchild-a', check: () => true }],
+              },
+              { name: 'child-b', check: () => true },
+            ],
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results.map((r) => ({ name: r.name, depth: r.depth }))).toStrictEqual([
+        { name: 'failing-parent', depth: 0 },
+        { name: 'child-a', depth: 1 },
+        { name: 'grandchild-a', depth: 2 },
+        { name: 'child-b', depth: 1 },
+      ]);
     });
 
     it('produces depth-first ordering for multi-level nesting', async () => {

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -10,11 +10,11 @@ import { formatJsonReport } from './formatJsonReport.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { type FromSource, parseFromValue } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
-import { reportRdy, tallyResult } from './reportRdy.ts';
+import { countResults, reportRdy } from './reportRdy.ts';
 import { resolveBitbucketToken } from './resolveBitbucketToken.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
 import { resolveRequestedNames } from './resolveRequestedNames.ts';
-import { meetsThreshold, runRdy } from './runRdy.ts';
+import { runRdy } from './runRdy.ts';
 import type {
   ChecklistSummary,
   FixLocation,
@@ -23,7 +23,6 @@ import type {
   RdyReport,
   RdyStagedChecklist,
   Severity,
-  SummaryCounts,
 } from './types.ts';
 import { extractMessage } from './utils/error-handling.ts';
 import { translateParseArgsError } from './utils/parse-args-error.ts';
@@ -306,22 +305,9 @@ function resolveFixLocation(checklist: RdyChecklist | RdyStagedChecklist, kitDef
   return checklist.fixLocation ?? kitDefault ?? 'end';
 }
 
-/** Build a checklist summary from a report, filtering results by reporting threshold. */
-function summarizeReport(name: string, report: RdyReport, reportOn: Severity): ChecklistSummary {
-  const counts: SummaryCounts = {
-    passed: 0,
-    errors: 0,
-    warnings: 0,
-    recommendations: 0,
-    blocked: 0,
-    optional: 0,
-    worstSeverity: null,
-  };
-  for (const r of report.results) {
-    if (!meetsThreshold(r.severity, reportOn)) continue;
-    tallyResult(counts, r);
-  }
-  return { name, ...counts, durationMs: report.durationMs };
+/** Build a checklist summary from a report. */
+function summarizeReport(name: string, report: RdyReport): ChecklistSummary {
+  return { name, ...countResults(report.results), durationMs: report.durationMs };
 }
 
 /** Resolve threshold values from the cascade: CLI flag > kit field > default. */
@@ -565,7 +551,7 @@ async function runSingleKitHumanMode(
       }
 
       if (showChecklistHeader) {
-        summaries.push(summarizeReport(checklist.name, report, thresholds.reportOn));
+        summaries.push(summarizeReport(checklist.name, report));
       }
     }
   } catch (error: unknown) {

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -1,4 +1,4 @@
-import { tallyResult } from './reportRdy.ts';
+import { countResults, emptyCounts } from './reportRdy.ts';
 import { meetsThreshold } from './runRdy.ts';
 import type {
   JsonCheckEntry,
@@ -27,19 +27,6 @@ export interface FormatJsonReportOptions {
   reportOn?: Severity;
 }
 
-/** Create a zeroed `SummaryCounts` object. */
-function emptyCounts(): SummaryCounts {
-  return {
-    passed: 0,
-    errors: 0,
-    warnings: 0,
-    recommendations: 0,
-    blocked: 0,
-    optional: 0,
-    worstSeverity: null,
-  };
-}
-
 /** Aggregate `source` counts into `target` in place. */
 function mergeCounts(target: SummaryCounts, source: SummaryCounts): void {
   target.passed += source.passed;
@@ -51,15 +38,14 @@ function mergeCounts(target: SummaryCounts, source: SummaryCounts): void {
   target.worstSeverity = worseSeverity(target.worstSeverity, source.worstSeverity);
 }
 
-/** Build a single checklist entry from a name and report. */
+/**
+ * Build a single checklist entry from a name and report.
+ *
+ * Counts cover the whole run; the reporting threshold prunes only the serialized detail tree.
+ */
 function buildChecklistEntry(name: string, report: RdyReport, reportOn: Severity): JsonChecklistEntry {
-  const counts = emptyCounts();
+  const counts = countResults(report.results);
   const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
-
-  for (const result of visibleResults) {
-    tallyResult(counts, result);
-  }
-
   const { entries: checks } = buildCheckEntries(visibleResults, 0, 0);
 
   return {

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -126,22 +126,7 @@ function collectInlineDetails(result: RdyResult, includeFix: boolean): string[] 
   return details;
 }
 
-/** Iterate visible results, skipping N/A descendants (depth > N/A parent). */
-function* iterateWithNaSuppression(results: RdyResult[]): Generator<RdyResult> {
-  let suppressBelowDepth: number | null = null;
-  for (const result of results) {
-    if (suppressBelowDepth !== null) {
-      if (result.depth > suppressBelowDepth) continue;
-      suppressBelowDepth = null;
-    }
-    if (result.status === 'skipped' && result.skipReason === 'n/a') {
-      suppressBelowDepth = result.depth;
-    }
-    yield result;
-  }
-}
-
-/** Count results by severity and skip reason after N/A descendant suppression. */
+/** Count results by severity and skip reason. */
 function countResults(results: RdyResult[]): SummaryCounts {
   const counts: SummaryCounts = {
     passed: 0,
@@ -152,7 +137,7 @@ function countResults(results: RdyResult[]): SummaryCounts {
     optional: 0,
     worstSeverity: null,
   };
-  for (const r of iterateWithNaSuppression(results)) {
+  for (const r of results) {
     tallyResult(counts, r);
   }
   return counts;
@@ -196,7 +181,7 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
 
   const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
 
-  for (const result of iterateWithNaSuppression(visibleResults)) {
+  for (const result of visibleResults) {
     const indent = ' '.repeat(3).repeat(result.depth);
     const icon = getIcon(result);
     let checkLine = `${indent}${icon} ${result.name} (${formatDuration(result.durationMs)})`;

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -126,9 +126,9 @@ function collectInlineDetails(result: RdyResult, includeFix: boolean): string[] 
   return details;
 }
 
-/** Count results by severity and skip reason. */
-function countResults(results: RdyResult[]): SummaryCounts {
-  const counts: SummaryCounts = {
+/** Create a zeroed `SummaryCounts` object. */
+export function emptyCounts(): SummaryCounts {
+  return {
     passed: 0,
     errors: 0,
     warnings: 0,
@@ -137,6 +137,17 @@ function countResults(results: RdyResult[]): SummaryCounts {
     optional: 0,
     worstSeverity: null,
   };
+}
+
+/**
+ * Count results by severity and skip reason.
+ *
+ * This is the only entry point for tallying a result list, and it expects the run's
+ * complete results. The reporting threshold selects what is *displayed*; passing a
+ * pre-filtered list here is what once made the human, table, and JSON counts disagree.
+ */
+export function countResults(results: RdyResult[]): SummaryCounts {
+  const counts = emptyCounts();
   for (const r of results) {
     tallyResult(counts, r);
   }
@@ -171,7 +182,8 @@ export function tallyResult(counts: SummaryCounts, result: RdyResult): void {
  *
  * In `end` mode (default), errors appear inline but fix messages are collected in a "Fixes" section at the bottom.
  * In `inline` mode, error and fix messages appear directly below each failed check.
- * Results below the reporting threshold are omitted from output.
+ * Results below the reporting threshold are omitted from the detail tree; the summary
+ * counts always reflect the whole run.
  */
 export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string {
   const fixLocation = options?.fixLocation ?? 'end';
@@ -204,7 +216,7 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
     }
   }
 
-  const counts = countResults(visibleResults);
+  const counts = countResults(report.results);
   lines.push('', `${formatSummaryCounts(counts)} (${formatDuration(report.durationMs)})`);
 
   if (fixLocation === 'end' && collectedFixes.length > 0) {

--- a/packages/readyup/src/runRdy.ts
+++ b/packages/readyup/src/runRdy.ts
@@ -30,6 +30,14 @@ const SEVERITY_RANK: Record<Severity, number> = {
   recommend: 2,
 };
 
+/**
+ * Severity assigned to a check whose `check` or `skip` function throws.
+ *
+ * An exception is a defect in the check itself, not a soft finding, so it overrides
+ * whatever severity the check declares.
+ */
+const THROWN_SEVERITY: Severity = 'error';
+
 /** Return true if `severity` is at or above (more severe than or equal to) `threshold`. */
 export function meetsThreshold(severity: Severity, threshold: Severity): boolean {
   return SEVERITY_RANK[severity] <= SEVERITY_RANK[threshold];
@@ -107,15 +115,14 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
     try {
       const skipResult = await check.skip();
       if (typeof skipResult === 'string') {
-        const result = buildSkippedResult(check.name, severity, 'n/a', skipResult, fix, depth);
-        const childResults = skipAllDescendants(children, defaultSeverity, 'n/a', depth + 1);
-        return [result, ...childResults];
+        // An `n/a` skip terminates its subtree: descendants produce no results at all.
+        return [buildSkippedResult(check.name, severity, 'n/a', skipResult, fix, depth)];
       }
     } catch (error_: unknown) {
       const durationMs = performance.now() - start;
       const error = error_ instanceof Error ? error_ : new Error(String(error_));
-      const result = buildFailedResult(check.name, severity, durationMs, null, fix, error, null, depth);
-      const childResults = skipAllDescendants(children, defaultSeverity, 'precondition', depth + 1);
+      const result = buildFailedResult(check.name, THROWN_SEVERITY, durationMs, null, fix, error, null, depth);
+      const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
       return [result, ...childResults];
     }
   }
@@ -124,7 +131,7 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
   try {
     const raw = await check.check();
     const durationMs = performance.now() - start;
-    let result: RdyResult;
+    let result: PassedResult | FailedResult;
     if (typeof raw === 'boolean') {
       result = raw
         ? buildPassedResult(check.name, severity, durationMs, null, fix, null, depth)
@@ -142,8 +149,8 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
   } catch (error_: unknown) {
     const durationMs = performance.now() - start;
     const error = error_ instanceof Error ? error_ : new Error(String(error_));
-    const result = buildFailedResult(check.name, severity, durationMs, null, fix, error, null, depth);
-    const childResults = skipAllDescendants(children, defaultSeverity, 'precondition', depth + 1);
+    const result = buildFailedResult(check.name, THROWN_SEVERITY, durationMs, null, fix, error, null, depth);
+    const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
     return [result, ...childResults];
   }
 }
@@ -152,10 +159,10 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
  * Collect results from child checks based on the parent's outcome.
  *
  * Passed parents: execute children concurrently, then iterate in declaration order
- * to produce depth-first results. Failed/skipped parents: skip all descendants.
+ * to produce depth-first results. Failed parents: skip all descendants.
  */
 async function collectChildResults(
-  parentResult: RdyResult,
+  parentResult: PassedResult | FailedResult,
   children: RdyCheck[],
   defaultSeverity: Severity,
   childDepth: number,
@@ -163,12 +170,7 @@ async function collectChildResults(
   if (children.length === 0) return [];
 
   if (parentResult.status === 'failed') {
-    return skipAllDescendants(children, defaultSeverity, 'precondition', childDepth);
-  }
-
-  if (parentResult.status === 'skipped') {
-    const reason = parentResult.skipReason === 'n/a' ? 'n/a' : 'precondition';
-    return skipAllDescendants(children, defaultSeverity, reason, childDepth);
+    return skipAllDescendants(children, defaultSeverity, childDepth);
   }
 
   return runSiblingChecks(children, defaultSeverity, childDepth);
@@ -186,32 +188,27 @@ async function runSiblingChecks(checks: RdyCheck[], defaultSeverity: Severity, d
   return siblingTrees.flat();
 }
 
-/** Recursively skip a check and all its descendants. */
-function skipAllDescendants(
-  checks: RdyCheck[],
-  defaultSeverity: Severity,
-  skipReason: 'n/a' | 'precondition',
-  depth: number,
-): RdyResult[] {
+/**
+ * Recursively skip a check and all its descendants.
+ *
+ * Every skip produced here is a `precondition` skip: an `n/a` skip terminates its own
+ * subtree in `executeCheck` and so never reaches this function.
+ */
+function skipAllDescendants(checks: RdyCheck[], defaultSeverity: Severity, depth: number): RdyResult[] {
   const results: RdyResult[] = [];
   for (const check of checks) {
-    results.push(skipCheck(check, defaultSeverity, skipReason, depth));
+    results.push(skipCheck(check, defaultSeverity, depth));
     if (check.checks !== undefined && check.checks.length > 0) {
-      results.push(...skipAllDescendants(check.checks, defaultSeverity, skipReason, depth + 1));
+      results.push(...skipAllDescendants(check.checks, defaultSeverity, depth + 1));
     }
   }
   return results;
 }
 
-/** Mark a check as skipped due to a failed precondition or N/A parent. */
-function skipCheck(
-  check: RdyCheck,
-  defaultSeverity: Severity,
-  skipReason: 'n/a' | 'precondition' = 'precondition',
-  depth = 0,
-): RdyResult {
+/** Mark a check as skipped because a precondition or ancestor check failed. */
+function skipCheck(check: RdyCheck, defaultSeverity: Severity, depth: number): RdyResult {
   const severity = resolveSeverity(check, defaultSeverity);
-  return buildSkippedResult(check.name, severity, skipReason, null, check.fix ?? null, depth);
+  return buildSkippedResult(check.name, severity, 'precondition', null, check.fix ?? null, depth);
 }
 
 /** Run preconditions concurrently. Return true if all passed. */
@@ -226,8 +223,9 @@ async function runPreconditions(
   const flat = trees.flat();
   results.push(...flat);
 
-  // Only top-level precondition results (depth 0) determine pass/fail.
-  return flat.filter((r) => r.depth === 0).every((r) => r.status === 'passed');
+  // Only top-level precondition results (depth 0) determine pass/fail. A precondition
+  // skipped `n/a` does not gate: "the gate does not apply" is not "the gate failed".
+  return flat.filter((r) => r.depth === 0).every((r) => r.status !== 'failed');
 }
 
 /** Run a flat checklist: all checks concurrently. */
@@ -238,7 +236,7 @@ async function runFlatChecks(
   defaultSeverity: Severity,
 ): Promise<void> {
   if (!preconditionsPassed) {
-    results.push(...skipAllDescendants(checklist.checks, defaultSeverity, 'precondition', 0));
+    results.push(...skipAllDescendants(checklist.checks, defaultSeverity, 0));
     return;
   }
 
@@ -256,7 +254,7 @@ async function runStagedChecks(
 ): Promise<void> {
   if (!preconditionsPassed) {
     for (const group of checklist.groups) {
-      results.push(...skipAllDescendants(group, defaultSeverity, 'precondition', 0));
+      results.push(...skipAllDescendants(group, defaultSeverity, 0));
     }
     return;
   }
@@ -264,7 +262,7 @@ async function runStagedChecks(
   let shouldSkipRemaining = false;
   for (const group of checklist.groups) {
     if (shouldSkipRemaining) {
-      results.push(...skipAllDescendants(group, defaultSeverity, 'precondition', 0));
+      results.push(...skipAllDescendants(group, defaultSeverity, 0));
       continue;
     }
 
@@ -285,7 +283,8 @@ async function runStagedChecks(
 /**
  * Run all checks in a checklist and produce a report.
  *
- * Preconditions run first. If any fails, all subsequent checks are skipped.
+ * Preconditions run first. If any fails, all subsequent checks are skipped; a precondition
+ * skipped `n/a` does not gate the checklist.
  * Flat checklists run all checks concurrently. Staged checklists run groups
  * sequentially, bailing on later groups when an earlier group has a failure
  * at or above the failure threshold.


### PR DESCRIPTION
## What

When a checklist's gating check reports that it does not apply, the checklist's own checks now run rather than being skipped along with it; a case that previously produced a passing run with nothing verified. A check that crashes now fails the run as an error, no matter what severity it was assigned. Summary counts now cover results that `--report-on` hides, so a run failing on a warning-level check no longer reports zero warnings. And a check skipped as not applicable no longer adds skipped entries for the checks beneath it.

## Why

A verification tool that reports a passing run while its checks never executed is worse than no tool: the failure mode is silent, and it is indistinguishable from success. All three corrections here close a path where `rdy` reported an outcome that did not describe what happened: A gated checklist reporting passed with nothing run, a crashed check filed as a soft recommendation, and a failing run reporting zero failures because the reporting threshold had pruned the tally.

## Details

### 🎉 Features

- 🚨 **Breaking:** A precondition that skips as not applicable no longer blocks its checklist

  "The gate does not apply" and "the gate failed" were treated identically, so a checklist behind an inapplicable precondition had every check skipped while the run still reported passed. An `n/a` precondition now leaves its checklist to run normally. Gating by a precondition that genuinely fails is unchanged.

- 🚨 **Breaking:** A check skipped as not applicable no longer emits results for its descendants

  An `n/a` skip now terminates its subtree at the skip point. Previously the descendants were materialized as skipped results, then suppressed at render time but still counted, which is what allowed two views to report different totals for the same checklist.

- A check that throws is reported at `error` severity

  An exception is a defect in the check rather than a soft finding, so it now overrides the severity the check declares. A crashing `recommend`-severity check previously landed as a recommendation and could not fail a run.

### 🐛 Bug fixes

- Counts stay truthful when `--report-on` prunes the detail tree

  Counts were tallied from the already-filtered result list, so raising the reporting threshold silently zeroed the tally: a run failing on a warn-severity check could emit `errors: 0, warnings: 0` while still exiting non-zero. All views -- the human tail line, the multi-checklist summary table, and the `--json` payload -- now tally from the complete result set through one shared counting function, and the threshold prunes only the rendered or serialized detail tree.

### 🧪 Tests

- Added `countAgreement.test.ts`, locking that every view reports identical counts under a pruning threshold, that pruning alters the detail tree without altering counts, and that no descendants of an `n/a` result appear in any view.
- Extended `runRdy.test.ts` with coverage for subtree termination, non-gating `n/a` preconditions, and severity escalation for checks that throw in both the `check` and `skip` positions.

## Scope

Partial implementation of #118, which carries nine acceptance criteria. This covers criteria 2, 3, and 4: the runner-semantics corrections, which required no CLI surface change. The remaining criteria (differentiated exit codes, the JSON error envelope, partial results across kits, and short-flag retirement) all alter the machine-facing contract and ship separately.


Part of #118
