### PR TITLE
#118 Differentiate exit codes and route failures through JSON

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -107,7 +107,7 @@ The distinction is between "fix the repo" (`1`) and "fix the invocation" (`2`), 
 
 ### JSON output
 
-With `--json`, stdout carries exactly one JSON document, chosen by how far the invocation got: the report when a run produced one, and otherwise an error envelope.
+With `--json`, stdout carries exactly one JSON document, chosen by how far the invocation got: the report when a run produced one, and otherwise an error envelope. The exceptions are `--help` and `--version`, which have no JSON form: their text goes to stderr and stdout stays empty.
 
 ```json
 { "error": { "code": "usage", "message": "Unknown option '--bogus'" } }

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -77,6 +77,7 @@ rdy <command> [options]
 | `compile [file]` | Bundle TypeScript kit(s) into self-contained ESM |
 | `init`           | Scaffold a starter config and kit                |
 | `list`           | List available kits                              |
+| `verify`         | Check compiled kits against manifest hashes      |
 
 ### Run options
 
@@ -93,6 +94,26 @@ rdy <command> [options]
 | `--report-on, -R <severity>`  | Show this severity or above (`error`, `warn`, `recommend`)    |
 
 `--report-on` prunes only the reported detail tree, and keeps the parent checks of anything it shows so nesting stays intact. Summary counts, worst severity, and the exit code always reflect the whole run.
+
+### Exit codes
+
+| Code | Meaning                                                                                                                       |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | Ran and found no problems                                                                                                     |
+| `1`  | Ran and found problems with the repo or its kits: failed checks, a `verify` drift or missing kit, a kit that fails to compile |
+| `2`  | Could not complete the invocation: a usage, config, kit-load, or internal error                                               |
+
+The distinction is between "fix the repo" (`1`) and "fix the invocation" (`2`), so a pipeline can branch on which is which. `rdy list` and `rdy init` produce only `0` and `2` — neither can find problems to report.
+
+### JSON output
+
+With `--json`, stdout carries exactly one JSON document, chosen by how far the invocation got: the report when a run produced one, and otherwise an error envelope.
+
+```json
+{ "error": { "code": "usage", "message": "Unknown option '--bogus'" } }
+```
+
+`code` is one of `usage`, `config`, `kit-load`, or `internal`. Every human-readable line — help text, progress headers, warnings — goes to stderr, and the exit code does not determine which document appears.
 
 ### Kit sources
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -66,6 +66,7 @@ vi.mock('../src/loadRemoteKit.ts', () => ({
 }));
 
 import { parseRunArgs, resolveKitSources, runCommand } from '../src/cli.ts';
+import { captureRdyError } from './helpers/captureRdyError.ts';
 
 describe(parseRunArgs, () => {
   it('returns undefined checklists and empty specifiers when no flags are given', () => {
@@ -799,17 +800,14 @@ describe(runCommand, () => {
     expect(exitCode).toBe(0);
   });
 
-  it('errors when an unknown checklist name is given', async () => {
+  it('reports a usage error when an unknown checklist name is given', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
 
-    const exitCode = await runCommand({
-      kitEntries: singleKitEntry(['nonexistent']),
-      json: false,
-    });
+    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(['nonexistent']), json: false }));
 
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown name(s): nonexistent'));
-    expect(exitCode).toBe(1);
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain('Unknown name(s): nonexistent');
   });
 
   it('returns exit code 1 when any checklist fails', async () => {
@@ -937,16 +935,13 @@ describe(runCommand, () => {
     expect(mockReportRdy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ fixLocation: 'end' }));
   });
 
-  it('reports kit loading errors to stderr', async () => {
+  it('reports a kit-load error when the kit cannot be loaded', async () => {
     mockLoadRdyKit.mockRejectedValue(new Error('Kit not found'));
 
-    const exitCode = await runCommand({
-      kitEntries: singleKitEntry(),
-      json: false,
-    });
+    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: false }));
 
-    expect(stderrSpy).toHaveBeenCalledWith('Error: Kit not found\n');
-    expect(exitCode).toBe(1);
+    expect(error.code).toBe('kit-load');
+    expect(error.message).toBe('Kit not found');
   });
 
   it('prints combined summary for a single kit with multiple checklists', async () => {
@@ -1002,18 +997,16 @@ describe(runCommand, () => {
 
   // -- --jit error handling (Task 6) --
 
-  it('throws friendly error when --jit kit import fails due to missing readyup', async () => {
+  it('throws a friendly kit-load error when --jit kit import fails due to missing readyup', async () => {
     const moduleError = Object.assign(new Error("Cannot find package 'readyup'"), {
       code: 'MODULE_NOT_FOUND',
     });
     mockLoadRdyKit.mockRejectedValue(moduleError);
 
-    const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
+    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: false }, true));
 
-    expect(stderrSpy).toHaveBeenCalledWith(
-      'Error: Running from source requires readyup to be installed as a project dependency.\n',
-    );
-    expect(exitCode).toBe(1);
+    expect(error.code).toBe('kit-load');
+    expect(error.message).toBe('Running from source requires readyup to be installed as a project dependency.');
   });
 
   it('passes through non-readyup module errors even with --jit', async () => {
@@ -1022,19 +1015,17 @@ describe(runCommand, () => {
     });
     mockLoadRdyKit.mockRejectedValue(moduleError);
 
-    const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
+    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: false }, true));
 
-    expect(stderrSpy).toHaveBeenCalledWith("Error: Cannot find package 'chalk'\n");
-    expect(exitCode).toBe(1);
+    expect(error.message).toBe("Cannot find package 'chalk'");
   });
 
   it('passes through non-module errors with --jit', async () => {
     mockLoadRdyKit.mockRejectedValue(new Error('Syntax error in kit'));
 
-    const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
+    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: false }, true));
 
-    expect(stderrSpy).toHaveBeenCalledWith('Error: Syntax error in kit\n');
-    expect(exitCode).toBe(1);
+    expect(error.message).toBe('Syntax error in kit');
   });
 
   describe('threshold cascade', () => {
@@ -1149,32 +1140,27 @@ describe(runCommand, () => {
       expect(exitCode).toBe(1);
     });
 
-    it('emits JSON error to stdout for kit loading errors', async () => {
+    it('throws a kit-load error without writing to either stream', async () => {
       mockLoadRdyKit.mockRejectedValue(new Error('Kit not found'));
 
-      const exitCode = await runCommand({
-        kitEntries: singleKitEntry(),
-        json: true,
-      });
+      const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: true }));
 
-      expect(mockFormatJsonError).toHaveBeenCalledWith('Kit not found');
-      expect(stdoutSpy).toHaveBeenCalledWith('{"error":"boom"}\n');
+      expect(error.code).toBe('kit-load');
+      expect(stdoutSpy).not.toHaveBeenCalled();
       expect(stderrSpy).not.toHaveBeenCalled();
-      expect(exitCode).toBe(1);
     });
 
-    it('emits JSON error to stdout for unknown checklist names', async () => {
+    it('throws a usage error for unknown checklist names without writing to either stream', async () => {
       const kit = makeKit();
       mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
 
-      const exitCode = await runCommand({
-        kitEntries: singleKitEntry(['nonexistent']),
-        json: true,
-      });
+      const error = await captureRdyError(() =>
+        runCommand({ kitEntries: singleKitEntry(['nonexistent']), json: true }),
+      );
 
-      expect(mockFormatJsonError).toHaveBeenCalledWith(expect.stringContaining('Unknown name(s): nonexistent'));
+      expect(error.code).toBe('usage');
+      expect(stdoutSpy).not.toHaveBeenCalled();
       expect(stderrSpy).not.toHaveBeenCalled();
-      expect(exitCode).toBe(1);
     });
 
     it('passes kit-grouped entries to formatJsonReport', async () => {
@@ -1204,19 +1190,16 @@ describe(runCommand, () => {
       );
     });
 
-    it('emits JSON error to stdout when runRdy throws', async () => {
+    it('lets a runner crash escape undiagnosed so the boundary classifies it internal', async () => {
       const kit = makeKit();
       mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockRejectedValue(new Error('runner crashed'));
 
-      const exitCode = await runCommand({
-        kitEntries: singleKitEntry(['deploy']),
-        json: true,
-      });
-
-      expect(mockFormatJsonError).toHaveBeenCalledWith('runner crashed');
+      await expect(runCommand({ kitEntries: singleKitEntry(['deploy']), json: true })).rejects.toThrow(
+        'runner crashed',
+      );
+      expect(stdoutSpy).not.toHaveBeenCalled();
       expect(stderrSpy).not.toHaveBeenCalled();
-      expect(exitCode).toBe(1);
     });
 
     it('does not write headers in JSON mode', async () => {
@@ -1359,33 +1342,31 @@ describe(runCommand, () => {
     expect(firstRemoteKitCall[0]).not.toHaveProperty('headers');
   });
 
-  it('reports a 404 for a Bitbucket URL with the URL in stderr', async () => {
+  it('reports a 404 for a Bitbucket URL with the URL in the error message', async () => {
     const url = 'https://api.bitbucket.org/2.0/repositories/myteam/repo/src/main/.readyup/kits/missing.js';
     mockResolveBitbucketToken.mockReturnValue(undefined);
     mockLoadRemoteKit.mockRejectedValue(new Error(`Failed to fetch remote kit from ${url}: 404 Not Found`));
 
-    const exitCode = await runCommand({
-      kitEntries: [{ name: 'missing', source: { url }, checklists: [] }],
-      json: false,
-    });
+    const error = await captureRdyError(() =>
+      runCommand({ kitEntries: [{ name: 'missing', source: { url }, checklists: [] }], json: false }),
+    );
 
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(url));
-    expect(exitCode).toBe(1);
+    expect(error.code).toBe('kit-load');
+    expect(error.message).toContain(url);
   });
 
-  it('reports a network failure for a Bitbucket URL with the URL in stderr', async () => {
+  it('reports a network failure for a Bitbucket URL with the URL in the error message', async () => {
     const url = 'https://api.bitbucket.org/2.0/repositories/myteam/repo/src/main/.readyup/kits/deploy.js';
     mockResolveBitbucketToken.mockReturnValue(undefined);
     // Raw fetch rejection — no URL in the error message; loadKit must inject it.
     mockLoadRemoteKit.mockRejectedValue(new TypeError('fetch failed'));
 
-    const exitCode = await runCommand({
-      kitEntries: [{ name: 'deploy', source: { url }, checklists: [] }],
-      json: false,
-    });
+    const error = await captureRdyError(() =>
+      runCommand({ kitEntries: [{ name: 'deploy', source: { url }, checklists: [] }], json: false }),
+    );
 
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(url));
-    expect(exitCode).toBe(1);
+    expect(error.code).toBe('kit-load');
+    expect(error.message).toContain(url);
   });
 
   // URL source tests
@@ -1407,17 +1388,15 @@ describe(runCommand, () => {
     expect(exitCode).toBe(0);
   });
 
-  it('reports remote kit loading errors to stderr, prepending the URL when missing from the message', async () => {
+  it('prepends the URL to a remote kit-load error message when it is missing', async () => {
     const url = 'https://example.com/config.js';
     mockLoadRemoteKit.mockRejectedValue(new Error('Failed to fetch remote kit'));
 
-    const exitCode = await runCommand({
-      kitEntries: [{ name: 'config', source: { url }, checklists: [] }],
-      json: false,
-    });
+    const error = await captureRdyError(() =>
+      runCommand({ kitEntries: [{ name: 'config', source: { url }, checklists: [] }], json: false }),
+    );
 
-    expect(stderrSpy).toHaveBeenCalledWith(`Error: Failed to reach ${url}: Failed to fetch remote kit\n`);
-    expect(exitCode).toBe(1);
+    expect(error.message).toBe(`Failed to reach ${url}: Failed to fetch remote kit`);
   });
 });
 

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -55,6 +55,7 @@ import { compileCommand } from '../src/compile/compileCommand.ts';
 import { ManifestNotFoundError } from '../src/manifest/readManifest.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../src/reportRdy.ts';
 import { VERSION } from '../src/version.ts';
+import { captureRdyError } from './helpers/captureRdyError.ts';
 
 describe(compileCommand, () => {
   let stdoutSpy: MockInstance;
@@ -136,25 +137,25 @@ describe(compileCommand, () => {
     expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', 'custom.js');
   });
 
-  it('returns 1 when --output is provided without a value', async () => {
-    const exitCode = await compileCommand(['input.ts', '--output']);
+  it('reports a usage error when --output is provided without a value', async () => {
+    const error = await captureRdyError(() => compileCommand(['input.ts', '--output']));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--output requires a path argument'));
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain('--output requires a path argument');
   });
 
-  it('returns 1 when --output is given an empty value', async () => {
-    const exitCode = await compileCommand(['input.ts', '--output=']);
+  it('reports a usage error when --output is given an empty value', async () => {
+    const error = await captureRdyError(() => compileCommand(['input.ts', '--output=']));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--output requires a path argument'));
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain('--output requires a path argument');
   });
 
-  it('returns 1 for unknown flags', async () => {
-    const exitCode = await compileCommand(['input.ts', '--verbose']);
+  it('reports a usage error for unknown flags', async () => {
+    const error = await captureRdyError(() => compileCommand(['input.ts', '--verbose']));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown option '--verbose'"));
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain("Unknown option '--verbose'");
   });
 
   it('returns 1 when compileConfig throws', async () => {
@@ -166,11 +167,11 @@ describe(compileCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('esbuild is required'));
   });
 
-  it('returns 1 when multiple positional arguments are provided', async () => {
-    const exitCode = await compileCommand(['a.ts', 'b.ts']);
+  it('reports a usage error when multiple positional arguments are provided', async () => {
+    const error = await captureRdyError(() => compileCommand(['a.ts', 'b.ts']));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Too many arguments'));
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain('Too many arguments');
   });
 
   // Batch compile tests
@@ -222,18 +223,18 @@ describe(compileCommand, () => {
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_NO_CHANGES} b.ts — no changes`));
   });
 
