### PR TITLE
#131 Retire case-colliding short flags

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -85,13 +85,15 @@ rdy <command> [options]
 | ----------------------------- | ------------------------------------------------------------- |
 | `--from <source>`             | Kit source (see [kit sources](#kit-sources) below)            |
 | `--file, -f <path>`           | Path to a local kit file                                      |
-| `--url, -u <url>`             | Fetch kit from a URL                                          |
-| `--jit, -J`                   | Run from TypeScript source instead of compiled JS             |
-| `--internal, -i`              | Use internal kit directory and infix from config              |
-| `--checklists, -c <name,...>` | Filter checklists (with `--file` or `--url` only)             |
-| `--json, -j`                  | Output results as JSON                                        |
-| `--fail-on, -F <severity>`    | Fail on this severity or above (`error`, `warn`, `recommend`) |
-| `--report-on, -R <severity>`  | Show this severity or above (`error`, `warn`, `recommend`)    |
+| `--url <url>`                 | Fetch kit from a URL                                          |
+| `--jit`                       | Run from TypeScript source instead of compiled JS             |
+| `--internal`                  | Use internal kit directory and infix from config              |
+| `--checklists, -c <name,...>` | Filter checklists within the selected kit                     |
+| `--json`                      | Output results as JSON                                        |
+| `--fail-on <severity>`        | Fail on this severity or above (`error`, `warn`, `recommend`) |
+| `--report-on <severity>`      | Show this severity or above (`error`, `warn`, `recommend`)    |
+
+`--checklists` selects checklists within one kit. Pair it with a single positional kit, with `--file` or `--url`, or with no kit at all to filter the default kit. Naming two or more kits, or naming one that already carries a `:checklist` filter, is an error rather than a merge.
 
 `--report-on` prunes only the reported detail tree, and keeps the parent checks of anything it shows so nesting stays intact. Summary counts, worst severity, and the exit code always reflect the whole run.
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -111,15 +111,35 @@ describe(parseRunArgs, () => {
     expect(result.checklists).toStrictEqual(['check1']);
   });
 
-  it('throws when --checklists is used without --file or --url', () => {
-    expect(() => parseRunArgs(['--checklists', 'check1'])).toThrow(
-      '--checklists can only be used with --file or --url',
+  it('parses --checklists with a single positional kit', () => {
+    const result = parseRunArgs(['deploy', '--checklists', 'build,test']);
+
+    expect(result.checklists).toStrictEqual(['build', 'test']);
+    expect(result.kitSpecifiers).toStrictEqual([{ kitName: 'deploy', checklists: [] }]);
+  });
+
+  it('parses --checklists with no positional kit, selecting within the default kit', () => {
+    const result = parseRunArgs(['--checklists', 'build']);
+
+    expect(result.checklists).toStrictEqual(['build']);
+    expect(result.kitSpecifiers).toStrictEqual([]);
+  });
+
+  it('parses --checklists with --from and a single positional kit', () => {
+    const result = parseRunArgs(['--checklists', 'check1', '--from', 'github:org/repo', 'deploy']);
+
+    expect(result.checklists).toStrictEqual(['check1']);
+  });
+
+  it('throws when --checklists competes with a ":" filter on the positional kit', () => {
+    expect(() => parseRunArgs(['deploy:build', '--checklists', 'test'])).toThrow(
+      '--checklists cannot be combined with the ":" checklist filter on "deploy"',
     );
   });
 
-  it('throws when --checklists is used with --from', () => {
-    expect(() => parseRunArgs(['--checklists', 'check1', '--from', 'github:org/repo'])).toThrow(
-      '--checklists can only be used with --file or --url',
+  it('throws when --checklists is given more than one positional kit', () => {
+    expect(() => parseRunArgs(['a', 'b', '--checklists', 'x'])).toThrow(
+      '--checklists requires a single kit, but 2 were given: a, b',
     );
   });
 
@@ -414,6 +434,18 @@ describe(resolveKitSources, () => {
   it('resolves slash-separated kit name', () => {
     expect(resolve({ kitSpecifiers: [{ kitName: 'shared/deploy', checklists: [] }] })).toStrictEqual([
       { name: 'shared/deploy', source: { path: '.readyup/kits/shared/deploy.js' }, checklists: [] },
+    ]);
+  });
+
+  it('applies --checklists to the named kit', () => {
+    expect(
+      resolve({ kitSpecifiers: [{ kitName: 'deploy', checklists: [] }], checklists: ['build', 'test'] }),
+    ).toStrictEqual([{ name: 'deploy', source: { path: '.readyup/kits/deploy.js' }, checklists: ['build', 'test'] }]);
+  });
+
+  it('applies --checklists to the default kit when no kit is named', () => {
+    expect(resolve({ checklists: ['build'] })).toStrictEqual([
+      { name: 'default', source: { path: '.readyup/kits/default.js' }, checklists: ['build'] },
     ]);
   });
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -137,6 +137,14 @@ describe(parseRunArgs, () => {
     );
   });
 
+  it.each([
+    { label: 'no value', args: ['--checklists='] },
+    { label: 'only separators', args: ['--checklists', ',,,'] },
+    { label: 'only separators alongside a kit', args: ['deploy', '--checklists', ','] },
+  ])('throws when --checklists is given $label', ({ args }) => {
+    expect(() => parseRunArgs(args)).toThrow('--checklists requires a comma-separated list of checklist names');
+  });
+
   it('throws when --checklists is given more than one positional kit', () => {
     expect(() => parseRunArgs(['a', 'b', '--checklists', 'x'])).toThrow(
       '--checklists requires a single kit, but 2 were given: a, b',

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -185,21 +185,9 @@ describe(parseRunArgs, () => {
     expect(result.jit).toBe(true);
   });
 
-  it('parses -J as short form of --jit', () => {
-    const result = parseRunArgs(['-J']);
-
-    expect(result.jit).toBe(true);
-  });
-
   // --internal flag
   it('parses --internal flag', () => {
     const result = parseRunArgs(['--internal']);
-
-    expect(result.internal).toBe(true);
-  });
-
-  it('parses -i as short form of --internal', () => {
-    const result = parseRunArgs(['-i']);
 
     expect(result.internal).toBe(true);
   });
@@ -241,36 +229,23 @@ describe(parseRunArgs, () => {
     expect(result.filePath).toBe('custom/path.ts');
   });
 
-  it('parses -u as short form of --url', () => {
-    const result = parseRunArgs(['-u', 'https://example.com/config.js']);
-
-    expect(result.urlValue).toBe('https://example.com/config.js');
+  it.each(['-J', '-F', '-R', '-i', '-u', '-j'])('rejects the retired short flag %s', (short) => {
+    expect(() => parseRunArgs([short])).toThrow(`Unknown option '${short}'`);
   });
 
-  it('parses -j as short form of --json', () => {
-    const result = parseRunArgs(['-j']);
-
-    expect(result.json).toBe(true);
-  });
-
-  // node:util.parseArgs expands grouped boolean shorts (`-jJ`) into separate flags.
-  it('accepts grouped short boolean flags', () => {
-    const result = parseRunArgs(['-jJ']);
-
-    expect(result.json).toBe(true);
-    expect(result.jit).toBe(true);
-  });
-
-  it('parses -F as short form of --fail-on', () => {
-    const result = parseRunArgs(['-F', 'warn']);
-
-    expect(result.failOn).toBe('warn');
-  });
-
-  it('parses -R as short form of --report-on', () => {
-    const result = parseRunArgs(['-R', 'error']);
-
-    expect(result.reportOn).toBe('error');
+  it.each([
+    { long: '--internal', args: ['--internal'], expected: { internal: true } },
+    { long: '--jit', args: ['--jit'], expected: { jit: true } },
+    { long: '--json', args: ['--json'], expected: { json: true } },
+    { long: '--fail-on', args: ['--fail-on', 'warn'], expected: { failOn: 'warn' } },
+    { long: '--report-on', args: ['--report-on', 'error'], expected: { reportOn: 'error' } },
+    {
+      long: '--url',
+      args: ['--url', 'https://example.com/kit.js'],
+      expected: { urlValue: 'https://example.com/kit.js' },
+    },
+  ])('keeps $long working after its short is retired', ({ args, expected }) => {
+    expect(parseRunArgs(args)).toMatchObject(expected);
   });
 
   // --url flag

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -16,6 +16,14 @@ const FAILING_KIT = `export default { checklists: [{ name: 'main', checks: [{ na
 /** A kit that is not a valid kit at all, so loading it fails. */
 const INVALID_KIT = `export default { nope: true };\n`;
 
+/** A kit with three named checklists, for exercising checklist selection. */
+const MULTI_KIT =
+  `export default { checklists: [\n` +
+  `  { name: 'build', checks: [{ name: 'build-ok', check: () => true }] },\n` +
+  `  { name: 'test', checks: [{ name: 'test-ok', check: () => true }] },\n` +
+  `  { name: 'lint', checks: [{ name: 'lint-ok', check: () => true }] },\n` +
+  `] };\n`;
+
 let cwd: string;
 let originalCwd: string;
 let stdout: string[];
@@ -30,6 +38,7 @@ beforeAll(() => {
   writeFileSync(path.join(cwd, '.readyup/kits/passing.js'), PASSING_KIT);
   writeFileSync(path.join(cwd, '.readyup/kits/failing.js'), FAILING_KIT);
   writeFileSync(path.join(cwd, '.readyup/kits/invalid.js'), INVALID_KIT);
+  writeFileSync(path.join(cwd, '.readyup/kits/deploy.js'), MULTI_KIT);
   // A manifest whose recorded hash cannot match the file on disk, so `verify` reports drift.
   writeFileSync(
     path.join(cwd, '.readyup/manifest.json'),
@@ -157,6 +166,62 @@ describe('stdout purity under --json', () => {
     expect(exitCode).toBe(2);
     expect(readStdout()).toBe('');
     expect(readStderr()).toContain('Error:');
+  });
+});
+
+describe('flag surface', () => {
+  it.each(['-J', '-F', '-R', '-i', '-u', '-j'])(
+    'exits 2 with a usage error for the retired short %s',
+    async (short) => {
+      const exitCode = await routeCommand(['--json', short]);
+
+      expect(exitCode).toBe(2);
+      expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'usage' } });
+    },
+  );
+
+  it.each([
+    { long: '--jit', args: ['--jit'] },
+    { long: '--internal', args: ['--internal'] },
+    { long: '--url', args: ['--url', 'file://absent'] },
+    { long: '--fail-on', args: ['passing', '--fail-on', 'warn'] },
+    { long: '--report-on', args: ['passing', '--report-on', 'error'] },
+  ])('leaves $long accepted after its short is retired', async ({ args }) => {
+    // The flag may still fail for want of a kit; what matters is that it is not a usage error.
+    const exitCode = await routeCommand([...args, '--json']);
+
+    if (exitCode === 2) {
+      expect(JSON.parse(readStdout())).not.toMatchObject({ error: { code: 'usage' } });
+    }
+  });
+
+  it('runs the named checklists from a single positional kit', async () => {
+    const exitCode = await routeCommand(['deploy', '--checklists', 'build,test', '--json']);
+
+    expect(exitCode).toBe(0);
+    const written = readStdout();
+    expect(written).toContain('build');
+    expect(written).toContain('test');
+    expect(written).not.toContain('lint');
+  });
+
+  it.each([
+    { label: 'a ":" filter competing with --checklists', args: ['deploy:build', '--checklists', 'test'] },
+    { label: 'more than one positional kit', args: ['deploy', 'passing', '--checklists', 'build'] },
+  ])('exits 2 with a usage error for $label', async ({ args }) => {
+    const exitCode = await routeCommand([...args, '--json']);
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'usage' } });
+  });
+
+  // Asserted without `--json`, which `init` does not accept either; adding it would let this pass
+  // on the wrong flag.
+  it('exits 2 for the retired init -f short', async () => {
+    const exitCode = await routeCommand(['init', '-f']);
+
+    expect(exitCode).toBe(2);
+    expect(readStderr()).toContain("Unknown option '-f'");
   });
 });
 

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -149,14 +149,14 @@ describe('stdout purity under --json', () => {
   });
 
   it.each([
-    { label: 'the short flag', flag: '-j' },
-    { label: 'a short cluster', flag: '-jJ' },
-  ])('takes the envelope path for a flag-parse failure spelled with $label', async ({ flag }) => {
-    const exitCode = await routeCommand(['--bogus', flag]);
+    { label: 'the retired short flag', flag: '-j' },
+    { label: 'a short cluster containing j', flag: '-jJ' },
+  ])('takes the prose path for a flag-parse failure spelled with $label', async ({ flag }) => {
+    const exitCode = await routeCommand([flag]);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(readStdout())).toStrictEqual({ error: { code: 'usage', message: expect.any(String) } });
-    expect(readStderr()).toBe('');
+    expect(readStdout()).toBe('');
+    expect(readStderr()).toContain('Error:');
   });
 });
 

--- a/packages/readyup/__tests__/hasJsonFlag.test.ts
+++ b/packages/readyup/__tests__/hasJsonFlag.test.ts
@@ -5,9 +5,6 @@ import { hasJsonFlag } from '../src/hasJsonFlag.ts';
 describe(hasJsonFlag, () => {
   it.each([
     { label: 'the long flag', argv: ['run', '--json'] },
-    { label: 'the short flag', argv: ['run', '-j'] },
-    { label: 'a short cluster leading with j', argv: ['run', '-jJ'] },
-    { label: 'a short cluster ending with j', argv: ['run', '-Jj'] },
     { label: 'a flag preceding an unparseable one', argv: ['--json', '--bogus'] },
   ])('detects JSON mode from $label', ({ argv }) => {
     expect(hasJsonFlag(argv)).toBe(true);
@@ -16,17 +13,15 @@ describe(hasJsonFlag, () => {
   it.each([
     { label: 'no flags at all', argv: ['run', 'deploy'] },
     { label: 'an unrelated long flag', argv: ['run', '--jit'] },
-    { label: 'an unrelated short cluster', argv: ['run', '-Ji'] },
+    { label: 'the retired -j short', argv: ['run', '-j'] },
+    { label: 'a short cluster containing j', argv: ['run', '-jJ'] },
     { label: 'a positional that merely contains j', argv: ['run', 'json'] },
   ])('reports no JSON mode for $label', ({ argv }) => {
     expect(hasJsonFlag(argv)).toBe(false);
   });
 
-  it.each([
-    { label: 'the long flag', argv: ['run', '--', '--json'] },
-    { label: 'the short flag', argv: ['run', '--', '-j'] },
-  ])('ignores $label after the -- terminator', ({ argv }) => {
-    expect(hasJsonFlag(argv)).toBe(false);
+  it('ignores the long flag after the -- terminator', () => {
+    expect(hasJsonFlag(['run', '--', '--json'])).toBe(false);
   });
 
   it('detects a flag appearing before the -- terminator', () => {

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -427,13 +427,20 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(0);
   });
 
-  it('passes -n and -f short flags to initCommand', async () => {
+  it('passes the -n short flag to initCommand', async () => {
     mockInitCommand.mockReturnValue(0);
 
-    const exitCode = await routeCommand(['init', '-n', '-f']);
+    const exitCode = await routeCommand(['init', '-n']);
 
-    expect(mockInitCommand).toHaveBeenCalledWith({ dryRun: true, force: true });
+    expect(mockInitCommand).toHaveBeenCalledWith({ dryRun: true, force: false });
     expect(exitCode).toBe(0);
+  });
+
+  it('rejects the retired init -f short flag', async () => {
+    const exitCode = await routeCommand(['init', '-f']);
+
+    expect(exitCode).toBe(2);
+    expect(mockInitCommand).not.toHaveBeenCalled();
   });
 
   it('returns 2 for unknown init flags', async () => {

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -106,12 +106,25 @@ describe(routeCommand, () => {
     const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(output).toContain('--from');
     expect(output).toContain('--file, -f');
-    expect(output).toContain('--url, -u');
-    expect(output).toContain('--jit, -J');
-    expect(output).toContain('--internal, -i');
+    expect(output).toContain('--url');
+    expect(output).toContain('--jit');
+    expect(output).toContain('--internal');
     expect(output).toContain('--checklists, -c');
-    expect(output).toContain('--json, -j');
+    expect(output).toContain('--json');
     expect(output).toContain('--version, -V');
+  });
+
+  it.each([
+    { label: 'top-level', args: ['--help'] },
+    { label: 'run', args: ['run', '--help'] },
+    { label: 'init', args: ['init', '--help'] },
+  ])('names no retired short flag in $label help', async ({ args }) => {
+    await routeCommand(args);
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    for (const short of ['-J', '-F', '-R', '-i', '-u', '-j']) {
+      expect(output).not.toContain(`, ${short}`);
+    }
   });
 
   it('marks run as the default command in top-level help', async () => {

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -295,7 +295,7 @@ async function handleRun(flags: string[], json: boolean): Promise<number> {
 function handleInit(flags: string[]): number {
   const initOptions = {
     'dry-run': { type: 'boolean', short: 'n' },
-    force: { type: 'boolean', short: 'f' },
+    force: { type: 'boolean' },
   } as const;
 
   let parsed;

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -32,13 +32,13 @@ Commands:
 Run options:
   --from <source>                    Kit source (github:org/repo, bitbucket:ws/repo, global, dir:path, or local path)
   --file, -f <path>                  Path to a local kit file
-  --url, -u <url>                    Fetch kit from a URL
-  --jit, -J                          Run from TypeScript source instead of compiled JS
-  --internal, -i                     Use internal kit directory and infix from config
-  --checklists, -c <name,...>        Filter checklists (with --file or --url only)
-  --json, -j                         Output results as JSON
-  --fail-on, -F <severity>           Fail on this severity or above (error, warn, recommend)
-  --report-on, -R <severity>         Show this severity or above in the detail tree (error, warn, recommend),
+  --url <url>                        Fetch kit from a URL
+  --jit                              Run from TypeScript source instead of compiled JS
+  --internal                         Use internal kit directory and infix from config
+  --checklists, -c <name,...>        Filter checklists within the selected kit
+  --json                             Output results as JSON
+  --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
+  --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
                                      plus the parent checks of anything shown; summary counts always
                                      cover the whole run
 
@@ -69,17 +69,18 @@ Kit source (mutually exclusive):
   --from <source>                    Kit source (github:org/repo[@ref], bitbucket:ws/repo[@ref],
                                      global, dir:path, or local repo path)
   --file, -f <path>                  Path to a local kit file
-  --url, -u <url>                    Fetch kit from a URL
+  --url <url>                        Fetch kit from a URL
 
 Mode flags (incompatible with --from, --file, --url):
-  --jit, -J                          Run from TypeScript source instead of compiled JS
-  --internal, -i                     Use internal kit directory and infix from config
+  --jit                              Run from TypeScript source instead of compiled JS
+  --internal                         Use internal kit directory and infix from config
 
 Options:
-  --checklists, -c <name,...>        Filter checklists (with --file or --url only)
-  --json, -j                         Output results as JSON
-  --fail-on, -F <severity>           Fail on this severity or above (error, warn, recommend)
-  --report-on, -R <severity>         Show this severity or above in the detail tree (error, warn, recommend),
+  --checklists, -c <name,...>        Filter checklists within the selected kit; requires a
+                                     single kit and no ":" filter on it
+  --json                             Output results as JSON
+  --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
+  --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
                                      plus the parent checks of anything shown; summary counts always
                                      cover the whole run
   --help, -h                         Show this help message
@@ -165,7 +166,7 @@ Scaffold a starter config and kit file.
 
 Options:
   --dry-run, -n   Preview changes without writing files
-  --force, -f     Overwrite existing files
+  --force         Overwrite existing files
   --help, -h      Show this help message
 `;
 

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -110,18 +110,18 @@ const flagErrorHints: Record<string, string> = {
   '--url': '--url requires a URL argument',
 };
 
-/** Collect active source flags and validate mutual exclusivity and mode-flag constraints. */
-function validateFlagConstraints(
-  parsed: {
-    file: string | undefined;
-    from: string | undefined;
-    url: string | undefined;
-    jit: boolean;
-    internal: boolean;
-    checklists: string | undefined;
-  },
-  positionalCount: number,
-): string | undefined {
+/** The subset of parsed run flags whose combinations are constrained. */
+interface RunFlagConstraints {
+  checklists: string | undefined;
+  file: string | undefined;
+  from: string | undefined;
+  internal: boolean;
+  jit: boolean;
+  url: string | undefined;
+}
+
+/** Collects the active source flags and enforces mutual exclusivity, mode-flag, and selection constraints. */
+function validateFlagConstraints(parsed: RunFlagConstraints, kitSpecifiers: KitSpecifier[]): string | undefined {
   const sourceFlags: string[] = [];
   if (parsed.file !== undefined) sourceFlags.push('--file');
   if (parsed.from !== undefined) sourceFlags.push('--from');
@@ -140,15 +140,38 @@ function validateFlagConstraints(
     throw usageError(`--internal cannot be combined with ${sourceType}`);
   }
 
-  if (parsed.checklists !== undefined && sourceType !== '--file' && sourceType !== '--url') {
-    throw usageError('--checklists can only be used with --file or --url');
-  }
-
-  if ((sourceType === '--file' || sourceType === '--url') && positionalCount > 0) {
+  if ((sourceType === '--file' || sourceType === '--url') && kitSpecifiers.length > 0) {
     throw usageError(`${sourceType} cannot be combined with positional kit arguments`);
   }
 
+  if (parsed.checklists !== undefined) {
+    validateChecklistsSelection(sourceType, kitSpecifiers);
+  }
+
   return sourceType;
+}
+
+/**
+ * Rejects `--checklists` when the selection it expresses is ambiguous.
+ *
+ * The flag names checklists within one kit, so it needs exactly one kit and no competing per-kit
+ * filter. `--file` and `--url` each name their one kit implicitly; a bare invocation names the
+ * default kit. Conflicting selections error rather than merging: an invocation carrying both is a
+ * bug in whatever generated it, and no merge rule for "run `deploy:build`, filtered to `test`" is
+ * obviously right.
+ */
+function validateChecklistsSelection(sourceType: string | undefined, kitSpecifiers: KitSpecifier[]): void {
+  if (sourceType === '--file' || sourceType === '--url') return;
+
+  if (kitSpecifiers.length > 1) {
+    const names = kitSpecifiers.map((spec) => spec.kitName).join(', ');
+    throw usageError(`--checklists requires a single kit, but ${kitSpecifiers.length} were given: ${names}`);
+  }
+
+  const spec = kitSpecifiers[0];
+  if (spec !== undefined && spec.checklists.length > 0) {
+    throw usageError(`--checklists cannot be combined with the ":" checklist filter on "${spec.kitName}"`);
+  }
 }
 
 /** Tokenize run-subcommand flags via node:util.parseArgs, translating parse errors into domain-specific messages. */
@@ -184,18 +207,19 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
     reportOn: values['report-on'],
   };
 
-  validateFlagConstraints(parsed, positionals.length);
-
-  // Parse checklists from the flag value.
-  const checklists = parsed.checklists !== undefined ? parsed.checklists.split(',').filter((s) => s !== '') : undefined;
-
-  // Parse kit specifiers from positional args.
+  // Parse kit specifiers from positional args. This precedes validation because `--checklists`
+  // is constrained by how many kits were named and whether the one named carries its own filter.
   let kitSpecifiers: KitSpecifier[];
   try {
     kitSpecifiers = parseKitSpecifiers(positionals);
   } catch (error: unknown) {
     throw usageError(extractMessage(error), { cause: error });
   }
+
+  validateFlagConstraints(parsed, kitSpecifiers);
+
+  // Parse checklists from the flag value.
+  const checklists = parsed.checklists !== undefined ? parsed.checklists.split(',').filter((s) => s !== '') : undefined;
 
   // Validate severity flags.
   const failOn = parsed.failOn !== undefined ? parseSeverityFlag('--fail-on', parsed.failOn) : undefined;
@@ -247,7 +271,10 @@ export function resolveKitSources({
 
   // Assume `jit` is always false when `fromValue` is present; `parseRunArgs` enforces this constraint.
   const extension = jit ? '.ts' : '.js';
-  const specs = kitSpecifiers.length > 0 ? kitSpecifiers : [{ kitName: 'default', checklists: [] }];
+  const declaredSpecs = kitSpecifiers.length > 0 ? kitSpecifiers : [{ kitName: 'default', checklists: [] }];
+  // `--checklists` names checklists within one kit, and `parseRunArgs` has already rejected every
+  // invocation where "one kit" is ambiguous, so this map never covers more than a single spec.
+  const specs = checklists === undefined ? declaredSpecs : declaredSpecs.map((spec) => ({ ...spec, checklists }));
 
   if (fromValue !== undefined) {
     let source: FromSource;

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -61,9 +61,8 @@ export interface ParsedRunArgs {
  *
  * A letter earns a short flag only when it carries no dominant conflicting meaning in comparable
  * tools and means one thing across every `rdy` subcommand. The second clause is why `-f` is
- * `--file` here and nothing anywhere else. The retired rule — first letter, uppercased on
- * collision — manufactured `-j`/`-J` and `-f`/`-F`, pairs differing only by case where a typo
- * silently changed what ran.
+ * `--file` here and nothing anywhere else. Pairs differing only by case are barred outright: a
+ * shift-key slip must not be able to change what runs.
  */
 const runOptions = {
   checklists: { type: 'string', short: 'c' },
@@ -100,9 +99,12 @@ function buildBitbucketKitUrl(workspace: string, repo: string, ref: string, kit:
   return `https://api.bitbucket.org/2.0/repositories/${workspace}/${repo}/src/${ref}/${KITS_DIR}/${kit}${extension}`;
 }
 
+/** Guidance shown for every spelling of `--checklists` that names no checklist. */
+const CHECKLISTS_HINT = '--checklists requires a comma-separated list of checklist names';
+
 /** Map generic "requires a value" errors to domain-specific hints for run-subcommand flags. */
 const flagErrorHints: Record<string, string> = {
-  '--checklists': '--checklists requires a comma-separated list of checklist names',
+  '--checklists': CHECKLISTS_HINT,
   '--fail-on': '--fail-on requires a severity level (error, warn, recommend)',
   '--file': '--file requires a path argument',
   '--from': '--from requires a source argument (path, github:org/repo, global, dir:path)',
@@ -218,8 +220,12 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
 
   validateFlagConstraints(parsed, kitSpecifiers);
 
-  // Parse checklists from the flag value.
+  // Parse checklists from the flag value. An empty list selects every checklist, so a value that
+  // names none — `,,,` — would invert what an explicit filter asks for.
   const checklists = parsed.checklists !== undefined ? parsed.checklists.split(',').filter((s) => s !== '') : undefined;
+  if (checklists?.length === 0) {
+    throw usageError(CHECKLISTS_HINT);
+  }
 
   // Validate severity flags.
   const failOn = parsed.failOn !== undefined ? parseSeverityFlag('--fail-on', parsed.failOn) : undefined;

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -56,16 +56,25 @@ export interface ParsedRunArgs {
   urlValue: string | undefined;
 }
 
+/**
+ * Options accepted by the `run` subcommand.
+ *
+ * A letter earns a short flag only when it carries no dominant conflicting meaning in comparable
+ * tools and means one thing across every `rdy` subcommand. The second clause is why `-f` is
+ * `--file` here and nothing anywhere else. The retired rule — first letter, uppercased on
+ * collision — manufactured `-j`/`-J` and `-f`/`-F`, pairs differing only by case where a typo
+ * silently changed what ran.
+ */
 const runOptions = {
   checklists: { type: 'string', short: 'c' },
+  'fail-on': { type: 'string' },
   file: { type: 'string', short: 'f' },
   from: { type: 'string' },
-  url: { type: 'string', short: 'u' },
-  jit: { type: 'boolean', short: 'J' },
-  internal: { type: 'boolean', short: 'i' },
-  json: { type: 'boolean', short: 'j' },
-  'fail-on': { type: 'string', short: 'F' },
-  'report-on': { type: 'string', short: 'R' },
+  internal: { type: 'boolean' },
+  jit: { type: 'boolean' },
+  json: { type: 'boolean' },
+  'report-on': { type: 'string' },
+  url: { type: 'string' },
 } as const;
 
 /** Validate and narrow a string to a Severity value. */

--- a/packages/readyup/src/hasJsonFlag.ts
+++ b/packages/readyup/src/hasJsonFlag.ts
@@ -1,23 +1,19 @@
-/** A cluster of short boolean flags, as `parseArgs` accepts them (`-jJ`). */
-const SHORT_FLAG_CLUSTER = /^-[a-zA-Z]+$/;
-
 /**
  * Detects JSON mode by scanning raw argv, before any flag parsing happens.
  *
  * Answering this without `parseArgs` is what lets a flag-parse failure still be reported through the JSON error
- * envelope. The scan matches `--json`, the short `-j`, and any short cluster containing `j`; it stops at the `--`
- * terminator, after which arguments are positional rather than flags.
+ * envelope. The scan matches only `--json`, and stops at the `--` terminator, after which arguments are positional
+ * rather than flags.
  *
- * The scan over-detects in cases a parser would resolve differently — `-Fj` is `--fail-on=j`, and `--file --json`
- * gives `--file` the literal value `--json`. That is deliberate. This answer is consulted only when rendering a
- * failure, never on the success path where parsed values govern, so over-detection sends an error to the wrong
- * channel while under-detection leaves it unreportable in JSON at all.
+ * The scan over-detects in one case a parser would resolve differently: `--file --json` gives `--file` the literal
+ * value `--json`. That is deliberate. This answer is consulted only when rendering a failure, never on the success
+ * path where parsed values govern, so over-detection sends an error to the wrong channel while under-detection
+ * leaves it unreportable in JSON at all.
  */
 export function hasJsonFlag(argv: string[]): boolean {
   for (const arg of argv) {
     if (arg === '--') return false;
     if (arg === '--json') return true;
-    if (SHORT_FLAG_CLUSTER.test(arg) && arg.includes('j')) return true;
   }
   return false;
 }


### PR DESCRIPTION
## What

Removes most short flags from `rdy run` and the `-f` flag from `rdy init`; scripts and aliases using them must switch to the long forms. `--checklists` now filters within whichever single kit is selected, not just when that kit comes from a file or URL.

## Why

Short flags were assigned by a rule that manufactured hazards: the first letter of the long name, uppercased when the lowercase was already claimed. That produced `-j`/`-J` and `-f`/`-F`, pairs distinguishable only by a shift key. A user reaching for JSON output and slipping to `-J` got a run against unbundled TypeScript source instead of an error — the failure was silent, and the two behaviors were unrelated enough that the result would be confusing rather than obviously wrong.

Separately, `--checklists` was unavailable in the case users reach for most: naming a kit and filtering the checklists inside it. The flag was rejected unless `--file` or `--url` was present, even though a single positional kit is exactly as unambiguous.

## Details

### 🎉 Features

- `--checklists` is accepted with a single positional kit, with `--file`/`--url` as before, and with no kit at all, where it filters the default kit. An ambiguous selection is rejected rather than merged: naming two or more kits, or naming one kit that already carries its own `:checklist` filter, is a usage error naming the conflict.

### 🪦 Removed

- 🚨 **Breaking:** `rdy run` no longer accepts `-F`, `-i`, `-J`, `-j`, `-R`, or `-u`, and `rdy init` no longer accepts `-f`. Use `--fail-on`, `--internal`, `--jit`, `--json`, `--report-on`, `--url`, and `--force`. A letter now earns a short flag only when it carries no dominant conflicting meaning in comparable tools and means one thing across every `rdy` subcommand — the second clause is why `-f` is `--file` on `run` and nothing anywhere else.

### 🐛 Bug fixes

- A mistyped `-j` reports its error as prose on stderr, as any other unrecognized flag does. The pre-parse scan that decides JSON mode before flag parsing runs recognized `-j` and short clusters containing `j` independently of the option table, so retiring the flag at the parser alone would have left a caller who never asked for `--json` receiving a JSON error document anyway.
- `rdy run --checklists ,,,` exits 2 with the same guidance as `--checklists=`, rather than running every checklist in the kit. A value composed only of separators reduced to an empty list, and an empty list selects everything — the opposite of what an explicit filter asks for.

### 🧪 Tests

- A `flag surface` block drives `routeCommand` end to end for every retired short, every long form that outlives one, and each accepted and rejected pairing of `--checklists` with a kit. A three-checklist fixture lets checklist selection be asserted by exclusion as well as inclusion.
- Help-text assertions are parameterized across the top-level, `run`, and `init` blocks so a future edit cannot reintroduce a retired short unnoticed.

### 📚 Documentation

- Help text and the README run-options table list only the short flags the CLI still accepts, and describe `--checklists` as filtering within the selected kit rather than as a `--file`/`--url` companion. The README states the rule for pairing `--checklists` with a kit.

Closes #131
