### PR TITLE
#128 Add runtime-alignment primitives to check-utils

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -193,6 +193,11 @@ import { fileExists, fileContains, hasPackageJsonField } from 'readyup/check-uti
 | `readPackageJson()`                         | Parse package.json                                                      |
 | `discoverWorkspaces(options?)`              | Enumerate monorepo workspaces (single-workspace repos return one entry) |
 | `compareVersions(a, b)`                     | Compare semver strings                                                  |
+| `readTsconfigLanguageLevel(path)`           | Effective `lib` and `target` of a tsconfig, resolved through `extends`  |
+| `readEnginesNodeFloor(manifest)`            | Minimum Node version a parsed manifest declares in `engines.node`       |
+| `satisfiesNodeFloor(version, floor)`        | Runtime version is at or above a floor                                  |
+| `readToolVersionsNode(path?)`               | Node version declared in `.tool-versions`                               |
+| `esYearForNodeMajor(major)`                 | ECMAScript year a Node major supports (`24` → `es2025`)                 |
 | `runGit(path, ...args)`                     | Run a git command and return trimmed stdout                             |
 | `expandHome(path)`                          | Expand leading `~` or `~/` to the home directory                        |
 | `isAtRepoRoot(path)`                        | Path is the top of a git working tree                                   |
@@ -215,6 +220,27 @@ const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
 ```
 
 Note: `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs using YAML anchors, flow sequences, negation patterns, or other non-trivial features will raise a clear error with a pointer to file an issue.
+
+### Reading runtime alignment
+
+`readTsconfigLanguageLevel(path)` reports what language level a tsconfig actually declares, which may be several `extends` hops away. Alongside `lib` and `target` — lowercased, so comparisons are string equality — it returns `chain`, the configs it read with the entry file first, and `unresolvedExtends`, the references it could not follow. Bare package specifiers such as `@tsconfig/node24/tsconfig.json` are never followed, and a missing or unparseable parent ends that branch of the walk; both land in `unresolvedExtends`, so a check can tell an incomplete answer from a genuinely undeclared setting. A missing or unparseable entry file returns `undefined`. Configs are read as JSONC, so comments and trailing commas are fine.
+
+`readEnginesNodeFloor(manifest)` recognizes only the range forms from which a single floor follows: `>=24`, `^22.1`, and a bare `24.1.0`. Anything else — a union such as `^20 || ^22`, a hyphen range, a wildcard — comes back as `{ kind: 'unparseable' }` rather than an invented floor. It takes an already-parsed manifest, so it composes with `discoverWorkspaces` without re-reading files:
+
+```ts
+import {
+  discoverWorkspaces,
+  readEnginesNodeFloor,
+  readToolVersionsNode,
+  satisfiesNodeFloor,
+} from 'readyup/check-utils';
+
+const runtime = readToolVersionsNode();
+const unmetFloors = discoverWorkspaces().filter((workspace) => {
+  const declared = readEnginesNodeFloor(workspace.packageJson);
+  return runtime !== undefined && declared.kind === 'found' && !satisfiesNodeFloor(runtime, declared.floor);
+});
+```
 
 ## Compatibility
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -195,7 +195,7 @@ import { fileExists, fileContains, hasPackageJsonField } from 'readyup/check-uti
 | `compareVersions(a, b)`                     | Compare semver strings                                                  |
 | `readTsconfigLanguageLevel(path)`           | Effective `lib` and `target` of a tsconfig, resolved through `extends`  |
 | `readEnginesNodeFloor(manifest)`            | Minimum Node version a parsed manifest declares in `engines.node`       |
-| `satisfiesNodeFloor(version, floor)`        | Runtime version is at or above a floor                                  |
+| `satisfiesNodeFloor(version, floor)`        | Runtime is at or above a floor (`undefined` if either is uncomparable)  |
 | `readToolVersionsNode(path?)`               | Node version declared in `.tool-versions`                               |
 | `esYearForNodeMajor(major)`                 | ECMAScript year a Node major supports (`24` → `es2025`)                 |
 | `runGit(path, ...args)`                     | Run a git command and return trimmed stdout                             |
