### PR TITLE
#132 Keep partial results when a kit fails after dispatch

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -125,7 +125,7 @@ The envelope covers only failures that precede dispatch. Once the run reaches it
 { "name": "release", "error": { "code": "kit-load", "message": "Cannot find .readyup/kits/release.js" } }
 ```
 
-An error entry carries no counts, because a kit that never ran has none to report; the top-level totals cover only the kits that ran. In human mode the same failure goes to stderr as `Error [release]: ...`, which keeps it distinct from a failed check.
+An error entry carries no counts, because a kit that never ran has none to report; the top-level totals cover only the kits that ran. In human mode the same failure goes to stderr, which keeps it distinct from a failed check. A run of more than one kit prefixes the kit's name, as `Error [release]: ...`.
 
 ### Kit sources
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -107,6 +107,8 @@ rdy <command> [options]
 
 The distinction is between "fix the repo" (`1`) and "fix the invocation" (`2`), so a pipeline can branch on which is which. `rdy list` and `rdy init` produce only `0` and `2` — neither can find problems to report.
 
+A run that loses a kit part-way exits `2` even when the kits that ran also found problems, since part of the invocation did not complete. It still reports what it collected.
+
 ### JSON output
 
 With `--json`, stdout carries exactly one JSON document, chosen by how far the invocation got: the report when a run produced one, and otherwise an error envelope. The exceptions are `--help` and `--version`, which have no JSON form: their text goes to stderr and stdout stays empty.
@@ -116,6 +118,14 @@ With `--json`, stdout carries exactly one JSON document, chosen by how far the i
 ```
 
 `code` is one of `usage`, `config`, `kit-load`, or `internal`. Every human-readable line — help text, progress headers, warnings — goes to stderr, and the exit code does not determine which document appears.