-  it('returns 1 when --output is given without an input file', async () => {
-    const exitCode = await compileCommand(['--output', 'out.js']);
+  it('reports a usage error when --output is given without an input file', async () => {
+    const error = await captureRdyError(() => compileCommand(['--output', 'out.js']));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--output requires an input file'));
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain('--output requires an input file');
   });
 
-  it('returns 1 for --all (removed flag)', async () => {
-    const exitCode = await compileCommand(['--all']);
+  it('reports a usage error for --all (removed flag)', async () => {
+    const error = await captureRdyError(() => compileCommand(['--all']));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown option '--all'"));
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain("Unknown option '--all'");
   });
 
   it('uses compile.include glob to filter files during batch compile', async () => {
@@ -334,7 +335,7 @@ describe(compileCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('references unknown checklist'));
   });
 
-  it('returns 1 with structured error when readdirSync throws during batch compile', async () => {
+  it('reports a config error when readdirSync throws during batch compile', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
     });
@@ -343,11 +344,11 @@ describe(compileCommand, () => {
       throw new Error('EACCES: permission denied');
     });
 
-    const exitCode = await compileCommand([]);
+    const error = await captureRdyError(() => compileCommand([]));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to read source directory'));
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('EACCES'));
+    expect(error.code).toBe('config');
+    expect(error.message).toContain('Failed to read source directory');
+    expect(error.message).toContain('EACCES');
   });
 
   it('writes empty manifest when glob matches only non-.ts files during batch compile', async () => {
@@ -520,7 +521,7 @@ describe(compileCommand, () => {
     expect(mockReadManifest).not.toHaveBeenCalled();
   });
 
-  it('returns 1 when writeManifest throws during batch compile', async () => {
+  it('reports a config error when writeManifest throws during batch compile', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
     });
@@ -531,11 +532,11 @@ describe(compileCommand, () => {
       throw new Error('EACCES: permission denied');
     });
 
-    const exitCode = await compileCommand([]);
+    const error = await captureRdyError(() => compileCommand([]));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error writing manifest'));
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('EACCES'));
+    expect(error.code).toBe('config');
+    expect(error.message).toContain('Error writing manifest');
+    expect(error.message).toContain('EACCES');
   });
 
   it('writes warning to stderr when upsert encounters non-missing-file error', async () => {

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -100,7 +100,7 @@ describe('exit codes', () => {
     const exitCode = await routeCommand([...args, '--json']);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(readStdout())).toMatchObject({ error: { code }, schemaVersion: 1 });
+    expect(JSON.parse(readStdout())).toStrictEqual({ error: { code, message: expect.any(String) } });
   });
 
   it('reports code "config" for an unreadable config file', async () => {
@@ -114,7 +114,7 @@ describe('exit codes', () => {
       const exitCode = await routeCommand(['--json']);
 
       expect(exitCode).toBe(2);
-      expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'config' }, schemaVersion: 1 });
+      expect(JSON.parse(readStdout())).toStrictEqual({ error: { code: 'config', message: expect.any(String) } });
     } finally {
       process.chdir(cwd);
       rmSync(brokenCwd, { recursive: true, force: true });

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -23,16 +23,6 @@ let stderr: string[];
 let stdoutSpy: MockInstance;
 let stderrSpy: MockInstance;
 
-/** Everything written to stdout during the current test. */
-function readStdout(): string {
-  return stdout.join('');
-}
-
-/** Everything written to stderr during the current test. */
-function readStderr(): string {
-  return stderr.join('');
-}
-
 beforeAll(() => {
   originalCwd = process.cwd();
   cwd = mkdtempSync(path.join(tmpdir(), 'readyup-exit-codes-'));
@@ -182,3 +172,13 @@ describe('subcommand error classification', () => {
     expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'usage' } });
   });
 });
+
+/** Everything written to stdout during the current test. */
+function readStdout(): string {
+  return stdout.join('');
+}
+
+/** Everything written to stderr during the current test. */
+function readStderr(): string {
+  return stderr.join('');
+}

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -155,6 +155,17 @@ describe('stdout purity under --json', () => {
     expect(readStderr()).toContain('Error:');
     expect(readStdout()).toBe('');
   });
+
+  it.each([
+    { label: 'the short flag', flag: '-j' },
+    { label: 'a short cluster', flag: '-jJ' },
+  ])('takes the envelope path for a flag-parse failure spelled with $label', async ({ flag }) => {
+    const exitCode = await routeCommand(['--bogus', flag]);
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(readStdout())).toStrictEqual({ error: { code: 'usage', message: expect.any(String) } });
+    expect(readStderr()).toBe('');
+  });
 });
 
 describe('subcommand error classification', () => {

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -1,0 +1,173 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { routeCommand } from '../src/bin/route.ts';
+
+/** A kit whose single check passes. */
+const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
+
+/** A kit whose single error-severity check fails. */
+const FAILING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'nope', check: () => false }] }] };\n`;
+
+/** A kit that is not a valid kit at all, so loading it fails. */
+const INVALID_KIT = `export default { nope: true };\n`;
+
+let cwd: string;
+let originalCwd: string;
+let stdout: string[];
+let stderr: string[];
+let stdoutSpy: MockInstance;
+let stderrSpy: MockInstance;
+
+/** Everything written to stdout during the current test. */
+function readStdout(): string {
+  return stdout.join('');
+}
+
+/** Everything written to stderr during the current test. */
+function readStderr(): string {
+  return stderr.join('');
+}
+
+beforeAll(() => {
+  originalCwd = process.cwd();
+  cwd = mkdtempSync(path.join(tmpdir(), 'readyup-exit-codes-'));
+  mkdirSync(path.join(cwd, '.readyup/kits'), { recursive: true });
+  writeFileSync(path.join(cwd, '.readyup/kits/passing.js'), PASSING_KIT);
+  writeFileSync(path.join(cwd, '.readyup/kits/failing.js'), FAILING_KIT);
+  writeFileSync(path.join(cwd, '.readyup/kits/invalid.js'), INVALID_KIT);
+  // A manifest whose recorded hash cannot match the file on disk, so `verify` reports drift.
+  writeFileSync(
+    path.join(cwd, '.readyup/manifest.json'),
+    JSON.stringify({
+      version: 1,
+      kits: [{ name: 'passing', path: 'kits/passing.js', targetHash: '0'.repeat(8) }],
+    }),
+  );
+  writeFileSync(path.join(cwd, 'broken.ts'), 'export default { this is not valid TypeScript\n');
+  process.chdir(cwd);
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  stdout = [];
+  stderr = [];
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  });
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    stderr.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+describe('exit codes', () => {
+  it.each([
+    { label: 'a passing run', args: ['passing'], expected: 0 },
+    { label: 'a failing run', args: ['failing'], expected: 1 },
+    { label: 'verify drift', args: ['verify'], expected: 1 },
+    { label: 'a kit that fails to compile', args: ['compile', 'broken.ts'], expected: 1 },
+    { label: 'a bad flag', args: ['--bogus'], expected: 2 },
+    { label: 'a missing kit', args: ['absent'], expected: 2 },
+    { label: 'an unloadable kit', args: ['invalid'], expected: 2 },
+    { label: 'an unreadable config', args: ['--from', 'https://example.com'], expected: 2 },
+    { label: 'a missing manifest for verify', args: ['verify', '--manifest', 'absent.json'], expected: 2 },
+    { label: 'listing an absent source', args: ['list', '--from', 'dir:/definitely/absent'], expected: 2 },
+  ])('exits $expected for $label', async ({ args, expected }) => {
+    await expect(routeCommand(args)).resolves.toBe(expected);
+  });
+
+  it.each([
+    { label: 'a bad flag', args: ['--bogus'], code: 'usage' },
+    { label: 'an unknown checklist', args: ['passing:absent'], code: 'usage' },
+    { label: 'a missing kit', args: ['absent'], code: 'kit-load' },
+    { label: 'an unloadable kit', args: ['invalid'], code: 'kit-load' },
+  ])('reports code "$code" for $label', async ({ args, code }) => {
+    const exitCode = await routeCommand([...args, '--json']);
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(readStdout())).toMatchObject({ error: { code }, schemaVersion: 1 });
+  });
+
+  it('reports code "config" for an unreadable config file', async () => {
+    // A separate tree, so the broken config does not reach the other cases in this file.
+    const brokenCwd = mkdtempSync(path.join(tmpdir(), 'readyup-bad-config-'));
+    mkdirSync(path.join(brokenCwd, '.config'), { recursive: true });
+    writeFileSync(path.join(brokenCwd, '.config/readyup.config.ts'), 'export default { compile: 42 };\n');
+    process.chdir(brokenCwd);
+
+    try {
+      const exitCode = await routeCommand(['--json']);
+
+      expect(exitCode).toBe(2);
+      expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'config' }, schemaVersion: 1 });
+    } finally {
+      process.chdir(cwd);
+      rmSync(brokenCwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('stdout purity under --json', () => {
+  it.each([
+    { label: 'a passing run', args: ['passing', '--json'] },
+    { label: 'a failing run', args: ['failing', '--json'] },
+    { label: 'a bad flag', args: ['--bogus', '--json'] },
+    { label: 'a missing kit', args: ['absent', '--json'] },
+    { label: 'an unknown command', args: ['compil', '--json'] },
+    { label: 'a list failure', args: ['list', '--from', 'dir:/definitely/absent', '--json'] },
+    { label: 'a verify failure', args: ['verify', '--manifest', 'absent.json', '--json'] },
+    { label: 'an init usage error', args: ['init', '--json'] },
+  ])('writes exactly one JSON document to stdout for $label', async ({ args }) => {
+    await routeCommand(args);
+
+    const written = readStdout();
+    expect(() => {
+      JSON.parse(written);
+    }).not.toThrow();
+    expect(written.trimEnd().includes('\n')).toBe(false);
+  });
+
+  it('keeps stderr empty when an error is reported through the envelope', async () => {
+    await routeCommand(['--bogus', '--json']);
+
+    expect(readStderr()).toBe('');
+  });
+
+  it('reports errors as prose on stderr when --json is absent', async () => {
+    const exitCode = await routeCommand(['--bogus']);
+
+    expect(exitCode).toBe(2);
+    expect(readStderr()).toContain('Error:');
+    expect(readStdout()).toBe('');
+  });
+});
+
+describe('subcommand error classification', () => {
+  it.each([
+    { command: 'run', args: ['run', '--bogus'] },
+    { command: 'list', args: ['list', '--bogus'] },
+    { command: 'verify', args: ['verify', '--bogus'] },
+    { command: 'compile', args: ['compile', '--bogus'] },
+    { command: 'init', args: ['init', '--bogus'] },
+  ])('exits 2 with a usage error for $command', async ({ args }) => {
+    const exitCode = await routeCommand([...args, '--json']);
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'usage' } });
+  });
+});

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -38,6 +38,8 @@ beforeAll(() => {
       kits: [{ name: 'passing', path: 'kits/passing.js', targetHash: '0'.repeat(8) }],
     }),
   );
+  // Compiling this drives real esbuild, which writes its own diagnostic straight to stderr; the
+  // error banner that appears in an otherwise-passing test run belongs to this fixture.
   writeFileSync(path.join(cwd, 'broken.ts'), 'export default { this is not valid TypeScript\n');
   process.chdir(cwd);
 });

--- a/packages/readyup/__tests__/formatJsonError.test.ts
+++ b/packages/readyup/__tests__/formatJsonError.test.ts
@@ -1,24 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { configError, internalError, kitLoadError, RdyError, usageError } from '../src/errors.ts';
+import { configError, internalError, kitLoadError, usageError } from '../src/errors.ts';
 import { formatJsonError } from '../src/formatJsonError.ts';
 
 describe(formatJsonError, () => {
-  it('wraps the message, code, and remedy in a versioned envelope', () => {
+  it('wraps the code and message in an envelope carrying nothing else', () => {
     const output = formatJsonError(usageError('something went wrong'));
     const parsed: unknown = JSON.parse(output);
 
-    expect(parsed).toStrictEqual({
-      error: { code: 'usage', message: 'something went wrong', remedy: '' },
-      schemaVersion: 1,
-    });
-  });
-
-  it('carries the remedy when one is supplied', () => {
-    const output = formatJsonError(new RdyError('config', 'bad config', { remedy: 'Run `rdy init`.' }));
-    const parsed: unknown = JSON.parse(output);
-
-    expect(parsed).toMatchObject({ error: { remedy: 'Run `rdy init`.' } });
+    expect(parsed).toStrictEqual({ error: { code: 'usage', message: 'something went wrong' } });
   });
 
   it.each([

--- a/packages/readyup/__tests__/formatJsonError.test.ts
+++ b/packages/readyup/__tests__/formatJsonError.test.ts
@@ -1,17 +1,37 @@
 import { describe, expect, it } from 'vitest';
 
+import { configError, internalError, kitLoadError, RdyError, usageError } from '../src/errors.ts';
 import { formatJsonError } from '../src/formatJsonError.ts';
 
 describe(formatJsonError, () => {
-  it('returns valid JSON with an error field', () => {
-    const output = formatJsonError('something went wrong');
+  it('wraps the message, code, and remedy in a versioned envelope', () => {
+    const output = formatJsonError(usageError('something went wrong'));
     const parsed: unknown = JSON.parse(output);
 
-    expect(parsed).toStrictEqual({ error: 'something went wrong' });
+    expect(parsed).toStrictEqual({
+      error: { code: 'usage', message: 'something went wrong', remedy: '' },
+      schemaVersion: 1,
+    });
+  });
+
+  it('carries the remedy when one is supplied', () => {
+    const output = formatJsonError(new RdyError('config', 'bad config', { remedy: 'Run `rdy init`.' }));
+    const parsed: unknown = JSON.parse(output);
+
+    expect(parsed).toMatchObject({ error: { remedy: 'Run `rdy init`.' } });
+  });
+
+  it.each([
+    ['usage', usageError('x')],
+    ['config', configError('x')],
+    ['kit-load', kitLoadError('x')],
+    ['internal', internalError('x')],
+  ])('reports the %s code', (code, error) => {
+    expect(JSON.parse(formatJsonError(error))).toMatchObject({ error: { code } });
   });
 
   it('produces a single-line string', () => {
-    const output = formatJsonError('multi\nline\nmessage');
+    const output = formatJsonError(usageError('multi\nline\nmessage'));
 
     expect(output.includes('\n')).toBe(false);
   });

--- a/packages/readyup/__tests__/hasJsonFlag.test.ts
+++ b/packages/readyup/__tests__/hasJsonFlag.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasJsonFlag } from '../src/hasJsonFlag.ts';
+
+describe(hasJsonFlag, () => {
+  it.each([
+    { label: 'the long flag', argv: ['run', '--json'] },
+    { label: 'the short flag', argv: ['run', '-j'] },
+    { label: 'a short cluster leading with j', argv: ['run', '-jJ'] },
+    { label: 'a short cluster ending with j', argv: ['run', '-Jj'] },
+    { label: 'a flag preceding an unparseable one', argv: ['--json', '--bogus'] },
+  ])('detects JSON mode from $label', ({ argv }) => {
+    expect(hasJsonFlag(argv)).toBe(true);
+  });
+
+  it.each([
+    { label: 'no flags at all', argv: ['run', 'deploy'] },
+    { label: 'an unrelated long flag', argv: ['run', '--jit'] },
+    { label: 'an unrelated short cluster', argv: ['run', '-Ji'] },
+    { label: 'a positional that merely contains j', argv: ['run', 'json'] },
+  ])('reports no JSON mode for $label', ({ argv }) => {
+    expect(hasJsonFlag(argv)).toBe(false);
+  });
+
+  it.each([
+    { label: 'the long flag', argv: ['run', '--', '--json'] },
+    { label: 'the short flag', argv: ['run', '--', '-j'] },
+  ])('ignores $label after the -- terminator', ({ argv }) => {
+    expect(hasJsonFlag(argv)).toBe(false);
+  });
+
+  it('detects a flag appearing before the -- terminator', () => {
+    expect(hasJsonFlag(['run', '--json', '--', '-x'])).toBe(true);
+  });
+});

--- a/packages/readyup/__tests__/helpers/captureRdyError.ts
+++ b/packages/readyup/__tests__/helpers/captureRdyError.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+
+import { RdyError } from '../../src/errors.ts';
+
+/**
+ * Run a command expected to fail and return the `RdyError` it threw.
+ *
+ * Fails the test when the command completes normally or throws anything else.
+ */
+export async function captureRdyError(run: () => number | Promise<number>): Promise<RdyError> {
+  try {
+    await run();
+  } catch (error: unknown) {
+    assert.ok(error instanceof RdyError, `Expected an RdyError, got: ${String(error)}`);
+    return error;
+  }
+  return assert.fail('Expected the command to throw an RdyError');
+}

--- a/packages/readyup/__tests__/helpers/captureRdyError.ts
+++ b/packages/readyup/__tests__/helpers/captureRdyError.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { RdyError } from '../../src/errors.ts';
 
 /**
- * Run a command expected to fail and return the `RdyError` it threw.
+ * Runs a command expected to fail and returns the `RdyError` it threw.
  *
  * Fails the test when the command completes normally or throws anything else.
  */

--- a/packages/readyup/__tests__/initCommand.unit.test.ts
+++ b/packages/readyup/__tests__/initCommand.unit.test.ts
@@ -39,32 +39,32 @@ describe(`${initCommand.name} error handling`, () => {
     mockReportWriteResult.mockReset();
   });
 
-  it('throws an internal error when scaffoldConfig throws', () => {
+  it('throws a config error when scaffoldConfig throws', () => {
     mockScaffoldConfig.mockImplementation(() => {
       throw new Error('disk full');
     });
 
     expect(() => initCommand({ dryRun: false, force: false })).toThrow(
-      expect.objectContaining({ code: 'internal', message: expect.stringContaining('disk full') }),
+      expect.objectContaining({ code: 'config', message: expect.stringContaining('disk full') }),
     );
   });
 
-  it('throws an internal error naming the file when the config result failed', () => {
+  it('throws a config error naming the file when the config result failed', () => {
     mockScaffoldConfig.mockReturnValue(makeScaffoldResult('failed'));
 
     expect(() => initCommand({ dryRun: false, force: false })).toThrow(
-      expect.objectContaining({ code: 'internal', message: 'Failed to scaffold .config/readyup.config.ts' }),
+      expect.objectContaining({ code: 'config', message: 'Failed to scaffold .config/readyup.config.ts' }),
     );
   });
 
-  it('throws an internal error naming the file when the kit result failed', () => {
+  it('throws a config error naming the file when the kit result failed', () => {
     mockScaffoldConfig.mockReturnValue({
       configResult: { filePath: '.config/readyup.config.ts', outcome: 'created' },
       kitResult: { filePath: '.readyup/kits/default.ts', outcome: 'failed' },
     });
 
     expect(() => initCommand({ dryRun: false, force: false })).toThrow(
-      expect.objectContaining({ code: 'internal', message: 'Failed to scaffold .readyup/kits/default.ts' }),
+      expect.objectContaining({ code: 'config', message: 'Failed to scaffold .readyup/kits/default.ts' }),
     );
   });
 

--- a/packages/readyup/__tests__/initCommand.unit.test.ts
+++ b/packages/readyup/__tests__/initCommand.unit.test.ts
@@ -39,33 +39,33 @@ describe(`${initCommand.name} error handling`, () => {
     mockReportWriteResult.mockReset();
   });
 
-  it('returns exit code 1 when scaffoldConfig throws', () => {
+  it('throws an internal error when scaffoldConfig throws', () => {
     mockScaffoldConfig.mockImplementation(() => {
       throw new Error('disk full');
     });
 
-    const exitCode = initCommand({ dryRun: false, force: false });
-
-    expect(exitCode).toBe(1);
+    expect(() => initCommand({ dryRun: false, force: false })).toThrow(
+      expect.objectContaining({ code: 'internal', message: expect.stringContaining('disk full') }),
+    );
   });
 
-  it('returns exit code 1 when config result is failed', () => {
+  it('throws an internal error naming the file when the config result failed', () => {
     mockScaffoldConfig.mockReturnValue(makeScaffoldResult('failed'));
 
-    const exitCode = initCommand({ dryRun: false, force: false });
-
-    expect(exitCode).toBe(1);
+    expect(() => initCommand({ dryRun: false, force: false })).toThrow(
+      expect.objectContaining({ code: 'internal', message: 'Failed to scaffold .config/readyup.config.ts' }),
+    );
   });
 
-  it('returns exit code 1 when kit result is failed', () => {
+  it('throws an internal error naming the file when the kit result failed', () => {
     mockScaffoldConfig.mockReturnValue({
       configResult: { filePath: '.config/readyup.config.ts', outcome: 'created' },
       kitResult: { filePath: '.readyup/kits/default.ts', outcome: 'failed' },
     });
 
-    const exitCode = initCommand({ dryRun: false, force: false });
-
-    expect(exitCode).toBe(1);
+    expect(() => initCommand({ dryRun: false, force: false })).toThrow(
+      expect.objectContaining({ code: 'internal', message: 'Failed to scaffold .readyup/kits/default.ts' }),
+    );
   });
 
   it('returns exit code 0 when both results are created', () => {
@@ -87,7 +87,12 @@ describe(`${initCommand.name} error handling`, () => {
     const result = makeScaffoldResult(outcome);
     mockScaffoldConfig.mockReturnValue(result);
 
-    initCommand({ dryRun, force: false });
+    // A failed write is reported per-file before the command throws, so both calls land either way.
+    try {
+      initCommand({ dryRun, force: false });
+    } catch {
+      // The thrown failure is asserted by its own test.
+    }
 
     expect(mockReportWriteResult).toHaveBeenCalledWith(result.configResult, dryRun);
     expect(mockReportWriteResult).toHaveBeenCalledWith(result.kitResult, dryRun);

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../src/resolveGitHubToken.ts', () => ({
 vi.stubGlobal('fetch', mockFetch);
 
 import { listCommand } from '../../src/list/listCommand.ts';
+import { captureRdyError } from '../helpers/captureRdyError.ts';
 import { mockResponse } from '../helpers/mockResponse.ts';
 
 const validRemoteManifestBody = JSON.stringify({
@@ -46,11 +47,10 @@ const validRemoteManifestBody = JSON.stringify({
 
 describe(listCommand, () => {
   let stdoutSpy: MockInstance;
-  let stderrSpy: MockInstance;
 
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     mockEnumerateKits.mockReturnValue([]);
     mockReadManifest.mockReturnValue({ version: 1, kits: [] });
     mockResolveBitbucketToken.mockReturnValue(undefined);
@@ -115,12 +115,11 @@ describe(listCommand, () => {
     expect(calledPath).toBe(path.join(path.resolve('/some/repo'), '.readyup/manifest.json'));
   });
 
-  it('returns exit code 1 with a user-readable error for malformed --from values', async () => {
-    const exitCode = await listCommand(['--from', 'https://example.com']);
+  it('reports a usage error for malformed --from values', async () => {
+    const error = await captureRdyError(() => listCommand(['--from', 'https://example.com']));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error:'));
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('URLs are not accepted by --from'));
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain('URLs are not accepted by --from');
     expect(mockReadManifest).not.toHaveBeenCalled();
   });
 
@@ -170,79 +169,73 @@ describe(listCommand, () => {
     );
   });
 
-  it('with --from github:... and a 404 response, writes a stderr message naming the URL', async () => {
+  it('with --from github:... and a 404 response, reports a config error naming the URL', async () => {
     mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
 
-    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+    const error = await captureRdyError(() => listCommand(['--from', 'github:williamthorsen/workshop']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
-      'Error: No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json.',
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
+      'No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json.',
     );
   });
 
-  it('with --from github:... and an HTML soft-404 body, writes a stderr message naming the URL', async () => {
+  it('with --from github:... and an HTML soft-404 body, reports a config error naming the URL', async () => {
     mockFetch.mockResolvedValue(mockResponse('<!DOCTYPE html><html><body>Not Found</body></html>'));
 
-    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+    const error = await captureRdyError(() => listCommand(['--from', 'github:williamthorsen/workshop']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
-      'Error: No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json.',
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
+      'No manifest found at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json.',
     );
   });
 
-  it('with --from github:... and a malformed manifest, writes a stderr message including the URL and "malformed"', async () => {
+  it('with --from github:... and a malformed manifest, reports a config error naming the URL and "malformed"', async () => {
     mockFetch.mockResolvedValue(mockResponse('{ not valid json'));
 
-    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+    const error = await captureRdyError(() => listCommand(['--from', 'github:williamthorsen/workshop']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
       'Manifest at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json is malformed:',
     );
   });
 
-  it('with --from github:... and a schema-invalid manifest, writes a stderr message including the URL and "malformed"', async () => {
+  it('with --from github:... and a schema-invalid manifest, reports a config error naming the URL and "malformed"', async () => {
     mockFetch.mockResolvedValue(mockResponse(JSON.stringify({ version: 1, kits: 'not-an-array' })));
 
-    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+    const error = await captureRdyError(() => listCommand(['--from', 'github:williamthorsen/workshop']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
       'Manifest at https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json is malformed:',
     );
   });
 
-  it('with --from github:... and a 500 response, writes a stderr message including the URL and status', async () => {
+  it('with --from github:... and a 500 response, reports a config error naming the URL and status', async () => {
     mockFetch.mockResolvedValue(
       mockResponse('Internal Server Error', { status: 500, statusText: 'Internal Server Error' }),
     );
 
-    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+    const error = await captureRdyError(() => listCommand(['--from', 'github:williamthorsen/workshop']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
       'Failed to fetch manifest from https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json: 500 Internal Server Error',
     );
   });
 
-  it('with --from github:... and a network failure, writes a stderr message including the URL', async () => {
+  it('with --from github:... and a network failure, reports a config error naming the URL', async () => {
     mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
 
-    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+    const error = await captureRdyError(() => listCommand(['--from', 'github:williamthorsen/workshop']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
       'Failed to reach https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json',
     );
-    expect(stderrCalls).toContain('ECONNREFUSED');
+    expect(error.message).toContain('ECONNREFUSED');
   });
 
   it('with --from bitbucket:ws/repo, fetches and renders the remote manifest', async () => {
@@ -304,66 +297,61 @@ describe(listCommand, () => {
     );
   });
 
-  it('with --from bitbucket:... and a 404 response, writes a stderr message naming the URL', async () => {
+  it('with --from bitbucket:... and a 404 response, reports a config error naming the URL', async () => {
     mockFetch.mockResolvedValue(mockResponse('Not Found', { status: 404, statusText: 'Not Found' }));
 
-    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+    const error = await captureRdyError(() => listCommand(['--from', 'bitbucket:tutorials/markdowndemo']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
-      'Error: No manifest found at https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json.',
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
+      'No manifest found at https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json.',
     );
   });
 
-  it('with --from bitbucket:... and a malformed manifest, writes a stderr message including the URL and "malformed"', async () => {
+  it('with --from bitbucket:... and a malformed manifest, reports a config error naming the URL and "malformed"', async () => {
     mockFetch.mockResolvedValue(mockResponse('{ not valid json'));
 
-    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+    const error = await captureRdyError(() => listCommand(['--from', 'bitbucket:tutorials/markdowndemo']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
       'Manifest at https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json is malformed:',
     );
   });
 
-  it('with --from bitbucket:... and a schema-invalid manifest, writes a stderr message including the URL and "malformed"', async () => {
+  it('with --from bitbucket:... and a schema-invalid manifest, reports a config error naming the URL and "malformed"', async () => {
     mockFetch.mockResolvedValue(mockResponse(JSON.stringify({ version: 1, kits: 'not-an-array' })));
 
-    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+    const error = await captureRdyError(() => listCommand(['--from', 'bitbucket:tutorials/markdowndemo']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
       'Manifest at https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json is malformed:',
     );
   });
 
-  it('with --from bitbucket:... and a 500 response, writes a stderr message including the URL and status', async () => {
+  it('with --from bitbucket:... and a 500 response, reports a config error naming the URL and status', async () => {
     mockFetch.mockResolvedValue(
       mockResponse('Internal Server Error', { status: 500, statusText: 'Internal Server Error' }),
     );
 
-    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+    const error = await captureRdyError(() => listCommand(['--from', 'bitbucket:tutorials/markdowndemo']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
       'Failed to fetch manifest from https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json: 500 Internal Server Error',
     );
   });
 
-  it('with --from bitbucket:... and a network failure, writes a stderr message including the URL', async () => {
+  it('with --from bitbucket:... and a network failure, reports a config error naming the URL', async () => {
     mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
 
-    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+    const error = await captureRdyError(() => listCommand(['--from', 'bitbucket:tutorials/markdowndemo']));
 
-    expect(exitCode).toBe(1);
-    const stderrCalls = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderrCalls).toContain(
+    expect(error.code).toBe('config');
+    expect(error.message).toContain(
       'Failed to reach https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json',
     );
-    expect(stderrCalls).toContain('ECONNREFUSED');
+    expect(error.message).toContain('ECONNREFUSED');
   });
 });

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -22,6 +22,7 @@ vi.mock('../src/manifest/readManifest.ts', async (importOriginal) => {
 
 import { listCommand } from '../src/list/listCommand.ts';
 import { ManifestNotFoundError } from '../src/manifest/readManifest.ts';
+import { captureRdyError } from './helpers/captureRdyError.ts';
 
 describe(listCommand, () => {
   let stdoutSpy: MockInstance;
@@ -124,25 +125,25 @@ describe(listCommand, () => {
       expect(output).toContain('No kits found.');
     });
 
-    it('returns 1 and writes to stderr when config load fails', async () => {
+    it('reports a config error when config load fails', async () => {
       mockLoadConfig.mockRejectedValue(new Error('bad config'));
 
-      const exitCode = await listCommand([]);
+      const error = await captureRdyError(() => listCommand([]));
 
-      expect(exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('bad config'));
+      expect(error.code).toBe('config');
+      expect(error.message).toContain('bad config');
     });
 
-    it('returns 1 and writes to stderr when enumerateKits throws', async () => {
+    it('reports a config error when enumerateKits throws', async () => {
       const permError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
       mockEnumerateKits.mockImplementation(() => {
         throw permError;
       });
 
-      const exitCode = await listCommand([]);
+      const error = await captureRdyError(() => listCommand([]));
 
-      expect(exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('permission denied'));
+      expect(error.code).toBe('config');
+      expect(error.message).toContain('permission denied');
     });
 
     it('renders Internal section without Compiled when manifest file is missing and internal kits exist', async () => {
@@ -212,15 +213,15 @@ describe(listCommand, () => {
       expect(output).toContain('No compiled kits found');
     });
 
-    it('returns 1 when manifest is not found at --from path', async () => {
+    it('reports a config error when the manifest is not found at the --from path', async () => {
       mockReadManifest.mockImplementation(() => {
         throw new Error('Manifest file not found: /nonexistent/.readyup/manifest.json');
       });
 
-      const exitCode = await listCommand(['--from', '/nonexistent']);
+      const error = await captureRdyError(() => listCommand(['--from', '/nonexistent']));
 
-      expect(exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Manifest file not found'));
+      expect(error.code).toBe('config');
+      expect(error.message).toContain('Manifest file not found');
     });
   });
 
@@ -242,29 +243,29 @@ describe(listCommand, () => {
       expect(output).toContain('deploy');
     });
 
-    it('returns 1 when manifest file cannot be read', async () => {
+    it('reports a config error when the manifest file cannot be read', async () => {
       mockReadManifest.mockImplementation(() => {
         throw new Error('Manifest file not found: /missing/manifest.json');
       });
 
-      const exitCode = await listCommand(['--manifest', '/missing/manifest.json']);
+      const error = await captureRdyError(() => listCommand(['--manifest', '/missing/manifest.json']));
 
-      expect(exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Manifest file not found'));
+      expect(error.code).toBe('config');
+      expect(error.message).toContain('Manifest file not found');
     });
 
-    it('returns 1 when --from and --manifest are both provided', async () => {
-      const exitCode = await listCommand(['--from', '.', '--manifest', '.readyup/manifest.json']);
+    it('reports a usage error when --from and --manifest are both provided', async () => {
+      const error = await captureRdyError(() => listCommand(['--from', '.', '--manifest', '.readyup/manifest.json']));
 
-      expect(exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('mutually exclusive'));
+      expect(error.code).toBe('usage');
+      expect(error.message).toContain('mutually exclusive');
     });
   });
 
-  it('returns 1 for unknown flags', async () => {
-    const exitCode = await listCommand(['--unknown']);
+  it('reports a usage error for unknown flags', async () => {
+    const error = await captureRdyError(() => listCommand(['--unknown']));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown option '--unknown'"));
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain("Unknown option '--unknown'");
   });
 });

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -35,13 +35,29 @@ vi.mock('../src/version.ts', () => ({
 }));
 
 import { routeCommand } from '../src/bin/route.ts';
+import { usageError } from '../src/errors.ts';
+
+/** Build a `parseRunArgs` return value with the no-flags defaults. */
+function parsedRunArgs(overrides?: Record<string, unknown>) {
+  return {
+    kitSpecifiers: [],
+    checklists: undefined,
+    filePath: undefined,
+    fromValue: undefined,
+    urlValue: undefined,
+    jit: false,
+    internal: false,
+    json: false,
+    ...overrides,
+  };
+}
 
 describe(routeCommand, () => {
-  let infoSpy: MockInstance;
+  let stdoutSpy: MockInstance;
   let stderrSpy: MockInstance;
 
   beforeEach(() => {
-    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
@@ -67,7 +83,7 @@ describe(routeCommand, () => {
     const exitCode = await routeCommand([]);
 
     expect(exitCode).toBe(0);
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('Usage: rdy');
   });
 
@@ -75,7 +91,7 @@ describe(routeCommand, () => {
     const exitCode = await routeCommand(['--help']);
 
     expect(exitCode).toBe(0);
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('Usage: rdy');
   });
 
@@ -89,20 +105,20 @@ describe(routeCommand, () => {
     const exitCode = await routeCommand(['--version']);
 
     expect(exitCode).toBe(0);
-    expect(infoSpy).toHaveBeenCalledWith('1.2.3');
+    expect(stdoutSpy).toHaveBeenCalledWith('1.2.3\n');
   });
 
   it('prints version and returns 0 for -V', async () => {
     const exitCode = await routeCommand(['-V']);
 
     expect(exitCode).toBe(0);
-    expect(infoSpy).toHaveBeenCalledWith('1.2.3');
+    expect(stdoutSpy).toHaveBeenCalledWith('1.2.3\n');
   });
 
   it('includes run options in top-level help', async () => {
     await routeCommand(['--help']);
 
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('--from');
     expect(output).toContain('--file, -f');
     expect(output).toContain('--url, -u');
@@ -116,7 +132,7 @@ describe(routeCommand, () => {
   it('marks run as the default command in top-level help', async () => {
     await routeCommand(['--help']);
 
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('(default)');
   });
 
@@ -124,7 +140,7 @@ describe(routeCommand, () => {
     const exitCode = await routeCommand(['run', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('Usage: rdy run');
   });
 
@@ -132,7 +148,7 @@ describe(routeCommand, () => {
     const exitCode = await routeCommand(['init', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('Usage: rdy init');
   });
 
@@ -214,22 +230,22 @@ describe(routeCommand, () => {
   it('includes --json in run help text', async () => {
     await routeCommand(['run', '--help']);
 
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('--json');
   });
 
-  it('returns 1 and writes to stderr when parseRunArgs throws', async () => {
+  it('returns 2 and writes to stderr when parseRunArgs throws', async () => {
     mockParseRunArgs.mockImplementation(() => {
       throw new Error("unknown flag '--bad'");
     });
 
     const exitCode = await routeCommand(['run', '--bad']);
 
-    expect(exitCode).toBe(1);
+    expect(exitCode).toBe(2);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("unknown flag '--bad'"));
   });
 
-  it('returns 1 and writes to stderr when resolveKitSources throws', async () => {
+  it('returns 2 and writes to stderr when resolveKitSources throws', async () => {
     mockParseRunArgs.mockReturnValue({
       kitSpecifiers: [],
       checklists: undefined,
@@ -246,11 +262,11 @@ describe(routeCommand, () => {
 
     const exitCode = await routeCommand(['run', '--file', 'path.ts']);
 
-    expect(exitCode).toBe(1);
+    expect(exitCode).toBe(2);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('resolution failed'));
   });
 
-  it('returns 1 and writes to stderr when loadConfig rejects', async () => {
+  it('returns 2 and writes to stderr when loadConfig rejects', async () => {
     mockParseRunArgs.mockReturnValue({
       kitSpecifiers: [],
       checklists: undefined,
@@ -265,7 +281,7 @@ describe(routeCommand, () => {
 
     const exitCode = await routeCommand(['run']);
 
-    expect(exitCode).toBe(1);
+    expect(exitCode).toBe(2);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('bad config'));
   });
 
@@ -372,7 +388,7 @@ describe(routeCommand, () => {
     const exitCode = await routeCommand(['compile', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('Usage: rdy compile');
     expect(output).toContain('If no file is given');
   });
@@ -404,7 +420,7 @@ describe(routeCommand, () => {
   it('lists compile in top-level help', async () => {
     await routeCommand([]);
 
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('compile');
   });
 
@@ -435,10 +451,10 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(0);
   });
 
-  it('returns 1 for unknown init flags', async () => {
+  it('returns 2 for unknown init flags', async () => {
     const exitCode = await routeCommand(['init', '--unknown']);
 
-    expect(exitCode).toBe(1);
+    expect(exitCode).toBe(2);
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown option '--unknown'"));
   });
 
@@ -446,7 +462,7 @@ describe(routeCommand, () => {
     const exitCode = await routeCommand(['list', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('Usage: rdy list');
   });
 
@@ -477,8 +493,80 @@ describe(routeCommand, () => {
   it('lists list in top-level help', async () => {
     await routeCommand([]);
 
-    const output = infoSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('list');
+  });
+
+  describe('error envelope and stdout purity', () => {
+    /** Collect everything written to stdout during the call, parsed as a single JSON document. */
+    function parseStdout(): unknown {
+      const written = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      return JSON.parse(written);
+    }
+
+    it('emits the error envelope on stdout and leaves stderr empty for a usage error under --json', async () => {
+      mockParseRunArgs.mockImplementation(() => {
+        throw usageError("Unknown option '--bogus'");
+      });
+
+      const exitCode = await routeCommand(['--json', '--bogus']);
+
+      expect(exitCode).toBe(2);
+      expect(parseStdout()).toStrictEqual({
+        error: { code: 'usage', message: "Unknown option '--bogus'", remedy: '' },
+        schemaVersion: 1,
+      });
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it('classifies a config-load failure as a config error in the envelope', async () => {
+      mockParseRunArgs.mockReturnValue(parsedRunArgs({ json: true }));
+      mockLoadConfig.mockRejectedValue(new Error('bad config'));
+
+      const exitCode = await routeCommand(['run', '--json']);
+
+      expect(exitCode).toBe(2);
+      expect(parseStdout()).toMatchObject({ error: { code: 'config', message: 'bad config' } });
+    });
+
+    it('classifies an undiagnosed failure as an internal error in the envelope', async () => {
+      mockParseRunArgs.mockImplementation(() => {
+        throw new Error('something unexpected');
+      });
+
+      const exitCode = await routeCommand(['--json']);
+
+      expect(exitCode).toBe(2);
+      expect(parseStdout()).toMatchObject({ error: { code: 'internal', message: 'something unexpected' } });
+    });
+
+    it('emits an unknown-command error as an envelope rather than prose under --json', async () => {
+      const exitCode = await routeCommand(['compil', '--json']);
+
+      expect(exitCode).toBe(2);
+      expect(parseStdout()).toMatchObject({ error: { code: 'usage' } });
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it('diverts help text to stderr under --json so stdout stays free of prose', async () => {
+      const exitCode = await routeCommand(['--help', '--json']);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).not.toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Usage: rdy'));
+    });
+
+    it('stops the --json scan at the `--` terminator', async () => {
+      mockParseRunArgs.mockImplementation(() => {
+        throw usageError('nope');
+      });
+
+      const exitCode = await routeCommand(['run', '--', '--json']);
+
+      expect(exitCode).toBe(2);
+      expect(stdoutSpy).not.toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('nope'));
+    });
   });
 
   describe('default command routing', () => {
@@ -531,7 +619,7 @@ describe(routeCommand, () => {
     ])('suggests "%s" -> "%s"', async (input, expected) => {
       const exitCode = await routeCommand([input]);
 
-      expect(exitCode).toBe(1);
+      expect(exitCode).toBe(2);
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`Did you mean 'rdy ${expected}'?`));
     });
 

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -512,10 +512,7 @@ describe(routeCommand, () => {
       const exitCode = await routeCommand(['--json', '--bogus']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout()).toStrictEqual({
-        error: { code: 'usage', message: "Unknown option '--bogus'", remedy: '' },
-        schemaVersion: 1,
-      });
+      expect(parseStdout()).toStrictEqual({ error: { code: 'usage', message: "Unknown option '--bogus'" } });
       expect(stderrSpy).not.toHaveBeenCalled();
     });
 

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -37,21 +37,6 @@ vi.mock('../src/version.ts', () => ({
 import { routeCommand } from '../src/bin/route.ts';
 import { usageError } from '../src/errors.ts';
 
-/** Build a `parseRunArgs` return value with the no-flags defaults. */
-function parsedRunArgs(overrides?: Record<string, unknown>) {
-  return {
-    kitSpecifiers: [],
-    checklists: undefined,
-    filePath: undefined,
-    fromValue: undefined,
-    urlValue: undefined,
-    jit: false,
-    internal: false,
-    json: false,
-    ...overrides,
-  };
-}
-
 describe(routeCommand, () => {
   let stdoutSpy: MockInstance;
   let stderrSpy: MockInstance;
@@ -498,7 +483,7 @@ describe(routeCommand, () => {
   });
 
   describe('error envelope and stdout purity', () => {
-    /** Collect everything written to stdout during the call, parsed as a single JSON document. */
+    /** Collects everything written to stdout during the call, parsed as a single JSON document. */
     function parseStdout(): unknown {
       const written = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       return JSON.parse(written);
@@ -660,3 +645,18 @@ describe(routeCommand, () => {
     });
   });
 });
+
+/** Builds a `parseRunArgs` return value with the no-flags defaults. */
+function parsedRunArgs(overrides?: Record<string, unknown>) {
+  return {
+    kitSpecifiers: [],
+    checklists: undefined,
+    filePath: undefined,
+    fromValue: undefined,
+    urlValue: undefined,
+    jit: false,
+    internal: false,
+    json: false,
+    ...overrides,
+  };
+}

--- a/packages/readyup/__tests__/verify/verifyCommand.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.test.ts
@@ -16,14 +16,14 @@ vi.mock('../../src/verify/checkDrift.ts', () => ({
 }));
 
 import { verifyCommand } from '../../src/verify/verifyCommand.ts';
+import { captureRdyError } from '../helpers/captureRdyError.ts';
 
 describe(verifyCommand, () => {
   let stdoutSpy: MockInstance;
-  let stderrSpy: MockInstance;
 
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -111,15 +111,15 @@ describe(verifyCommand, () => {
     expect(mockCheckDrift).not.toHaveBeenCalled();
   });
 
-  it('returns 1 when the manifest cannot be read', () => {
+  it('reports a config error when the manifest cannot be read', async () => {
     mockReadManifest.mockImplementation(() => {
       throw new Error('Manifest file not found: /path/to/manifest.json');
     });
 
-    const exitCode = verifyCommand([]);
+    const error = await captureRdyError(() => verifyCommand([]));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Manifest file not found'));
+    expect(error.code).toBe('config');
+    expect(error.message).toContain('Manifest file not found');
   });
 
   it('honors --manifest flag to resolve a custom path', () => {
@@ -130,10 +130,10 @@ describe(verifyCommand, () => {
     expect(mockReadManifest).toHaveBeenCalledWith(expect.stringContaining('custom/manifest.json'));
   });
 
-  it('returns 1 when positional arguments are supplied', () => {
-    const exitCode = verifyCommand(['unexpected']);
+  it('reports a usage error when positional arguments are supplied', async () => {
+    const error = await captureRdyError(() => verifyCommand(['unexpected']));
 
-    expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('does not accept positional arguments'));
+    expect(error.code).toBe('usage');
+    expect(error.message).toContain('does not accept positional arguments');
   });
 });

--- a/packages/readyup/src/bin/rdy.ts
+++ b/packages/readyup/src/bin/rdy.ts
@@ -4,10 +4,11 @@
 import module from 'node:module';
 import process from 'node:process';
 
-import { extractMessage } from '../utils/error-handling.ts';
+import { hasJsonFlag } from '../hasJsonFlag.ts';
 import { resolveHookSpecifier } from './resolveHookSpecifier.ts';
-import { routeCommand } from './route.ts';
+import { reportFailure, routeCommand } from './route.ts';
 
+const args = process.argv.slice(2);
 let exitCode: number;
 try {
   // Register the readyup resolver hook before any kit is loaded. Externalized
@@ -20,16 +21,15 @@ try {
   // in import/export/`import()` positions, never a `module.register()` argument, so the
   // extension cannot be deferred to the build.) Wrapping this call in the runner's error
   // boundary ensures any registration failure (missing hook file, bad path, Node
-  // rejection) surfaces as `rdy: unexpected error: ...` rather than an opaque unhandled
-  // exception.
+  // rejection) surfaces through the same error channel as any other failure rather than as
+  // an opaque unhandled exception.
   module.register(resolveHookSpecifier(import.meta.url), {
     parentURL: import.meta.url,
     data: { readyupParentURL: import.meta.url },
   });
-  exitCode = await routeCommand(process.argv.slice(2));
+  exitCode = await routeCommand(args);
 } catch (error: unknown) {
-  const message = extractMessage(error);
-  process.stderr.write(`rdy: unexpected error: ${message}\n`);
-  exitCode = 1;
+  // Anything reaching here escaped `routeCommand`'s boundary, so it is classified `internal`.
+  exitCode = reportFailure(error, hasJsonFlag(args));
 }
 process.exit(exitCode);

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -45,6 +45,16 @@ Run options:
 Global options:
   --help, -h           Show this help message
   --version, -V        Show version number
+
+Exit codes:
+  0  Ran and found no problems
+  1  Ran and found problems with the repo or its kits
+  2  Could not complete the invocation (usage, config, kit-load, or internal error)
+
+  list and init use only 0 and 2; neither can find problems to report.
+
+With --json, stdout carries exactly one JSON document: the report when a run produced
+one, otherwise {"error": {"code", "message"}}. Prose goes to stderr.
 `;
 
 const RUN_HELP = `
@@ -98,6 +108,9 @@ Drift detection:
   rdy compile refuses to overwrite a compiled kit whose on-disk hash differs from the
   manifest's recorded targetHash (e.g. someone edited the compiled file directly).
   Drifted kits are reported and skipped; use --force to overwrite anyway.
+
+Exits 1 when a kit fails to compile or is skipped as drifted, and 2 when the config or
+manifest cannot be read or written.
 `;
 
 const VERIFY_HELP = `
@@ -111,7 +124,8 @@ Each kit is reported as one of:
   missing     compiled file is absent
   unverified  manifest entry has no targetHash (predates the feature)
 
-Exits non-zero when any kit is in drift or missing; unverified kits do not fail.
+Exits 1 when any kit is in drift or missing; unverified kits do not fail. An unreadable
+manifest exits 2.
 
 Options:
   --manifest <path>  Manifest file path (default: .readyup/manifest.json)

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -169,7 +169,7 @@ Options:
 `;
 
 /**
- * Route CLI arguments to the appropriate subcommand.
+ * Routes CLI arguments to the appropriate subcommand.
  *
  * Returns a numeric exit code. Every failure that prevents the invocation from completing
  * is rendered here — as prose on stderr, or as the JSON error envelope on stdout when
@@ -185,7 +185,7 @@ export async function routeCommand(args: string[]): Promise<number> {
 }
 
 /**
- * Render a failed invocation and return its exit code.
+ * Renders a failed invocation and returns its exit code.
  *
  * Exported so the runner's outer boundary reports a failure that escaped `routeCommand`
  * through the same channel.
@@ -200,7 +200,7 @@ export function reportFailure(error: unknown, json: boolean): number {
   return EXIT_TOOL_FAILURE;
 }
 
-/** Select and run the subcommand named by the first argument. */
+/** Selects and runs the subcommand named by the first argument. */
 async function dispatchCommand(args: string[], json: boolean): Promise<number> {
   const command = args[0];
 
@@ -247,7 +247,7 @@ async function dispatchCommand(args: string[], json: boolean): Promise<number> {
   return handleRun(args, json);
 }
 
-/** Parse and execute the `run` subcommand. */
+/** Parses and executes the `run` subcommand. */
 async function handleRun(flags: string[], json: boolean): Promise<number> {
   if (wantsHelp(flags)) return writeHelp(RUN_HELP, json);
 
@@ -290,7 +290,7 @@ async function handleRun(flags: string[], json: boolean): Promise<number> {
   );
 }
 
-/** Parse and execute the `init` subcommand. */
+/** Parses and executes the `init` subcommand. */
 function handleInit(flags: string[]): number {
   const initOptions = {
     'dry-run': { type: 'boolean', short: 'n' },
@@ -307,24 +307,24 @@ function handleInit(flags: string[]): number {
   return initCommand({ dryRun: parsed.values['dry-run'] === true, force: parsed.values.force === true });
 }
 
-/** Return true when the flags request help for the current subcommand. */
+/** Returns true when the flags request help for the current subcommand. */
 function wantsHelp(flags: string[]): boolean {
   return flags.some((f) => f === '--help' || f === '-h');
 }
 
-/** Emit help text through the human channel and report success. */
+/** Emits help text through the human channel and reports success. */
 function writeHelp(text: string, json: boolean): number {
   writeHuman(`${text}\n`, json);
   return EXIT_OK;
 }
 
-/** Write human-readable prose, diverting it to stderr when JSON mode owns stdout. */
+/** Writes human-readable prose, diverting it to stderr when JSON mode owns stdout. */
 function writeHuman(text: string, json: boolean): void {
   const stream = json ? process.stderr : process.stdout;
   stream.write(text);
 }
 
-/** Check whether a positional arg is a close prefix of a known subcommand. */
+/** Checks whether a positional arg is a close prefix of a known subcommand. */
 function findTypoMatch(input: string): string | undefined {
   if (input.length < MIN_PREFIX_LENGTH || input.startsWith('-')) {
     return undefined;

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -3,10 +3,13 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 
 import { parseRunArgs, resolveKitSources, runCommand } from '../cli.ts';
 import { compileCommand } from '../compile/compileCommand.ts';
+import { configError, toRdyError, usageError } from '../errors.ts';
+import { EXIT_OK, EXIT_TOOL_FAILURE } from '../exitCodes.ts';
+import { formatJsonError } from '../formatJsonError.ts';
+import { hasJsonFlag } from '../hasJsonFlag.ts';
 import { initCommand } from '../init/initCommand.ts';
 import { listCommand } from '../list/listCommand.ts';
 import { loadConfig } from '../loadConfig.ts';
-import { extractMessage } from '../utils/error-handling.ts';
 import { translateParseArgsError } from '../utils/parse-args-error.ts';
 import { verifyCommand } from '../verify/verifyCommand.ts';
 import { VERSION } from '../version.ts';
@@ -14,8 +17,7 @@ import { VERSION } from '../version.ts';
 const SUBCOMMANDS = ['compile', 'init', 'list', 'verify'];
 const MIN_PREFIX_LENGTH = 3;
 
-function showHelp(): void {
-  console.info(`
+const HELP = `
 Usage: rdy [kit[:checklist,...] ...] [options]
        rdy <command> [options]
 
@@ -42,11 +44,9 @@ Run options:
 Global options:
   --help, -h           Show this help message
   --version, -V        Show version number
-`);
-}
+`;
 
-function showRunHelp(): void {
-  console.info(`
+const RUN_HELP = `
 Usage: rdy run [kit[:checklist,...] ...] [options]
 
 Run rdy checklists. Positional arguments select kits to run; use colon syntax
@@ -74,11 +74,9 @@ Options:
 
 Positional args accept relative paths (e.g., shared/deploy).
 Defaults to .readyup/kits/default.js when no source is given.
-`);
-}
+`;
 
-function showCompileHelp(): void {
-  console.info(`
+const COMPILE_HELP = `
 Usage: rdy compile [<file>] [options]
 
 Bundle TypeScript kit(s) into self-contained ESM bundle(s).
@@ -99,11 +97,9 @@ Drift detection:
   rdy compile refuses to overwrite a compiled kit whose on-disk hash differs from the
   manifest's recorded targetHash (e.g. someone edited the compiled file directly).
   Drifted kits are reported and skipped; use --force to overwrite anyway.
-`);
-}
+`;
 
-function showVerifyHelp(): void {
-  console.info(`
+const VERIFY_HELP = `
 Usage: rdy verify [options]
 
 Check compiled kits against the hashes recorded in the manifest.
@@ -119,11 +115,9 @@ Exits non-zero when any kit is in drift or missing; unverified kits do not fail.
 Options:
   --manifest <path>  Manifest file path (default: .readyup/manifest.json)
   --help, -h         Show this help message
-`);
-}
+`;
 
-function showListHelp(): void {
-  console.info(`
+const LIST_HELP = `
 Usage: rdy list [options]
 
 List available kits without running them.
@@ -146,11 +140,9 @@ Examples:
   rdy list --from global                           Show kits in the global directory
   rdy list --from github:williamthorsen/workshop   Show kits in a remote GitHub repository
   rdy list --from bitbucket:tutorials/markdowndemo@master Show kits in a remote Bitbucket repository
-`);
-}
+`;
 
-function showInitHelp(): void {
-  console.info(`
+const INIT_HELP = `
 Usage: rdy init [options]
 
 Scaffold a starter config and kit file.
@@ -159,7 +151,162 @@ Options:
   --dry-run, -n   Preview changes without writing files
   --force, -f     Overwrite existing files
   --help, -h      Show this help message
-`);
+`;
+
+/**
+ * Route CLI arguments to the appropriate subcommand.
+ *
+ * Returns a numeric exit code. Every failure that prevents the invocation from completing
+ * is rendered here — as prose on stderr, or as the JSON error envelope on stdout when
+ * `--json` is in argv — so no command carries its own error-reporting path.
+ */
+export async function routeCommand(args: string[]): Promise<number> {
+  const json = hasJsonFlag(args);
+  try {
+    return await dispatchCommand(args, json);
+  } catch (error: unknown) {
+    return reportFailure(error, json);
+  }
+}
+
+/**
+ * Render a failed invocation and return its exit code.
+ *
+ * Exported so the runner's outer boundary reports a failure that escaped `routeCommand`
+ * through the same channel.
+ */
+export function reportFailure(error: unknown, json: boolean): number {
+  const rdyError = toRdyError(error);
+  if (json) {
+    process.stdout.write(formatJsonError(rdyError) + '\n');
+  } else {
+    process.stderr.write(`Error: ${rdyError.message}\n`);
+  }
+  return EXIT_TOOL_FAILURE;
+}
+
+/** Select and run the subcommand named by the first argument. */
+async function dispatchCommand(args: string[], json: boolean): Promise<number> {
+  const command = args[0];
+
+  if (command === undefined || command === '--help' || command === '-h') {
+    return writeHelp(HELP, json);
+  }
+
+  if (command === '--version' || command === '-V') {
+    writeHuman(`${VERSION}\n`, json);
+    return EXIT_OK;
+  }
+
+  if (command === 'run') {
+    return handleRun(args.slice(1), json);
+  }
+
+  if (command === 'compile') {
+    const flags = args.slice(1);
+    return wantsHelp(flags) ? writeHelp(COMPILE_HELP, json) : compileCommand(flags);
+  }
+
+  if (command === 'init') {
+    const flags = args.slice(1);
+    return wantsHelp(flags) ? writeHelp(INIT_HELP, json) : handleInit(flags);
+  }
+
+  if (command === 'list') {
+    const flags = args.slice(1);
+    return wantsHelp(flags) ? writeHelp(LIST_HELP, json) : listCommand(flags);
+  }
+
+  if (command === 'verify') {
+    const flags = args.slice(1);
+    return wantsHelp(flags) ? writeHelp(VERIFY_HELP, json) : verifyCommand(flags);
+  }
+
+  // Check for typos before falling through to the default command.
+  const typoMatch = findTypoMatch(command);
+  if (typoMatch !== undefined) {
+    throw usageError(`Unknown command '${command}'. Did you mean 'rdy ${typoMatch}'?`);
+  }
+
+  // Default: treat all args as `run` arguments.
+  return handleRun(args, json);
+}
+
+/** Parse and execute the `run` subcommand. */
+async function handleRun(flags: string[], json: boolean): Promise<number> {
+  if (wantsHelp(flags)) return writeHelp(RUN_HELP, json);
+
+  const parsed = parseRunArgs(flags);
+
+  // Skip config when an external source flag is active — external modes don't use config values.
+  const hasExternalSource =
+    parsed.filePath !== undefined || parsed.fromValue !== undefined || parsed.urlValue !== undefined;
+
+  let configFields: { internalDir: string; internalInfix: string | undefined } | undefined;
+  if (!hasExternalSource) {
+    let config;
+    try {
+      config = await loadConfig();
+    } catch (error: unknown) {
+      throw configError(toRdyError(error).message, { cause: error });
+    }
+    configFields = { internalDir: config.internal.dir, internalInfix: config.internal.infix };
+  }
+
+  const kitEntries = resolveKitSources({
+    filePath: parsed.filePath,
+    fromValue: parsed.fromValue,
+    urlValue: parsed.urlValue,
+    kitSpecifiers: parsed.kitSpecifiers,
+    checklists: parsed.checklists,
+    jit: parsed.jit,
+    internal: parsed.internal,
+    ...configFields,
+  });
+
+  return runCommand(
+    {
+      kitEntries,
+      json: parsed.json,
+      ...(parsed.failOn !== undefined && { failOn: parsed.failOn }),
+      ...(parsed.reportOn !== undefined && { reportOn: parsed.reportOn }),
+    },
+    parsed.jit,
+  );
+}
+
+/** Parse and execute the `init` subcommand. */
+function handleInit(flags: string[]): number {
+  const initOptions = {
+    'dry-run': { type: 'boolean', short: 'n' },
+    force: { type: 'boolean', short: 'f' },
+  } as const;
+
+  let parsed;
+  try {
+    parsed = nodeParseArgs({ args: flags, options: initOptions, strict: true, allowPositionals: true });
+  } catch (error: unknown) {
+    throw usageError(translateParseArgsError(error), { cause: error });
+  }
+
+  return initCommand({ dryRun: parsed.values['dry-run'] === true, force: parsed.values.force === true });
+}
+
+/** Return true when the flags request help for the current subcommand. */
+function wantsHelp(flags: string[]): boolean {
+  return flags.some((f) => f === '--help' || f === '-h');
+}
+
+/** Emit help text through the human channel and report success. */
+function writeHelp(text: string, json: boolean): number {
+  writeHuman(`${text}\n`, json);
+  return EXIT_OK;
+}
+
+/** Write human-readable prose, diverting it to stderr when JSON mode owns stdout. */
+function writeHuman(text: string, json: boolean): void {
+  const stream = json ? process.stderr : process.stdout;
+  stream.write(text);
 }
 
 /** Check whether a positional arg is a close prefix of a known subcommand. */
@@ -173,161 +320,4 @@ function findTypoMatch(input: string): string | undefined {
     }
   }
   return undefined;
-}
-
-/**
- * Route CLI arguments to the appropriate subcommand.
- *
- * Returns a numeric exit code: 0 for success, 1 for errors.
- */
-export async function routeCommand(args: string[]): Promise<number> {
-  const command = args[0];
-
-  if (command === undefined || command === '--help' || command === '-h') {
-    showHelp();
-    return 0;
-  }
-
-  if (command === '--version' || command === '-V') {
-    console.info(VERSION);
-    return 0;
-  }
-
-  if (command === 'run') {
-    return handleRun(args.slice(1));
-  }
-
-  if (command === 'compile') {
-    const flags = args.slice(1);
-    if (flags.some((f) => f === '--help' || f === '-h')) {
-      showCompileHelp();
-      return 0;
-    }
-    try {
-      return await compileCommand(flags);
-    } catch (error: unknown) {
-      process.stderr.write(`Error: ${extractMessage(error)}\n`);
-      return 1;
-    }
-  }
-
-  if (command === 'init') {
-    const flags = args.slice(1);
-    if (flags.some((f) => f === '--help' || f === '-h')) {
-      showInitHelp();
-      return 0;
-    }
-
-    const initOptions = {
-      'dry-run': { type: 'boolean', short: 'n' },
-      force: { type: 'boolean', short: 'f' },
-    } as const;
-
-    let parsed;
-    try {
-      parsed = nodeParseArgs({ args: flags, options: initOptions, strict: true, allowPositionals: true });
-    } catch (error: unknown) {
-      process.stderr.write(`Error: ${translateParseArgsError(error)}\n`);
-      return 1;
-    }
-
-    return initCommand({ dryRun: parsed.values['dry-run'] === true, force: parsed.values.force === true });
-  }
-
-  if (command === 'list') {
-    const flags = args.slice(1);
-    if (flags.some((f) => f === '--help' || f === '-h')) {
-      showListHelp();
-      return 0;
-    }
-    try {
-      return await listCommand(flags);
-    } catch (error: unknown) {
-      process.stderr.write(`Error: ${extractMessage(error)}\n`);
-      return 1;
-    }
-  }
-
-  if (command === 'verify') {
-    const flags = args.slice(1);
-    if (flags.some((f) => f === '--help' || f === '-h')) {
-      showVerifyHelp();
-      return 0;
-    }
-    try {
-      return verifyCommand(flags);
-    } catch (error: unknown) {
-      process.stderr.write(`Error: ${extractMessage(error)}\n`);
-      return 1;
-    }
-  }
-
-  // Check for typos before falling through to the default command
-  const typoMatch = findTypoMatch(command);
-  if (typoMatch !== undefined) {
-    process.stderr.write(`Error: Unknown command '${command}'. Did you mean 'rdy ${typoMatch}'?\n`);
-    return 1;
-  }
-
-  // Default: treat all args as `run` arguments
-  return handleRun(args);
-}
-
-/** Parse and execute the `run` subcommand. */
-async function handleRun(flags: string[]): Promise<number> {
-  if (flags.some((f) => f === '--help' || f === '-h')) {
-    showRunHelp();
-    return 0;
-  }
-
-  let parsed: ReturnType<typeof parseRunArgs>;
-  try {
-    parsed = parseRunArgs(flags);
-  } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
-    return 1;
-  }
-
-  // Skip config when an external source flag is active — external modes don't use config values.
-  const hasExternalSource =
-    parsed.filePath !== undefined || parsed.fromValue !== undefined || parsed.urlValue !== undefined;
-
-  let configFields: { internalDir: string; internalInfix: string | undefined } | undefined;
-  if (!hasExternalSource) {
-    let config;
-    try {
-      config = await loadConfig();
-    } catch (error: unknown) {
-      process.stderr.write(`Error: ${extractMessage(error)}\n`);
-      return 1;
-    }
-    configFields = { internalDir: config.internal.dir, internalInfix: config.internal.infix };
-  }
-
-  let kitEntries;
-  try {
-    kitEntries = resolveKitSources({
-      filePath: parsed.filePath,
-      fromValue: parsed.fromValue,
-      urlValue: parsed.urlValue,
-      kitSpecifiers: parsed.kitSpecifiers,
-      checklists: parsed.checklists,
-      jit: parsed.jit,
-      internal: parsed.internal,
-      ...configFields,
-    });
-  } catch (error: unknown) {
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
-    return 1;
-  }
-
-  return runCommand(
-    {
-      kitEntries,
-      json: parsed.json,
-      ...(parsed.failOn !== undefined && { failOn: parsed.failOn }),
-      ...(parsed.reportOn !== undefined && { reportOn: parsed.reportOn }),
-    },
-    parsed.jit,
-  );
 }

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -54,7 +54,8 @@ Exit codes:
   list and init use only 0 and 2; neither can find problems to report.
 
 With --json, stdout carries exactly one JSON document: the report when a run produced
-one, otherwise {"error": {"code", "message"}}. Prose goes to stderr.
+one, otherwise {"error": {"code", "message"}}. Prose goes to stderr. --help and --version
+have no JSON form: their text goes to stderr and stdout stays empty.
 `;
 
 const RUN_HELP = `

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -10,6 +10,7 @@ import { hasJsonFlag } from '../hasJsonFlag.ts';
 import { initCommand } from '../init/initCommand.ts';
 import { listCommand } from '../list/listCommand.ts';
 import { loadConfig } from '../loadConfig.ts';
+import { extractMessage } from '../utils/error-handling.ts';
 import { translateParseArgsError } from '../utils/parse-args-error.ts';
 import { verifyCommand } from '../verify/verifyCommand.ts';
 import { VERSION } from '../version.ts';
@@ -248,7 +249,7 @@ async function handleRun(flags: string[], json: boolean): Promise<number> {
     try {
       config = await loadConfig();
     } catch (error: unknown) {
-      throw configError(toRdyError(error).message, { cause: error });
+      throw configError(extractMessage(error), { cause: error });
     }
     configFields = { internalDir: config.internal.dir, internalInfix: config.internal.infix };
   }

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -526,7 +526,7 @@ async function runSingleKitHumanMode(
   return allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
 }
 
-/** Resolve a kit's requested checklist names to the checklists themselves, in requested order. */
+/** Resolves a kit's requested checklist names to the checklists themselves, in requested order. */
 function selectChecklists(kit: RdyKit, checklistFilter: string[]): Array<RdyChecklist | RdyStagedChecklist> {
   let resolvedNames: string[];
   try {

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -4,8 +4,9 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 
 import { buildKitFilename } from './buildKitFilename.ts';
 import { type LoadedRdyKit, loadRdyKit } from './config.ts';
+import { kitLoadError, usageError } from './errors.ts';
+import { EXIT_OK, EXIT_PROBLEMS_FOUND } from './exitCodes.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
-import { formatJsonError } from './formatJsonError.ts';
 import { formatJsonReport } from './formatJsonReport.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { type FromSource, parseFromValue } from './parseFromValue.ts';
@@ -70,7 +71,7 @@ const runOptions = {
 /** Validate and narrow a string to a Severity value. */
 function parseSeverityFlag(flagName: string, value: string): Severity {
   if (!VALID_SEVERITIES.has(value)) {
-    throw new Error(`${flagName} must be one of: error, warn, recommend (got "${value}")`);
+    throw usageError(`${flagName} must be one of: error, warn, recommend (got "${value}")`);
   }
   if (value === 'error') return 'error';
   if (value === 'warn') return 'warn';
@@ -118,24 +119,24 @@ function validateFlagConstraints(
   if (parsed.url !== undefined) sourceFlags.push('--url');
 
   if (sourceFlags.length > 1) {
-    throw new Error(`Cannot combine ${sourceFlags.join(', ')} flags`);
+    throw usageError(`Cannot combine ${sourceFlags.join(', ')} flags`);
   }
 
   const sourceType = sourceFlags[0];
 
   if (parsed.jit && sourceType !== undefined) {
-    throw new Error(`--jit cannot be combined with ${sourceType}`);
+    throw usageError(`--jit cannot be combined with ${sourceType}`);
   }
   if (parsed.internal && sourceType !== undefined) {
-    throw new Error(`--internal cannot be combined with ${sourceType}`);
+    throw usageError(`--internal cannot be combined with ${sourceType}`);
   }
 
   if (parsed.checklists !== undefined && sourceType !== '--file' && sourceType !== '--url') {
-    throw new Error('--checklists can only be used with --file or --url');
+    throw usageError('--checklists can only be used with --file or --url');
   }
 
   if ((sourceType === '--file' || sourceType === '--url') && positionalCount > 0) {
-    throw new Error(`${sourceType} cannot be combined with positional kit arguments`);
+    throw usageError(`${sourceType} cannot be combined with positional kit arguments`);
   }
 
   return sourceType;
@@ -146,7 +147,7 @@ function parseRunFlags(flags: string[]) {
   try {
     return nodeParseArgs({ args: flags, options: runOptions, strict: true, allowPositionals: true });
   } catch (error: unknown) {
-    throw new Error(translateParseArgsError(error, flagErrorHints));
+    throw usageError(translateParseArgsError(error, flagErrorHints), { cause: error });
   }
 }
 
@@ -158,7 +159,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   for (const [name, value] of Object.entries(values)) {
     if (value === '') {
       const flag = `--${name}`;
-      throw new Error(flagErrorHints[flag] ?? `${flag} requires a value`);
+      throw usageError(flagErrorHints[flag] ?? `${flag} requires a value`);
     }
   }
 
@@ -180,7 +181,12 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   const checklists = parsed.checklists !== undefined ? parsed.checklists.split(',').filter((s) => s !== '') : undefined;
 
   // Parse kit specifiers from positional args.
-  const kitSpecifiers = parseKitSpecifiers(positionals);
+  let kitSpecifiers: KitSpecifier[];
+  try {
+    kitSpecifiers = parseKitSpecifiers(positionals);
+  } catch (error: unknown) {
+    throw usageError(extractMessage(error), { cause: error });
+  }
 
   // Validate severity flags.
   const failOn = parsed.failOn !== undefined ? parseSeverityFlag('--fail-on', parsed.failOn) : undefined;
@@ -235,7 +241,13 @@ export function resolveKitSources({
   const specs = kitSpecifiers.length > 0 ? kitSpecifiers : [{ kitName: 'default', checklists: [] }];
 
   if (fromValue !== undefined) {
-    return resolveFromSource(parseFromValue(fromValue), specs, extension);
+    let source: FromSource;
+    try {
+      source = parseFromValue(fromValue);
+    } catch (error: unknown) {
+      throw usageError(extractMessage(error), { cause: error });
+    }
+    return resolveFromSource(source, specs, extension);
   }
 
   // Default/internal case: resolve from the current repo.
@@ -351,8 +363,8 @@ async function loadKit(source: KitSource, isJit: boolean): Promise<LoadedRdyKit>
     } catch (error: unknown) {
       const message = extractMessage(error);
       // Network failures (raw `fetch` rejections) carry no URL context; thrown errors from `loadRemoteKit` already include the URL.
-      if (message.includes(source.url)) throw error;
-      throw new Error(`Failed to reach ${source.url}: ${message}`);
+      const detail = message.includes(source.url) ? message : `Failed to reach ${source.url}: ${message}`;
+      throw kitLoadError(detail, { cause: error });
     }
   }
 
@@ -360,9 +372,11 @@ async function loadKit(source: KitSource, isJit: boolean): Promise<LoadedRdyKit>
     return await loadRdyKit(source.path);
   } catch (error: unknown) {
     if (isJit && isModuleNotFoundError(error, 'readyup')) {
-      throw new Error('Running from source requires readyup to be installed as a project dependency.');
+      throw kitLoadError('Running from source requires readyup to be installed as a project dependency.', {
+        cause: error,
+      });
     }
-    throw error;
+    throw kitLoadError(extractMessage(error), { cause: error });
   }
 }
 
@@ -416,50 +430,23 @@ async function runMultiKitJsonMode(
   }> = [];
 
   for (const entry of kitEntries) {
-    let kit: RdyKit;
-    let compileTimeVersion: string | undefined;
-    try {
-      ({ kit, compileTimeVersion } = await loadKit(entry.source, isJit));
-    } catch (error: unknown) {
-      const message = extractMessage(error);
-      process.stdout.write(formatJsonError(message) + '\n');
-      return 1;
-    }
+    const { kit, compileTimeVersion } = await loadKit(entry.source, isJit);
 
     warnOnVersionSkew(entry.name, compileTimeVersion);
 
     const thresholds = resolveThresholds(kit, failOn, reportOn);
-    let resolvedNames: string[];
-    try {
-      resolvedNames = resolveRequestedNames(entry.checklists, kit);
-    } catch (error: unknown) {
-      const message = extractMessage(error);
-      process.stdout.write(formatJsonError(message) + '\n');
-      return 1;
-    }
-
-    const checklistByName = new Map(kit.checklists.map((c) => [c.name, c]));
-    const checklists = resolvedNames.flatMap((name) => {
-      const checklist = checklistByName.get(name);
-      return checklist !== undefined ? [checklist] : [];
-    });
+    const checklists = selectChecklists(kit, entry.checklists);
 
     const entries: Array<{ name: string; report: RdyReport }> = [];
     let kitPassed = true;
 
-    try {
-      for (const checklist of checklists) {
-        const report = await runRdy(checklist, {
-          defaultSeverity: thresholds.defaultSeverity,
-          failOn: thresholds.failOn,
-        });
-        entries.push({ name: checklist.name, report });
-        if (!report.passed) kitPassed = false;
-      }
-    } catch (error: unknown) {
-      const message = extractMessage(error);
-      process.stdout.write(formatJsonError(message) + '\n');
-      return 1;
+    for (const checklist of checklists) {
+      const report = await runRdy(checklist, {
+        defaultSeverity: thresholds.defaultSeverity,
+        failOn: thresholds.failOn,
+      });
+      entries.push({ name: checklist.name, report });
+      if (!report.passed) kitPassed = false;
     }
 
     kitResults.push({ name: entry.name, entries, passed: kitPassed });
@@ -468,7 +455,7 @@ async function runMultiKitJsonMode(
   const resolvedReportOn = reportOn ?? 'recommend';
   process.stdout.write(formatJsonReport(kitResults, { reportOn: resolvedReportOn }) + '\n');
   const allPassed = kitResults.every((k) => k.passed);
-  return allPassed ? 0 : 1;
+  return allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
 }
 
 /** Run all kit entries in human-readable mode. */
@@ -481,15 +468,7 @@ async function runMultiKitHumanMode(
   const showKitHeader = kitEntries.length > 1;
   let allPassed = true;
   for (const entry of kitEntries) {
-    let kit: RdyKit;
-    let compileTimeVersion: string | undefined;
-    try {
-      ({ kit, compileTimeVersion } = await loadKit(entry.source, isJit));
-    } catch (error: unknown) {
-      const message = extractMessage(error);
-      process.stderr.write(`Error: ${message}\n`);
-      return 1;
-    }
+    const { kit, compileTimeVersion } = await loadKit(entry.source, isJit);
 
     warnOnVersionSkew(entry.name, compileTimeVersion);
 
@@ -498,10 +477,10 @@ async function runMultiKitHumanMode(
     }
 
     const exitCode = await runSingleKitHumanMode(kit, entry.checklists, failOn, reportOn, showKitHeader);
-    if (exitCode !== 0) allPassed = false;
+    if (exitCode !== EXIT_OK) allPassed = false;
   }
 
-  return allPassed ? 0 : 1;
+  return allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
 }
 
 /** Run checklists from a single kit in human-readable mode. */
@@ -512,57 +491,53 @@ async function runSingleKitHumanMode(
   reportOn: Severity | undefined,
   isMultiKit: boolean,
 ): Promise<number> {
-  let resolvedNames: string[];
-  try {
-    resolvedNames = resolveRequestedNames(checklistFilter, kit);
-  } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
-  }
-
-  const checklistByName = new Map(kit.checklists.map((c) => [c.name, c]));
-  const checklists = resolvedNames.flatMap((name) => {
-    const checklist = checklistByName.get(name);
-    return checklist !== undefined ? [checklist] : [];
-  });
-
+  const checklists = selectChecklists(kit, checklistFilter);
   const thresholds = resolveThresholds(kit, failOn, reportOn);
   const showChecklistHeader = checklists.length > 1;
   let allPassed = true;
   const summaries: ChecklistSummary[] = [];
 
-  try {
-    for (const checklist of checklists) {
-      if (showChecklistHeader) {
-        process.stdout.write(`\n--- ${checklist.name} ---\n\n`);
-      }
-
-      const report = await runRdy(checklist, {
-        defaultSeverity: thresholds.defaultSeverity,
-        failOn: thresholds.failOn,
-      });
-      const fixLocation = resolveFixLocation(checklist, kit.fixLocation);
-      const output = reportRdy(report, { fixLocation, reportOn: thresholds.reportOn });
-      process.stdout.write(output + '\n');
-
-      if (!report.passed) {
-        allPassed = false;
-      }
-
-      if (showChecklistHeader) {
-        summaries.push(summarizeReport(checklist.name, report));
-      }
+  for (const checklist of checklists) {
+    if (showChecklistHeader) {
+      process.stdout.write(`\n--- ${checklist.name} ---\n\n`);
     }
-  } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
+
+    const report = await runRdy(checklist, {
+      defaultSeverity: thresholds.defaultSeverity,
+      failOn: thresholds.failOn,
+    });
+    const fixLocation = resolveFixLocation(checklist, kit.fixLocation);
+    const output = reportRdy(report, { fixLocation, reportOn: thresholds.reportOn });
+    process.stdout.write(output + '\n');
+
+    if (!report.passed) {
+      allPassed = false;
+    }
+
+    if (showChecklistHeader) {
+      summaries.push(summarizeReport(checklist.name, report));
+    }
   }
 
   if (summaries.length > 1 && !isMultiKit) {
     process.stdout.write('\n' + formatCombinedSummary(summaries) + '\n');
   }
 
-  return allPassed ? 0 : 1;
+  return allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
+}
+
+/** Resolve a kit's requested checklist names to the checklists themselves, in requested order. */
+function selectChecklists(kit: RdyKit, checklistFilter: string[]): Array<RdyChecklist | RdyStagedChecklist> {
+  let resolvedNames: string[];
+  try {
+    resolvedNames = resolveRequestedNames(checklistFilter, kit);
+  } catch (error: unknown) {
+    throw usageError(extractMessage(error), { cause: error });
+  }
+
+  const checklistByName = new Map(kit.checklists.map((c) => [c.name, c]));
+  return resolvedNames.flatMap((name) => {
+    const checklist = checklistByName.get(name);
+    return checklist !== undefined ? [checklist] : [];
+  });
 }

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -5,6 +5,8 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 
 import picomatch from 'picomatch';
 
+import { configError, usageError } from '../errors.ts';
+import { EXIT_OK, EXIT_PROBLEMS_FOUND } from '../exitCodes.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
@@ -42,8 +44,7 @@ export async function compileCommand(args: string[]): Promise<number> {
   try {
     parsed = nodeParseArgs({ args, options: compileOptions, strict: true, allowPositionals: true });
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${translateParseArgsError(error, compileHints)}\n`);
-    return 1;
+    throw usageError(translateParseArgsError(error, compileHints), { cause: error });
   }
   const { values, positionals } = parsed;
 
@@ -51,8 +52,7 @@ export async function compileCommand(args: string[]): Promise<number> {
   for (const [name, value] of Object.entries(values)) {
     if (value === '') {
       const flag = `--${name}`;
-      process.stderr.write(`Error: ${compileHints[flag] ?? `${flag} requires a value`}\n`);
-      return 1;
+      throw usageError(compileHints[flag] ?? `${flag} requires a value`);
     }
   }
 
@@ -62,8 +62,7 @@ export async function compileCommand(args: string[]): Promise<number> {
   const manifestPath = resolveManifestPath(values.manifest);
 
   if (positionals.length > 1) {
-    process.stderr.write('Error: Too many arguments. Expected a single input file.\n');
-    return 1;
+    throw usageError('Too many arguments. Expected a single input file.');
   }
 
   const inputPath = positionals[0];
@@ -75,8 +74,7 @@ export async function compileCommand(args: string[]): Promise<number> {
 
   // No input file -- compile all sources from config
   if (outputPath !== undefined) {
-    process.stderr.write('Error: --output requires an input file\n');
-    return 1;
+    throw usageError('--output requires an input file');
   }
 
   return compileBatch({ skipManifest, force, manifestPath });
@@ -108,7 +106,7 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
     const relInput = path.relative(process.cwd(), resolvedInputPath);
     process.stdout.write(formatDriftLine(relInput, drift.status));
     process.stdout.write('\nRe-run with --force to overwrite, or move edits into the source.\n');
-    return 1;
+    return EXIT_PROBLEMS_FOUND;
   }
 
   let result;
@@ -117,9 +115,9 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
     result = await compileConfig(inputPath, outputPath);
     metadata = await validateCompiledOutput(result.outputPath);
   } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
+    // A kit that fails to compile is a problem with the kit, not with the invocation.
+    process.stderr.write(`Error: ${extractMessage(error)}\n`);
+    return EXIT_PROBLEMS_FOUND;
   }
 
   const relInput = path.relative(process.cwd(), resolvedInputPath);
@@ -136,13 +134,11 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
         targetHash: result.targetHash,
       });
     } catch (error: unknown) {
-      const message = extractMessage(error);
-      process.stderr.write(`Error writing manifest: ${message}\n`);
-      return 1;
+      throw configError(`Error writing manifest: ${extractMessage(error)}`, { cause: error });
     }
   }
 
-  return 0;
+  return EXIT_OK;
 }
 
 /** Resolve the manifest output path from the optional `--manifest` flag. */
@@ -171,9 +167,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
   try {
     config = await loadConfig();
   } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
+    throw configError(extractMessage(error), { cause: error });
   }
 
   const srcDir = path.resolve(process.cwd(), config.compile.srcDir);
@@ -188,9 +182,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
     try {
       tsFiles = collectSourceFiles(srcDir, config.compile.include);
     } catch (error: unknown) {
-      const message = extractMessage(error);
-      process.stderr.write(`Error: Failed to read source directory: ${message}\n`);
-      return 1;
+      throw configError(`Failed to read source directory: ${extractMessage(error)}`, { cause: error });
     }
   }
 
@@ -204,12 +196,10 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
       try {
         writeManifest(manifestPath, { version: 1, kits: [] });
       } catch (error: unknown) {
-        const message = extractMessage(error);
-        process.stderr.write(`Error writing manifest: ${message}\n`);
-        return 1;
+        throw configError(`Error writing manifest: ${extractMessage(error)}`, { cause: error });
       }
     }
-    return 0;
+    return EXIT_OK;
   }
 
   const relSrcDir = path.relative(process.cwd(), srcDir);
@@ -253,9 +243,9 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
         ...(metadata.description !== undefined && { description: metadata.description }),
       });
     } catch (error: unknown) {
-      const message = extractMessage(error);
-      process.stderr.write(`Error compiling ${fileName}: ${message}\n`);
-      return 1;
+      // A kit that fails to compile is a problem with the kit, not with the invocation.
+      process.stderr.write(`Error compiling ${fileName}: ${extractMessage(error)}\n`);
+      return EXIT_PROBLEMS_FOUND;
     }
   }
 
@@ -271,13 +261,11 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
       kitEntries.sort((a, b) => a.name.localeCompare(b.name));
       writeManifest(manifestPath, { version: 1, kits: kitEntries });
     } catch (error: unknown) {
-      const message = extractMessage(error);
-      process.stderr.write(`Error writing manifest: ${message}\n`);
-      return 1;
+      throw configError(`Error writing manifest: ${extractMessage(error)}`, { cause: error });
     }
   }
 
-  return skippedCount > 0 ? 1 : 0;
+  return skippedCount > 0 ? EXIT_PROBLEMS_FOUND : EXIT_OK;
 }
 
 /** Location fields for a manifest kit entry. */

--- a/packages/readyup/src/errors.ts
+++ b/packages/readyup/src/errors.ts
@@ -32,28 +32,28 @@ export class RdyError extends Error {
   }
 }
 
-/** Build a `usage` error: the invocation itself is malformed. */
+/** Builds a `usage` error: the invocation itself is malformed. */
 export function usageError(message: string, options?: RdyErrorOptions): RdyError {
   return new RdyError('usage', message, options);
 }
 
-/** Build a `config` error: repo configuration or a manifest could not be read or written. */
+/** Builds a `config` error: repo configuration or a manifest could not be read or written. */
 export function configError(message: string, options?: RdyErrorOptions): RdyError {
   return new RdyError('config', message, options);
 }
 
-/** Build a `kit-load` error: a kit could not be resolved, fetched, or evaluated. */
+/** Builds a `kit-load` error: a kit could not be resolved, fetched, or evaluated. */
 export function kitLoadError(message: string, options?: RdyErrorOptions): RdyError {
   return new RdyError('kit-load', message, options);
 }
 
-/** Build an `internal` error: a defect in rdy or an unexpected environment failure. */
+/** Builds an `internal` error: a defect in rdy or an unexpected environment failure. */
 export function internalError(message: string, options?: RdyErrorOptions): RdyError {
   return new RdyError('internal', message, options);
 }
 
 /**
- * Coerce an unknown thrown value into an `RdyError`.
+ * Coerces an unknown thrown value into an `RdyError`.
  *
  * Anything not already classified is `internal`: escaping the command boundary undiagnosed
  * is itself the definition of a defect rather than a known failure mode.

--- a/packages/readyup/src/errors.ts
+++ b/packages/readyup/src/errors.ts
@@ -60,5 +60,5 @@ export function internalError(message: string, options?: RdyErrorOptions): RdyEr
  */
 export function toRdyError(error: unknown): RdyError {
   if (error instanceof RdyError) return error;
-  return new RdyError('internal', extractMessage(error), { cause: error });
+  return internalError(extractMessage(error), { cause: error });
 }

--- a/packages/readyup/src/errors.ts
+++ b/packages/readyup/src/errors.ts
@@ -1,0 +1,68 @@
+import { extractMessage } from './utils/error-handling.ts';
+
+/**
+ * Diagnosis of a failure that prevented rdy from completing an invocation.
+ *
+ * - `usage`: the invocation is malformed — an unknown flag, a missing value, an impossible
+ *   combination of arguments.
+ * - `config`: repo configuration or a kit manifest could not be read, written, or parsed.
+ * - `kit-load`: a kit could not be resolved, fetched, or evaluated.
+ * - `internal`: anything else — a defect in rdy or an unexpected environment failure.
+ */
+export type RdyErrorCode = 'config' | 'internal' | 'kit-load' | 'usage';
+
+/** Optional fields accepted by every `RdyError` constructor and factory. */
+export interface RdyErrorOptions {
+  cause?: unknown;
+  remedy?: string;
+}
+
+/**
+ * A failure that prevented rdy from completing the invocation.
+ *
+ * Every code maps to the same exit status, because the exit code answers "can I retry this
+ * invocation?" while `code` carries the diagnosis. `remedy` is emitted in the JSON error
+ * envelope and may be empty.
+ */
+export class RdyError extends Error {
+  readonly code: RdyErrorCode;
+  readonly remedy: string;
+
+  constructor(code: RdyErrorCode, message: string, options: RdyErrorOptions = {}) {
+    super(message, ...(options.cause === undefined ? [] : [{ cause: options.cause }]));
+    this.name = 'RdyError';
+    this.code = code;
+    this.remedy = options.remedy ?? '';
+  }
+}
+
+/** Build a `usage` error: the invocation itself is malformed. */
+export function usageError(message: string, options?: RdyErrorOptions): RdyError {
+  return new RdyError('usage', message, options);
+}
+
+/** Build a `config` error: repo configuration or a manifest could not be read or written. */
+export function configError(message: string, options?: RdyErrorOptions): RdyError {
+  return new RdyError('config', message, options);
+}
+
+/** Build a `kit-load` error: a kit could not be resolved, fetched, or evaluated. */
+export function kitLoadError(message: string, options?: RdyErrorOptions): RdyError {
+  return new RdyError('kit-load', message, options);
+}
+
+/** Build an `internal` error: a defect in rdy or an unexpected environment failure. */
+export function internalError(message: string, options?: RdyErrorOptions): RdyError {
+  return new RdyError('internal', message, options);
+}
+
+/**
+ * Coerce an unknown thrown value into an `RdyError`.
+ *
+ * Anything not already classified is `internal`: escaping the command boundary undiagnosed
+ * is itself the definition of a defect rather than a known failure mode.
+ */
+export function toRdyError(error: unknown): RdyError {
+  if (error instanceof RdyError) return error;
+  return new RdyError('internal', extractMessage(error), { cause: error });
+}

--- a/packages/readyup/src/errors.ts
+++ b/packages/readyup/src/errors.ts
@@ -14,25 +14,21 @@ export type RdyErrorCode = 'config' | 'internal' | 'kit-load' | 'usage';
 /** Optional fields accepted by every `RdyError` constructor and factory. */
 export interface RdyErrorOptions {
   cause?: unknown;
-  remedy?: string;
 }
 
 /**
  * A failure that prevented rdy from completing the invocation.
  *
  * Every code maps to the same exit status, because the exit code answers "can I retry this
- * invocation?" while `code` carries the diagnosis. `remedy` is emitted in the JSON error
- * envelope and may be empty.
+ * invocation?" while `code` carries the diagnosis.
  */
 export class RdyError extends Error {
   readonly code: RdyErrorCode;
-  readonly remedy: string;
 
   constructor(code: RdyErrorCode, message: string, options: RdyErrorOptions = {}) {
     super(message, ...(options.cause === undefined ? [] : [{ cause: options.cause }]));
     this.name = 'RdyError';
     this.code = code;
-    this.remedy = options.remedy ?? '';
   }
 }
 

--- a/packages/readyup/src/exitCodes.ts
+++ b/packages/readyup/src/exitCodes.ts
@@ -1,0 +1,16 @@
+/**
+ * Process exit codes, following the grep/ripgrep/eslint convention.
+ *
+ * The code answers "can I retry this invocation?": 1 means the invocation was well-formed
+ * and the repo has problems to fix; 2 means rdy could not complete the invocation at all.
+ * `rdy list` and `rdy init` produce only 0 and 2 — neither can find problems to report.
+ */
+
+/** Ran to completion and found no problems. */
+export const EXIT_OK = 0;
+
+/** Ran to completion and found problems with the repo or its kits. */
+export const EXIT_PROBLEMS_FOUND = 1;
+
+/** Could not complete the invocation: a usage, config, kit-load, or internal error. */
+export const EXIT_TOOL_FAILURE = 2;

--- a/packages/readyup/src/formatJsonError.ts
+++ b/packages/readyup/src/formatJsonError.ts
@@ -1,6 +1,6 @@
 import type { RdyError } from './errors.ts';
 
-/** Serialize a failed invocation as the single-line JSON error envelope. */
+/** Serializes a failed invocation as the single-line JSON error envelope. */
 export function formatJsonError(error: RdyError): string {
   return JSON.stringify({ error: { code: error.code, message: error.message } });
 }

--- a/packages/readyup/src/formatJsonError.ts
+++ b/packages/readyup/src/formatJsonError.ts
@@ -1,15 +1,6 @@
 import type { RdyError } from './errors.ts';
-import { SCHEMA_VERSION } from './schemaVersion.ts';
 
-/**
- * Serialize a failed invocation as the single-line JSON error envelope.
- *
- * `remedy` is always present and may be empty; a consumer treats an empty string as
- * "no remediation text is available" rather than as a missing field.
- */
+/** Serialize a failed invocation as the single-line JSON error envelope. */
 export function formatJsonError(error: RdyError): string {
-  return JSON.stringify({
-    error: { code: error.code, message: error.message, remedy: error.remedy },
-    schemaVersion: SCHEMA_VERSION,
-  });
+  return JSON.stringify({ error: { code: error.code, message: error.message } });
 }

--- a/packages/readyup/src/formatJsonError.ts
+++ b/packages/readyup/src/formatJsonError.ts
@@ -1,4 +1,15 @@
-/** Serialize an error message into a single-line JSON string. */
-export function formatJsonError(message: string): string {
-  return JSON.stringify({ error: message });
+import type { RdyError } from './errors.ts';
+import { SCHEMA_VERSION } from './schemaVersion.ts';
+
+/**
+ * Serialize a failed invocation as the single-line JSON error envelope.
+ *
+ * `remedy` is always present and may be empty; a consumer treats an empty string as
+ * "no remediation text is available" rather than as a missing field.
+ */
+export function formatJsonError(error: RdyError): string {
+  return JSON.stringify({
+    error: { code: error.code, message: error.message, remedy: error.remedy },
+    schemaVersion: SCHEMA_VERSION,
+  });
 }

--- a/packages/readyup/src/hasJsonFlag.ts
+++ b/packages/readyup/src/hasJsonFlag.ts
@@ -2,18 +2,16 @@
 const SHORT_FLAG_CLUSTER = /^-[a-zA-Z]+$/;
 
 /**
- * Detect JSON mode by scanning raw argv, before any flag parsing happens.
+ * Detects JSON mode by scanning raw argv, before any flag parsing happens.
  *
- * Answering this without `parseArgs` is what lets a flag-parse failure still be reported
- * through the JSON error envelope. The scan matches `--json`, the short `-j`, and any short
- * cluster containing `j`; it stops at the `--` terminator, after which arguments are
- * positional rather than flags.
+ * Answering this without `parseArgs` is what lets a flag-parse failure still be reported through the JSON error
+ * envelope. The scan matches `--json`, the short `-j`, and any short cluster containing `j`; it stops at the `--`
+ * terminator, after which arguments are positional rather than flags.
  *
- * The scan over-detects in cases a parser would resolve differently — `-Fj` is
- * `--fail-on=j`, and `--file --json` gives `--file` the literal value `--json`. That is
- * deliberate. This answer is consulted only when rendering a failure, never on the success
- * path where parsed values govern, so over-detection sends an error to the wrong channel
- * while under-detection leaves it unreportable in JSON at all.
+ * The scan over-detects in cases a parser would resolve differently — `-Fj` is `--fail-on=j`, and `--file --json`
+ * gives `--file` the literal value `--json`. That is deliberate. This answer is consulted only when rendering a
+ * failure, never on the success path where parsed values govern, so over-detection sends an error to the wrong
+ * channel while under-detection leaves it unreportable in JSON at all.
  */
 export function hasJsonFlag(argv: string[]): boolean {
   for (const arg of argv) {

--- a/packages/readyup/src/hasJsonFlag.ts
+++ b/packages/readyup/src/hasJsonFlag.ts
@@ -1,14 +1,25 @@
+/** A cluster of short boolean flags, as `parseArgs` accepts them (`-jJ`). */
+const SHORT_FLAG_CLUSTER = /^-[a-zA-Z]+$/;
+
 /**
  * Detect JSON mode by scanning raw argv, before any flag parsing happens.
  *
  * Answering this without `parseArgs` is what lets a flag-parse failure still be reported
- * through the JSON error envelope. The scan matches the exact token `--json` and stops at
- * the `--` terminator, after which arguments are positional rather than flags.
+ * through the JSON error envelope. The scan matches `--json`, the short `-j`, and any short
+ * cluster containing `j`; it stops at the `--` terminator, after which arguments are
+ * positional rather than flags.
+ *
+ * The scan over-detects in cases a parser would resolve differently — `-Fj` is
+ * `--fail-on=j`, and `--file --json` gives `--file` the literal value `--json`. That is
+ * deliberate. This answer is consulted only when rendering a failure, never on the success
+ * path where parsed values govern, so over-detection sends an error to the wrong channel
+ * while under-detection leaves it unreportable in JSON at all.
  */
 export function hasJsonFlag(argv: string[]): boolean {
   for (const arg of argv) {
     if (arg === '--') return false;
     if (arg === '--json') return true;
+    if (SHORT_FLAG_CLUSTER.test(arg) && arg.includes('j')) return true;
   }
   return false;
 }

--- a/packages/readyup/src/hasJsonFlag.ts
+++ b/packages/readyup/src/hasJsonFlag.ts
@@ -1,0 +1,14 @@
+/**
+ * Detect JSON mode by scanning raw argv, before any flag parsing happens.
+ *
+ * Answering this without `parseArgs` is what lets a flag-parse failure still be reported
+ * through the JSON error envelope. The scan matches the exact token `--json` and stops at
+ * the `--` terminator, after which arguments are positional rather than flags.
+ */
+export function hasJsonFlag(argv: string[]): boolean {
+  for (const arg of argv) {
+    if (arg === '--') return false;
+    if (arg === '--json') return true;
+  }
+  return false;
+}

--- a/packages/readyup/src/init/initCommand.ts
+++ b/packages/readyup/src/init/initCommand.ts
@@ -1,4 +1,6 @@
-import { printError, printStep, reportWriteResult } from '../terminal.ts';
+import { internalError } from '../errors.ts';
+import { EXIT_OK } from '../exitCodes.ts';
+import { printStep, reportWriteResult } from '../terminal.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { scaffoldConfig } from './scaffold.ts';
 
@@ -10,8 +12,8 @@ interface InitOptions {
 /**
  * Run the `rdy init` command.
  *
- * Scaffolds a starter config file and kit file, then prints next steps.
- * Returns the process exit code (0 for success, 1 for failure).
+ * Scaffolds a starter config file and kit file, then prints next steps. Scaffolding is
+ * either completed or not attempted, so the only outcomes are success and a thrown failure.
  */
 export function initCommand({ dryRun, force }: InitOptions): number {
   if (dryRun) {
@@ -23,15 +25,16 @@ export function initCommand({ dryRun, force }: InitOptions): number {
   try {
     result = scaffoldConfig({ dryRun, force });
   } catch (error: unknown) {
-    printError(`Failed to scaffold config: ${extractMessage(error)}`);
-    return 1;
+    throw internalError(`Failed to scaffold config: ${extractMessage(error)}`, { cause: error });
   }
 
   reportWriteResult(result.configResult, dryRun);
   reportWriteResult(result.kitResult, dryRun);
 
-  if (result.configResult.outcome === 'failed' || result.kitResult.outcome === 'failed') {
-    return 1;
+  // `reportWriteResult` has already printed the per-file reason, so the thrown message stays terse.
+  const failure = [result.configResult, result.kitResult].find((r) => r.outcome === 'failed');
+  if (failure !== undefined) {
+    throw internalError(`Failed to scaffold ${failure.filePath}`);
   }
 
   if (!dryRun) {
@@ -44,5 +47,5 @@ export function initCommand({ dryRun, force }: InitOptions): number {
 `);
   }
 
-  return 0;
+  return EXIT_OK;
 }

--- a/packages/readyup/src/init/initCommand.ts
+++ b/packages/readyup/src/init/initCommand.ts
@@ -10,7 +10,7 @@ interface InitOptions {
 }
 
 /**
- * Run the `rdy init` command.
+ * Runs the `rdy init` command.
  *
  * Scaffolds a starter config file and kit file, then prints next steps. Scaffolding is
  * either completed or not attempted, so the only outcomes are success and a thrown failure.

--- a/packages/readyup/src/init/initCommand.ts
+++ b/packages/readyup/src/init/initCommand.ts
@@ -1,4 +1,4 @@
-import { internalError } from '../errors.ts';
+import { configError } from '../errors.ts';
 import { EXIT_OK } from '../exitCodes.ts';
 import { printStep, reportWriteResult } from '../terminal.ts';
 import { extractMessage } from '../utils/error-handling.ts';
@@ -25,7 +25,7 @@ export function initCommand({ dryRun, force }: InitOptions): number {
   try {
     result = scaffoldConfig({ dryRun, force });
   } catch (error: unknown) {
-    throw internalError(`Failed to scaffold config: ${extractMessage(error)}`, { cause: error });
+    throw configError(`Failed to scaffold config: ${extractMessage(error)}`, { cause: error });
   }
 
   reportWriteResult(result.configResult, dryRun);
@@ -34,7 +34,7 @@ export function initCommand({ dryRun, force }: InitOptions): number {
   // `reportWriteResult` has already printed the per-file reason, so the thrown message stays terse.
   const failure = [result.configResult, result.kitResult].find((r) => r.outcome === 'failed');
   if (failure !== undefined) {
-    throw internalError(`Failed to scaffold ${failure.filePath}`);
+    throw configError(`Failed to scaffold ${failure.filePath}`);
   }
 
   if (!dryRun) {

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -177,7 +177,7 @@ async function runOwnerMode(): Promise<number> {
   return EXIT_OK;
 }
 
-/** Read a manifest, reporting an unreadable or invalid one as a config failure. */
+/** Reads a manifest, reporting an unreadable or invalid one as a config failure. */
 function readManifestOrThrow(manifestPath: string): ReturnType<typeof readManifest> {
   try {
     return readManifest(manifestPath);

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -2,6 +2,8 @@ import path from 'node:path';
 import process from 'node:process';
 import { parseArgs as nodeParseArgs } from 'node:util';
 
+import { configError, usageError } from '../errors.ts';
+import { EXIT_OK } from '../exitCodes.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { loadRemoteManifest, RemoteManifestNotFoundError } from '../loadRemoteManifest.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
@@ -30,15 +32,13 @@ export async function listCommand(args: string[]): Promise<number> {
   try {
     parsed = nodeParseArgs({ args, options: listOptions, strict: true, allowPositionals: true });
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${translateParseArgsError(error)}\n`);
-    return 1;
+    throw usageError(translateParseArgsError(error), { cause: error });
   }
   const { values } = parsed;
 
   for (const [name, value] of Object.entries(values)) {
     if (value === '') {
-      process.stderr.write(`Error: --${name} requires a value\n`);
-      return 1;
+      throw usageError(`--${name} requires a value`);
     }
   }
 
@@ -46,8 +46,7 @@ export async function listCommand(args: string[]): Promise<number> {
   const manifestArg = values.manifest;
 
   if (fromArg !== undefined && manifestArg !== undefined) {
-    process.stderr.write('Error: --from and --manifest are mutually exclusive\n');
-    return 1;
+    throw usageError('--from and --manifest are mutually exclusive');
   }
 
   if (manifestArg !== undefined) {
@@ -64,20 +63,12 @@ export async function listCommand(args: string[]): Promise<number> {
 /** Display kits from a manifest file. */
 function runManifestMode(manifestArg: string): number {
   const manifestPath = path.resolve(process.cwd(), manifestArg);
-
-  let manifest;
-  try {
-    manifest = readManifest(manifestPath);
-  } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
-  }
+  const manifest = readManifestOrThrow(manifestPath);
 
   const relPath = path.relative(process.cwd(), manifestPath);
   const output = formatManifestView({ kits: manifest.kits, manifestPath: relPath });
   process.stdout.write(output + '\n');
-  return 0;
+  return EXIT_OK;
 }
 
 /** Resolve the manifest path for a `--from` source and display its kits. */
@@ -86,9 +77,7 @@ async function runFromMode(fromArg: string): Promise<number> {
   try {
     source = parseFromValue(fromArg);
   } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
+    throw usageError(extractMessage(error), { cause: error });
   }
 
   if (source.type === 'github') {
@@ -106,20 +95,12 @@ async function runFromMode(fromArg: string): Promise<number> {
   }
 
   const manifestPath = resolveFromManifestPath(source);
-
-  let manifest;
-  try {
-    manifest = readManifest(manifestPath);
-  } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
-  }
+  const manifest = readManifestOrThrow(manifestPath);
 
   const kitNames = manifest.kits.map((kit) => kit.name);
   const output = formatConsumerView({ compiledKits: kitNames, fromArg, kitsDir: path.dirname(manifestPath) });
   process.stdout.write(output + '\n');
-  return 0;
+  return EXIT_OK;
 }
 
 /** Fetch and display kits from a remote manifest URL. */
@@ -135,19 +116,17 @@ async function runRemoteFromMode({
     manifest = await loadRemoteManifest({ url, headers });
   } catch (error: unknown) {
     if (error instanceof RemoteManifestNotFoundError) {
-      process.stderr.write(`Error: No manifest found at ${url}.\n`);
-      return 1;
+      throw configError(`No manifest found at ${url}.`, { cause: error });
     }
     const message = extractMessage(error);
     // Network failures (raw `fetch` rejections) carry no URL context; thrown errors from `loadRemoteManifest` already include the URL.
     const detail = message.includes(url) ? message : `Failed to reach ${url}: ${message}`;
-    process.stderr.write(`Error: ${detail}\n`);
-    return 1;
+    throw configError(detail, { cause: error });
   }
 
   const output = formatManifestView({ kits: manifest.kits, manifestPath: url });
   process.stdout.write(output + '\n');
-  return 0;
+  return EXIT_OK;
 }
 
 /** Enumerate kits using the project config. */
@@ -158,9 +137,7 @@ async function runOwnerMode(): Promise<number> {
   try {
     config = await loadConfig();
   } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
+    throw configError(extractMessage(error), { cause: error });
   }
 
   const internalDir = path.join(cwd, '.readyup/kits', config.internal.dir);
@@ -170,9 +147,7 @@ async function runOwnerMode(): Promise<number> {
   try {
     internalKits = enumerateKits({ dir: internalDir, extension: internalExtension });
   } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
+    throw configError(extractMessage(error), { cause: error });
   }
 
   const manifestPath = path.resolve(cwd, DEFAULT_MANIFEST_PATH);
@@ -187,7 +162,7 @@ async function runOwnerMode(): Promise<number> {
         process.stdout.write(
           'No kits found.\nRun `rdy init` to scaffold an internal kit or `rdy compile` to compile a kit from source.\n',
         );
-        return 0;
+        return EXIT_OK;
       }
     } else {
       // Corrupt or unreadable manifest — warn and continue with empty compiled list.
@@ -199,7 +174,16 @@ async function runOwnerMode(): Promise<number> {
   const compiledStyle = resolveCompiledStyle(cwd, config.compile.outDir);
   const output = formatOwnerView({ internalKits, compiledKits, compiledStyle });
   process.stdout.write(output + '\n');
-  return 0;
+  return EXIT_OK;
+}
+
+/** Read a manifest, reporting an unreadable or invalid one as a config failure. */
+function readManifestOrThrow(manifestPath: string): ReturnType<typeof readManifest> {
+  try {
+    return readManifest(manifestPath);
+  } catch (error: unknown) {
+    throw configError(extractMessage(error), { cause: error });
+  }
 }
 
 /** Resolve the manifest path for a parsed `--from` source. */

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -7,6 +7,7 @@ import { EXIT_OK } from '../exitCodes.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { loadRemoteManifest, RemoteManifestNotFoundError } from '../loadRemoteManifest.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
+import type { RdyManifest } from '../manifest/manifestSchema.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { parseFromValue } from '../parseFromValue.ts';
 import { resolveBitbucketToken } from '../resolveBitbucketToken.ts';
@@ -178,7 +179,7 @@ async function runOwnerMode(): Promise<number> {
 }
 
 /** Reads a manifest, reporting an unreadable or invalid one as a config failure. */
-function readManifestOrThrow(manifestPath: string): ReturnType<typeof readManifest> {
+function readManifestOrThrow(manifestPath: string): RdyManifest {
   try {
     return readManifest(manifestPath);
   } catch (error: unknown) {

--- a/packages/readyup/src/schemaVersion.ts
+++ b/packages/readyup/src/schemaVersion.ts
@@ -1,6 +1,0 @@
-/**
- * Version of the `--json` payload contract, incremented independently of the tool version.
- *
- * Adding an optional field does not bump it; removing, renaming, or re-typing a field does.
- */
-export const SCHEMA_VERSION = 1;

--- a/packages/readyup/src/schemaVersion.ts
+++ b/packages/readyup/src/schemaVersion.ts
@@ -1,0 +1,6 @@
+/**
+ * Version of the `--json` payload contract, incremented independently of the tool version.
+ *
+ * Adding an optional field does not bump it; removing, renaming, or re-typing a field does.
+ */
+export const SCHEMA_VERSION = 1;

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -2,6 +2,8 @@ import path from 'node:path';
 import process from 'node:process';
 import { parseArgs as nodeParseArgs } from 'node:util';
 
+import { configError, usageError } from '../errors.ts';
+import { EXIT_OK, EXIT_PROBLEMS_FOUND } from '../exitCodes.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { readManifest } from '../manifest/readManifest.ts';
@@ -18,26 +20,24 @@ const verifyOptions = {
  * Handle the `verify` subcommand: read the manifest, hash each compiled kit, and report drift.
  *
  * Returns 0 when every kit is `ok` or `unverified`; 1 when any kit has `drift` or `missing`.
+ * An unreadable manifest is a config failure and is thrown rather than reported as drift.
  */
 export function verifyCommand(args: string[]): number {
   let parsed;
   try {
     parsed = nodeParseArgs({ args, options: verifyOptions, strict: true, allowPositionals: true });
   } catch (error: unknown) {
-    process.stderr.write(`Error: ${translateParseArgsError(error)}\n`);
-    return 1;
+    throw usageError(translateParseArgsError(error), { cause: error });
   }
   const { values, positionals } = parsed;
 
   if (positionals.length > 0) {
-    process.stderr.write('Error: rdy verify does not accept positional arguments.\n');
-    return 1;
+    throw usageError('rdy verify does not accept positional arguments.');
   }
 
   for (const [name, value] of Object.entries(values)) {
     if (value === '') {
-      process.stderr.write(`Error: --${name} requires a value\n`);
-      return 1;
+      throw usageError(`--${name} requires a value`);
     }
   }
 
@@ -48,9 +48,7 @@ export function verifyCommand(args: string[]): number {
   try {
     manifest = readManifest(manifestPath);
   } catch (error: unknown) {
-    const message = extractMessage(error);
-    process.stderr.write(`Error: ${message}\n`);
-    return 1;
+    throw configError(extractMessage(error), { cause: error });
   }
 
   const relManifestPath = path.relative(process.cwd(), manifestPath);
@@ -58,7 +56,7 @@ export function verifyCommand(args: string[]): number {
 
   if (manifest.kits.length === 0) {
     process.stdout.write('  (no kits in manifest)\n');
-    return 0;
+    return EXIT_OK;
   }
 
   let failed = 0;
@@ -74,7 +72,7 @@ export function verifyCommand(args: string[]): number {
     process.stdout.write(`\n${failed} of ${manifest.kits.length} kits failed verification.\n`);
   }
 
-  return failed > 0 ? 1 : 0;
+  return failed > 0 ? EXIT_PROBLEMS_FOUND : EXIT_OK;
 }
 
 /** Format a single per-kit status line for the verify report. */


### PR DESCRIPTION
## What

`rdy` now distinguishes kinds of failure by exit code. A run that completes but finds problems in the repo or its kits exits 1; an invocation that `rdy` cannot complete at all -- such as a bad flag, an unreadable configuration, or a kit that will not load -- exits 2. Under `--json`, every failure that produces no report now arrives as a parseable JSON error on stdout; previously some printed prose to stderr, leaving stdout empty.

## Why

Pipelines and agents consuming `rdy` had no way to act on a failure. Every failure exited 1, so a checks-failed result was indistinguishable from a typo in the command line — the first calls for fixing the repo, the second for fixing the invocation, and automation could not tell which it had hit. Under `--json` the problem compounded: whether a failure arrived as a parseable document depended on how far the invocation got, so a consumer could not rely on parsing stdout at all.

## Details

### 🎉 Features

- 🚨 **Breaking:** Exit codes now carry three meanings instead of two: 0 for a run that found no problems, 1 for a run that found problems with the repo or its kits (failed checks, `verify` drift or a missing kit, a kit that fails to compile), and 2 for an invocation that could not be completed. `rdy list` and `rdy init` produce only 0 and 2. Consumers branching on exit 1 alone will see invocation errors move to 2.
- Under `--json`, a failure that produced no report writes a single error envelope to stdout carrying a `code` — one of `usage`, `config`, `kit-load`, or `internal` — alongside the message. Which document stdout carries follows whether a report was produced, not the exit code. `--help` and `--version` have no JSON form, so their text goes to stderr and stdout stays empty.

### 🐛 Bug fixes

- Flag-parse failures now take the JSON envelope path under every spelling of the flag the CLI accepts (`--json`, `-j`, and grouped shorts such as `-jJ`), detected by an argv pre-scan that respects the `--` terminator. Previously they printed prose to stderr and left stdout empty, because argument parsing ran before the `--json` flag was read.
- A failed `rdy init` scaffold is reported as a config error rather than an internal one, matching how `rdy compile` already classifies a manifest it cannot write.

### ♻️ Refactoring

- Commands raise a classified error instead of writing their own message and choosing their own exit code; a single boundary in the runner renders every failure and owns the choice of stream and format. This removes roughly two dozen duplicated error-render sites, including the per-kit `try`/`catch` blocks in the multi-kit loops, whose removal #132 depends on.
- Help text moved from per-command `console.info` calls to string constants routed through one writer, so prose can be diverted to stderr when JSON mode owns stdout.

### 🧪 Tests

- New end-to-end coverage drives the runner against a real temp-directory fixture with no mocks, asserting every exit-code class, the envelope's `code` for each error class, and stdout purity under `--json` — including that exactly one document is written, with no interior newline.
- Roughly 30 existing tests moved from asserting on stderr strings to asserting on the raised error's classification, so the render has one owner and one test.

### 📚 Documentation

- README documents the exit codes and the JSON output contract, and its command table now lists `verify`.
- Help text states specific exit codes where it previously said "non-zero", and the root help gains an exit-code block.

Closes #118
