### PR TITLE
#126 Unify n/a semantics and make all report views agree

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -90,7 +90,9 @@ rdy <command> [options]
 | `--checklists, -c <name,...>` | Filter checklists (with `--file` or `--url` only)             |
 | `--json, -j`                  | Output results as JSON                                        |
 | `--fail-on, -F <severity>`    | Fail on this severity or above (`error`, `warn`, `recommend`) |
-| `--report-on, -R <severity>`  | Report this severity or above (`error`, `warn`, `recommend`)  |
+| `--report-on, -R <severity>`  | Show this severity or above (`error`, `warn`, `recommend`)    |
+
+`--report-on` prunes only the reported detail tree. Summary counts, worst severity, and the exit code always reflect the whole run.
 
 ### Kit sources
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -92,7 +92,7 @@ rdy <command> [options]
 | `--fail-on, -F <severity>`    | Fail on this severity or above (`error`, `warn`, `recommend`) |
 | `--report-on, -R <severity>`  | Show this severity or above (`error`, `warn`, `recommend`)    |
 
-`--report-on` prunes only the reported detail tree. Summary counts, worst severity, and the exit code always reflect the whole run.
+`--report-on` prunes only the reported detail tree, and keeps the parent checks of anything it shows so nesting stays intact. Summary counts, worst severity, and the exit code always reflect the whole run.
 
 ### Kit sources
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -4,7 +4,7 @@ import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import type { RdyKit } from '../src/types.ts';
+import type { FailedResult, PassedResult, RdyKit, Severity } from '../src/types.ts';
 
 const mockLoadRdyKit = vi.hoisted(() => vi.fn());
 const mockRunRdy = vi.hoisted(() => vi.fn());
@@ -66,16 +66,6 @@ vi.mock('../src/loadRemoteKit.ts', () => ({
 }));
 
 import { parseRunArgs, resolveKitSources, runCommand } from '../src/cli.ts';
-
-function makeKit(overrides?: Partial<RdyKit>): RdyKit {
-  return {
-    checklists: [
-      { name: 'deploy', checks: [{ name: 'a', check: () => true }] },
-      { name: 'infra', checks: [{ name: 'b', check: () => true }] },
-    ],
-    ...overrides,
-  };
-}
 
 describe(parseRunArgs, () => {
   it('returns undefined checklists and empty specifiers when no flags are given', () => {
@@ -976,6 +966,27 @@ describe(runCommand, () => {
     );
   });
 
+  it('counts results pruned by the reporting threshold in each combined-summary row', async () => {
+    const kit = makeKit();
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
+    mockRunRdy.mockResolvedValue({
+      results: [makePassedResult('gate', 'error'), makeFailedResult('lint', 'warn')],
+      passed: true,
+      durationMs: 0,
+    });
+
+    await runCommand({
+      kitEntries: singleKitEntry(),
+      json: false,
+      reportOn: 'error',
+    });
+
+    expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
+      expect.objectContaining({ name: 'deploy', passed: 1, warnings: 1, worstSeverity: 'warn' }),
+      expect.objectContaining({ name: 'infra', passed: 1, warnings: 1, worstSeverity: 'warn' }),
+    ]);
+  });
+
   it('does not print combined summary for a single checklist', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
@@ -1409,3 +1420,46 @@ describe(runCommand, () => {
     expect(exitCode).toBe(1);
   });
 });
+
+/** Builds a two-checklist kit named `deploy` and `infra`. */
+function makeKit(overrides?: Partial<RdyKit>): RdyKit {
+  return {
+    checklists: [
+      { name: 'deploy', checks: [{ name: 'a', check: () => true }] },
+      { name: 'infra', checks: [{ name: 'b', check: () => true }] },
+    ],
+    ...overrides,
+  };
+}
+
+/** Builds a passed result at the given severity. */
+function makePassedResult(name: string, severity: Severity): PassedResult {
+  return {
+    name,
+    status: 'passed',
+    ok: true,
+    severity,
+    detail: null,
+    fix: null,
+    error: null,
+    progress: null,
+    durationMs: 0,
+    depth: 0,
+  };
+}
+
+/** Builds a failed result at the given severity. */
+function makeFailedResult(name: string, severity: Severity): FailedResult {
+  return {
+    name,
+    status: 'failed',
+    ok: false,
+    severity,
+    detail: null,
+    fix: null,
+    error: null,
+    progress: null,
+    durationMs: 0,
+    depth: 0,
+  };
+}

--- a/packages/readyup/__tests__/countAgreement.test.ts
+++ b/packages/readyup/__tests__/countAgreement.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCombinedSummary } from '../src/formatCombinedSummary.ts';
+import { formatJsonReport } from '../src/formatJsonReport.ts';
+import { countResults, formatSummaryCounts, formatSummaryCountsPlain, reportRdy } from '../src/reportRdy.ts';
+import { runRdy } from '../src/runRdy.ts';
+import type { RdyChecklist, SummaryCounts } from '../src/types.ts';
+
+/**
+ * A checklist exercising every count-divergence hazard at once: a nested n/a parent, an
+ * n/a precondition, a failed gate with dependents, and a failure below the reporting threshold.
+ */
+const checklist: RdyChecklist = {
+  name: 'deploy',
+  preconditions: [{ name: 'pre-na', check: () => true, skip: () => 'not applicable' }],
+  checks: [
+    {
+      name: 'na-parent',
+      check: () => true,
+      skip: () => 'not applicable',
+      checks: [
+        {
+          name: 'na-child',
+          check: () => true,
+          checks: [{ name: 'na-grandchild', check: () => true }],
+        },
+      ],
+    },
+    {
+      name: 'gate-fails',
+      check: () => false,
+      checks: [{ name: 'blocked-child', check: () => true }],
+    },
+    { name: 'warn-fail', check: () => false, severity: 'warn' },
+    { name: 'passes', check: () => true },
+  ],
+};
+
+const expectedCounts: SummaryCounts = {
+  passed: 1,
+  errors: 1,
+  warnings: 1,
+  recommendations: 0,
+  blocked: 1,
+  optional: 2,
+  worstSeverity: 'error',
+};
+
+describe('count agreement across views', () => {
+  it('tallies the same counts for every view when the reporting threshold prunes results', async () => {
+    const report = await runRdy(checklist);
+    const counts = countResults(report.results);
+
+    expect(counts).toStrictEqual(expectedCounts);
+
+    // Human tail line.
+    const human = reportRdy(report, { reportOn: 'error' });
+    expect(human).toContain(formatSummaryCounts(expectedCounts));
+
+    // Combined-summary table row.
+    const table = formatCombinedSummary([{ name: 'deploy', ...counts, durationMs: report.durationMs }]);
+    expect(table).toContain(formatSummaryCountsPlain(expectedCounts));
+
+    // JSON payload.
+    const parsed: unknown = JSON.parse(
+      formatJsonReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }], { reportOn: 'error' }),
+    );
+    expect(parsed).toMatchObject(expectedCounts);
+  });
+
+  it('prunes below-threshold results from the detail tree without altering the counts', async () => {
+    const report = await runRdy(checklist);
+
+    const human = reportRdy(report, { reportOn: 'error' });
+    const json = formatJsonReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }], { reportOn: 'error' });
+
+    expect(human).not.toContain('warn-fail');
+    expect(json).not.toContain('warn-fail');
+    expect(human).toContain('gate-fails');
+    expect(json).toContain('gate-fails');
+  });
+
+  it('emits no descendants of an n/a result in any view', async () => {
+    const report = await runRdy(checklist);
+
+    const human = reportRdy(report);
+    const json = formatJsonReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }]);
+
+    for (const name of ['na-child', 'na-grandchild']) {
+      expect(human).not.toContain(name);
+      expect(json).not.toContain(name);
+    }
+    expect(human).toContain('na-parent');
+    expect(json).toContain('na-parent');
+  });
+});