@@ -225,7 +225,11 @@ Note: `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs 
 
 `readTsconfigLanguageLevel(path)` reports what language level a tsconfig actually declares, which may be several `extends` hops away. Alongside `lib` and `target` — lowercased, so comparisons are string equality — it returns `chain`, the configs it read with the entry file first, and `unresolvedExtends`, the references it could not follow. Bare package specifiers such as `@tsconfig/node24/tsconfig.json` are never followed, and a missing or unparseable parent ends that branch of the walk; both land in `unresolvedExtends`, so a check can tell an incomplete answer from a genuinely undeclared setting. A missing or unparseable entry file returns `undefined`. Configs are read as JSONC, so comments and trailing commas are fine.
 
-`readEnginesNodeFloor(manifest)` recognizes only the range forms from which a single floor follows: `>=24`, `^22.1`, and a bare `24.1.0`. Anything else — a union such as `^20 || ^22`, a hyphen range, a wildcard — comes back as `{ kind: 'unparseable' }` rather than an invented floor. It takes an already-parsed manifest, so it composes with `discoverWorkspaces` without re-reading files:
+`readEnginesNodeFloor(manifest)` recognizes only the range forms from which a single floor follows: `>=24`, `^22.1`, and a bare `24.1.0`. Anything else — a union such as `^20 || ^22`, a hyphen range, a wildcard — comes back as `{ kind: 'unparseable' }` rather than an invented floor. It takes an already-parsed manifest, so it composes with `discoverWorkspaces` without re-reading files.
+
+`satisfiesNodeFloor(version, floor)` compares two dotted numeric versions and returns `undefined` for anything else. That matters because `readToolVersionsNode` reports whatever the file names, and `lts`, `latest`, `system`, and `ref:<git ref>` are all valid pins: without the `undefined`, an unreadable pin would be indistinguishable from a runtime that genuinely sits below the floor.
+
+Each reader answers only what it can see, so a check composing them decides for itself what each unknown means. Collapsing them into a single boolean is what lets real drift pass unreported:
 
 ```ts
 import {
@@ -236,9 +240,15 @@ import {
 } from 'readyup/check-utils';
 
 const runtime = readToolVersionsNode();
-const unmetFloors = discoverWorkspaces().filter((workspace) => {
-  const declared = readEnginesNodeFloor(workspace.packageJson);
-  return runtime !== undefined && declared.kind === 'found' && !satisfiesNodeFloor(runtime, declared.floor);
+
+const findings = discoverWorkspaces().flatMap(({ dir, packageJson }) => {
+  const declared = readEnginesNodeFloor(packageJson);
+  if (declared.kind === 'absent') return [`${dir}: declares no engines.node`];
+  if (declared.kind === 'unparseable') return [`${dir}: engines.node "${declared.raw}" names no single floor`];
+
+  const meetsFloor = runtime === undefined ? undefined : satisfiesNodeFloor(runtime, declared.floor);
+  if (meetsFloor === undefined) return [`${dir}: floor ${declared.floor} has no comparable runtime`];
+  return meetsFloor ? [] : [`${dir}: runtime ${runtime} is below its ${declared.floor} floor`];
 });
 ```
 

--- a/packages/readyup/__tests__/check-utils/engines.test.ts
+++ b/packages/readyup/__tests__/check-utils/engines.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { readEnginesNodeFloor, satisfiesNodeFloor } from '../../src/check-utils/engines.ts';
+
+describe(readEnginesNodeFloor, () => {
+  it('reads a `>=` floor', () => {
+    expect(readEnginesNodeFloor({ engines: { node: '>=20.6.0' } })).toEqual({
+      kind: 'found',
+      floor: '20.6.0',
+      raw: '>=20.6.0',
+    });
+  });
+
+  it('reads a caret floor', () => {
+    expect(readEnginesNodeFloor({ engines: { node: '^22.0.0' } })).toEqual({
+      kind: 'found',
+      floor: '22.0.0',
+      raw: '^22.0.0',
+    });
+  });
+
+  it('reads a bare version as its own floor', () => {
+    expect(readEnginesNodeFloor({ engines: { node: '24.1.0' } })).toEqual({
+      kind: 'found',
+      floor: '24.1.0',
+      raw: '24.1.0',
+    });
+  });
+
+  it('keeps a partial version as written', () => {
+    expect(readEnginesNodeFloor({ engines: { node: '>=24' } })).toMatchObject({ kind: 'found', floor: '24' });
+    expect(readEnginesNodeFloor({ engines: { node: '^20.6' } })).toMatchObject({ kind: 'found', floor: '20.6' });
+  });
+
+  it('tolerates whitespace around and after the operator', () => {
+    expect(readEnginesNodeFloor({ engines: { node: '  >= 24  ' } })).toEqual({
+      kind: 'found',
+      floor: '24',
+      raw: '  >= 24  ',
+    });
+  });
+
+  it.each([
+    ['no engines field', {}],
+    ['a non-record engines field', { engines: 'node' }],
+    ['no engines.node field', { engines: { npm: '>=10' } }],
+    ['a non-string engines.node field', { engines: { node: 24 } }],
+  ])('reports absence for %s', (_label, manifest) => {
+    expect(readEnginesNodeFloor(manifest)).toEqual({ kind: 'absent' });
+  });
+
+  it.each(['^20 || ^22', '20 - 22', '20.x', '*', '>24', '~20.1'])('reports %s as unparseable', (range) => {
+    expect(readEnginesNodeFloor({ engines: { node: range } })).toEqual({ kind: 'unparseable', raw: range });
+  });
+});
+
+describe(satisfiesNodeFloor, () => {
+  it('is true at the floor', () => {
+    expect(satisfiesNodeFloor('20.6.0', '20.6.0')).toBe(true);
+  });
+
+  it('is true above the floor', () => {
+    expect(satisfiesNodeFloor('24.18.0', '20.6.0')).toBe(true);
+  });
+
+  it('is false below the floor', () => {
+    expect(satisfiesNodeFloor('20.5.9', '20.6.0')).toBe(false);
+  });
+
+  it('treats a partial floor as zero-filled', () => {
+    expect(satisfiesNodeFloor('24.0.0', '24')).toBe(true);
+    expect(satisfiesNodeFloor('23.9.9', '24')).toBe(false);
+  });
+
+  it('accepts a leading `v`, as `process.version` carries', () => {
+    expect(satisfiesNodeFloor('v24.18.0', '24')).toBe(true);
+    expect(satisfiesNodeFloor('v20.6.0', 'v24')).toBe(false);
+  });
+});

--- a/packages/readyup/__tests__/check-utils/engines.test.ts
+++ b/packages/readyup/__tests__/check-utils/engines.test.ts
@@ -76,4 +76,15 @@ describe(satisfiesNodeFloor, () => {
     expect(satisfiesNodeFloor('v24.18.0', '24')).toBe(true);
     expect(satisfiesNodeFloor('v20.6.0', 'v24')).toBe(false);
   });
+
+  it.each(['lts', 'latest', 'system', 'ref:v24.0.0', 'lts-jod', '24.18.0-rc.1', ''])(
+    'returns undefined for the uncomparable version %s',
+    (version) => {
+      expect(satisfiesNodeFloor(version, '24')).toBeUndefined();
+    },
+  );
+
+  it('returns undefined for an uncomparable floor', () => {
+    expect(satisfiesNodeFloor('24.18.0', 'latest')).toBeUndefined();
+  });
 });

--- a/packages/readyup/__tests__/check-utils/es-year.test.ts
+++ b/packages/readyup/__tests__/check-utils/es-year.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { esYearForNodeMajor } from '../../src/check-utils/es-year.ts';
+
+describe(esYearForNodeMajor, () => {
+  it.each([
+    [18, 'es2022'],
+    [20, 'es2023'],
+    [22, 'es2024'],
+    [24, 'es2025'],
+  ])('maps Node %i to %s', (major, esYear) => {
+    expect(esYearForNodeMajor(major)).toBe(esYear);
+  });
+
+  it('returns undefined for a non-LTS odd major', () => {
+    expect(esYearForNodeMajor(23)).toBeUndefined();
+  });
+
+  it('returns undefined for a major below the table', () => {
+    expect(esYearForNodeMajor(16)).toBeUndefined();
+  });
+
+  it('returns undefined for a major above the table', () => {
+    expect(esYearForNodeMajor(26)).toBeUndefined();
+  });
+});

--- a/packages/readyup/__tests__/check-utils/tool-versions.test.ts
+++ b/packages/readyup/__tests__/check-utils/tool-versions.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { readToolVersionsNode } from '../../src/check-utils/tool-versions.ts';
+
+let tempDir: string;
+let cwdSpy: MockInstance;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rdy-tool-versions-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+});
+
+describe(readToolVersionsNode, () => {
+  it('reads a plain nodejs entry', () => {
+    writeToolVersions(['nodejs 24.18.0', '']);
+
+    expect(readToolVersionsNode()).toBe('24.18.0');
+  });
+
+  it('reads an entry written with the `node` tool name', () => {
+    writeToolVersions(['node 22.11.0', '']);
+
+    expect(readToolVersionsNode()).toBe('22.11.0');
+  });
+
+  it('ignores a trailing comment', () => {
+    writeToolVersions(['nodejs 24.18.0 # pinned to the engines floor', '']);
+
+    expect(readToolVersionsNode()).toBe('24.18.0');
+  });
+
+  it('takes the first of several fallback versions', () => {
+    writeToolVersions(['nodejs 24.18.0 22.11.0 20.19.0', '']);
+
+    expect(readToolVersionsNode()).toBe('24.18.0');
+  });
+
+  it('skips other tools, comment lines, and blank lines', () => {
+    writeToolVersions(['# Managed by mise', '', 'pnpm 11.15.0', '\tnodejs\t24.18.0', 'python 3.13.0', '']);
+
+    expect(readToolVersionsNode()).toBe('24.18.0');
+  });
+
+  it('takes the first Node declaration when several are present', () => {
+    writeToolVersions(['nodejs 24.18.0', 'nodejs 22.11.0', '']);
+
+    expect(readToolVersionsNode()).toBe('24.18.0');
+  });
+
+  it('skips a Node line that names no version', () => {
+    writeToolVersions(['nodejs', 'nodejs 24.18.0', '']);
+
+    expect(readToolVersionsNode()).toBe('24.18.0');
+  });
+
+  it('returns undefined when no Node entry is present', () => {
+    writeToolVersions(['pnpm 11.15.0', '']);
+
+    expect(readToolVersionsNode()).toBeUndefined();
+  });
+
+  it('returns undefined when the file is absent', () => {
+    expect(readToolVersionsNode()).toBeUndefined();
+  });
+
+  it('reads a file at a caller-supplied path', () => {
+    writeFileSync(join(tempDir, '.tool-versions.local'), 'nodejs 20.19.0\n');
+
+    expect(readToolVersionsNode('.tool-versions.local')).toBe('20.19.0');
+  });
+});
+
+// region | Helpers
+
+/** Writes the given lines to `.tool-versions` in the temp directory. */
+function writeToolVersions(lines: string[]): void {
+  writeFileSync(join(tempDir, '.tool-versions'), lines.join('\n'));
+}
+
+// endregion | Helpers

--- a/packages/readyup/__tests__/check-utils/tsconfig.test.ts
+++ b/packages/readyup/__tests__/check-utils/tsconfig.test.ts
@@ -91,6 +91,21 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
+  it('reads a shared parent once, along the higher-priority branch', () => {
+    writeConfig('base.json', { compilerOptions: { lib: ['ES2021'], target: 'ES2021' } });
+    writeConfig('low.json', { extends: './base.json', compilerOptions: { target: 'ES2022' } });
+    writeConfig('high.json', { extends: './base.json', compilerOptions: { target: 'ES2024' } });
+    writeConfig('tsconfig.json', { extends: ['./low.json', './high.json'] });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toEqual({
+      // `high` outranks `low`, so `base` is reached through it; `low` is visited with both fields already resolved.
+      lib: ['es2021'],
+      target: 'es2024',
+      chain: ['tsconfig.json', 'high.json', 'base.json', 'low.json'],
+      unresolvedExtends: [],
+    });
+  });
+
   it('parses JSONC comments and trailing commas', () => {
     writeRawConfig(
       'tsconfig.json',

--- a/packages/readyup/__tests__/check-utils/tsconfig.test.ts
+++ b/packages/readyup/__tests__/check-utils/tsconfig.test.ts
@@ -1,0 +1,197 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { readTsconfigLanguageLevel } from '../../src/check-utils/tsconfig.ts';
+
+let tempDir: string;
+let cwdSpy: MockInstance;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rdy-tsconfig-'));
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
+});
+
+afterEach(() => {
+  cwdSpy.mockRestore();
+});
+
+describe(readTsconfigLanguageLevel, () => {
+  it('reads lib and target from a single config', () => {
+    writeConfig('tsconfig.json', { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toEqual({
+      lib: ['es2025'],
+      target: 'es2025',
+      chain: ['tsconfig.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('reports lib and target as undefined when no config declares them', () => {
+    writeConfig('tsconfig.json', { compilerOptions: { strict: true } });
+
+    const result = readTsconfigLanguageLevel('tsconfig.json');
+
+    expect(result?.lib).toBeUndefined();
+    expect(result?.target).toBeUndefined();
+  });
+
+  it('resolves lib and target through a relative extends chain', () => {
+    writeConfig('base.json', { compilerOptions: { lib: ['ES2023'], target: 'ES2023' } });
+    writeConfig('middle.json', { extends: './base.json' });
+    writeConfig('tsconfig.json', { extends: './middle.json' });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toEqual({
+      lib: ['es2023'],
+      target: 'es2023',
+      chain: ['tsconfig.json', 'middle.json', 'base.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('lets a package config override the root config it extends', () => {
+    writeConfig('tsconfig.json', { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } });
+    writeConfig('packages/alpha/tsconfig.json', {
+      extends: '../../tsconfig.json',
+      compilerOptions: { lib: ['ES2022'] },
+    });
+
+    expect(readTsconfigLanguageLevel('packages/alpha/tsconfig.json')).toEqual({
+      // `target` is undeclared in the package config, so the root's value carries through.
+      lib: ['es2022'],
+      target: 'es2025',
+      chain: ['packages/alpha/tsconfig.json', 'tsconfig.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('appends .json to an extends specifier written without an extension', () => {
+    writeConfig('base.json', { compilerOptions: { target: 'ES2022' } });
+    writeConfig('tsconfig.json', { extends: './base' });
+
+    const result = readTsconfigLanguageLevel('tsconfig.json');
+
+    expect(result?.target).toBe('es2022');
+    expect(result?.chain).toEqual(['tsconfig.json', 'base.json']);
+  });
+
+  it('gives a later array-extends entry precedence over an earlier one', () => {
+    writeConfig('first.json', { compilerOptions: { lib: ['ES2021'], target: 'ES2021' } });
+    writeConfig('second.json', { compilerOptions: { lib: ['ES2024'] } });
+    writeConfig('tsconfig.json', { extends: ['./first.json', './second.json'] });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toEqual({
+      lib: ['es2024'],
+      target: 'es2021',
+      chain: ['tsconfig.json', 'second.json', 'first.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('parses JSONC comments and trailing commas', () => {
+    writeRawConfig(
+      'tsconfig.json',
+      [
+        '// TSConfig for monorepo root',
+        '{',
+        '  "compilerOptions": {',
+        '    "lib": ["ES2025"], // Keep aligned with the `engines` floor.',
+        '    /* Block comments are legal too. */',
+        '    "target": "ES2025",',
+        '  },',
+        '}',
+        '',
+      ].join('\n'),
+    );
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toEqual({
+      lib: ['es2025'],
+      target: 'es2025',
+      chain: ['tsconfig.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('reports a bare package specifier as unresolved without following it', () => {
+    writeConfig('tsconfig.json', {
+      extends: '@tsconfig/node24/tsconfig.json',
+      compilerOptions: { target: 'ES2025' },
+    });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toEqual({
+      lib: undefined,
+      target: 'es2025',
+      chain: ['tsconfig.json'],
+      unresolvedExtends: ['@tsconfig/node24/tsconfig.json'],
+    });
+  });
+
+  it('reports a missing parent as unresolved', () => {
+    writeConfig('tsconfig.json', { extends: './absent.json', compilerOptions: { lib: ['ES2025'] } });
+
+    const result = readTsconfigLanguageLevel('tsconfig.json');
+
+    expect(result?.lib).toEqual(['es2025']);
+    expect(result?.unresolvedExtends).toEqual(['./absent.json']);
+  });
+
+  it('reports a malformed parent as unresolved and keeps reading the rest of the chain', () => {
+    writeRawConfig('broken.json', 'this is not a config at all');
+    writeConfig('good.json', { compilerOptions: { target: 'ES2024' } });
+    writeConfig('tsconfig.json', { extends: ['./broken.json', './good.json'] });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toEqual({
+      lib: undefined,
+      target: 'es2024',
+      chain: ['tsconfig.json', 'good.json'],
+      unresolvedExtends: ['./broken.json'],
+    });
+  });
+
+  it('stops at a cycle in the extends chain', () => {
+    writeConfig('a.json', { extends: './b.json', compilerOptions: { target: 'ES2022' } });
+    writeConfig('b.json', { extends: './a.json', compilerOptions: { lib: ['ES2022'] } });
+
+    expect(readTsconfigLanguageLevel('a.json')).toEqual({
+      lib: ['es2022'],
+      target: 'es2022',
+      chain: ['a.json', 'b.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('returns undefined when the entry file is missing', () => {
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();
+  });
+
+  it('returns undefined when the entry file is malformed', () => {
+    writeRawConfig('tsconfig.json', '@@@ not json @@@');
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();
+  });
+
+  it('returns undefined when the entry file holds a non-object', () => {
+    writeRawConfig('tsconfig.json', '["ES2025"]');
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();
+  });
+});
+
+// region | Helpers
+
+/** Writes a config as JSON at a temp-dir-relative path, creating parent directories as needed. */
+function writeConfig(relativePath: string, content: Record<string, unknown>): void {
+  writeRawConfig(relativePath, JSON.stringify(content));
+}
+
+/** Writes verbatim config text at a temp-dir-relative path, creating parent directories as needed. */
+function writeRawConfig(relativePath: string, content: string): void {
+  const fullPath = join(tempDir, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content);
+}
+
+// endregion | Helpers

--- a/packages/readyup/package.json
+++ b/packages/readyup/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "jiti": "2.7.0",
+    "jsonc-parser": "3.3.1",
     "picomatch": "4.0.5",
     "zod": "4.4.3"
   },

--- a/packages/readyup/src/check-utils/engines.ts
+++ b/packages/readyup/src/check-utils/engines.ts
@@ -13,6 +13,9 @@ export type EnginesNodeFloor =
 /** Matches the simple floor forms: `>=x[.y[.z]]`, `^x[.y[.z]]`, and a bare `x[.y[.z]]`. */
 const SIMPLE_FLOOR = /^(?:>=|\^)?\s*(\d+(?:\.\d+){0,2})$/;
 
+/** Matches a dotted numeric version, the only shape `compareVersions` can order. */
+const COMPARABLE_VERSION = /^\d+(?:\.\d+)*$/;
+
 /**
  * Reads the minimum Node version a parsed manifest declares in `engines.node`.
  * Ranges outside the simple floor forms are reported as unparseable rather than guessed at.
@@ -29,11 +32,15 @@ export function readEnginesNodeFloor(manifest: Record<string, unknown>): Engines
 }
 
 /**
- * Reports whether a Node version is at or above a floor.
+ * Reports whether a Node version is at or above a floor, and undefined when either argument is not a
+ * dotted numeric version — the shape `.tool-versions` tokens such as `lts` and `system` do not take.
  * A leading `v` is tolerated on either argument, so `process.version` can be passed as it comes.
  */
-export function satisfiesNodeFloor(version: string, floor: string): boolean {
-  return compareVersions(normalizeVersion(version), normalizeVersion(floor)) >= 0;
+export function satisfiesNodeFloor(version: string, floor: string): boolean | undefined {
+  const normalizedVersion = normalizeVersion(version);
+  const normalizedFloor = normalizeVersion(floor);
+  if (!COMPARABLE_VERSION.test(normalizedVersion) || !COMPARABLE_VERSION.test(normalizedFloor)) return undefined;
+  return compareVersions(normalizedVersion, normalizedFloor) >= 0;
 }
 
 // region | Helpers

--- a/packages/readyup/src/check-utils/engines.ts
+++ b/packages/readyup/src/check-utils/engines.ts
@@ -1,0 +1,47 @@
+import { isRecord } from '../isRecord.ts';
+import { compareVersions } from './semver.ts';
+
+/** Outcome of reading a manifest's `engines.node`. */
+export type EnginesNodeFloor =
+  /** A simple floor form was recognized; `floor` is the version it names. */
+  | { kind: 'found'; floor: string; raw: string }
+  /** No `engines.node` string is declared. */
+  | { kind: 'absent' }
+  /** A range was declared, but not in a form from which a single floor follows. */
+  | { kind: 'unparseable'; raw: string };
+
+/** Matches the simple floor forms: `>=x[.y[.z]]`, `^x[.y[.z]]`, and a bare `x[.y[.z]]`. */
+const SIMPLE_FLOOR = /^(?:>=|\^)?\s*(\d+(?:\.\d+){0,2})$/;
+
+/**
+ * Reads the minimum Node version a parsed manifest declares in `engines.node`.
+ * Ranges outside the simple floor forms are reported as unparseable rather than guessed at.
+ */
+export function readEnginesNodeFloor(manifest: Record<string, unknown>): EnginesNodeFloor {
+  const engines = manifest.engines;
+  if (!isRecord(engines)) return { kind: 'absent' };
+  const raw = engines.node;
+  if (typeof raw !== 'string') return { kind: 'absent' };
+
+  const floor = SIMPLE_FLOOR.exec(raw.trim())?.[1];
+  if (floor === undefined) return { kind: 'unparseable', raw };
+  return { kind: 'found', floor, raw };
+}
+
+/**
+ * Reports whether a Node version is at or above a floor.
+ * A leading `v` is tolerated on either argument, so `process.version` can be passed as it comes.
+ */
+export function satisfiesNodeFloor(version: string, floor: string): boolean {
+  return compareVersions(normalizeVersion(version), normalizeVersion(floor)) >= 0;
+}
+
+// region | Helpers
+
+/** Trims a version string and strips the leading `v` that Node's own version carries. */
+function normalizeVersion(version: string): string {
+  const trimmed = version.trim();
+  return trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/es-year.ts
+++ b/packages/readyup/src/check-utils/es-year.ts
@@ -1,0 +1,18 @@
+/** ECMAScript language level, lowercased to match the `lib` and `target` values a tsconfig reader returns. */
+export type EsYear = 'es2022' | 'es2023' | 'es2024' | 'es2025';
+
+/** Node LTS major versions and the ECMAScript year each one supports. */
+const ES_YEAR_BY_NODE_MAJOR: Readonly<Record<number, EsYear>> = {
+  18: 'es2022',
+  20: 'es2023',
+  22: 'es2024',
+  24: 'es2025',
+};
+
+/**
+ * Maps a Node major version to the ECMAScript year it supports.
+ * Returns undefined for majors outside the table, leaving the caller to decide what an unrecognized major means.
+ */
+export function esYearForNodeMajor(major: number): EsYear | undefined {
+  return ES_YEAR_BY_NODE_MAJOR[major];
+}

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -1,4 +1,8 @@
 export { isRecord } from '../isRecord.ts';
+export type { EnginesNodeFloor } from './engines.ts';
+export { readEnginesNodeFloor, satisfiesNodeFloor } from './engines.ts';
+export type { EsYear } from './es-year.ts';
+export { esYearForNodeMajor } from './es-year.ts';
 export { commandExists, fileContains, fileDoesNotContain, fileExists, filesExist, readFile } from './filesystem.ts';
 export {
   compareLocalRefs,
@@ -15,5 +19,8 @@ export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json
 export { getJsonValue, hasJsonValue } from './json-value.ts';
 export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
 export { compareVersions } from './semver.ts';
+export { readToolVersionsNode } from './tool-versions.ts';
+export type { TsconfigLanguageLevel } from './tsconfig.ts';
+export { readTsconfigLanguageLevel } from './tsconfig.ts';
 export type { DiscoverWorkspacesOptions, Workspace } from './workspaces.ts';
 export { discoverWorkspaces } from './workspaces.ts';

--- a/packages/readyup/src/check-utils/tool-versions.ts
+++ b/packages/readyup/src/check-utils/tool-versions.ts
@@ -1,0 +1,28 @@
+import { readFile } from './filesystem.ts';
+
+/** Tool names under which a `.tool-versions` file declares Node. asdf writes `nodejs`; mise also accepts `node`. */
+const NODE_TOOL_NAMES = new Set(['node', 'nodejs']);
+
+/**
+ * Reads the Node version declared in a `.tool-versions` file.
+ * Returns undefined when the file is absent or declares no Node version.
+ */
+export function readToolVersionsNode(relativePath = '.tool-versions'): string | undefined {
+  const content = readFile(relativePath);
+  if (content === undefined) return undefined;
+
+  for (const line of content.split('\n')) {
+    // A `#` opens a comment that runs to the end of the line, whether or not anything precedes it.
+    const declaration = (line.split('#')[0] ?? '').trim();
+    if (declaration === '') continue;
+
+    const [tool, ...versions] = declaration.split(/\s+/);
+    if (tool === undefined || !NODE_TOOL_NAMES.has(tool)) continue;
+
+    // Versions after the first are fallbacks; the first is the one in force.
+    const version = versions[0];
+    if (version !== undefined) return version;
+  }
+
+  return undefined;
+}

--- a/packages/readyup/src/check-utils/tool-versions.ts
+++ b/packages/readyup/src/check-utils/tool-versions.ts
@@ -13,7 +13,7 @@ export function readToolVersionsNode(relativePath = '.tool-versions'): string | 
 
   for (const line of content.split('\n')) {
     // A `#` opens a comment that runs to the end of the line, whether or not anything precedes it.
-    const declaration = (line.split('#')[0] ?? '').trim();
+    const declaration = (line.split('#', 1)[0] ?? '').trim();
     if (declaration === '') continue;
 
     const [tool, ...versions] = declaration.split(/\s+/);

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -1,0 +1,156 @@
+import { readFileSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
+
+import { parse as parseJsonc } from 'jsonc-parser';
+
+import { isRecord } from '../isRecord.ts';
+
+/** Effective language-level settings of a tsconfig, resolved through its `extends` chain. */
+export interface TsconfigLanguageLevel {
+  /** Effective `lib`, lowercased; `undefined` if no config in the chain declares it. */
+  lib: string[] | undefined;
+  /** Effective `target`, lowercased; `undefined` if no config in the chain declares it. */
+  target: string | undefined;
+  /** Config paths visited, entry file first, cwd-relative. */
+  chain: string[];
+  /** `extends` references resolution could not follow: bare specifiers, missing files, malformed configs. */
+  unresolvedExtends: string[];
+}
+
+/** Accumulator threaded through the `extends` walk. */
+interface Resolution {
+  cwd: string;
+  visited: Set<string>;
+  chain: string[];
+  unresolvedExtends: string[];
+  lib: string[] | undefined;
+  target: string | undefined;
+}
+
+/**
+ * Reads a tsconfig's effective `lib` and `target`, resolving relative and array-form `extends`.
+ * Returns undefined if the entry file is missing or unparseable; unresolvable parents are reported
+ * in `unresolvedExtends` rather than treated as failures.
+ */
+export function readTsconfigLanguageLevel(relativePath: string): TsconfigLanguageLevel | undefined {
+  const cwd = process.cwd();
+  const entryPath = resolve(cwd, relativePath);
+  const entryConfig = readTsconfigFile(entryPath);
+  if (entryConfig === undefined) return undefined;
+
+  const resolution: Resolution = {
+    cwd,
+    visited: new Set([entryPath]),
+    chain: [toCwdRelative(cwd, entryPath)],
+    unresolvedExtends: [],
+    lib: undefined,
+    target: undefined,
+  };
+  applyConfig(entryConfig, entryPath, resolution);
+
+  const { lib, target, chain, unresolvedExtends } = resolution;
+  return { lib, target, chain, unresolvedExtends };
+}
+
+// region | Helpers
+
+/**
+ * Folds one config into the resolution, then walks its parents. Fields already resolved are left
+ * alone, so the nearest declaration wins; parents are visited rightmost-first because a later
+ * `extends` entry overrides an earlier one.
+ */
+function applyConfig(config: Record<string, unknown>, configPath: string, resolution: Resolution): void {
+  const compilerOptions = isRecord(config.compilerOptions) ? config.compilerOptions : {};
+  if (resolution.lib === undefined) {
+    resolution.lib = readLib(compilerOptions.lib);
+  }
+  if (resolution.target === undefined) {
+    resolution.target = readTarget(compilerOptions.target);
+  }
+
+  for (const specifier of readExtends(config.extends).toReversed()) {
+    visitParent(specifier, configPath, resolution);
+  }
+}
+
+/** Resolves one `extends` specifier and folds the parent config into the resolution. */
+function visitParent(specifier: string, configPath: string, resolution: Resolution): void {
+  const parentPath = resolveExtendsPath(specifier, dirname(configPath));
+  if (parentPath === undefined) {
+    resolution.unresolvedExtends.push(specifier);
+    return;
+  }
+  // A config reached twice (cycle or diamond) has already contributed everything it can.
+  if (resolution.visited.has(parentPath)) return;
+  resolution.visited.add(parentPath);
+
+  const parentConfig = readTsconfigFile(parentPath);
+  if (parentConfig === undefined) {
+    resolution.unresolvedExtends.push(specifier);
+    return;
+  }
+  resolution.chain.push(toCwdRelative(resolution.cwd, parentPath));
+  applyConfig(parentConfig, parentPath, resolution);
+}
+
+/**
+ * Resolves a relative `extends` specifier against the extending config's directory, retrying with a
+ * `.json` suffix as TypeScript does for `"./base"`. Bare package specifiers are not followed.
+ */
+function resolveExtendsPath(specifier: string, configDir: string): string | undefined {
+  if (!specifier.startsWith('.') && !isAbsolute(specifier)) return undefined;
+  const candidate = resolve(configDir, specifier);
+  if (isFile(candidate)) return candidate;
+  const withJsonSuffix = `${candidate}.json`;
+  if (isFile(withJsonSuffix)) return withJsonSuffix;
+  return undefined;
+}
+
+/** Reads and JSONC-parses a tsconfig. Returns undefined when the file is unreadable or is not an object. */
+function readTsconfigFile(absolutePath: string): Record<string, unknown> | undefined {
+  if (!isFile(absolutePath)) return undefined;
+  let content: string;
+  try {
+    content = readFileSync(absolutePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+  const parsed: unknown = parseJsonc(content, [], { allowTrailingComma: true });
+  if (!isRecord(parsed)) return undefined;
+  return parsed;
+}
+
+/** Normalizes a declared `lib` to lowercased strings. Returns undefined when the value is not an array. */
+function readLib(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((entry): entry is string => typeof entry === 'string').map((entry) => entry.toLowerCase());
+}
+
+/** Normalizes a declared `target` to lowercase. Returns undefined when the value is not a string. */
+function readTarget(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return value.toLowerCase();
+}
+
+/** Normalizes an `extends` value to a list of specifiers, dropping non-string entries. */
+function readExtends(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.filter((entry): entry is string => typeof entry === 'string');
+  return [];
+}
+
+/** Reports whether a path exists and is a regular file. */
+function isFile(absolutePath: string): boolean {
+  try {
+    return statSync(absolutePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Expresses an absolute path relative to cwd, using forward slashes. */
+function toCwdRelative(cwd: string, absolutePath: string): string {
+  return relative(cwd, absolutePath).split('\\').join('/');
+}
+
+// endregion | Helpers

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       jiti:
         specifier: 2.7.0
         version: 2.7.0
+      jsonc-parser:
+        specifier: 3.3.1
+        version: 3.3.1
       picomatch:
         specifier: 4.0.5
         version: 4.0.5
@@ -1706,6 +1709,9 @@ packages:
   jsonc-eslint-parser@3.1.0:
     resolution: {integrity: sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -4355,6 +4361,8 @@ snapshots:
       acorn: 8.17.0
       eslint-visitor-keys: 5.0.1
       semver: 7.8.5
+
+  jsonc-parser@3.3.1: {}
 
   jsonparse@1.3.1: {}
 


### PR DESCRIPTION
## What

`readyup/check-utils` now exports functions for checking that a repo's runtime declarations agree with each other. The functions check for the ECMAScript year supported by a Node major version, the minimum Node version required by `engines.node`, the Node version pinned in `.tool-versions`, and the `lib` and `target` values set for TypeScript.

## Why

Runtime declarations drift apart quietly, and nothing was watching them. This repo's own manifest demanded Node `>=20.6.0` while pinning 24.18.0, and its tsconfigs held the language level two years behind the runtime — which cost four call sites a workaround for a built-in that was available all along. Neither gap announced itself; both had to be noticed by hand. The drift kit in `templates.node-monorepo` can now check these axes across the fleet, which it could not do while the readers existed nowhere.

## Details

### 🎉 Features

- `readTsconfigLanguageLevel(path)` resolves effective `lib` and `target` through relative and array-form `extends`, with the nearest declaration winning and the rightmost array entry outranking earlier ones. Configs are read as JSONC. Alongside the values it returns `chain` (the configs actually read) and `unresolvedExtends` (bare package specifiers, missing parents, unparseable parents), so a caller can tell a stalled walk from an undeclared setting.
- `readEnginesNodeFloor(manifest)` returns a discriminated result: the floor for `>=x`, `^x`, and bare-version forms; `absent` when nothing is declared; `unparseable` for any range naming no single floor, so a union or wildcard is never mistaken for one. It takes an already-parsed manifest, composing with `discoverWorkspaces` without re-reading files.
- `satisfiesNodeFloor(version, floor)` compares a runtime against a floor, tolerating the leading `v` that `process.version` carries and returning `undefined` when either side is not a dotted numeric version — `.tool-versions` accepts `lts`, `latest`, `system`, and `ref:<git ref>`, none of which order against a number.
- `readToolVersionsNode(path?)` reads the Node version from `.tool-versions` under either asdf's `nodejs` or mise's `node`, skipping comments, blank lines, and other tools, and resolving a fallback list to its first entry.
- `esYearForNodeMajor(major)` maps Node LTS majors 18 through 24 to their ECMAScript year, returning `undefined` outside the table rather than guessing.
- The README documents each function, the tsconfig reader's result shape, the engines grammar, the comparator's contract, and a worked example composing all four readers.

### 🧪 Tests

- 60 cases across the four modules. The tsconfig suite fixtures `extends` chains, extensionless specifiers, package-level overrides, array precedence, a diamond where two branches share a parent, cycles, JSONC syntax, unresolved specifiers, and every absent or malformed input.

### 📦 Dependencies

- Adds `jsonc-parser` (3.3.1) to readyup's runtime dependencies. Tsconfigs are JSONC, and a hand-rolled comment stripper's edge-case failures would surface as silent absence — masking exactly the drift these readers exist to find.

Closes #128