+
+The envelope covers only failures that precede dispatch. Once the run reaches its kits, a kit that fails is reported inside the report instead of replacing it, so each entry in `kits` takes one of two shapes, told apart by whether `error` is present:
+
+```json
+{ "name": "release", "error": { "code": "kit-load", "message": "Cannot find .readyup/kits/release.js" } }
+```
+
+An error entry carries no counts, because a kit that never ran has none to report; the top-level totals cover only the kits that ran. In human mode the same failure goes to stderr as `Error [release]: ...`, which keeps it distinct from a failed check.
 
 ### Kit sources
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -782,7 +782,7 @@ describe(runCommand, () => {
     return [{ name: 'default', source: { path: '.readyup/kits/default.js' }, checklists }];
   }
 
-  /** Concatenate every stderr write into one string, where human mode reports a failed kit. */
+  /** Every stderr write concatenated into one string. */
   function stderrText(): string {
     return stderrSpy.mock.calls.map((c) => String(c[0])).join('');
   }
@@ -826,7 +826,7 @@ describe(runCommand, () => {
     const exitCode = await runCommand({ kitEntries: singleKitEntry(['nonexistent']), json: false });
 
     expect(exitCode).toBe(2);
-    expect(stderrText()).toContain('Error [default]: Unknown name(s): nonexistent');
+    expect(stderrText()).toContain('Error: Unknown name(s): nonexistent');
   });
 
   it('returns exit code 1 when any checklist fails', async () => {
@@ -960,7 +960,7 @@ describe(runCommand, () => {
     const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false });
 
     expect(exitCode).toBe(2);
-    expect(stderrText()).toBe('Error [default]: Kit not found\n');
+    expect(stderrText()).toBe('Error: Kit not found\n');
   });
 
   it('prints combined summary for a single kit with multiple checklists', async () => {
@@ -1024,9 +1024,7 @@ describe(runCommand, () => {
 
     await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
 
-    expect(stderrText()).toBe(
-      'Error [default]: Running from source requires readyup to be installed as a project dependency.\n',
-    );
+    expect(stderrText()).toBe('Error: Running from source requires readyup to be installed as a project dependency.\n');
   });
 
   it('passes through non-readyup module errors even with --jit', async () => {
@@ -1037,7 +1035,7 @@ describe(runCommand, () => {
 
     await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
 
-    expect(stderrText()).toBe("Error [default]: Cannot find package 'chalk'\n");
+    expect(stderrText()).toBe("Error: Cannot find package 'chalk'\n");
   });
 
   it('passes through non-module errors with --jit', async () => {
@@ -1045,7 +1043,7 @@ describe(runCommand, () => {
 
     await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
 
-    expect(stderrText()).toBe('Error [default]: Syntax error in kit\n');
+    expect(stderrText()).toBe('Error: Syntax error in kit\n');
   });
 
   describe('threshold cascade', () => {
@@ -1416,7 +1414,7 @@ describe(runCommand, () => {
 
     await runCommand({ kitEntries: [{ name: 'config', source: { url }, checklists: [] }], json: false });
 
-    expect(stderrText()).toBe(`Error [config]: Failed to reach ${url}: Failed to fetch remote kit\n`);
+    expect(stderrText()).toBe(`Error: Failed to reach ${url}: Failed to fetch remote kit\n`);
   });
 });
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -66,7 +66,6 @@ vi.mock('../src/loadRemoteKit.ts', () => ({
 }));
 
 import { parseRunArgs, resolveKitSources, runCommand } from '../src/cli.ts';
-import { captureRdyError } from './helpers/captureRdyError.ts';
 
 describe(parseRunArgs, () => {
   it('returns undefined checklists and empty specifiers when no flags are given', () => {
@@ -783,6 +782,11 @@ describe(runCommand, () => {
     return [{ name: 'default', source: { path: '.readyup/kits/default.js' }, checklists }];
   }
 
+  /** Concatenate every stderr write into one string, where human mode reports a failed kit. */
+  function stderrText(): string {
+    return stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+  }
+
   it('runs all checklists when no checklist filter is given', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
@@ -815,14 +819,14 @@ describe(runCommand, () => {
     expect(exitCode).toBe(0);
   });
 
-  it('reports a usage error when an unknown checklist name is given', async () => {
+  it('reports an unknown checklist name against its kit and exits 2', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
 
-    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(['nonexistent']), json: false }));
+    const exitCode = await runCommand({ kitEntries: singleKitEntry(['nonexistent']), json: false });
 
-    expect(error.code).toBe('usage');
-    expect(error.message).toContain('Unknown name(s): nonexistent');
+    expect(exitCode).toBe(2);
+    expect(stderrText()).toContain('Error [default]: Unknown name(s): nonexistent');
   });
 
   it('returns exit code 1 when any checklist fails', async () => {
@@ -950,13 +954,13 @@ describe(runCommand, () => {
     expect(mockReportRdy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ fixLocation: 'end' }));
   });
 
-  it('reports a kit-load error when the kit cannot be loaded', async () => {
+  it('reports an unloadable kit against its kit name and exits 2', async () => {
     mockLoadRdyKit.mockRejectedValue(new Error('Kit not found'));
 
-    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: false }));
+    const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false });
 
-    expect(error.code).toBe('kit-load');
-    expect(error.message).toBe('Kit not found');
+    expect(exitCode).toBe(2);
+    expect(stderrText()).toBe('Error [default]: Kit not found\n');
   });
 
   it('prints combined summary for a single kit with multiple checklists', async () => {
@@ -1012,16 +1016,17 @@ describe(runCommand, () => {
 
   // -- --jit error handling (Task 6) --
 
-  it('throws a friendly kit-load error when --jit kit import fails due to missing readyup', async () => {
+  it('reports a friendly message when a --jit kit import fails due to missing readyup', async () => {
     const moduleError = Object.assign(new Error("Cannot find package 'readyup'"), {
       code: 'MODULE_NOT_FOUND',
     });
     mockLoadRdyKit.mockRejectedValue(moduleError);
 
-    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: false }, true));
+    await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
 
-    expect(error.code).toBe('kit-load');
-    expect(error.message).toBe('Running from source requires readyup to be installed as a project dependency.');
+    expect(stderrText()).toBe(
+      'Error [default]: Running from source requires readyup to be installed as a project dependency.\n',
+    );
   });
 
   it('passes through non-readyup module errors even with --jit', async () => {
@@ -1030,17 +1035,17 @@ describe(runCommand, () => {
     });
     mockLoadRdyKit.mockRejectedValue(moduleError);
 
-    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: false }, true));
+    await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
 
-    expect(error.message).toBe("Cannot find package 'chalk'");
+    expect(stderrText()).toBe("Error [default]: Cannot find package 'chalk'\n");
   });
 
   it('passes through non-module errors with --jit', async () => {
     mockLoadRdyKit.mockRejectedValue(new Error('Syntax error in kit'));
 
-    const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: false }, true));
+    await runCommand({ kitEntries: singleKitEntry(), json: false }, true);
 
-    expect(error.message).toBe('Syntax error in kit');
+    expect(stderrText()).toBe('Error [default]: Syntax error in kit\n');
   });
 
   describe('threshold cascade', () => {
@@ -1155,26 +1160,32 @@ describe(runCommand, () => {
       expect(exitCode).toBe(1);
     });
 
-    it('throws a kit-load error without writing to either stream', async () => {
+    it('records an unloadable kit as an error entry, leaving stderr clean', async () => {
       mockLoadRdyKit.mockRejectedValue(new Error('Kit not found'));
+      mockFormatJsonReport.mockReturnValue('{}');
 
-      const error = await captureRdyError(() => runCommand({ kitEntries: singleKitEntry(), json: true }));
+      const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: true });
 
-      expect(error.code).toBe('kit-load');
-      expect(stdoutSpy).not.toHaveBeenCalled();
+      expect(exitCode).toBe(2);
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        [{ name: 'default', error: { code: 'kit-load', message: 'Kit not found' } }],
+        expect.anything(),
+      );
       expect(stderrSpy).not.toHaveBeenCalled();
     });
 
-    it('throws a usage error for unknown checklist names without writing to either stream', async () => {
+    it('records an unknown checklist name as an error entry, leaving stderr clean', async () => {
       const kit = makeKit();
       mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
+      mockFormatJsonReport.mockReturnValue('{}');
 
-      const error = await captureRdyError(() =>
-        runCommand({ kitEntries: singleKitEntry(['nonexistent']), json: true }),
+      const exitCode = await runCommand({ kitEntries: singleKitEntry(['nonexistent']), json: true });
+
+      expect(exitCode).toBe(2);
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        [{ name: 'default', error: { code: 'usage', message: expect.stringContaining('nonexistent') } }],
+        expect.anything(),
       );
-
-      expect(error.code).toBe('usage');
-      expect(stdoutSpy).not.toHaveBeenCalled();
       expect(stderrSpy).not.toHaveBeenCalled();
     });
 
@@ -1198,23 +1209,25 @@ describe(runCommand, () => {
               { name: 'deploy', report: report1 },
               { name: 'infra', report: report2 },
             ],
-            passed: true,
           },
         ],
         expect.objectContaining({ reportOn: 'recommend' }),
       );
     });
 
-    it('lets a runner crash escape undiagnosed so the boundary classifies it internal', async () => {
+    it('records an undiagnosed runner crash as an internal error entry', async () => {
       const kit = makeKit();
       mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockRejectedValue(new Error('runner crashed'));
+      mockFormatJsonReport.mockReturnValue('{}');
 
-      await expect(runCommand({ kitEntries: singleKitEntry(['deploy']), json: true })).rejects.toThrow(
-        'runner crashed',
+      const exitCode = await runCommand({ kitEntries: singleKitEntry(['deploy']), json: true });
+
+      expect(exitCode).toBe(2);
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        [{ name: 'default', error: { code: 'internal', message: 'runner crashed' } }],
+        expect.anything(),
       );
-      expect(stdoutSpy).not.toHaveBeenCalled();
-      expect(stderrSpy).not.toHaveBeenCalled();
     });
 
     it('does not write headers in JSON mode', async () => {
@@ -1362,12 +1375,9 @@ describe(runCommand, () => {
     mockResolveBitbucketToken.mockReturnValue(undefined);
     mockLoadRemoteKit.mockRejectedValue(new Error(`Failed to fetch remote kit from ${url}: 404 Not Found`));
 
-    const error = await captureRdyError(() =>
-      runCommand({ kitEntries: [{ name: 'missing', source: { url }, checklists: [] }], json: false }),
-    );
+    await runCommand({ kitEntries: [{ name: 'missing', source: { url }, checklists: [] }], json: false });
 
-    expect(error.code).toBe('kit-load');
-    expect(error.message).toContain(url);
+    expect(stderrText()).toContain(url);
   });
 
   it('reports a network failure for a Bitbucket URL with the URL in the error message', async () => {
@@ -1376,12 +1386,9 @@ describe(runCommand, () => {
     // Raw fetch rejection — no URL in the error message; loadKit must inject it.
     mockLoadRemoteKit.mockRejectedValue(new TypeError('fetch failed'));
 
-    const error = await captureRdyError(() =>
-      runCommand({ kitEntries: [{ name: 'deploy', source: { url }, checklists: [] }], json: false }),
-    );
+    await runCommand({ kitEntries: [{ name: 'deploy', source: { url }, checklists: [] }], json: false });
 
-    expect(error.code).toBe('kit-load');
-    expect(error.message).toContain(url);
+    expect(stderrText()).toContain(url);
   });
 
   // URL source tests
@@ -1407,11 +1414,9 @@ describe(runCommand, () => {
     const url = 'https://example.com/config.js';
     mockLoadRemoteKit.mockRejectedValue(new Error('Failed to fetch remote kit'));
 
-    const error = await captureRdyError(() =>
-      runCommand({ kitEntries: [{ name: 'config', source: { url }, checklists: [] }], json: false }),
-    );
+    await runCommand({ kitEntries: [{ name: 'config', source: { url }, checklists: [] }], json: false });
 
-    expect(error.message).toBe(`Failed to reach ${url}: Failed to fetch remote kit`);
+    expect(stderrText()).toBe(`Error [config]: Failed to reach ${url}: Failed to fetch remote kit\n`);
   });
 });
 

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -92,16 +92,24 @@ describe('exit codes', () => {
     await expect(routeCommand(args)).resolves.toBe(expected);
   });
 
+  it('reports a pre-dispatch failure through the error envelope', async () => {
+    const exitCode = await routeCommand(['--bogus', '--json']);
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(readStdout())).toStrictEqual({ error: { code: 'usage', message: expect.any(String) } });
+  });
+
   it.each([
-    { label: 'a bad flag', args: ['--bogus'], code: 'usage' },
-    { label: 'an unknown checklist', args: ['passing:absent'], code: 'usage' },
-    { label: 'a missing kit', args: ['absent'], code: 'kit-load' },
-    { label: 'an unloadable kit', args: ['invalid'], code: 'kit-load' },
-  ])('reports code "$code" for $label', async ({ args, code }) => {
+    { label: 'an unknown checklist', args: ['passing:absent'], kit: 'passing', code: 'usage' },
+    { label: 'a missing kit', args: ['absent'], kit: 'absent', code: 'kit-load' },
+    { label: 'an unloadable kit', args: ['invalid'], kit: 'invalid', code: 'kit-load' },
+  ])('reports code "$code" as a per-kit error entry for $label', async ({ args, kit, code }) => {
     const exitCode = await routeCommand([...args, '--json']);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(readStdout())).toStrictEqual({ error: { code, message: expect.any(String) } });
+    expect(JSON.parse(readStdout())).toMatchObject({
+      kits: [{ name: kit, error: { code, message: expect.any(String) } }],
+    });
   });
 
   it('reports code "config" for an unreadable config file', async () => {

--- a/packages/readyup/__tests__/formatJsonReport.test.ts
+++ b/packages/readyup/__tests__/formatJsonReport.test.ts
@@ -161,6 +161,55 @@ describe(formatJsonReport, () => {
     });
   });
 
+  describe('kits that produced no results', () => {
+    const FAILURE = { name: 'release', error: { code: 'kit-load' as const, message: 'Cannot find release.js' } };
+
+    /** A one-check kit that passes in 10ms, for pairing with a failed kit. */
+    function ranKit(name: string) {
+      const report = makeReport({ results: [makePassedResult({ name: 'a' })], passed: true, durationMs: 10 });
+      return { name, entries: [{ name: 'check', report }] };
+    }
+
+    it('passes a failed kit through carrying only its name and error', () => {
+      const parsed: unknown = JSON.parse(formatJsonReport([FAILURE]));
+
+      expect(parsed).toStrictEqual({
+        passed: 0,
+        errors: 0,
+        warnings: 0,
+        recommendations: 0,
+        blocked: 0,
+        optional: 0,
+        worstSeverity: null,
+        durationMs: 0,
+        kits: [FAILURE],
+      });
+    });
+
+    it('keeps kits in the order they were requested', () => {
+      const parsed: unknown = JSON.parse(formatJsonReport([ranKit('first'), FAILURE, ranKit('last')]));
+
+      expect(parsed).toMatchObject({
+        kits: [{ name: 'first' }, { name: 'release' }, { name: 'last' }],
+      });
+    });
+
+    it('leaves top-level counts and duration to the kits that ran', () => {
+      const parsed: unknown = JSON.parse(formatJsonReport([ranKit('deploy'), FAILURE]));
+
+      expect(parsed).toMatchObject({
+        passed: 1,
+        errors: 0,
+        warnings: 0,
+        recommendations: 0,
+        blocked: 0,
+        optional: 0,
+        worstSeverity: null,
+        durationMs: 10,
+      });
+    });
+  });
+
   it('includes granular checklist-level counts and null worstSeverity when all passed', () => {
     const report = makeReport({
       results: [makePassedResult({ name: 'a' })],

--- a/packages/readyup/__tests__/partialResults.test.ts
+++ b/packages/readyup/__tests__/partialResults.test.ts
@@ -116,6 +116,12 @@ describe('partial results when a kit fails after dispatch', () => {
 
       expect(readStdout()).not.toContain('Error [absent]:');
     });
+
+    it('drops the kit label when a lone kit leaves nothing to disambiguate', async () => {
+      await routeCommand(['absent']);
+
+      expect(readStderr()).toMatch(/^Error: /);
+    });
   });
 });
 

--- a/packages/readyup/__tests__/partialResults.test.ts
+++ b/packages/readyup/__tests__/partialResults.test.ts
@@ -1,0 +1,130 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { routeCommand } from '../src/bin/route.ts';
+
+/** A kit whose single check passes. */
+const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
+
+/** A kit whose single error-severity check fails. */
+const FAILING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'nope', check: () => false }] }] };\n`;
+
+let cwd: string;
+let originalCwd: string;
+let stdout: string[];
+let stderr: string[];
+let stdoutSpy: MockInstance;
+let stderrSpy: MockInstance;
+
+beforeAll(() => {
+  originalCwd = process.cwd();
+  cwd = mkdtempSync(path.join(tmpdir(), 'readyup-partial-results-'));
+  mkdirSync(path.join(cwd, '.readyup/kits'), { recursive: true });
+  writeFileSync(path.join(cwd, '.readyup/kits/passing.js'), PASSING_KIT);
+  writeFileSync(path.join(cwd, '.readyup/kits/failing.js'), FAILING_KIT);
+  process.chdir(cwd);
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  stdout = [];
+  stderr = [];
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  });
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    stderr.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+describe('partial results when a kit fails after dispatch', () => {
+  describe('JSON mode', () => {
+    it('keeps results from the kits on either side of a failed kit', async () => {
+      const exitCode = await routeCommand(['passing', 'absent', 'failing', '--json']);
+
+      expect(exitCode).toBe(2);
+      expect(JSON.parse(readStdout())).toMatchObject({
+        kits: [
+          { name: 'passing', passed: 1, errors: 0 },
+          { name: 'absent', error: { code: 'kit-load', message: expect.any(String) } },
+          { name: 'failing', passed: 0, errors: 1 },
+        ],
+      });
+    });
+
+    it('aggregates top-level counts over only the kits that ran', async () => {
+      await routeCommand(['passing', 'absent', '--json']);
+
+      expect(JSON.parse(readStdout())).toMatchObject({
+        passed: 1,
+        errors: 0,
+        warnings: 0,
+        recommendations: 0,
+        blocked: 0,
+        optional: 0,
+        worstSeverity: null,
+      });
+    });
+
+    it('emits a report rather than an envelope when the only kit fails', async () => {
+      const exitCode = await routeCommand(['absent', '--json']);
+
+      expect(exitCode).toBe(2);
+      expect(JSON.parse(readStdout())).toMatchObject({
+        kits: [{ name: 'absent', error: { code: 'kit-load', message: expect.any(String) } }],
+      });
+    });
+
+    it('exits 2 rather than 1 when a kit fails alongside failing checks', async () => {
+      await expect(routeCommand(['failing', 'absent', '--json'])).resolves.toBe(2);
+    });
+  });
+
+  describe('human mode', () => {
+    it('reports the failure on stderr and continues to the next kit', async () => {
+      const exitCode = await routeCommand(['absent', 'passing']);
+
+      expect(exitCode).toBe(2);
+      expect(readStderr()).toContain('Error [absent]:');
+      expect(readStdout()).toContain('ok');
+    });
+
+    it('heads every requested kit on stdout, including one that never ran', async () => {
+      await routeCommand(['passing', 'absent']);
+
+      expect(readStdout()).toContain('=== passing ===');
+      expect(readStdout()).toContain('=== absent ===');
+    });
+
+    it('keeps the failure off stdout, where a failed check would appear', async () => {
+      await routeCommand(['passing', 'absent']);
+
+      expect(readStdout()).not.toContain('Error [absent]:');
+    });
+  });
+});
+
+/** Everything written to stdout during the current test. */
+function readStdout(): string {
+  return stdout.join('');
+}
+
+/** Everything written to stderr during the current test. */
+function readStderr(): string {
+  return stderr.join('');
+}

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -59,7 +59,8 @@ have no JSON form: their text goes to stderr and stdout stays empty.
 
 A kit that fails once the run has reached its kits does not discard the kits that ran.
 Under --json it becomes a kits entry carrying "error" in place of results; otherwise it
-is reported on stderr as Error [kit]. Either way the run continues and exits 2.
+is reported on stderr, prefixed with the kit's name when more than one kit was
+requested. Either way the run continues and exits 2.
 `;
 
 const RUN_HELP = `

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -56,6 +56,10 @@ Exit codes:
 With --json, stdout carries exactly one JSON document: the report when a run produced
 one, otherwise {"error": {"code", "message"}}. Prose goes to stderr. --help and --version
 have no JSON form: their text goes to stderr and stdout stays empty.
+
+A kit that fails once the run has reached its kits does not discard the kits that ran.
+Under --json it becomes a kits entry carrying "error" in place of results; otherwise it
+is reported on stderr as Error [kit]. Either way the run continues and exits 2.
 `;
 
 const RUN_HELP = `

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -541,7 +541,9 @@ async function runMultiKitHumanMode(
       const exitCode = await runSingleKitHumanMode(kit, entry.checklists, failOn, reportOn, showKitHeader);
       if (exitCode !== EXIT_OK) allPassed = false;
     } catch (error: unknown) {
-      process.stderr.write(`Error [${entry.name}]: ${toRdyError(error).message}\n`);
+      // A lone kit needs no label: nothing to disambiguate, and its source is already in the message.
+      const label = showKitHeader ? ` [${entry.name}]` : '';
+      process.stderr.write(`Error${label}: ${toRdyError(error).message}\n`);
       anyKitFailed = true;
     }
   }

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -4,10 +4,10 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 
 import { buildKitFilename } from './buildKitFilename.ts';
 import { type LoadedRdyKit, loadRdyKit } from './config.ts';
-import { kitLoadError, usageError } from './errors.ts';
-import { EXIT_OK, EXIT_PROBLEMS_FOUND } from './exitCodes.ts';
+import { kitLoadError, toRdyError, usageError } from './errors.ts';
+import { EXIT_OK, EXIT_PROBLEMS_FOUND, EXIT_TOOL_FAILURE } from './exitCodes.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
-import { formatJsonReport } from './formatJsonReport.ts';
+import { formatJsonReport, type KitInput } from './formatJsonReport.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { type FromSource, parseFromValue } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
@@ -458,49 +458,65 @@ export async function runCommand(
   return runMultiKitHumanMode(kitEntries, failOn, reportOn, isJit);
 }
 
-/** Run all kit entries in JSON mode, producing a single JSON report. */
+/**
+ * Runs all kit entries in JSON mode, producing a single JSON report.
+ *
+ * Each iteration is its own error boundary: once the run has dispatched, anything the loop body
+ * throws is attributable to that kit alone, so it becomes an entry in the report rather than
+ * discarding the kits that already ran. The scope is positional rather than keyed on `RdyErrorCode`
+ * — a consumer cannot predict which codes would escape, and a new code would silently pick a branch.
+ */
 async function runMultiKitJsonMode(
   kitEntries: ResolvedKitEntry[],
   failOn: Severity | undefined,
   reportOn: Severity | undefined,
   isJit: boolean,
 ): Promise<number> {
-  const kitResults: Array<{
-    name: string;
-    entries: Array<{ name: string; report: RdyReport }>;
-    passed: boolean;
-  }> = [];
+  const kitInputs: KitInput[] = [];
+  let allPassed = true;
+  let anyKitFailed = false;
 
   for (const entry of kitEntries) {
-    const { kit, compileTimeVersion } = await loadKit(entry.source, isJit);
+    try {
+      const { kit, compileTimeVersion } = await loadKit(entry.source, isJit);
 
-    warnOnVersionSkew(entry.name, compileTimeVersion);
+      warnOnVersionSkew(entry.name, compileTimeVersion);
 
-    const thresholds = resolveThresholds(kit, failOn, reportOn);
-    const checklists = selectChecklists(kit, entry.checklists);
+      const thresholds = resolveThresholds(kit, failOn, reportOn);
+      const checklists = selectChecklists(kit, entry.checklists);
 
-    const entries: Array<{ name: string; report: RdyReport }> = [];
-    let kitPassed = true;
+      const entries: Array<{ name: string; report: RdyReport }> = [];
 
-    for (const checklist of checklists) {
-      const report = await runRdy(checklist, {
-        defaultSeverity: thresholds.defaultSeverity,
-        failOn: thresholds.failOn,
-      });
-      entries.push({ name: checklist.name, report });
-      if (!report.passed) kitPassed = false;
+      for (const checklist of checklists) {
+        const report = await runRdy(checklist, {
+          defaultSeverity: thresholds.defaultSeverity,
+          failOn: thresholds.failOn,
+        });
+        entries.push({ name: checklist.name, report });
+        if (!report.passed) allPassed = false;
+      }
+
+      kitInputs.push({ name: entry.name, entries });
+    } catch (error: unknown) {
+      const { code, message } = toRdyError(error);
+      kitInputs.push({ name: entry.name, error: { code, message } });
+      anyKitFailed = true;
     }
-
-    kitResults.push({ name: entry.name, entries, passed: kitPassed });
   }
 
   const resolvedReportOn = reportOn ?? 'recommend';
-  process.stdout.write(formatJsonReport(kitResults, { reportOn: resolvedReportOn }) + '\n');
-  const allPassed = kitResults.every((k) => k.passed);
-  return allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
+  process.stdout.write(formatJsonReport(kitInputs, { reportOn: resolvedReportOn }) + '\n');
+
+  return resolveRunExitCode(anyKitFailed, allPassed);
 }
 
-/** Run all kit entries in human-readable mode. */
+/**
+ * Runs all kit entries in human-readable mode.
+ *
+ * Carries the same per-kit boundary as JSON mode, reporting the failure on stderr so it stays
+ * distinguishable from a failed check, which prints into the stdout report and means a different
+ * exit code.
+ */
 async function runMultiKitHumanMode(
   kitEntries: ResolvedKitEntry[],
   failOn: Severity | undefined,
@@ -509,20 +525,28 @@ async function runMultiKitHumanMode(
 ): Promise<number> {
   const showKitHeader = kitEntries.length > 1;
   let allPassed = true;
+  let anyKitFailed = false;
+
   for (const entry of kitEntries) {
-    const { kit, compileTimeVersion } = await loadKit(entry.source, isJit);
-
-    warnOnVersionSkew(entry.name, compileTimeVersion);
-
+    // Precedes the load so stdout lists every requested kit, including one that never ran.
     if (showKitHeader) {
       process.stdout.write(`\n=== ${entry.name} ===\n`);
     }
 
-    const exitCode = await runSingleKitHumanMode(kit, entry.checklists, failOn, reportOn, showKitHeader);
-    if (exitCode !== EXIT_OK) allPassed = false;
+    try {
+      const { kit, compileTimeVersion } = await loadKit(entry.source, isJit);
+
+      warnOnVersionSkew(entry.name, compileTimeVersion);
+
+      const exitCode = await runSingleKitHumanMode(kit, entry.checklists, failOn, reportOn, showKitHeader);
+      if (exitCode !== EXIT_OK) allPassed = false;
+    } catch (error: unknown) {
+      process.stderr.write(`Error [${entry.name}]: ${toRdyError(error).message}\n`);
+      anyKitFailed = true;
+    }
   }
 
-  return allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
+  return resolveRunExitCode(anyKitFailed, allPassed);
 }
 
 /** Run checklists from a single kit in human-readable mode. */
@@ -582,4 +606,15 @@ function selectChecklists(kit: RdyKit, checklistFilter: string[]): Array<RdyChec
     const checklist = checklistByName.get(name);
     return checklist !== undefined ? [checklist] : [];
   });
+}
+
+/**
+ * Reduces a run's outcomes to one exit code, worst first.
+ *
+ * A kit that never ran outranks failed checks: part of the invocation was not completed, so
+ * reporting "ran, found problems" would be false.
+ */
+function resolveRunExitCode(anyKitFailed: boolean, allPassed: boolean): number {
+  if (anyKitFailed) return EXIT_TOOL_FAILURE;
+  return allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
 }

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -3,6 +3,7 @@ import type {
   JsonCheckEntry,
   JsonChecklistEntry,
   JsonKitEntry,
+  JsonKitErrorEntry,
   JsonReport,
   RdyReport,
   RdyResult,
@@ -14,10 +15,19 @@ interface ChecklistEntry {
   report: RdyReport;
 }
 
-interface KitInput {
+/** Input for a kit that ran, carrying the reports its checklists produced. */
+interface KitResultInput {
   name: string;
   entries: ChecklistEntry[];
 }
+
+/**
+ * Input for one kit, discriminated by the presence of `error`.
+ *
+ * A failed kit is described by the entry it serializes to, because it passes through verbatim.
+ * Failures arrive interleaved rather than appended so kits keep the order they were requested in.
+ */
+export type KitInput = JsonKitErrorEntry | KitResultInput;
 
 /** Options controlling which results appear in JSON output. */
 export interface FormatJsonReportOptions {
@@ -48,7 +58,11 @@ export function formatJsonReport(kitInputs: KitInput[], options?: FormatJsonRepo
   const reportOn = options?.reportOn ?? 'recommend';
   const totals = emptyCounts();
 
-  const kits: JsonKitEntry[] = kitInputs.map(({ name, entries }) => {
+  const kits: JsonKitEntry[] = kitInputs.map((input) => {
+    // A kit that never ran contributes nothing to the totals, so they cover only the kits that did.
+    if ('error' in input) return input;
+
+    const { name, entries } = input;
     const kitCounts = emptyCounts();
     const checklists: JsonChecklistEntry[] = entries.map(({ name: checklistName, report }) => {
       const entry = buildChecklistEntry(checklistName, report, reportOn);
@@ -67,7 +81,7 @@ export function formatJsonReport(kitInputs: KitInput[], options?: FormatJsonRepo
     };
   });
 
-  const totalDurationMs = kits.reduce((sum, k) => sum + k.durationMs, 0);
+  const totalDurationMs = kits.reduce((sum, k) => sum + ('error' in k ? 0 : k.durationMs), 0);
 
   const output: JsonReport = {
     ...totals,

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -10,6 +10,8 @@ export type {
   JsonCheckEntry,
   JsonChecklistEntry,
   JsonKitEntry,
+  JsonKitErrorEntry,
+  JsonKitResultEntry,
   JsonReport,
   LocalRefsCompareResult,
   PassedResult,
@@ -29,6 +31,9 @@ export type {
   SkipResult,
   SummaryCounts,
 } from './types.ts';
+
+// Error taxonomy
+export type { RdyErrorCode } from './errors.ts';
 
 // Type guards
 export { isFlatChecklist, isPercentProgress } from './types.ts';

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -1,3 +1,5 @@
+import type { RdyErrorCode } from './errors.ts';
+
 // -- Ahead/behind --
 
 /** Directional commit counts between two refs. */
@@ -370,12 +372,29 @@ export interface JsonChecklistEntry extends SummaryCounts {
   checks: JsonCheckEntry[];
 }
 
-/** Per-kit entry in JSON output, grouping checklists with per-kit summary counts. */
-export interface JsonKitEntry extends SummaryCounts {
+/** Entry for a kit that ran, grouping its checklists with per-kit summary counts. */
+export interface JsonKitResultEntry extends SummaryCounts {
   name: string;
   durationMs: number;
   checklists: JsonChecklistEntry[];
 }
+
+/**
+ * Entry for a kit that produced no results, carrying the same object as the error envelope.
+ *
+ * Deliberately counts-free: a kit that never ran has no `errors: 0` to report, and emitting
+ * zeroes would misstate the run.
+ */
+export interface JsonKitErrorEntry {
+  name: string;
+  error: {
+    code: RdyErrorCode;
+    message: string;
+  };
+}
+
+/** Per-kit entry in JSON output, discriminated by the presence of `error`. */
+export type JsonKitEntry = JsonKitErrorEntry | JsonKitResultEntry;
 
 /** Top-level shape of `--json` output. */
 export interface JsonReport extends SummaryCounts {


### PR DESCRIPTION
## What

A run that names several kits no longer discards everything it collected when one of those kits fails: results from every kit that ran are now reported alongside the failure, which names the failed kit and why it failed. Failures are reported this way however many kits a run names, including a run whose only kit fails. A run that exits with code 2 can now carry results rather than none at all, and reading the `--json` output now requires checking whether a kit failed before reading its results.

## Why

Work that had already completed was being thrown away. A run that loaded several kits lost every result it had collected the moment a later kit failed to load, and the caller had no way to tell which kits had run — the same invocation could report nothing whether one kit failed or all of them did.

#118 established that stdout carries the report whenever a report was produced, but delivered that rule only for failures that happen before dispatch. This completes it: the rule now holds for the whole run, not just its opening.

## Details

### 🎉 Features

- Entries in the `--json` `kits` array take one of two shapes, discriminated by the presence of `error`. A kit that ran carries its checklists and counts as before; a kit that failed carries `{code, message}` and no counts, because a kit that never ran has no `errors: 0` to report. Top-level totals and `durationMs` therefore cover only the kits that ran. Consumers reading `entry.checklists` unconditionally must narrow first. The exported `JsonKitEntry` type widens to the union, with `JsonKitResultEntry` and `JsonKitErrorEntry` as its members.

- Once a run dispatches into its kit loop, a failure attributable to a single kit is recorded against that kit and the run continues to the next one. This covers a kit that cannot be found or loaded, and a checklist name the kit does not define — whether requested through the `:` filter or `--checklists`. Failures that precede dispatch (flag parsing, config load, kit-source resolution) still replace the output with the error envelope.

- Exit code 2 takes precedence over 1: a run where one kit fails and another finds problems exits 2, because part of the invocation did not complete.

- In human-readable mode the failure goes to stderr, which keeps it distinct from a failed check. A run of more than one kit prefixes the kit's name (`Error [release]: ...`) and prints a heading for every requested kit, including one that never ran; a lone kit has nothing to disambiguate, so its failure reports as `Error: ...`.

- `RdyErrorCode` is now exported from the package entry point, so a consumer reading `entry.error.code` can name its type.

### 🧪 Tests

- New end-to-end coverage drives `routeCommand` against on-disk kit fixtures in both output modes: results surviving on both sides of a failed kit, top-level counts aggregating over only the kits that ran, a lone failing kit producing a report rather than an envelope, and exit 2 winning over exit 1.

- The cases that previously asserted an error envelope for a post-dispatch failure now assert a per-kit error entry. The `--bogus` cases anchoring both stdout-purity tests still assert the envelope, holding the pre-dispatch boundary in place.

### 📚 Documentation

- The `--json` contract, the exit-code table, and `rdy --help` all state that exit 2 can accompany a report, and document the two kit-entry shapes with a worked example.

Closes #132