--- a/packages/readyup/__tests__/countAgreement.test.ts
+++ b/packages/readyup/__tests__/countAgreement.test.ts
@@ -36,6 +36,19 @@ const checklist: RdyChecklist = {
   ],
 };
 
+/** A checklist whose only failing check sits under a passing parent that is below the reporting threshold. */
+const nestedChecklist: RdyChecklist = {
+  name: 'nested',
+  checks: [
+    {
+      name: 'context-parent',
+      check: () => true,
+      severity: 'recommend',
+      checks: [{ name: 'failing-child', check: () => false, severity: 'error' }],
+    },
+  ],
+};
+
 const expectedCounts: SummaryCounts = {
   passed: 1,
   errors: 1,
@@ -78,6 +91,21 @@ describe('count agreement across views', () => {
     expect(json).not.toContain('warn-fail');
     expect(human).toContain('gate-fails');
     expect(json).toContain('gate-fails');
+  });
+
+  it('retains the parent chain of a visible result in every view', async () => {
+    const report = await runRdy(nestedChecklist);
+
+    const human = reportRdy(report, { reportOn: 'error' });
+    const parsed: unknown = JSON.parse(
+      formatJsonReport([{ name: 'kit', entries: [{ name: 'nested', report }] }], { reportOn: 'error' }),
+    );
+
+    expect(human).toContain('context-parent');
+    expect(human.indexOf('context-parent')).toBeLessThan(human.indexOf('failing-child'));
+    expect(parsed).toMatchObject({
+      kits: [{ checklists: [{ checks: [{ name: 'context-parent', checks: [{ name: 'failing-child' }] }] }] }],
+    });
   });
 
   it('emits no descendants of an n/a result in any view', async () => {

--- a/packages/readyup/__tests__/formatJsonReport.test.ts
+++ b/packages/readyup/__tests__/formatJsonReport.test.ts
@@ -612,7 +612,7 @@ describe(formatJsonReport, () => {
       });
     });
 
-    it('counts only visible results in granular buckets', () => {
+    it('counts every result in granular buckets, including results pruned from the tree', () => {
       const report = makeReport({
         results: [
           makePassedResult({ name: 'a', severity: 'error' }),
@@ -628,11 +628,31 @@ describe(formatJsonReport, () => {
         passed: 1,
         errors: 0,
         warnings: 0,
-        recommendations: 0,
+        recommendations: 1,
         blocked: 0,
         optional: 0,
-        worstSeverity: null,
+        worstSeverity: 'recommend',
       });
+    });
+
+    it('reports a below-threshold failure in the counts while omitting it from the detail tree', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'error-pass', severity: 'error' }),
+          makeFailedResult({ name: 'warn-fail', severity: 'warn' }),
+        ],
+        passed: false,
+        durationMs: 15,
+      });
+
+      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report), { reportOn: 'error' }));
+
+      expect(parsed).toMatchObject({
+        warnings: 1,
+        worstSeverity: 'warn',
+        kits: [{ warnings: 1, checklists: [{ warnings: 1, checks: [{ name: 'error-pass' }] }] }],
+      });
+      expect(JSON.stringify(parsed)).not.toContain('warn-fail');
     });
   });
 });

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -386,11 +386,10 @@ describe(reportRdy, () => {
       expect(lines[0]).toBe(`${ICON_PASSED} top-check (7ms)`);
     });
 
-    it('shows n/a parent but suppresses descendants', () => {
+    it('renders an n/a result and the results that follow it', () => {
       const report = makeReport({
         results: [
           makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
-          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 1 }),
           makePassedResult({ name: 'next-sibling', depth: 0, durationMs: 10 }),
         ],
       });
@@ -398,7 +397,6 @@ describe(reportRdy, () => {
       const output = reportRdy(report);
 
       expect(output).toContain('na-parent');
-      expect(output).not.toContain('na-child');
       expect(output).toContain('next-sibling');
     });
 
@@ -466,11 +464,10 @@ describe(reportRdy, () => {
       expect(output).toContain(`${ICON_PASSED} 2 passed. Failed: ${ICON_ERROR_FAILED} 1 error`);
     });
 
-    it('counts n/a parent as optional skip and excludes suppressed descendants from summary', () => {
+    it('counts an n/a result as an optional skip', () => {
       const report = makeReport({
         results: [
           makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
-          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 1 }),
           makePassedResult({ name: 'sibling', depth: 0, durationMs: 10 }),
         ],
         durationMs: 50,
@@ -478,18 +475,17 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report);
 
-      // na-parent counts as optional skip; na-child is suppressed; sibling counts as passed.
       expect(output).toContain(`${ICON_PASSED} 1 passed`);
       expect(output).toContain(`${ICON_SKIPPED_NA} 1 optional`);
-      expect(output).toContain('na-parent');
-      expect(output).not.toContain('na-child');
     });
 
-    it('resumes output after n/a subtree at same depth', () => {
+    it('renders every result it is given, applying no suppression of its own', () => {
+      // `runRdy` no longer emits descendants of an n/a result, so the renderer must not
+      // second-guess its input: whatever arrives is displayed and counted.
       const report = makeReport({
         results: [
           makeSkippedResult({ name: 'na-check', skipReason: 'n/a', depth: 1 }),
-          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 2 }),
+          makeSkippedResult({ name: 'deeper', skipReason: 'precondition', depth: 2 }),
           makePassedResult({ name: 'sibling', depth: 1, durationMs: 5 }),
         ],
       });
@@ -497,8 +493,9 @@ describe(reportRdy, () => {
       const output = reportRdy(report);
 
       expect(output).toContain('na-check');
-      expect(output).not.toContain('na-child');
+      expect(output).toContain('deeper');
       expect(output).toContain('sibling');
+      expect(output).toContain(`${ICON_SKIPPED_PRECONDITION} 1 blocked`);
     });
   });
 

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -515,7 +515,7 @@ describe(reportRdy, () => {
       expect(output).not.toContain('recommend-check');
     });
 
-    it('counts only visible results in the summary', () => {
+    it('counts every result in the summary, including results pruned from the tree', () => {
       const report = makeReport({
         results: [
           makePassedResult({ name: 'error-pass', severity: 'error' }),
@@ -525,8 +525,23 @@ describe(reportRdy, () => {
 
       const output = reportRdy(report, { reportOn: 'error' });
 
-      expect(output).toContain(`${ICON_PASSED} 1 passed`);
-      expect(output).not.toContain('2 passed');
+      expect(output).toContain(`${ICON_PASSED} 2 passed`);
+      expect(output).not.toContain('recommend-pass');
+    });
+
+    it('reports a below-threshold failure in the counts and worst severity', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'error-pass', severity: 'error' }),
+          makeFailedResult({ name: 'warn-fail', severity: 'warn' }),
+        ],
+        passed: false,
+      });
+
+      const output = reportRdy(report, { reportOn: 'error' });
+
+      expect(output).toContain(`${ICON_WARN_FAILED} 1 warning`);
+      expect(output).not.toContain('warn-fail');
     });
 
     it('hides precondition result when its severity is below the reporting threshold', () => {

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  countResults,
   formatSummaryCounts,
   formatSummaryCountsPlain,
   ICON_ERROR_FAILED,
@@ -11,7 +12,7 @@ import {
   ICON_SKIPPED_PRECONDITION,
   ICON_WARN_FAILED,
   reportRdy,
-  tallyResult,
+  selectVisibleResults,
 } from '../src/reportRdy.ts';
 import type { FailedResult, PassedResult, RdyReport, RdyResult, SkippedResult, SummaryCounts } from '../src/types.ts';
 
@@ -751,29 +752,28 @@ describe(formatSummaryCountsPlain, () => {
   });
 });
 
-describe(tallyResult, () => {
-  it('increments `passed` for a passed result', () => {
-    const counts = makeCounts();
+describe(countResults, () => {
+  it('returns zeroed counts for an empty result list', () => {
+    const counts = countResults([]);
 
-    tallyResult(counts, makePassedResult());
+    expect(counts).toStrictEqual(makeCounts());
+  });
+
+  it('increments `passed` for a passed result', () => {
+    const counts = countResults([makePassedResult()]);
 
     expect(counts.passed).toBe(1);
     expect(counts.worstSeverity).toBeNull();
   });
 
   it('leaves `worstSeverity` null after a passing result', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makePassedResult());
-    tallyResult(counts, makePassedResult());
+    const counts = countResults([makePassedResult(), makePassedResult()]);
 
     expect(counts.worstSeverity).toBeNull();
   });
 
   it('increments `errors` and sets worstSeverity to error for a failed error result', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeFailedResult({ severity: 'error' }));
+    const counts = countResults([makeFailedResult({ severity: 'error' })]);
 
     expect(counts.errors).toBe(1);
     expect(counts.warnings).toBe(0);
@@ -782,9 +782,7 @@ describe(tallyResult, () => {
   });
 
   it('increments `warnings` and sets worstSeverity to warn for a failed warn result', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
+    const counts = countResults([makeFailedResult({ severity: 'warn' })]);
 
     expect(counts.warnings).toBe(1);
     expect(counts.errors).toBe(0);
@@ -793,9 +791,7 @@ describe(tallyResult, () => {
   });
 
   it('increments `recommendations` and sets worstSeverity to recommend for a failed recommend result', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
+    const counts = countResults([makeFailedResult({ severity: 'recommend' })]);
 
     expect(counts.recommendations).toBe(1);
     expect(counts.errors).toBe(0);
@@ -804,9 +800,7 @@ describe(tallyResult, () => {
   });
 
   it('increments `blocked` for a precondition-skipped result', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeSkippedResult({ skipReason: 'precondition' }));
+    const counts = countResults([makeSkippedResult({ skipReason: 'precondition' })]);
 
     expect(counts.blocked).toBe(1);
     expect(counts.optional).toBe(0);
@@ -814,9 +808,7 @@ describe(tallyResult, () => {
   });
 
   it('increments `optional` for an n/a-skipped result', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeSkippedResult({ skipReason: 'n/a' }));
+    const counts = countResults([makeSkippedResult({ skipReason: 'n/a' })]);
 
     expect(counts.optional).toBe(1);
     expect(counts.blocked).toBe(0);
@@ -824,58 +816,45 @@ describe(tallyResult, () => {
   });
 
   it('escalates worstSeverity from null to recommend on first recommend failure', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
+    const counts = countResults([makeFailedResult({ severity: 'recommend' })]);
 
     expect(counts.worstSeverity).toBe('recommend');
   });
 
   it('escalates worstSeverity from recommend to warn', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
-    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
+    const counts = countResults([makeFailedResult({ severity: 'recommend' }), makeFailedResult({ severity: 'warn' })]);
 
     expect(counts.worstSeverity).toBe('warn');
   });
 
   it('escalates worstSeverity from warn to error', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
-    tallyResult(counts, makeFailedResult({ severity: 'error' }));
+    const counts = countResults([makeFailedResult({ severity: 'warn' }), makeFailedResult({ severity: 'error' })]);
 
     expect(counts.worstSeverity).toBe('error');
   });
 
   it('does not de-escalate worstSeverity when a lower-severity failure follows a higher one', () => {
-    const counts = makeCounts();
+    const twoFailures = countResults([makeFailedResult({ severity: 'error' }), makeFailedResult({ severity: 'warn' })]);
 
-    tallyResult(counts, makeFailedResult({ severity: 'error' }));
-    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
+    expect(twoFailures.worstSeverity).toBe('error');
 
-    expect(counts.worstSeverity).toBe('error');
+    const threeFailures = countResults([
+      makeFailedResult({ severity: 'error' }),
+      makeFailedResult({ severity: 'warn' }),
+      makeFailedResult({ severity: 'recommend' }),
+    ]);
 
-    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
-
-    expect(counts.worstSeverity).toBe('error');
+    expect(threeFailures.worstSeverity).toBe('error');
   });
 
   it('does not de-escalate worstSeverity from warn when a recommend failure follows', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
-    tallyResult(counts, makeFailedResult({ severity: 'recommend' }));
+    const counts = countResults([makeFailedResult({ severity: 'warn' }), makeFailedResult({ severity: 'recommend' })]);
 
     expect(counts.worstSeverity).toBe('warn');
   });
 
   it('does not change worstSeverity when a passed result follows a failure', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeFailedResult({ severity: 'warn' }));
-    tallyResult(counts, makePassedResult());
+    const counts = countResults([makeFailedResult({ severity: 'warn' }), makePassedResult()]);
 
     expect(counts.worstSeverity).toBe('warn');
     expect(counts.passed).toBe(1);
@@ -883,15 +862,96 @@ describe(tallyResult, () => {
   });
 
   it('does not change worstSeverity when a skipped result follows a failure', () => {
-    const counts = makeCounts();
-
-    tallyResult(counts, makeFailedResult({ severity: 'error' }));
-    tallyResult(counts, makeSkippedResult({ skipReason: 'precondition' }));
-    tallyResult(counts, makeSkippedResult({ skipReason: 'n/a' }));
+    const counts = countResults([
+      makeFailedResult({ severity: 'error' }),
+      makeSkippedResult({ skipReason: 'precondition' }),
+      makeSkippedResult({ skipReason: 'n/a' }),
+    ]);
 
     expect(counts.worstSeverity).toBe('error');
     expect(counts.blocked).toBe(1);
     expect(counts.optional).toBe(1);
+  });
+});
+
+describe(selectVisibleResults, () => {
+  it('returns an empty list when given no results', () => {
+    expect(selectVisibleResults([], 'error')).toStrictEqual([]);
+  });
+
+  it('keeps a below-threshold parent when a descendant meets the threshold', () => {
+    const visible = selectVisibleResults(
+      [
+        makePassedResult({ name: 'parent', severity: 'recommend', depth: 0 }),
+        makeFailedResult({ name: 'child', severity: 'error', depth: 1 }),
+      ],
+      'error',
+    );
+
+    expect(visible.map((r) => r.name)).toStrictEqual(['parent', 'child']);
+  });
+
+  it('prunes a below-threshold parent when no descendant meets the threshold', () => {
+    const visible = selectVisibleResults(
+      [
+        makePassedResult({ name: 'parent', severity: 'recommend', depth: 0 }),
+        makeFailedResult({ name: 'child', severity: 'warn', depth: 1 }),
+      ],
+      'error',
+    );
+
+    expect(visible).toStrictEqual([]);
+  });
+
+  it('keeps an entire ancestor chain for a single deep survivor', () => {
+    const visible = selectVisibleResults(
+      [
+        makePassedResult({ name: 'a', severity: 'recommend', depth: 0 }),
+        makePassedResult({ name: 'b', severity: 'recommend', depth: 1 }),
+        makeFailedResult({ name: 'c', severity: 'error', depth: 2 }),
+      ],
+      'error',
+    );
+
+    expect(visible.map((r) => r.name)).toStrictEqual(['a', 'b', 'c']);
+  });
+
+  it('keeps only the sibling subtree containing a survivor', () => {
+    const visible = selectVisibleResults(
+      [
+        makePassedResult({ name: 'first', severity: 'recommend', depth: 0 }),
+        makeFailedResult({ name: 'first-child', severity: 'warn', depth: 1 }),
+        makePassedResult({ name: 'second', severity: 'recommend', depth: 0 }),
+        makeFailedResult({ name: 'second-child', severity: 'error', depth: 1 }),
+      ],
+      'error',
+    );
+
+    expect(visible.map((r) => r.name)).toStrictEqual(['second', 'second-child']);
+  });
+
+  it('does not retain a pruned subtree because a later top-level result survives', () => {
+    const visible = selectVisibleResults(
+      [
+        makePassedResult({ name: 'pruned', severity: 'recommend', depth: 0 }),
+        makePassedResult({ name: 'pruned-child', severity: 'recommend', depth: 1 }),
+        makeFailedResult({ name: 'later', severity: 'error', depth: 0 }),
+      ],
+      'error',
+    );
+
+    expect(visible.map((r) => r.name)).toStrictEqual(['later']);
+  });
+
+  it('leaves the caller\u{2019}s list unmodified', () => {
+    const results = [
+      makePassedResult({ name: 'parent', severity: 'recommend', depth: 0 }),
+      makeFailedResult({ name: 'child', severity: 'error', depth: 1 }),
+    ];
+
+    selectVisibleResults(results, 'error');
+
+    expect(results.map((r) => r.name)).toStrictEqual(['parent', 'child']);
   });
 });
 

--- a/packages/readyup/__tests__/runRdy.test.ts
+++ b/packages/readyup/__tests__/runRdy.test.ts
@@ -187,6 +187,167 @@ describe(runRdy, () => {
       expect(report.results[0]?.status).toBe('passed');
       expect(report.results[1]?.status).toBe('passed');
     });
+
+    it('runs checks when a precondition is skipped n/a', async () => {
+      const checklist: RdyChecklist = {
+        name: 'gated',
+        preconditions: [{ name: 'pre-na', check: () => true, skip: () => 'not applicable here' }],
+        checks: [{ name: 'runs-anyway', check: () => true }],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.passed).toBe(true);
+      expect(report.results).toHaveLength(2);
+      expect(report.results[0]?.status).toBe('skipped');
+      expect(report.results[1]?.name).toBe('runs-anyway');
+      expect(report.results[1]?.status).toBe('passed');
+    });
+
+    it('runs the checklist when one precondition is n/a and the rest pass', async () => {
+      const checklist: RdyChecklist = {
+        name: 'gated',
+        preconditions: [
+          { name: 'pre-na', check: () => true, skip: () => 'not applicable here' },
+          { name: 'pre-pass', check: () => true },
+        ],
+        checks: [{ name: 'runs-anyway', check: () => false }],
+      };
+
+      const report = await runRdy(checklist);
+
+      const target = report.results.find((r) => r.name === 'runs-anyway');
+      expect(target?.status).toBe('failed');
+    });
+
+    it('still skips the checklist when one precondition is n/a and another fails', async () => {
+      const checklist: RdyChecklist = {
+        name: 'gated',
+        preconditions: [
+          { name: 'pre-na', check: () => true, skip: () => 'not applicable here' },
+          { name: 'pre-fail', check: () => false },
+        ],
+        checks: [{ name: 'should-skip', check: () => true }],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.passed).toBe(false);
+      const target = report.results.find((r) => r.name === 'should-skip');
+      assert.ok(target?.status === 'skipped');
+      expect(target.skipReason).toBe('precondition');
+    });
+  });
+
+  describe('thrown checks', () => {
+    it('reports a thrown check at error severity regardless of its declared severity', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'recommend-throws',
+            severity: 'recommend',
+            check: () => {
+              throw new Error('boom');
+            },
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.severity).toBe('error');
+      expect(report.results[0]?.error?.message).toBe('boom');
+    });
+
+    it('reports a thrown skip function at error severity regardless of declared severity', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'recommend-skip-throws',
+            severity: 'recommend',
+            check: () => true,
+            skip: () => {
+              throw new Error('skip boom');
+            },
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.severity).toBe('error');
+      expect(report.results[0]?.error?.message).toBe('skip boom');
+    });
+
+    it('fails the run when a recommend-severity check throws under the default failOn', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'recommend-throws',
+            severity: 'recommend',
+            check: () => {
+              throw new Error('boom');
+            },
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.passed).toBe(false);
+    });
+
+    it('leaves sibling results intact when one check throws', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'throws',
+            check: () => {
+              throw new Error('boom');
+            },
+          },
+          { name: 'sibling-passes', check: () => true },
+          { name: 'sibling-fails', check: () => false },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results.map((r) => ({ name: r.name, status: r.status }))).toStrictEqual([
+        { name: 'throws', status: 'failed' },
+        { name: 'sibling-passes', status: 'passed' },
+        { name: 'sibling-fails', status: 'failed' },
+      ]);
+    });
+
+    it('escalates only the thrown check, leaving descendant severities untouched', async () => {
+      const checklist: RdyChecklist = {
+        name: 'throwing',
+        checks: [
+          {
+            name: 'parent-throws',
+            severity: 'recommend',
+            check: () => {
+              throw new Error('boom');
+            },
+            checks: [{ name: 'child', check: () => true, severity: 'warn' }],
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.severity).toBe('error');
+      expect(report.results[1]?.name).toBe('child');
+      expect(report.results[1]?.status).toBe('skipped');
+      expect(report.results[1]?.severity).toBe('warn');
+    });
   });
 
   describe('staged checklists', () => {
@@ -665,7 +826,7 @@ describe(runRdy, () => {
       expect(child.depth).toBe(1);
     });
 
-    it('skips children of an n/a-skipped check with n/a reason', async () => {
+    it('emits no results for descendants of an n/a-skipped check', async () => {
       const checklist: RdyChecklist = {
         name: 'nested',
         checks: [
@@ -680,12 +841,96 @@ describe(runRdy, () => {
 
       const report = await runRdy(checklist);
 
-      expect(report.results).toHaveLength(2);
-      expect(report.results[0]?.status).toBe('skipped');
-      expect(report.results[1]?.name).toBe('child');
-      const child = report.results[1];
-      assert.ok(child?.status === 'skipped');
-      expect(child.skipReason).toBe('n/a');
+      expect(report.results).toHaveLength(1);
+      const parent = report.results[0];
+      assert.ok(parent?.status === 'skipped');
+      expect(parent.skipReason).toBe('n/a');
+    });
+
+    it('emits exactly one result for an n/a-skipped check with a multi-level subtree', async () => {
+      const checklist: RdyChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'na-parent',
+            check: () => true,
+            skip: () => 'not applicable',
+            checks: [
+              {
+                name: 'child-a',
+                check: () => true,
+                checks: [{ name: 'grandchild-a', check: () => true }],
+              },
+              {
+                name: 'child-b',
+                check: () => true,
+                checks: [{ name: 'grandchild-b', check: () => true }],
+              },
+            ],
+          },
+          { name: 'next-sibling', check: () => true },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results.map((r) => r.name)).toStrictEqual(['na-parent', 'next-sibling']);
+    });
+
+    it('does not run descendants of an n/a-skipped check', async () => {
+      let childCalled = false;
+      const checklist: RdyChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'na-parent',
+            check: () => true,
+            skip: () => 'not applicable',
+            checks: [
+              {
+                name: 'child',
+                check: () => {
+                  childCalled = true;
+                  return true;
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      await runRdy(checklist);
+
+      expect(childCalled).toBe(false);
+    });
+
+    it('emits one result per descendant of a precondition-skipped check', async () => {
+      const checklist: RdyChecklist = {
+        name: 'nested',
+        checks: [
+          {
+            name: 'failing-parent',
+            check: () => false,
+            checks: [
+              {
+                name: 'child-a',
+                check: () => true,
+                checks: [{ name: 'grandchild-a', check: () => true }],
+              },
+              { name: 'child-b', check: () => true },
+            ],
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results.map((r) => ({ name: r.name, depth: r.depth }))).toStrictEqual([
+        { name: 'failing-parent', depth: 0 },
+        { name: 'child-a', depth: 1 },
+        { name: 'grandchild-a', depth: 2 },
+        { name: 'child-b', depth: 1 },
+      ]);
     });
 
     it('produces depth-first ordering for multi-level nesting', async () => {

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -35,8 +35,9 @@ Run options:
   --checklists, -c <name,...>        Filter checklists (with --file or --url only)
   --json, -j                         Output results as JSON
   --fail-on, -F <severity>           Fail on this severity or above (error, warn, recommend)
-  --report-on, -R <severity>         Show this severity or above in the detail tree (error, warn, recommend);
-                                     summary counts always cover the whole run
+  --report-on, -R <severity>         Show this severity or above in the detail tree (error, warn, recommend),
+                                     plus the parent checks of anything shown; summary counts always
+                                     cover the whole run
 
 Global options:
   --help, -h           Show this help message
@@ -66,8 +67,9 @@ Options:
   --checklists, -c <name,...>        Filter checklists (with --file or --url only)
   --json, -j                         Output results as JSON
   --fail-on, -F <severity>           Fail on this severity or above (error, warn, recommend)
-  --report-on, -R <severity>         Show this severity or above in the detail tree (error, warn, recommend);
-                                     summary counts always cover the whole run
+  --report-on, -R <severity>         Show this severity or above in the detail tree (error, warn, recommend),
+                                     plus the parent checks of anything shown; summary counts always
+                                     cover the whole run
   --help, -h                         Show this help message
 
 Positional args accept relative paths (e.g., shared/deploy).

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -35,7 +35,8 @@ Run options:
   --checklists, -c <name,...>        Filter checklists (with --file or --url only)
   --json, -j                         Output results as JSON
   --fail-on, -F <severity>           Fail on this severity or above (error, warn, recommend)
-  --report-on, -R <severity>         Report this severity or above (error, warn, recommend)
+  --report-on, -R <severity>         Show this severity or above in the detail tree (error, warn, recommend);
+                                     summary counts always cover the whole run
 
 Global options:
   --help, -h           Show this help message
@@ -65,7 +66,8 @@ Options:
   --checklists, -c <name,...>        Filter checklists (with --file or --url only)
   --json, -j                         Output results as JSON
   --fail-on, -F <severity>           Fail on this severity or above (error, warn, recommend)
-  --report-on, -R <severity>         Report this severity or above (error, warn, recommend)
+  --report-on, -R <severity>         Show this severity or above in the detail tree (error, warn, recommend);
+                                     summary counts always cover the whole run
   --help, -h                         Show this help message
 
 Positional args accept relative paths (e.g., shared/deploy).

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -10,11 +10,11 @@ import { formatJsonReport } from './formatJsonReport.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { type FromSource, parseFromValue } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
-import { reportRdy, tallyResult } from './reportRdy.ts';
+import { countResults, reportRdy } from './reportRdy.ts';
 import { resolveBitbucketToken } from './resolveBitbucketToken.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
 import { resolveRequestedNames } from './resolveRequestedNames.ts';
-import { meetsThreshold, runRdy } from './runRdy.ts';
+import { runRdy } from './runRdy.ts';
 import type {
   ChecklistSummary,
   FixLocation,
@@ -23,7 +23,6 @@ import type {
   RdyReport,
   RdyStagedChecklist,
   Severity,
-  SummaryCounts,
 } from './types.ts';
 import { extractMessage } from './utils/error-handling.ts';
 import { translateParseArgsError } from './utils/parse-args-error.ts';
@@ -306,22 +305,9 @@ function resolveFixLocation(checklist: RdyChecklist | RdyStagedChecklist, kitDef
   return checklist.fixLocation ?? kitDefault ?? 'end';
 }
 
-/** Build a checklist summary from a report, filtering results by reporting threshold. */
-function summarizeReport(name: string, report: RdyReport, reportOn: Severity): ChecklistSummary {
-  const counts: SummaryCounts = {
-    passed: 0,
-    errors: 0,
-    warnings: 0,
-    recommendations: 0,
-    blocked: 0,
-    optional: 0,
-    worstSeverity: null,
-  };
-  for (const r of report.results) {
-    if (!meetsThreshold(r.severity, reportOn)) continue;
-    tallyResult(counts, r);
-  }
-  return { name, ...counts, durationMs: report.durationMs };
+/** Build a checklist summary from a report. */
+function summarizeReport(name: string, report: RdyReport): ChecklistSummary {
+  return { name, ...countResults(report.results), durationMs: report.durationMs };
 }
 
 /** Resolve threshold values from the cascade: CLI flag > kit field > default. */
@@ -565,7 +551,7 @@ async function runSingleKitHumanMode(
       }
 
       if (showChecklistHeader) {
-        summaries.push(summarizeReport(checklist.name, report, thresholds.reportOn));
+        summaries.push(summarizeReport(checklist.name, report));
       }
     }
   } catch (error: unknown) {

--- a/packages/readyup/src/formatCombinedSummary.ts
+++ b/packages/readyup/src/formatCombinedSummary.ts
@@ -1,13 +1,14 @@
 import {
+  emptyCounts,
   formatSummaryCounts,
   formatSummaryCountsPlain,
   ICON_ERROR_FAILED,
   ICON_PASSED,
   ICON_RECOMMEND_FAILED,
   ICON_WARN_FAILED,
+  mergeCounts,
 } from './reportRdy.ts';
 import type { ChecklistSummary, Severity, SummaryCounts } from './types.ts';
-import { worseSeverity } from './utils/severity.ts';
 
 /** Format a duration in milliseconds for display. */
 function formatDuration(ms: number): string {
@@ -24,23 +25,9 @@ function getRowIcon(worstSeverity: Severity | null): string {
 
 /** Sum granular counts across multiple summaries, propagating the worst severity. */
 function aggregateCounts(summaries: ChecklistSummary[]): SummaryCounts {
-  const totals: SummaryCounts = {
-    passed: 0,
-    errors: 0,
-    warnings: 0,
-    recommendations: 0,
-    blocked: 0,
-    optional: 0,
-    worstSeverity: null,
-  };
-  for (const s of summaries) {
-    totals.passed += s.passed;
-    totals.errors += s.errors;
-    totals.warnings += s.warnings;
-    totals.recommendations += s.recommendations;
-    totals.blocked += s.blocked;
-    totals.optional += s.optional;
-    totals.worstSeverity = worseSeverity(totals.worstSeverity, s.worstSeverity);
+  const totals = emptyCounts();
+  for (const summary of summaries) {
+    mergeCounts(totals, summary);
   }
   return totals;
 }

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -1,4 +1,4 @@
-import { tallyResult } from './reportRdy.ts';
+import { countResults, emptyCounts } from './reportRdy.ts';
 import { meetsThreshold } from './runRdy.ts';
 import type {
   JsonCheckEntry,
@@ -27,19 +27,6 @@ export interface FormatJsonReportOptions {
   reportOn?: Severity;
 }
 
-/** Create a zeroed `SummaryCounts` object. */
-function emptyCounts(): SummaryCounts {
-  return {
-    passed: 0,
-    errors: 0,
-    warnings: 0,
-    recommendations: 0,
-    blocked: 0,
-    optional: 0,
-    worstSeverity: null,
-  };
-}
-
 /** Aggregate `source` counts into `target` in place. */
 function mergeCounts(target: SummaryCounts, source: SummaryCounts): void {
   target.passed += source.passed;
@@ -51,15 +38,14 @@ function mergeCounts(target: SummaryCounts, source: SummaryCounts): void {
   target.worstSeverity = worseSeverity(target.worstSeverity, source.worstSeverity);
 }
 
-/** Build a single checklist entry from a name and report. */
+/**
+ * Build a single checklist entry from a name and report.
+ *
+ * Counts cover the whole run; the reporting threshold prunes only the serialized detail tree.
+ */
 function buildChecklistEntry(name: string, report: RdyReport, reportOn: Severity): JsonChecklistEntry {
-  const counts = emptyCounts();
+  const counts = countResults(report.results);
   const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
-
-  for (const result of visibleResults) {
-    tallyResult(counts, result);
-  }
-
   const { entries: checks } = buildCheckEntries(visibleResults, 0, 0);
 
   return {

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -1,5 +1,4 @@
-import { countResults, emptyCounts } from './reportRdy.ts';
-import { meetsThreshold } from './runRdy.ts';
+import { countResults, emptyCounts, mergeCounts, selectVisibleResults } from './reportRdy.ts';
 import type {
   JsonCheckEntry,
   JsonChecklistEntry,
@@ -8,9 +7,7 @@ import type {
   RdyReport,
   RdyResult,
   Severity,
-  SummaryCounts,
 } from './types.ts';
-import { worseSeverity } from './utils/severity.ts';
 
 interface ChecklistEntry {
   name: string;
@@ -27,25 +24,15 @@ export interface FormatJsonReportOptions {
   reportOn?: Severity;
 }
 
-/** Aggregate `source` counts into `target` in place. */
-function mergeCounts(target: SummaryCounts, source: SummaryCounts): void {
-  target.passed += source.passed;
-  target.errors += source.errors;
-  target.warnings += source.warnings;
-  target.recommendations += source.recommendations;
-  target.blocked += source.blocked;
-  target.optional += source.optional;
-  target.worstSeverity = worseSeverity(target.worstSeverity, source.worstSeverity);
-}
-
 /**
  * Build a single checklist entry from a name and report.
  *
- * Counts cover the whole run; the reporting threshold prunes only the serialized detail tree.
+ * Counts cover the whole run; the reporting threshold prunes only the serialized detail tree,
+ * retaining the ancestors of every result it keeps so the nesting stays intact.
  */
 function buildChecklistEntry(name: string, report: RdyReport, reportOn: Severity): JsonChecklistEntry {
   const counts = countResults(report.results);
-  const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
+  const visibleResults = selectVisibleResults(report.results, reportOn);
   const { entries: checks } = buildCheckEntries(visibleResults, 0, 0);
 
   return {

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -126,22 +126,7 @@ function collectInlineDetails(result: RdyResult, includeFix: boolean): string[] 
   return details;
 }
 
-/** Iterate visible results, skipping N/A descendants (depth > N/A parent). */
-function* iterateWithNaSuppression(results: RdyResult[]): Generator<RdyResult> {
-  let suppressBelowDepth: number | null = null;
-  for (const result of results) {
-    if (suppressBelowDepth !== null) {
-      if (result.depth > suppressBelowDepth) continue;
-      suppressBelowDepth = null;
-    }
-    if (result.status === 'skipped' && result.skipReason === 'n/a') {
-      suppressBelowDepth = result.depth;
-    }
-    yield result;
-  }
-}
-
-/** Count results by severity and skip reason after N/A descendant suppression. */
+/** Count results by severity and skip reason. */
 function countResults(results: RdyResult[]): SummaryCounts {
   const counts: SummaryCounts = {
     passed: 0,
@@ -152,7 +137,7 @@ function countResults(results: RdyResult[]): SummaryCounts {
     optional: 0,
     worstSeverity: null,
   };
-  for (const r of iterateWithNaSuppression(results)) {
+  for (const r of results) {
     tallyResult(counts, r);
   }
   return counts;
@@ -196,7 +181,7 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
 
   const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
 
-  for (const result of iterateWithNaSuppression(visibleResults)) {
+  for (const result of visibleResults) {
     const indent = ' '.repeat(3).repeat(result.depth);
     const icon = getIcon(result);
     let checkLine = `${indent}${icon} ${result.name} (${formatDuration(result.durationMs)})`;

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -155,13 +155,48 @@ export function countResults(results: RdyResult[]): SummaryCounts {
 }
 
 /**
+ * Selects the results a reporting threshold leaves visible, retaining the ancestors of every survivor.
+ *
+ * A result is visible when its own severity meets the threshold or when any of its descendants is visible, so a
+ * surviving check is never rendered under a pruned parent. Assumes the contiguous depth-first ordering `runRdy`
+ * produces: a result's descendants are exactly the run of deeper results that follows it.
+ *
+ * Visible results are returned in their original order.
+ */
+export function selectVisibleResults(results: RdyResult[], reportOn: Severity): RdyResult[] {
+  const visible: RdyResult[] = [];
+  // Scanning right to left, the nearest visible result is a descendant exactly when it is deeper, so its
+  // depth alone decides whether the current result must be retained as an ancestor.
+  let nearestVisibleDepth = -Infinity;
+
+  for (const result of results.toReversed()) {
+    if (!meetsThreshold(result.severity, reportOn) && nearestVisibleDepth <= result.depth) continue;
+    visible.push(result);
+    nearestVisibleDepth = result.depth;
+  }
+
+  return visible.toReversed();
+}
+
+/** Aggregates `source` counts into `target` in place, propagating the worse severity. */
+export function mergeCounts(target: SummaryCounts, source: SummaryCounts): void {
+  target.passed += source.passed;
+  target.errors += source.errors;
+  target.warnings += source.warnings;
+  target.recommendations += source.recommendations;
+  target.blocked += source.blocked;
+  target.optional += source.optional;
+  target.worstSeverity = worseSeverity(target.worstSeverity, source.worstSeverity);
+}
+
+/**
  * Update a `SummaryCounts` object in place with the contribution of a single result.
  *
  * Passed results increment `passed`. Failed results are bucketed by severity, and
  * `worstSeverity` is updated if the failure is more severe than the current worst.
  * Skipped results increment `blocked` (precondition) or `optional` (n/a).
  */
-export function tallyResult(counts: SummaryCounts, result: RdyResult): void {
+function tallyResult(counts: SummaryCounts, result: RdyResult): void {
   if (result.status === 'passed') {
     counts.passed++;
     return;
@@ -182,8 +217,8 @@ export function tallyResult(counts: SummaryCounts, result: RdyResult): void {
  *
  * In `end` mode (default), errors appear inline but fix messages are collected in a "Fixes" section at the bottom.
  * In `inline` mode, error and fix messages appear directly below each failed check.
- * Results below the reporting threshold are omitted from the detail tree; the summary
- * counts always reflect the whole run.
+ * Results below the reporting threshold are omitted from the detail tree unless they are an ancestor of a
+ * result that is shown; the summary counts always reflect the whole run.
  */
 export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string {
   const fixLocation = options?.fixLocation ?? 'end';
@@ -191,7 +226,7 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
   const lines: string[] = [];
   const collectedFixes: string[] = [];
 
-  const visibleResults = report.results.filter((r) => meetsThreshold(r.severity, reportOn));
+  const visibleResults = selectVisibleResults(report.results, reportOn);
 
   for (const result of visibleResults) {
     const indent = ' '.repeat(3).repeat(result.depth);

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -126,9 +126,9 @@ function collectInlineDetails(result: RdyResult, includeFix: boolean): string[] 
   return details;
 }
 
-/** Count results by severity and skip reason. */
-function countResults(results: RdyResult[]): SummaryCounts {
-  const counts: SummaryCounts = {
+/** Create a zeroed `SummaryCounts` object. */
+export function emptyCounts(): SummaryCounts {
+  return {
     passed: 0,
     errors: 0,
     warnings: 0,
@@ -137,6 +137,17 @@ function countResults(results: RdyResult[]): SummaryCounts {
     optional: 0,
     worstSeverity: null,
   };
+}
+
+/**
+ * Count results by severity and skip reason.
+ *
+ * This is the only entry point for tallying a result list, and it expects the run's
+ * complete results. The reporting threshold selects what is *displayed*; passing a
+ * pre-filtered list here is what once made the human, table, and JSON counts disagree.
+ */
+export function countResults(results: RdyResult[]): SummaryCounts {
+  const counts = emptyCounts();
   for (const r of results) {
     tallyResult(counts, r);
   }
@@ -171,7 +182,8 @@ export function tallyResult(counts: SummaryCounts, result: RdyResult): void {
  *
  * In `end` mode (default), errors appear inline but fix messages are collected in a "Fixes" section at the bottom.
  * In `inline` mode, error and fix messages appear directly below each failed check.
- * Results below the reporting threshold are omitted from output.
+ * Results below the reporting threshold are omitted from the detail tree; the summary
+ * counts always reflect the whole run.
  */
 export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string {
   const fixLocation = options?.fixLocation ?? 'end';
@@ -204,7 +216,7 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
     }
   }
 
-  const counts = countResults(visibleResults);
+  const counts = countResults(report.results);
   lines.push('', `${formatSummaryCounts(counts)} (${formatDuration(report.durationMs)})`);
 
   if (fixLocation === 'end' && collectedFixes.length > 0) {

--- a/packages/readyup/src/runRdy.ts
+++ b/packages/readyup/src/runRdy.ts
@@ -30,6 +30,14 @@ const SEVERITY_RANK: Record<Severity, number> = {
   recommend: 2,
 };
 
+/**
+ * Severity assigned to a check whose `check` or `skip` function throws.
+ *
+ * An exception is a defect in the check itself, not a soft finding, so it overrides
+ * whatever severity the check declares.
+ */
+const THROWN_SEVERITY: Severity = 'error';
+
 /** Return true if `severity` is at or above (more severe than or equal to) `threshold`. */
 export function meetsThreshold(severity: Severity, threshold: Severity): boolean {
   return SEVERITY_RANK[severity] <= SEVERITY_RANK[threshold];
@@ -107,15 +115,14 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
     try {
       const skipResult = await check.skip();
       if (typeof skipResult === 'string') {
-        const result = buildSkippedResult(check.name, severity, 'n/a', skipResult, fix, depth);
-        const childResults = skipAllDescendants(children, defaultSeverity, 'n/a', depth + 1);
-        return [result, ...childResults];
+        // An `n/a` skip terminates its subtree: descendants produce no results at all.
+        return [buildSkippedResult(check.name, severity, 'n/a', skipResult, fix, depth)];
       }
     } catch (error_: unknown) {
       const durationMs = performance.now() - start;
       const error = error_ instanceof Error ? error_ : new Error(String(error_));
-      const result = buildFailedResult(check.name, severity, durationMs, null, fix, error, null, depth);
-      const childResults = skipAllDescendants(children, defaultSeverity, 'precondition', depth + 1);
+      const result = buildFailedResult(check.name, THROWN_SEVERITY, durationMs, null, fix, error, null, depth);
+      const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
       return [result, ...childResults];
     }
   }
@@ -124,7 +131,7 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
   try {
     const raw = await check.check();
     const durationMs = performance.now() - start;
-    let result: RdyResult;
+    let result: PassedResult | FailedResult;
     if (typeof raw === 'boolean') {
       result = raw
         ? buildPassedResult(check.name, severity, durationMs, null, fix, null, depth)
@@ -142,8 +149,8 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
   } catch (error_: unknown) {
     const durationMs = performance.now() - start;
     const error = error_ instanceof Error ? error_ : new Error(String(error_));
-    const result = buildFailedResult(check.name, severity, durationMs, null, fix, error, null, depth);
-    const childResults = skipAllDescendants(children, defaultSeverity, 'precondition', depth + 1);
+    const result = buildFailedResult(check.name, THROWN_SEVERITY, durationMs, null, fix, error, null, depth);
+    const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
     return [result, ...childResults];
   }
 }
@@ -152,10 +159,10 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
  * Collect results from child checks based on the parent's outcome.
  *
  * Passed parents: execute children concurrently, then iterate in declaration order
- * to produce depth-first results. Failed/skipped parents: skip all descendants.
+ * to produce depth-first results. Failed parents: skip all descendants.
  */
 async function collectChildResults(
-  parentResult: RdyResult,
+  parentResult: PassedResult | FailedResult,
   children: RdyCheck[],
   defaultSeverity: Severity,
   childDepth: number,
@@ -163,12 +170,7 @@ async function collectChildResults(
   if (children.length === 0) return [];
 
   if (parentResult.status === 'failed') {
-    return skipAllDescendants(children, defaultSeverity, 'precondition', childDepth);
-  }
-
-  if (parentResult.status === 'skipped') {
-    const reason = parentResult.skipReason === 'n/a' ? 'n/a' : 'precondition';
-    return skipAllDescendants(children, defaultSeverity, reason, childDepth);
+    return skipAllDescendants(children, defaultSeverity, childDepth);
   }
 
   return runSiblingChecks(children, defaultSeverity, childDepth);
@@ -186,32 +188,27 @@ async function runSiblingChecks(checks: RdyCheck[], defaultSeverity: Severity, d
   return siblingTrees.flat();
 }
 
-/** Recursively skip a check and all its descendants. */
-function skipAllDescendants(
-  checks: RdyCheck[],
-  defaultSeverity: Severity,
-  skipReason: 'n/a' | 'precondition',
-  depth: number,
-): RdyResult[] {
+/**
+ * Recursively skip a check and all its descendants.
+ *
+ * Every skip produced here is a `precondition` skip: an `n/a` skip terminates its own
+ * subtree in `executeCheck` and so never reaches this function.
+ */
+function skipAllDescendants(checks: RdyCheck[], defaultSeverity: Severity, depth: number): RdyResult[] {
   const results: RdyResult[] = [];
   for (const check of checks) {
-    results.push(skipCheck(check, defaultSeverity, skipReason, depth));
+    results.push(skipCheck(check, defaultSeverity, depth));
     if (check.checks !== undefined && check.checks.length > 0) {
-      results.push(...skipAllDescendants(check.checks, defaultSeverity, skipReason, depth + 1));
+      results.push(...skipAllDescendants(check.checks, defaultSeverity, depth + 1));
     }
   }
   return results;
 }
 
-/** Mark a check as skipped due to a failed precondition or N/A parent. */
-function skipCheck(
-  check: RdyCheck,
-  defaultSeverity: Severity,
-  skipReason: 'n/a' | 'precondition' = 'precondition',
-  depth = 0,
-): RdyResult {
+/** Mark a check as skipped because a precondition or ancestor check failed. */
+function skipCheck(check: RdyCheck, defaultSeverity: Severity, depth: number): RdyResult {
   const severity = resolveSeverity(check, defaultSeverity);
-  return buildSkippedResult(check.name, severity, skipReason, null, check.fix ?? null, depth);
+  return buildSkippedResult(check.name, severity, 'precondition', null, check.fix ?? null, depth);
 }
 
 /** Run preconditions concurrently. Return true if all passed. */
@@ -226,8 +223,9 @@ async function runPreconditions(
   const flat = trees.flat();
   results.push(...flat);
 
-  // Only top-level precondition results (depth 0) determine pass/fail.
-  return flat.filter((r) => r.depth === 0).every((r) => r.status === 'passed');
+  // Only top-level precondition results (depth 0) determine pass/fail. A precondition
+  // skipped `n/a` does not gate: "the gate does not apply" is not "the gate failed".
+  return flat.filter((r) => r.depth === 0).every((r) => r.status !== 'failed');
 }
 
 /** Run a flat checklist: all checks concurrently. */
@@ -238,7 +236,7 @@ async function runFlatChecks(
   defaultSeverity: Severity,
 ): Promise<void> {
   if (!preconditionsPassed) {
-    results.push(...skipAllDescendants(checklist.checks, defaultSeverity, 'precondition', 0));
+    results.push(...skipAllDescendants(checklist.checks, defaultSeverity, 0));
     return;
   }
 
@@ -256,7 +254,7 @@ async function runStagedChecks(
 ): Promise<void> {
   if (!preconditionsPassed) {
     for (const group of checklist.groups) {
-      results.push(...skipAllDescendants(group, defaultSeverity, 'precondition', 0));
+      results.push(...skipAllDescendants(group, defaultSeverity, 0));
     }
     return;
   }
@@ -264,7 +262,7 @@ async function runStagedChecks(
   let shouldSkipRemaining = false;
   for (const group of checklist.groups) {
     if (shouldSkipRemaining) {
-      results.push(...skipAllDescendants(group, defaultSeverity, 'precondition', 0));
+      results.push(...skipAllDescendants(group, defaultSeverity, 0));
       continue;
     }
 
@@ -285,7 +283,8 @@ async function runStagedChecks(
 /**
  * Run all checks in a checklist and produce a report.
  *
- * Preconditions run first. If any fails, all subsequent checks are skipped.
+ * Preconditions run first. If any fails, all subsequent checks are skipped; a precondition
+ * skipped `n/a` does not gate the checklist.
  * Flat checklists run all checks concurrently. Staged checklists run groups
  * sequentially, bailing on later groups when an earlier group has a failure
  * at or above the failure threshold.

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -249,11 +249,12 @@ export interface RdyChecklist {
   /**
    * Gating checks. If any precondition fails, all downstream checks are skipped.
    *
-   * Reporting of precondition results and skipped dependent checks follows the
-   * same reporting-threshold rule as all other results: a result appears in
-   * output only when its severity is at or above the reporting threshold.
-   * Each dependent check's own severity determines whether its skipped entry
-   * is shown.
+   * Only a failure gates. A precondition skipped `n/a` does not: the checklist runs in full. To make a whole checklist
+   * inapplicable, nest its checks under a single parent check whose `skip` returns `n/a`, terminating that subtree.
+   *
+   * Reporting of precondition results and skipped dependent checks follows the same reporting-threshold rule as all
+   * other results: a result appears in output only when its severity is at or above the reporting threshold. Each
+   * dependent check's own severity determines whether its skipped entry is shown.
    */
   preconditions?: RdyCheck[] | undefined;
 


### PR DESCRIPTION
## What

Marking a check not applicable now takes that check and all checks nested beneath it out of the run entirely; they neither execute nor appear in the report. A checklist whose gating precondition was not applicable used to report a clean pass with nothing run; it now runs its checks and can surface real failures. A check whose code crashes now fails the run at error severity, whatever severity it declared. The run summary now describes the whole run: counts, worst severity, and exit code cover everything that happened, not only the severities selected with `--report-on`. Terminal and JSON output now report the same counts, and a check that survives the severity filter stays nested under the checks it sits beneath rather than appearing on its own.

## Why

A readyup run could report a clean pass while nothing had actually run, because a precondition skipped as not applicable silently blocked everything behind it. A run could also exit non-zero while its own summary read `0 warnings`, because the reporting threshold was applied before the tally rather than after it. Output that contradicts itself is output nobody can gate a deployment on, which is the only thing this tool is for.

The root cause was shared across every symptom: two layers each held a partial view of what counted as part of the run, and neither owned the whole.

## Details

### 🎉 Features

- 🚨 **Breaking:** A check skipped `n/a` terminates its own subtree. Descendants neither execute nor produce results, replacing the previous behavior where dependent checks appeared in the report as skipped.
- 🚨 **Breaking:** A precondition skipped `n/a` no longer gates its checklist. Only a failing precondition blocks downstream checks, so checklists previously disabled this way now run in full and may surface failures.
- 🚨 **Breaking:** A `check` or `skip` function that throws is reported at `error` severity regardless of the severity it declares, so a crashing check fails the run under the default threshold. Its skipped descendants keep their own declared severities.

### 🐛 Bug fixes

- Summary counts, worst severity, and the exit code reflect the whole run whatever `--report-on` is set to.
- The human tail line, the combined-summary table, and the `--json` payload report identical numbers for the same run.
- `--report-on` retains the parent chain of every result it shows. A surviving check is no longer indented beneath nothing in the terminal, nor promoted to a top-level entry in `--json`.

### ♻️ Refactoring

- Result filtering moved to the producer: `runRdy` emits exactly the results that exist, and `--report-on` touches only rendering.
- `countResults` is the single tallying entry point and always receives the run's complete result list; `tallyResult` is module-private.
- `selectVisibleResults` is the single pruning entry point shared by both renderers.
- `mergeCounts` is shared by the JSON report and the combined-summary table, which previously each carried their own copy.
- `iterateWithNaSuppression` is deleted, and `collectChildResults` is narrowed to `PassedResult | FailedResult`, making its skipped branch unreachable by type rather than merely unused.

### 🧪 Tests

- `countAgreement.test.ts` runs one checklist that trips every divergence hazard at once — nested `n/a` parent, `n/a` precondition, failed gate with dependents, and a below-threshold failure — then asserts all three views agree on both the counts and the tree structure.
- `countResults` gained direct coverage; every count assertion previously targeted the private per-result primitive.
- `runRdy` tests assert that descendants of an `n/a` check do not execute, separately from asserting that they produce no results.

### 📚 Documentation

- Both `--report-on` help blocks and the README run-options note describe pruning as detail-tree-only, with parent checks retained.
- The `preconditions` type doc states that only a failure gates, and that nesting a checklist's checks under a single `n/a`-able parent is what makes the whole checklist inapplicable.


Closes #126
