### PR TITLE
#124 Formalize and slim the JSON contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ coverage/
 
 # Generated files
 packages/*/src/version.ts
+packages/readyup/schemas/
 
 # TypeScript
 *.tsbuildinfo

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
+# Written by `rdy compile`, whose own formatting Prettier would fight over on every build.
+.readyup/manifest.json
 pnpm-lock.yaml

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -2,7 +2,12 @@
   "version": 1,
   "kits": [
     {
-      "checklists": ["project-foundations", "optional-integrations", "code-quality", "publishing-pipeline"],
+      "checklists": [
+        "project-foundations",
+        "optional-integrations",
+        "code-quality",
+        "publishing-pipeline"
+      ],
       "name": "demo",
       "path": "kits/demo.js",
       "readyupVersion": "0.21.2",

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -2,6 +2,7 @@
   "version": 1,
   "kits": [
     {
+      "checklists": ["project-foundations", "optional-integrations", "code-quality", "publishing-pipeline"],
       "name": "demo",
       "path": "kits/demo.js",
       "readyupVersion": "0.21.2",

--- a/packages/readyup/.prettierignore
+++ b/packages/readyup/.prettierignore
@@ -1,1 +1,2 @@
 dist/
+schemas/

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -90,6 +90,7 @@ rdy <command> [options]
 | `--internal`                  | Use internal kit directory and infix from config              |
 | `--checklists, -c <name,...>` | Filter checklists within the selected kit                     |
 | `--json`                      | Output results as JSON                                        |
+| `--detail <summary\|full>`    | How much of the JSON report to emit (default: `full`)         |
 | `--fail-on <severity>`        | Fail on this severity or above (`error`, `warn`, `recommend`) |
 | `--report-on <severity>`      | Show this severity or above (`error`, `warn`, `recommend`)    |
 
@@ -111,13 +112,41 @@ A run that loses a kit part-way exits `2` even when the kits that ran also found
 
 ### JSON output
 
-With `--json`, stdout carries exactly one JSON document, chosen by how far the invocation got: the report when a run produced one, and otherwise an error envelope. The exceptions are `--help` and `--version`, which have no JSON form: their text goes to stderr and stdout stays empty.
+`run`, `compile`, `list`, and `verify` all accept `--json`. `init` does not: scaffolding is interactive and stays human-only.
+
+With `--json`, stdout carries exactly one JSON document and every human-readable line — headers, progress, warnings, errors — goes to stderr. The exceptions are `--help` and `--version`, which have no JSON form: their text goes to stderr and stdout stays empty.
+
+#### Published schemas
+
+Each payload is specified by a JSON Schema shipped with the package, and carries an integer `schemaVersion` matching the `vN` in its schema's filename.
+
+| Payload        | Import path                              | `$id`                                                      |
+| -------------- | ---------------------------------------- | ---------------------------------------------------------- |
+| `compile`      | `readyup/schemas/compile.v1.json`        | `https://unpkg.com/readyup/schemas/compile.v1.json`        |
+| error envelope | `readyup/schemas/error-envelope.v1.json` | `https://unpkg.com/readyup/schemas/error-envelope.v1.json` |
+| `list`         | `readyup/schemas/list.v1.json`           | `https://unpkg.com/readyup/schemas/list.v1.json`           |
+| `run` report   | `readyup/schemas/report.v1.json`         | `https://unpkg.com/readyup/schemas/report.v1.json`         |
+| `verify`       | `readyup/schemas/verify.v1.json`         | `https://unpkg.com/readyup/schemas/verify.v1.json`         |
+
+The schemas are generated from the same definitions the exported `Json*` TypeScript types are derived from, so the published contract and the types cannot drift apart.
+
+#### Evolution policy
+
+The five payloads version independently: reshaping the report leaves a consumer pinned to `list.v1.json` untouched.
+
+- **Adding an optional field does not bump `schemaVersion`.** The schemas do not constrain properties they have not heard of, so a validator pinned to `v1` keeps accepting payloads from a later readyup that added one.
+- **Removing, renaming, or re-typing a field does bump it**, and publishes a new `vN` file beside the old one. Widening a closed set of values — an error `code`, a check `status` — counts as re-typing.
+- **A field is `required` only when every payload carries it.** Omission is reserved for genuinely absent or empty data, so a present field never means "nothing here".
+
+#### Error envelope
+
+An invocation that fails before it can produce anything else emits the envelope:
 
 ```json
-{ "error": { "code": "usage", "message": "Unknown option '--bogus'" } }
+{ "schemaVersion": 1, "error": { "code": "usage", "message": "Unknown option '--bogus'" } }
 ```
 
-`code` is one of `usage`, `config`, `kit-load`, or `internal`. Every human-readable line — help text, progress headers, warnings — goes to stderr, and the exit code does not determine which document appears.
+`code` is one of `usage`, `config`, `kit-load`, or `internal`. The exit code does not determine which document appears.
 
 The envelope covers only failures that precede dispatch. Once the run reaches its kits, a kit that fails is reported inside the report instead of replacing it, so each entry in `kits` takes one of two shapes, told apart by whether `error` is present:
 
@@ -125,7 +154,42 @@ The envelope covers only failures that precede dispatch. Once the run reaches it
 { "name": "release", "error": { "code": "kit-load", "message": "Cannot find .readyup/kits/release.js" } }
 ```
 
-An error entry carries no counts, because a kit that never ran has none to report; the top-level totals cover only the kits that ran. In human mode the same failure goes to stderr, which keeps it distinct from a failed check. A run of more than one kit prefixes the kit's name, as `Error [release]: ...`.
+An error entry carries no counts and no verdict, because a kit that never ran has neither to report; the top-level totals cover only the kits that ran. In human mode the same failure goes to stderr, which keeps it distinct from a failed check. A run of more than one kit prefixes the kit's name, as `Error [release]: ...`.
+
+#### The run report
+
+```json
+{
+  "schemaVersion": 1,
+  "readyupVersion": "0.21.2",
+  "passed": false,
+  "counts": { "passed": 4, "errors": 1, "warnings": 0, "recommendations": 0, "blocked": 2, "optional": 1 },
+  "worstSeverity": "error",
+  "failOn": "error",
+  "reportOn": "recommend",
+  "detail": "full",
+  "durationMs": 68,
+  "kits": [{ "name": "deploy", "passed": false, "counts": {}, "durationMs": 68, "checklists": [] }]
+}
+```
+
+- **`passed`** is the run verdict: true when every requested kit produced results and no result at or above `failOn` failed, so it agrees with exit code 0 in every case. Kit and checklist entries carry their own `passed`, which means the narrower "nothing here failed".
+- **`counts`** holds the six result tallies at the report, kit, and checklist levels. They nest rather than sitting flat so the count names and the verdict names share no namespace, which is what makes the additive-evolution rule above sound rather than merely conventional.
+- **`worstSeverity`** sits beside `counts` — it is derived verdict data, not a count — and is omitted when nothing failed.
+- **`failOn`**, **`reportOn`**, and **`detail`** echo the settings the run resolved, so a consumer holding only the payload can tell a clean run from one whose failures were filtered out of view. A kit that declares its own `failOn` overrides the run-level value for its own checks.
+- **`warnings`** carries any advisory the run raised, as `{ code, message, remedy? }`. Warnings keep their stderr line in both modes; under `--json` they are captured here as well, because a consumer that owns only stdout would otherwise never see them. The field is absent when the run raised none.
+
+Payloads are slim by construction: a field carrying nothing is omitted rather than emitted as `null`, empty `checks` arrays are dropped, durations are whole milliseconds, and `fix` appears only on checks that failed.
+
+#### Choosing how much detail to receive
+
+`--detail summary` keeps the counts, verdicts, and worst severity but reduces the detail tree to the checks that failed and the fixes they carry — the shape an agent needs to decide what to do next, at a fraction of the tokens. `--detail full` is the default and keeps every reported check.
+
+```bash
+rdy run --json --detail summary
+```
+
+Both projections are described by `report.v1.json`, so a consumer validates one document either way and reads the report's own `detail` field to learn which projection it received. Passing `--detail` without `--json`, or to any command other than `run`, is a usage error rather than a silently ignored flag.
 
 ### Kit sources
 
@@ -159,7 +223,35 @@ rdy list --from global         List compiled kits in the global directory
 rdy list --from dir:<path>     List kits in an arbitrary directory
 rdy list --from github:org/repo[@ref]      List kits from a GitHub manifest
 rdy list --from bitbucket:ws/repo[@ref]    List kits from a Bitbucket manifest
+rdy list --manifest <path>     List the kits a manifest file declares
 ```
+
+A local `--from` source with no manifest beside its kits falls back to listing the compiled kits on disk, which are the same kits `rdy run --from` would resolve. Those rows carry a name and a path only; descriptions, checklist names, and versions live in the manifest that is absent. A remote source still requires one.
+
+Under `--json`, each row reports `name`, `kind` (`internal` for a TypeScript source, `compiled` for a bundle), `path`, and — for kits a manifest describes — `checklists`, `description`, and `readyupVersion`. Checklist names are read from the manifest, so listing kits never imports a compiled bundle and never runs kit code.
+
+### Compile
+
+```
+rdy compile                    Compile every source in the config's srcDir
+rdy compile <file>             Compile a single file
+```
+
+A sweep runs to completion: a kit that fails to compile is reported and the next kit is tried, so one broken kit cannot hide the state of the kits that sort after it. A kit that failed is left out of the manifest rather than recorded as though it had compiled, and the run exits 1.
+
+`rdy compile` refuses to overwrite a compiled kit whose on-disk hash differs from the manifest's recorded `targetHash` — someone edited the compiled file directly. Drifted kits are reported and skipped; `--force` overwrites them anyway.
+
+Each kit's checklist names are recorded in the manifest so `rdy list` can report them without running the kit. The field is optional and absent from manifests written by earlier versions, so the manifest format stays at version 1.
+
+Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `failed`), and the reason it was skipped or failed.
+
+### Verify
+
+```
+rdy verify                     Check compiled kits against the manifest's hashes
+```
+
+Each kit is reported as `ok`, `drift`, `missing`, or `unverified`. Drift and missing fail the run; `unverified` — a manifest entry with no recorded hash — does not, since it says nothing about whether the kit has changed. Under `--json`, a `drift` entry carries the `expected` and `actual` hashes alongside an overall verdict.
 
 ## Authoring API
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -137,6 +137,7 @@ The five payloads version independently: reshaping the report leaves a consumer 
 - **Adding an optional field does not bump `schemaVersion`.** The schemas do not constrain properties they have not heard of, so a validator pinned to `v1` keeps accepting payloads from a later readyup that added one.
 - **Removing, renaming, or re-typing a field does bump it**, and publishes a new `vN` file beside the old one. Widening a closed set of values — an error `code`, a check `status` — counts as re-typing.
 - **A field is `required` only when every payload carries it.** Omission is reserved for genuinely absent or empty data, so a present field never means "nothing here".
+- **`warnings[].code` is an open set**, exempt from the widening rule above: the schema accepts a known code or any other string, so a newly raised advisory never bumps the version. Consumers must tolerate a code they have not heard of, displaying its `message` and `remedy` as they would any other. `error.code` stays closed, because an unknown error code leaves a consumer with no branch to select, and that is a break worth announcing.
 
 #### Error envelope
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -241,6 +241,8 @@ A local `--from` source with no manifest beside its kits falls back to listing t
 
 Under `--json`, each row reports `name`, `kind` (`internal` for a TypeScript source, `compiled` for a bundle), `path`, and — for kits a manifest describes — `checklists`, `description`, and `readyupVersion`. Checklist names are read from the manifest, so listing kits never imports a compiled bundle and never runs kit code.
 
+Rows are keyed by `name` and `kind` together, not by `name` alone. Under the default configuration both the internal source directory and the compile output directory resolve to `.readyup/kits`, so a compiled source appears twice: once as `internal`, which `rdy run --jit <name>` runs, and once as `compiled`, which `rdy run <name>` runs. Both rows are meaningful, so a consumer indexing on `name` alone silently drops one of them.
+
 ### Compile
 
 ```

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -248,7 +248,7 @@ rdy compile                    Compile every source in the config's srcDir
 rdy compile <file>             Compile a single file
 ```
 
-A sweep runs to completion: a kit that fails to compile is reported and the next kit is tried, so one broken kit cannot hide the state of the kits that sort after it. A kit that failed is left out of the manifest rather than recorded as though it had compiled, and the run exits 1.
+A sweep runs to completion: a kit that fails to compile is reported and the next kit is tried, so one broken kit cannot hide the state of the kits that sort after it. A kit that failed is never recorded as though it had compiled, and the run exits 1. A kit that had been compiled before keeps the entry it already had, because that entry still describes the tree: a bundling failure leaves the previous output and its recorded hash untouched, and a validation failure deletes the output, which `rdy verify` then reports as missing. Dropping the entry would hide both, and would leave the next successful compile with no record to check drift against.
 
 `rdy compile` refuses to overwrite a compiled kit whose on-disk hash differs from the manifest's recorded `targetHash` — someone edited the compiled file directly. Drifted kits are reported and skipped; `--force` overwrites them anyway.
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -165,18 +165,28 @@ An error entry carries no counts and no verdict, because a kit that never ran ha
   "passed": false,
   "counts": { "passed": 4, "errors": 1, "warnings": 0, "recommendations": 0, "blocked": 2, "optional": 1 },
   "worstSeverity": "error",
-  "failOn": "error",
-  "reportOn": "recommend",
   "detail": "full",
   "durationMs": 68,
-  "kits": [{ "name": "deploy", "passed": false, "counts": {}, "durationMs": 68, "checklists": [] }]
+  "kits": [
+    {
+      "name": "deploy",
+      "passed": false,
+      "counts": {},
+      "worstSeverity": "error",
+      "failOn": "error",
+      "reportOn": "recommend",
+      "durationMs": 68,
+      "checklists": []
+    }
+  ]
 }
 ```
 
-- **`passed`** is the run verdict: true when every requested kit produced results and no result at or above `failOn` failed, so it agrees with exit code 0 in every case. Kit and checklist entries carry their own `passed`, which means the narrower "nothing here failed".
+- **`passed`** is the run verdict: true when every requested kit produced results and every kit passed under its own `failOn`, so it agrees with exit code 0 in every case. Kit and checklist entries carry their own `passed`, which means the narrower "nothing at or above this kit's `failOn` failed here".
 - **`counts`** holds the six result tallies at the report, kit, and checklist levels. They nest rather than sitting flat so the count names and the verdict names share no namespace, which is what makes the additive-evolution rule above sound rather than merely conventional.
 - **`worstSeverity`** sits beside `counts` — it is derived verdict data, not a count — and is omitted when nothing failed.
-- **`failOn`**, **`reportOn`**, and **`detail`** echo the settings the run resolved, so a consumer holding only the payload can tell a clean run from one whose failures were filtered out of view. A kit that declares its own `failOn` overrides the run-level value for its own checks.
+- **`failOn`** and **`reportOn`** appear in two places, answering two different questions. At the top level they report what the invocation _requested_, so each is present only when you passed the flag: absence means "not requested", never "defaulted". On each kit that ran they report the threshold that _governed_ it, resolved as CLI flag, then the kit's own declaration, then the default, and both are always present there. The two differ whenever a kit declares its own, which is also why a kit's verdict cannot be recomputed from a run-level value and why a multi-kit run needs one threshold per kit rather than one for the report.
+- **`detail`** has no per-kit form, so requested and effective are the same value and it is always present at the top level.
 - **`warnings`** carries any advisory the run raised, as `{ code, message, remedy? }`. Warnings keep their stderr line in both modes; under `--json` they are captured here as well, because a consumer that owns only stdout would otherwise never see them. The field is absent when the run raised none.
 
 Payloads are slim by construction: a field carrying nothing is omitted rather than emitted as `null`, empty `checks` arrays are dropped, durations are whole milliseconds, and `fix` appears only on checks that failed.

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -1234,9 +1234,39 @@ describe(runCommand, () => {
               { name: 'deploy', report: report1 },
               { name: 'infra', report: report2 },
             ],
+            failOn: 'error',
+            reportOn: 'recommend',
           },
         ],
-        expect.objectContaining({ reportOn: 'recommend' }),
+        // A bare invocation requested no threshold, so the run-level options name none: the resolved
+        // values reach the serializer on the kit that they governed.
+        { detail: 'full' },
+      );
+    });
+
+    it('sends a kit its own declared thresholds while the run level stays silent', async () => {
+      const kit = makeKit({ failOn: 'warn', reportOn: 'error' });
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
+      mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      await runCommand({ kitEntries: singleKitEntry(), json: true });
+
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        [expect.objectContaining({ failOn: 'warn', reportOn: 'error' })],
+        { detail: 'full' },
+      );
+    });
+
+    it('echoes a threshold the invocation requested, which overrides what the kit declares', async () => {
+      const kit = makeKit({ failOn: 'warn' });
+      mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
+      mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      await runCommand({ kitEntries: singleKitEntry(), json: true, failOn: 'recommend' });
+
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        [expect.objectContaining({ failOn: 'recommend' })],
+        expect.objectContaining({ failOn: 'recommend' }),
       );
     });
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -403,6 +403,33 @@ describe(parseRunArgs, () => {
     expect(result).not.toHaveProperty('failOn');
     expect(result).not.toHaveProperty('reportOn');
   });
+
+  // --detail flag
+  it.each(['summary', 'full'])('parses --detail %s', (projection) => {
+    expect(parseRunArgs(['--json', '--detail', projection])).toMatchObject({ detail: projection });
+  });
+
+  it('parses --detail= syntax', () => {
+    expect(parseRunArgs(['--json', '--detail=summary'])).toMatchObject({ detail: 'summary' });
+  });
+
+  it('throws when --detail has an invalid value', () => {
+    expect(() => parseRunArgs(['--json', '--detail', 'terse'])).toThrow(
+      '--detail must be one of: summary, full (got "terse")',
+    );
+  });
+
+  it('throws when --detail has no value', () => {
+    expect(() => parseRunArgs(['--json', '--detail'])).toThrow('--detail requires a projection');
+  });
+
+  it('rejects --detail without --json rather than ignoring it', () => {
+    expect(() => parseRunArgs(['--detail', 'summary'])).toThrow('--detail requires --json');
+  });
+
+  it('omits detail when not specified', () => {
+    expect(parseRunArgs(['--json'])).not.toHaveProperty('detail');
+  });
 });
 
 describe(resolveKitSources, () => {

--- a/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
+++ b/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
@@ -30,7 +30,7 @@ describe(validateCompiledOutput, () => {
 
     const metadata = await validateCompiledOutput(outputPath);
 
-    expect(metadata).toStrictEqual({ description: 'A kit for testing' });
+    expect(metadata).toStrictEqual({ checklists: ['test'], description: 'A kit for testing' });
   });
 
   it('omits description key when the kit has none', async () => {
@@ -40,7 +40,20 @@ describe(validateCompiledOutput, () => {
 
     const metadata = await validateCompiledOutput(outputPath);
 
-    expect(metadata).toStrictEqual({ description: undefined });
+    expect(metadata).toStrictEqual({ checklists: ['test'], description: undefined });
+  });
+
+  it('records every checklist name in declaration order', async () => {
+    const outputPath = writeTempKit(testDir, 'kit-multi-checklist.mjs', {
+      checklists: [
+        { name: 'preflight', checks: [] },
+        { name: 'deploy', checks: [] },
+      ],
+    });
+
+    const metadata = await validateCompiledOutput(outputPath);
+
+    expect(metadata.checklists).toStrictEqual(['preflight', 'deploy']);
   });
 
   it('deletes the output file and throws when the bundle fails to load', async () => {

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -383,6 +383,40 @@ describe(compileCommand, () => {
         kits: [expect.objectContaining({ name: 'beta' })],
       });
     });
+
+    it('keeps the manifest entry a failed kit already had', async () => {
+      arrangeMixedBatch();
+      const recordedAlpha = {
+        name: 'alpha',
+        path: 'alpha.js',
+        readyupVersion: VERSION,
+        source: 'alpha.ts',
+        targetHash: 'aaaa1111',
+      };
+      mockReadManifest.mockReturnValue({ version: 1, kits: [recordedAlpha] });
+
+      await compileCommand([]);
+
+      expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+        version: 1,
+        kits: [recordedAlpha, expect.objectContaining({ name: 'beta' })],
+      });
+    });
+
+    it('reports the failure even though the kit keeps its entry', async () => {
+      arrangeMixedBatch();
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [
+          { name: 'alpha', path: 'alpha.js', readyupVersion: VERSION, source: 'alpha.ts', targetHash: 'aaaa1111' },
+        ],
+      });
+
+      const exitCode = await compileCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error compiling alpha.ts'));
+    });
   });
 
   describe('manifest checklist names', () => {

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -52,10 +52,16 @@ vi.mock('../src/verify/checkDrift.ts', () => ({
 }));
 
 import { compileCommand } from '../src/compile/compileCommand.ts';
+import type { KitMetadata } from '../src/compile/validateCompiledOutput.ts';
 import { ManifestNotFoundError } from '../src/manifest/readManifest.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../src/reportRdy.ts';
 import { VERSION } from '../src/version.ts';
 import { captureRdyError } from './helpers/captureRdyError.ts';
+
+/** Metadata as `validateCompiledOutput` returns it, defaulting to a kit with no checklists to record. */
+function kitMetadata(overrides: Partial<KitMetadata> = {}): KitMetadata {
+  return { checklists: [], ...overrides };
+}
 
 describe(compileCommand, () => {
   let stdoutSpy: MockInstance;
@@ -64,7 +70,7 @@ describe(compileCommand, () => {
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    mockValidateCompiledOutput.mockResolvedValue({});
+    mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockCheckDrift.mockReturnValue({ kind: 'unverified' });
   });
 
@@ -335,6 +341,150 @@ describe(compileCommand, () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('references unknown checklist'));
   });
 
+  describe('sweep completion', () => {
+    /** A two-kit batch whose first kit fails to compile and whose second succeeds. */
+    function arrangeMixedBatch(): void {
+      mockLoadConfig.mockResolvedValue({
+        compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
+      mockCompileConfig
+        .mockRejectedValueOnce(new Error('alpha is not valid TypeScript'))
+        .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
+    }
+
+    it('compiles the kits after a failed one instead of abandoning the sweep', async () => {
+      arrangeMixedBatch();
+
+      const exitCode = await compileCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(mockCompileConfig).toHaveBeenCalledTimes(2);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error compiling alpha.ts'));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('beta.ts'));
+    });
+
+    it('reports how many kits failed once the sweep finishes', async () => {
+      arrangeMixedBatch();
+
+      await compileCommand([]);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2 kits failed to compile.'));
+    });
+
+    it('leaves a failed kit out of the manifest rather than recording it as compiled', async () => {
+      arrangeMixedBatch();
+
+      await compileCommand([]);
+
+      expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+        version: 1,
+        kits: [expect.objectContaining({ name: 'beta' })],
+      });
+    });
+  });
+
+  describe('manifest checklist names', () => {
+    it('records the checklist names the compiled kit declares', async () => {
+      mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' });
+      mockValidateCompiledOutput.mockResolvedValue(kitMetadata({ checklists: ['preflight', 'deploy'] }));
+      mockReadManifest.mockImplementation(() => {
+        throw new ManifestNotFoundError('missing');
+      });
+
+      await compileCommand(['deploy.ts']);
+
+      expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+        version: 1,
+        kits: [expect.objectContaining({ name: 'deploy', checklists: ['preflight', 'deploy'] })],
+      });
+    });
+
+    it('omits the field for a kit with no checklists to record', async () => {
+      mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' });
+      mockReadManifest.mockImplementation(() => {
+        throw new ManifestNotFoundError('missing');
+      });
+
+      await compileCommand(['deploy.ts']);
+
+      const [call] = mockWriteManifest.mock.calls;
+      assert.ok(call);
+      const manifest: RdyManifest = call[1];
+
+      expect(manifest.kits[0]).not.toHaveProperty('checklists');
+    });
+  });
+
+  describe('--json', () => {
+    it('reports every kit status on stdout and keeps prose on stderr', async () => {
+      mockLoadConfig.mockResolvedValue({
+        compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
+      mockCompileConfig
+        .mockRejectedValueOnce(new Error('alpha is not valid TypeScript'))
+        .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
+
+      const exitCode = await compileCommand(['--json']);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledTimes(1);
+      const [jsonCall] = stdoutSpy.mock.calls;
+      assert.ok(jsonCall);
+      expect(JSON.parse(String(jsonCall[0]))).toStrictEqual({
+        schemaVersion: 1,
+        passed: false,
+        kits: [
+          { name: 'alpha', status: 'failed', error: 'alpha is not valid TypeScript' },
+          { name: 'beta', status: 'compiled' },
+        ],
+      });
+    });
+
+    it('reports a clean single-file compile as passed', async () => {
+      mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' });
+      mockReadManifest.mockImplementation(() => {
+        throw new ManifestNotFoundError('missing');
+      });
+
+      const exitCode = await compileCommand(['deploy.ts', '--json']);
+
+      expect(exitCode).toBe(0);
+      const [jsonCall] = stdoutSpy.mock.calls;
+      assert.ok(jsonCall);
+      expect(JSON.parse(String(jsonCall[0]))).toMatchObject({
+        passed: true,
+        kits: [{ name: 'deploy', status: 'compiled' }],
+      });
+    });
+
+    it('reports a drift-skipped kit with the reason it was left alone', async () => {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'deploy', path: 'deploy.js', targetHash: 'aaaa1111' }],
+      });
+      mockCheckDrift.mockReturnValue({
+        kind: 'drift',
+        expected: 'aaaa1111',
+        actual: 'ffff9999',
+        resolvedPath: '/abs/deploy.js',
+      });
+
+      const exitCode = await compileCommand(['deploy.ts', '--json']);
+
+      expect(exitCode).toBe(1);
+      const [jsonCall] = stdoutSpy.mock.calls;
+      assert.ok(jsonCall);
+      expect(JSON.parse(String(jsonCall[0]))).toMatchObject({
+        passed: false,
+        kits: [{ name: 'deploy', status: 'skipped', error: expect.stringContaining('drifted') }],
+      });
+    });
+  });
+
   it('reports a config error when readdirSync throws during batch compile', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
@@ -375,7 +525,9 @@ describe(compileCommand, () => {
     mockCompileConfig
       .mockResolvedValueOnce({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' })
       .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
-    mockValidateCompiledOutput.mockResolvedValueOnce({ description: 'Alpha checks' }).mockResolvedValueOnce({});
+    mockValidateCompiledOutput
+      .mockResolvedValueOnce(kitMetadata({ description: 'Alpha checks' }))
+      .mockResolvedValueOnce(kitMetadata());
 
     await compileCommand([]);
 
@@ -440,7 +592,7 @@ describe(compileCommand, () => {
 
   it('upserts manifest entry for single-file compile with location fields', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
-    mockValidateCompiledOutput.mockResolvedValue({ description: 'Deploy checks' });
+    mockValidateCompiledOutput.mockResolvedValue(kitMetadata({ description: 'Deploy checks' }));
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [{ name: 'default', description: 'Default checks' }],
@@ -466,7 +618,7 @@ describe(compileCommand, () => {
 
   it('creates new manifest for single-file compile when no manifest exists', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
-    mockValidateCompiledOutput.mockResolvedValue({});
+    mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockImplementation(() => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
@@ -489,7 +641,7 @@ describe(compileCommand, () => {
 
   it('replaces existing entry when upserting for single-file compile', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
-    mockValidateCompiledOutput.mockResolvedValue({ description: 'Updated' });
+    mockValidateCompiledOutput.mockResolvedValue(kitMetadata({ description: 'Updated' }));
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [{ name: 'deploy', description: 'Old' }],
@@ -541,7 +693,7 @@ describe(compileCommand, () => {
 
   it('writes warning to stderr when upsert encounters non-missing-file error', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
-    mockValidateCompiledOutput.mockResolvedValue({});
+    mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockImplementation(() => {
       throw new Error('Invalid manifest schema in .readyup/manifest.json: bad data');
     });
@@ -556,7 +708,7 @@ describe(compileCommand, () => {
 
   it('uses custom manifest path from --manifest flag for single-file compile', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
-    mockValidateCompiledOutput.mockResolvedValue({});
+    mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockImplementation(() => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
@@ -589,7 +741,7 @@ describe(compileCommand, () => {
 
   it('populates readyupVersion when upserting a single-file compile entry', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
-    mockValidateCompiledOutput.mockResolvedValue({});
+    mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockImplementation(() => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
@@ -606,7 +758,7 @@ describe(compileCommand, () => {
 
   it('maintains alphabetical order when upserting manifest entries', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' });
-    mockValidateCompiledOutput.mockResolvedValue({});
+    mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [{ name: 'charlie' }, { name: 'beta' }],
@@ -646,7 +798,7 @@ describe(compileCommand, () => {
 
   it('bypasses drift gate with --force on single-file compile', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'bbbb2222' });
-    mockValidateCompiledOutput.mockResolvedValue({});
+    mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [{ name: 'deploy', path: 'deploy.js', targetHash: 'aaaa1111' }],

--- a/packages/readyup/__tests__/countAgreement.test.ts
+++ b/packages/readyup/__tests__/countAgreement.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatCombinedSummary } from '../src/formatCombinedSummary.ts';
-import { formatJsonReport } from '../src/formatJsonReport.ts';
 import { countResults, formatSummaryCounts, formatSummaryCountsPlain, reportRdy } from '../src/reportRdy.ts';
 import { runRdy } from '../src/runRdy.ts';
 import type { RdyChecklist, SummaryCounts } from '../src/types.ts';
+import { formatReport } from './helpers/formatReport.ts';
 
 /**
  * A checklist exercising every count-divergence hazard at once: a nested n/a parent, an
@@ -74,18 +74,19 @@ describe('count agreement across views', () => {
     const table = formatCombinedSummary([{ name: 'deploy', ...counts, durationMs: report.durationMs }]);
     expect(table).toContain(formatSummaryCountsPlain(expectedCounts));
 
-    // JSON payload.
+    // JSON payload: the same tally, nested under `counts` with the verdict beside it.
+    const { worstSeverity, ...numericCounts } = expectedCounts;
     const parsed: unknown = JSON.parse(
-      formatJsonReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }], { reportOn: 'error' }),
+      formatReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }], { reportOn: 'error' }),
     );
-    expect(parsed).toMatchObject(expectedCounts);
+    expect(parsed).toMatchObject({ counts: numericCounts, worstSeverity });
   });
 
   it('prunes below-threshold results from the detail tree without altering the counts', async () => {
     const report = await runRdy(checklist);
 
     const human = reportRdy(report, { reportOn: 'error' });
-    const json = formatJsonReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }], { reportOn: 'error' });
+    const json = formatReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }], { reportOn: 'error' });
 
     expect(human).not.toContain('warn-fail');
     expect(json).not.toContain('warn-fail');
@@ -98,7 +99,7 @@ describe('count agreement across views', () => {
 
     const human = reportRdy(report, { reportOn: 'error' });
     const parsed: unknown = JSON.parse(
-      formatJsonReport([{ name: 'kit', entries: [{ name: 'nested', report }] }], { reportOn: 'error' }),
+      formatReport([{ name: 'kit', entries: [{ name: 'nested', report }] }], { reportOn: 'error' }),
     );
 
     expect(human).toContain('context-parent');
@@ -112,7 +113,7 @@ describe('count agreement across views', () => {
     const report = await runRdy(checklist);
 
     const human = reportRdy(report);
-    const json = formatJsonReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }]);
+    const json = formatReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }]);
 
     for (const name of ['na-child', 'na-grandchild']) {
       expect(human).not.toContain(name);

--- a/packages/readyup/__tests__/detailProjection.test.ts
+++ b/packages/readyup/__tests__/detailProjection.test.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { routeCommand } from '../src/bin/route.ts';
+
+/** A kit with one passing check and one failing check that carries a fix. */
+const MIXED_KIT =
+  `export default { checklists: [{ name: 'main', checks: [\n` +
+  `  { name: 'clean', check: () => true },\n` +
+  `  { name: 'nope', check: () => false, fix: 'do the thing' },\n` +
+  `] }] };\n`;
+
+let cwd: string;
+let originalCwd: string;
+let stdout: string[];
+let stdoutSpy: MockInstance;
+let stderrSpy: MockInstance;
+
+beforeAll(() => {
+  originalCwd = process.cwd();
+  cwd = mkdtempSync(path.join(tmpdir(), 'readyup-detail-'));
+  mkdirSync(path.join(cwd, '.readyup/kits'), { recursive: true });
+  writeFileSync(path.join(cwd, '.readyup/kits/default.js'), MIXED_KIT);
+  process.chdir(cwd);
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  stdout = [];
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  });
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+function readStdout(): string {
+  return stdout.join('');
+}
+
+describe('--detail projection', () => {
+  it('defaults to the full tree, echoing the projection it used', async () => {
+    await routeCommand(['--json']);
+
+    expect(JSON.parse(readStdout())).toMatchObject({
+      detail: 'full',
+      kits: [{ checklists: [{ checks: [{ name: 'clean' }, { name: 'nope' }] }] }],
+    });
+  });
+
+  it('reduces the tree to failed checks and their fixes under summary', async () => {
+    await routeCommand(['--json', '--detail', 'summary']);
+
+    expect(JSON.parse(readStdout())).toMatchObject({
+      detail: 'summary',
+      counts: { passed: 1, errors: 1 },
+      worstSeverity: 'error',
+      kits: [{ checklists: [{ checks: [{ name: 'nope', fix: 'do the thing' }] }] }],
+    });
+    expect(readStdout()).not.toContain('clean');
+  });
+
+  it('reports --detail without --json as a usage error rather than ignoring it', async () => {
+    const exitCode = await routeCommand(['--detail', 'summary']);
+
+    expect(exitCode).toBe(2);
+    expect(readStdout()).toBe('');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--detail requires --json'));
+  });
+
+  it.each(['compile', 'init', 'list', 'verify'])('reports --detail on %s as a usage error', async (command) => {
+    const exitCode = await routeCommand([command, '--detail', 'summary', '--json']);
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'usage' } });
+  });
+});

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -96,7 +96,10 @@ describe('exit codes', () => {
     const exitCode = await routeCommand(['--bogus', '--json']);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(readStdout())).toStrictEqual({ error: { code: 'usage', message: expect.any(String) } });
+    expect(JSON.parse(readStdout())).toStrictEqual({
+      schemaVersion: 1,
+      error: { code: 'usage', message: expect.any(String) },
+    });
   });
 
   it.each([
@@ -123,7 +126,10 @@ describe('exit codes', () => {
       const exitCode = await routeCommand(['--json']);
 
       expect(exitCode).toBe(2);
-      expect(JSON.parse(readStdout())).toStrictEqual({ error: { code: 'config', message: expect.any(String) } });
+      expect(JSON.parse(readStdout())).toStrictEqual({
+        schemaVersion: 1,
+        error: { code: 'config', message: expect.any(String) },
+      });
     } finally {
       process.chdir(cwd);
       rmSync(brokenCwd, { recursive: true, force: true });

--- a/packages/readyup/__tests__/formatJsonError.test.ts
+++ b/packages/readyup/__tests__/formatJsonError.test.ts
@@ -4,11 +4,14 @@ import { configError, internalError, kitLoadError, usageError } from '../src/err
 import { formatJsonError } from '../src/formatJsonError.ts';
 
 describe(formatJsonError, () => {
-  it('wraps the code and message in an envelope carrying nothing else', () => {
+  it('wraps the code and message in a versioned envelope carrying nothing else', () => {
     const output = formatJsonError(usageError('something went wrong'));
     const parsed: unknown = JSON.parse(output);
 
-    expect(parsed).toStrictEqual({ error: { code: 'usage', message: 'something went wrong' } });
+    expect(parsed).toStrictEqual({
+      schemaVersion: 1,
+      error: { code: 'usage', message: 'something went wrong' },
+    });
   });
 
   it.each([

--- a/packages/readyup/__tests__/formatJsonReport.test.ts
+++ b/packages/readyup/__tests__/formatJsonReport.test.ts
@@ -103,8 +103,6 @@ describe(formatJsonReport, () => {
       readyupVersion: VERSION,
       passed: true,
       counts,
-      failOn: 'error',
-      reportOn: 'recommend',
       detail: 'full',
       durationMs: 10,
       kits: [
@@ -112,6 +110,8 @@ describe(formatJsonReport, () => {
           name: 'deploy',
           passed: true,
           counts,
+          failOn: 'error',
+          reportOn: 'recommend',
           durationMs: 10,
           checklists: [
             {
@@ -135,8 +135,6 @@ describe(formatJsonReport, () => {
       readyupVersion: VERSION,
       passed: true,
       counts: NO_COUNTS,
-      failOn: 'error',
-      reportOn: 'recommend',
       detail: 'full',
       durationMs: 0,
       kits: [
@@ -144,6 +142,8 @@ describe(formatJsonReport, () => {
           name: 'deploy',
           passed: true,
           counts: NO_COUNTS,
+          failOn: 'error',
+          reportOn: 'recommend',
           durationMs: 0,
           checklists: [{ name: 'deploy', passed: true, counts: NO_COUNTS, durationMs: 0 }],
         },
@@ -158,12 +158,21 @@ describe(formatJsonReport, () => {
       expect(parsed).toMatchObject({ schemaVersion: 1, readyupVersion: VERSION });
     });
 
-    it('echoes the resolved thresholds and detail projection', () => {
+    it('echoes the requested thresholds and detail projection', () => {
       const parsed: unknown = JSON.parse(
         formatReport(singleKit('deploy', makeReport()), { failOn: 'warn', reportOn: 'error', detail: 'summary' }),
       );
 
       expect(parsed).toMatchObject({ failOn: 'warn', reportOn: 'error', detail: 'summary' });
+    });
+
+    it('names no run-level threshold when the invocation requested none', () => {
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', makeReport())));
+
+      expect(parsed).not.toHaveProperty('failOn');
+      expect(parsed).not.toHaveProperty('reportOn');
+      // `detail` has no per-kit form, so it is always resolved and always present.
+      expect(parsed).toHaveProperty('detail', 'full');
     });
 
     it('carries collected warnings alongside the results', () => {
@@ -180,6 +189,42 @@ describe(formatJsonReport, () => {
       // The `warnings` count survives under `counts`; only the top-level advisory array goes away.
       expect(parsed).not.toHaveProperty('warnings');
       expect(parsed).toHaveProperty('counts.warnings', 0);
+    });
+  });
+
+  describe('per-kit thresholds', () => {
+    /** Two kits under one invocation, the second declaring thresholds of its own. */
+    function mixedThresholdKits() {
+      const report = makeReport({
+        results: [makeFailedResult({ name: 'warn-fail', severity: 'warn' })],
+        passed: false,
+        durationMs: 5,
+      });
+
+      return [
+        { name: 'inherits', entries: [{ name: 'c', report }] },
+        { name: 'declares', entries: [{ name: 'c', report }], failOn: 'warn' as const, reportOn: 'error' as const },
+      ];
+    }
+
+    it('carries the threshold that governed each kit rather than one value for the run', () => {
+      const parsed: unknown = JSON.parse(formatReport(mixedThresholdKits()));
+
+      expect(parsed).toMatchObject({
+        kits: [
+          { name: 'inherits', failOn: 'error', reportOn: 'recommend' },
+          { name: 'declares', failOn: 'warn', reportOn: 'error' },
+        ],
+      });
+    });
+
+    it('prunes each kit detail tree with that kit own reporting threshold', () => {
+      const parsed: unknown = JSON.parse(formatReport(mixedThresholdKits()));
+
+      // The warn-severity failure clears `recommend` but not `error`, so it survives in the kit that
+      // inherited the default and is pruned from the kit that raised the bar.
+      expect(parsed).toHaveProperty('kits.0.checklists.0.checks.0.name', 'warn-fail');
+      expect(parsed).not.toHaveProperty('kits.1.checklists.0.checks');
     });
   });
 
@@ -699,8 +744,6 @@ describe(formatJsonReport, () => {
         passed: false,
         counts,
         worstSeverity: 'error',
-        failOn: 'error',
-        reportOn: 'recommend',
         detail: 'summary',
         durationMs: 20,
         kits: [
@@ -709,6 +752,8 @@ describe(formatJsonReport, () => {
             passed: false,
             counts,
             worstSeverity: 'error',
+            failOn: 'error',
+            reportOn: 'recommend',
             durationMs: 20,
             checklists: [
               {

--- a/packages/readyup/__tests__/formatJsonReport.test.ts
+++ b/packages/readyup/__tests__/formatJsonReport.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatJsonReport } from '../src/formatJsonReport.ts';
+import { ReportSchema } from '../src/schemas/index.ts';
 import type { FailedResult, PassedResult, RdyReport, RdyResult, SkippedResult } from '../src/types.ts';
+import { VERSION } from '../src/version.ts';
+import { formatReport } from './helpers/formatReport.ts';
 
 function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
   return {
@@ -61,103 +64,425 @@ function singleKit(checklistName: string, report: RdyReport, kitName = 'deploy')
   return [{ name: kitName, entries: [{ name: checklistName, report }] }];
 }
 
+/** The tally a run with nothing to report produces, spelled out for whole-payload assertions. */
+const NO_COUNTS = { passed: 0, errors: 0, warnings: 0, recommendations: 0, blocked: 0, optional: 0 };
+
 describe(formatJsonReport, () => {
   it('produces valid JSON', () => {
-    const output = formatJsonReport(singleKit('deploy', makeReport()));
+    const output = formatReport(singleKit('deploy', makeReport()));
 
     expect(() => {
       JSON.parse(output);
     }).not.toThrow();
   });
 
-  it('returns granular summary counts for a single checklist', () => {
+  it('emits a payload its own published schema accepts', () => {
     const report = makeReport({
-      results: [makePassedResult({ name: 'a' }), makeFailedResult({ name: 'b' }), makeSkippedResult({ name: 'c' })],
+      results: [
+        makePassedResult({ name: 'a' }),
+        makeFailedResult({ name: 'b', fix: 'run install', detail: 'missing' }),
+        makeSkippedResult({ name: 'c' }),
+      ],
       passed: false,
       durationMs: 15,
     });
 
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
+    const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
 
-    expect(parsed).toMatchObject({
-      passed: 1,
-      errors: 1,
-      warnings: 0,
-      recommendations: 0,
-      blocked: 1,
-      optional: 0,
-      worstSeverity: 'error',
-    });
+    expect(() => ReportSchema.parse(parsed)).not.toThrow();
   });
 
-  it('aggregates granular counts across multiple checklists in a kit', () => {
-    const report1 = makeReport({
-      results: [makePassedResult({ name: 'a' }), makePassedResult({ name: 'b' })],
-      passed: true,
-      durationMs: 15,
-    });
-    const report2 = makeReport({
-      results: [makeFailedResult({ name: 'c' })],
-      passed: false,
-      durationMs: 3,
-    });
+  it('emits every level of a clean single-check run and nothing besides', () => {
+    const report = makeReport({ results: [makePassedResult({ name: 'a' })], passed: true, durationMs: 10 });
+    const counts = { ...NO_COUNTS, passed: 1 };
 
-    const parsed: unknown = JSON.parse(
-      formatJsonReport([
+    const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+    expect(parsed).toStrictEqual({
+      schemaVersion: 1,
+      readyupVersion: VERSION,
+      passed: true,
+      counts,
+      failOn: 'error',
+      reportOn: 'recommend',
+      detail: 'full',
+      durationMs: 10,
+      kits: [
         {
           name: 'deploy',
-          entries: [
-            { name: 'deploy', report: report1 },
-            { name: 'infra', report: report2 },
+          passed: true,
+          counts,
+          durationMs: 10,
+          checklists: [
+            {
+              name: 'deploy',
+              passed: true,
+              counts,
+              durationMs: 10,
+              checks: [{ name: 'a', status: 'passed', ok: true, severity: 'error', durationMs: 10 }],
+            },
           ],
         },
-      ]),
-    );
+      ],
+    });
+  });
 
-    expect(parsed).toMatchObject({
-      passed: 2,
-      errors: 1,
-      warnings: 0,
-      recommendations: 0,
-      blocked: 0,
-      optional: 0,
-      worstSeverity: 'error',
+  it('omits the checks property from a checklist that reported nothing', () => {
+    const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', makeReport())));
+
+    expect(parsed).toStrictEqual({
+      schemaVersion: 1,
+      readyupVersion: VERSION,
+      passed: true,
+      counts: NO_COUNTS,
+      failOn: 'error',
+      reportOn: 'recommend',
+      detail: 'full',
+      durationMs: 0,
       kits: [
         {
           name: 'deploy',
-          checklists: expect.arrayContaining([expect.anything(), expect.anything()]),
+          passed: true,
+          counts: NO_COUNTS,
+          durationMs: 0,
+          checklists: [{ name: 'deploy', passed: true, counts: NO_COUNTS, durationMs: 0 }],
         },
       ],
     });
   });
 
-  it('aggregates counts across multiple kits', () => {
-    const report1 = makeReport({
-      results: [makePassedResult({ name: 'a' })],
-      passed: true,
-      durationMs: 10,
-    });
-    const report2 = makeReport({
-      results: [makeFailedResult({ name: 'b' })],
-      passed: false,
-      durationMs: 5,
+  describe('provenance and echoed settings', () => {
+    it('stamps the schema version and the runner version', () => {
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', makeReport())));
+
+      expect(parsed).toMatchObject({ schemaVersion: 1, readyupVersion: VERSION });
     });
 
-    const parsed: unknown = JSON.parse(
-      formatJsonReport([
-        { name: 'kit1', entries: [{ name: 'check1', report: report1 }] },
-        { name: 'kit2', entries: [{ name: 'check2', report: report2 }] },
-      ]),
-    );
+    it('echoes the resolved thresholds and detail projection', () => {
+      const parsed: unknown = JSON.parse(
+        formatReport(singleKit('deploy', makeReport()), { failOn: 'warn', reportOn: 'error', detail: 'summary' }),
+      );
 
-    expect(parsed).toMatchObject({
-      passed: 1,
-      errors: 1,
-      worstSeverity: 'error',
-      kits: [
-        { name: 'kit1', passed: 1, errors: 0 },
-        { name: 'kit2', passed: 0, errors: 1 },
-      ],
+      expect(parsed).toMatchObject({ failOn: 'warn', reportOn: 'error', detail: 'summary' });
+    });
+
+    it('carries collected warnings alongside the results', () => {
+      const warnings = [{ code: 'version-skew' as const, message: 'kit is stale', remedy: 'Run `rdy compile`.' }];
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', makeReport()), { warnings }));
+
+      expect(parsed).toMatchObject({ warnings });
+    });
+
+    it('omits the warnings array entirely when the run produced none', () => {
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', makeReport())));
+
+      // The `warnings` count survives under `counts`; only the top-level advisory array goes away.
+      expect(parsed).not.toHaveProperty('warnings');
+      expect(parsed).toHaveProperty('counts.warnings', 0);
+    });
+  });
+
+  describe('run verdict', () => {
+    it('passes when every kit ran and no result failed', () => {
+      const report = makeReport({ results: [makePassedResult({ name: 'a' })], passed: true });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({ passed: true });
+    });
+
+    it('fails when a checklist reports a failure at or above the threshold', () => {
+      const report = makeReport({ results: [makeFailedResult({ name: 'a' })], passed: false });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({ passed: false, kits: [{ passed: false, checklists: [{ passed: false }] }] });
+    });
+
+    it('fails when a kit never ran, even though everything that ran passed', () => {
+      const ran = { name: 'deploy', entries: [{ name: 'check', report: makeReport({ passed: true }) }] };
+      const failed = { name: 'release', error: { code: 'kit-load' as const, message: 'Cannot find release.js' } };
+
+      const parsed: unknown = JSON.parse(formatReport([ran, failed]));
+
+      expect(parsed).toMatchObject({ passed: false });
+    });
+
+    it('holds a kit verdict that is false when any of its checklists failed', () => {
+      const kit = {
+        name: 'deploy',
+        entries: [
+          { name: 'clean', report: makeReport({ passed: true }) },
+          { name: 'dirty', report: makeReport({ passed: false }) },
+        ],
+      };
+
+      const parsed: unknown = JSON.parse(formatReport([kit]));
+
+      expect(parsed).toMatchObject({
+        kits: [{ passed: false, checklists: [{ passed: true }, { passed: false }] }],
+      });
+    });
+  });
+
+  describe('counts', () => {
+    it('nests granular counts under `counts` for a single checklist', () => {
+      const report = makeReport({
+        results: [makePassedResult({ name: 'a' }), makeFailedResult({ name: 'b' }), makeSkippedResult({ name: 'c' })],
+        passed: false,
+        durationMs: 15,
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({
+        counts: { passed: 1, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
+        worstSeverity: 'error',
+      });
+    });
+
+    it('aggregates counts across multiple checklists in a kit', () => {
+      const report1 = makeReport({
+        results: [makePassedResult({ name: 'a' }), makePassedResult({ name: 'b' })],
+        passed: true,
+        durationMs: 15,
+      });
+      const report2 = makeReport({ results: [makeFailedResult({ name: 'c' })], passed: false, durationMs: 3 });
+
+      const parsed: unknown = JSON.parse(
+        formatReport([
+          {
+            name: 'deploy',
+            entries: [
+              { name: 'deploy', report: report1 },
+              { name: 'infra', report: report2 },
+            ],
+          },
+        ]),
+      );
+
+      expect(parsed).toMatchObject({
+        counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 0, optional: 0 },
+        worstSeverity: 'error',
+        kits: [{ name: 'deploy', checklists: [{ name: 'deploy' }, { name: 'infra' }] }],
+      });
+    });
+
+    it('aggregates counts across multiple kits', () => {
+      const report1 = makeReport({ results: [makePassedResult({ name: 'a' })], passed: true, durationMs: 10 });
+      const report2 = makeReport({ results: [makeFailedResult({ name: 'b' })], passed: false, durationMs: 5 });
+
+      const parsed: unknown = JSON.parse(
+        formatReport([
+          { name: 'kit1', entries: [{ name: 'check1', report: report1 }] },
+          { name: 'kit2', entries: [{ name: 'check2', report: report2 }] },
+        ]),
+      );
+
+      expect(parsed).toMatchObject({
+        counts: { passed: 1, errors: 1 },
+        worstSeverity: 'error',
+        kits: [
+          { name: 'kit1', counts: { passed: 1, errors: 0 } },
+          { name: 'kit2', counts: { passed: 0, errors: 1 } },
+        ],
+      });
+    });
+
+    it('selects the highest severity across multiple failure buckets for worstSeverity', () => {
+      const report = makeReport({
+        results: [
+          makeFailedResult({ name: 'e', severity: 'error' }),
+          makeFailedResult({ name: 'w', severity: 'warn' }),
+          makeFailedResult({ name: 'r', severity: 'recommend' }),
+        ],
+        passed: false,
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({
+        counts: { errors: 1, warnings: 1, recommendations: 1 },
+        worstSeverity: 'error',
+      });
+    });
+
+    it('distinguishes blocked skips from optional skips', () => {
+      const report = makeReport({
+        results: [
+          makeSkippedResult({ name: 'pre', skipReason: 'precondition' }),
+          makeSkippedResult({ name: 'na', skipReason: 'n/a' }),
+        ],
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({ counts: { blocked: 1, optional: 1 } });
+    });
+
+    it('counts all results across nesting levels', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'parent', depth: 0 }),
+          makePassedResult({ name: 'child-pass', depth: 1 }),
+          makeFailedResult({ name: 'child-fail', depth: 1 }),
+          makeSkippedResult({ name: 'child-skip', depth: 1 }),
+        ],
+        passed: false,
+        durationMs: 30,
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({
+        counts: { passed: 2, errors: 1, blocked: 1 },
+        worstSeverity: 'error',
+        kits: [{ checklists: [{ counts: { passed: 2, errors: 1, blocked: 1 }, worstSeverity: 'error' }] }],
+      });
+    });
+  });
+
+  describe('slimming', () => {
+    it('omits worstSeverity at every level when nothing failed', () => {
+      const report = makeReport({ results: [makePassedResult({ name: 'a' })], passed: true, durationMs: 10 });
+
+      const output = formatReport(singleKit('deploy', report));
+
+      expect(output).not.toContain('worstSeverity');
+    });
+
+    it('emits fix on a failed check and withholds it from a passed one', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'clean', fix: 'never needed' }),
+          makeFailedResult({ name: 'broken', fix: 'run install' }),
+        ],
+        passed: false,
+      });
+
+      const output = formatReport(singleKit('deploy', report));
+
+      expect(output).toContain('run install');
+      expect(output).not.toContain('never needed');
+    });
+
+    it('rounds every duration to whole milliseconds', () => {
+      const report = makeReport({
+        results: [makePassedResult({ name: 'a', durationMs: 3.6 })],
+        passed: true,
+        durationMs: 12.4,
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({
+        durationMs: 12,
+        kits: [{ durationMs: 12, checklists: [{ durationMs: 12, checks: [{ durationMs: 4 }] }] }],
+      });
+    });
+  });
+
+  describe('check entries', () => {
+    it('carries severity, ok, and skipReason where each applies', () => {
+      const report = makeReport({
+        results: [
+          makePassedResult({ name: 'a', severity: 'warn', durationMs: 1 }),
+          makeFailedResult({ name: 'b', severity: 'error', durationMs: 2 }),
+          makeSkippedResult({ name: 'c', severity: 'recommend', skipReason: 'n/a' }),
+        ],
+        passed: false,
+        durationMs: 15,
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({
+        kits: [
+          {
+            checklists: [
+              {
+                checks: [
+                  { name: 'a', status: 'passed', ok: true, severity: 'warn', durationMs: 1 },
+                  { name: 'b', status: 'failed', ok: false, severity: 'error', durationMs: 2 },
+                  { name: 'c', status: 'skipped', ok: null, severity: 'recommend', skipReason: 'n/a' },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('withholds skipReason from a check that ran', () => {
+      const report = makeReport({ results: [makePassedResult({ name: 'a' })], passed: true });
+
+      const output = formatReport(singleKit('deploy', report));
+
+      expect(output).not.toContain('skipReason');
+    });
+
+    it('serializes error as a string message', () => {
+      const report = makeReport({
+        results: [makeFailedResult({ name: 'a', error: new Error('connection refused') })],
+        passed: false,
+        durationMs: 5,
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({
+        kits: [{ checklists: [{ checks: [{ error: 'connection refused' }] }] }],
+      });
+    });
+
+    it('includes optional fields when present', () => {
+      const report = makeReport({
+        results: [
+          makeFailedResult({
+            name: 'a',
+            fix: 'run npm install',
+            detail: 'missing dependency',
+            progress: { type: 'fraction', passedCount: 3, count: 5 },
+          }),
+        ],
+        passed: false,
+        durationMs: 10,
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({
+        kits: [
+          {
+            checklists: [
+              {
+                checks: [
+                  {
+                    fix: 'run npm install',
+                    detail: 'missing dependency',
+                    progress: { type: 'fraction', passedCount: 3, count: 5 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('serializes percent-based progress', () => {
+      const report = makeReport({
+        results: [makePassedResult({ name: 'a', progress: { type: 'percent', percent: 75 } })],
+        passed: true,
+        durationMs: 10,
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({
+        kits: [{ checklists: [{ checks: [{ progress: { type: 'percent', percent: 75 } }] }] }],
+      });
     });
   });
 
@@ -171,289 +496,21 @@ describe(formatJsonReport, () => {
     }
 
     it('passes a failed kit through carrying only its name and error', () => {
-      const parsed: unknown = JSON.parse(formatJsonReport([FAILURE]));
+      const parsed: unknown = JSON.parse(formatReport([FAILURE]));
 
-      expect(parsed).toStrictEqual({
-        passed: 0,
-        errors: 0,
-        warnings: 0,
-        recommendations: 0,
-        blocked: 0,
-        optional: 0,
-        worstSeverity: null,
-        durationMs: 0,
-        kits: [FAILURE],
-      });
+      expect(parsed).toMatchObject({ counts: NO_COUNTS, durationMs: 0, kits: [FAILURE] });
     });
 
     it('keeps kits in the order they were requested', () => {
-      const parsed: unknown = JSON.parse(formatJsonReport([ranKit('first'), FAILURE, ranKit('last')]));
+      const parsed: unknown = JSON.parse(formatReport([ranKit('first'), FAILURE, ranKit('last')]));
 
-      expect(parsed).toMatchObject({
-        kits: [{ name: 'first' }, { name: 'release' }, { name: 'last' }],
-      });
+      expect(parsed).toMatchObject({ kits: [{ name: 'first' }, { name: 'release' }, { name: 'last' }] });
     });
 
     it('leaves top-level counts and duration to the kits that ran', () => {
-      const parsed: unknown = JSON.parse(formatJsonReport([ranKit('deploy'), FAILURE]));
+      const parsed: unknown = JSON.parse(formatReport([ranKit('deploy'), FAILURE]));
 
-      expect(parsed).toMatchObject({
-        passed: 1,
-        errors: 0,
-        warnings: 0,
-        recommendations: 0,
-        blocked: 0,
-        optional: 0,
-        worstSeverity: null,
-        durationMs: 10,
-      });
-    });
-  });
-
-  it('includes granular checklist-level counts and null worstSeverity when all passed', () => {
-    const report = makeReport({
-      results: [makePassedResult({ name: 'a' })],
-      passed: true,
-      durationMs: 10,
-    });
-
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-    expect(parsed).toMatchObject({
-      kits: [
-        {
-          name: 'deploy',
-          checklists: [
-            {
-              name: 'deploy',
-              passed: 1,
-              errors: 0,
-              warnings: 0,
-              recommendations: 0,
-              blocked: 0,
-              optional: 0,
-              worstSeverity: null,
-              durationMs: 10,
-            },
-          ],
-        },
-      ],
-    });
-  });
-
-  it('sets worstSeverity to null when checks are skipped but none failed', () => {
-    const report = makeReport({
-      results: [makeSkippedResult({ name: 'a' }), makeSkippedResult({ name: 'b' })],
-      passed: true,
-      durationMs: 0,
-    });
-
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-    expect(parsed).toMatchObject({
-      passed: 0,
-      errors: 0,
-      warnings: 0,
-      recommendations: 0,
-      blocked: 2,
-      optional: 0,
-      worstSeverity: null,
-    });
-  });
-
-  it('emits the expected top-level shape with kits array', () => {
-    const report = makeReport({
-      results: [makePassedResult({ name: 'a' })],
-      passed: true,
-      durationMs: 10,
-    });
-
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-    if (typeof parsed !== 'object' || parsed === null) throw new Error('expected object');
-    const topLevelKeys = Object.keys(parsed).toSorted();
-
-    expect(topLevelKeys).toStrictEqual([
-      'blocked',
-      'durationMs',
-      'errors',
-      'kits',
-      'optional',
-      'passed',
-      'recommendations',
-      'warnings',
-      'worstSeverity',
-    ]);
-  });
-
-  it('selects the highest severity across multiple failure buckets for worstSeverity', () => {
-    const report = makeReport({
-      results: [
-        makeFailedResult({ name: 'e', severity: 'error' }),
-        makeFailedResult({ name: 'w', severity: 'warn' }),
-        makeFailedResult({ name: 'r', severity: 'recommend' }),
-      ],
-      passed: false,
-      durationMs: 0,
-    });
-
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-    expect(parsed).toMatchObject({
-      errors: 1,
-      warnings: 1,
-      recommendations: 1,
-      worstSeverity: 'error',
-    });
-  });
-
-  it('distinguishes blocked skips from optional skips', () => {
-    const report = makeReport({
-      results: [
-        makeSkippedResult({ name: 'pre', skipReason: 'precondition' }),
-        makeSkippedResult({ name: 'na', skipReason: 'n/a' }),
-      ],
-      passed: true,
-      durationMs: 0,
-    });
-
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-    expect(parsed).toMatchObject({
-      blocked: 1,
-      optional: 1,
-    });
-  });
-
-  it('serializes error as a string message', () => {
-    const report = makeReport({
-      results: [makeFailedResult({ name: 'a', error: new Error('connection refused') })],
-      passed: false,
-      durationMs: 5,
-    });
-
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-    expect(parsed).toMatchObject({
-      kits: [{ checklists: [{ checks: [{ error: 'connection refused' }] }] }],
-    });
-  });
-
-  it('includes all fields as non-optional (null, not absent)', () => {
-    const report = makeReport({
-      results: [makePassedResult({ name: 'a' })],
-      passed: true,
-      durationMs: 10,
-    });
-
-    const output = formatJsonReport(singleKit('deploy', report));
-    const parsed: unknown = JSON.parse(output);
-
-    expect(parsed).toMatchObject({
-      kits: [
-        {
-          checklists: [
-            {
-              checks: [
-                {
-                  name: 'a',
-                  status: 'passed',
-                  ok: true,
-                  severity: 'error',
-                  skipReason: null,
-                  detail: null,
-                  fix: null,
-                  error: null,
-                  progress: null,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
-  });
-
-  it('includes severity, ok, and skipReason on every check entry', () => {
-    const report = makeReport({
-      results: [
-        makePassedResult({ name: 'a', severity: 'warn' }),
-        makeFailedResult({ name: 'b', severity: 'error' }),
-        makeSkippedResult({ name: 'c', severity: 'recommend', skipReason: 'n/a' }),
-      ],
-      passed: false,
-      durationMs: 15,
-    });
-
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-    expect(parsed).toMatchObject({
-      kits: [
-        {
-          checklists: [
-            {
-              checks: [
-                { severity: 'warn', ok: true, skipReason: null },
-                { severity: 'error', ok: false, skipReason: null },
-                { severity: 'recommend', ok: null, skipReason: 'n/a' },
-              ],
-            },
-          ],
-        },
-      ],
-    });
-  });
-
-  it('includes optional fields when present', () => {
-    const report = makeReport({
-      results: [
-        makeFailedResult({
-          name: 'a',
-          fix: 'run npm install',
-          detail: 'missing dependency',
-          progress: { type: 'fraction', passedCount: 3, count: 5 },
-        }),
-      ],
-      passed: false,
-      durationMs: 10,
-    });
-
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-    expect(parsed).toMatchObject({
-      kits: [
-        {
-          checklists: [
-            {
-              checks: [
-                {
-                  fix: 'run npm install',
-                  detail: 'missing dependency',
-                  progress: { type: 'fraction', passedCount: 3, count: 5 },
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
-  });
-
-  it('serializes percent-based progress', () => {
-    const report = makeReport({
-      results: [
-        makePassedResult({
-          name: 'a',
-          progress: { type: 'percent', percent: 75 },
-        }),
-      ],
-      passed: true,
-      durationMs: 10,
-    });
-
-    const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-    expect(parsed).toMatchObject({
-      kits: [{ checklists: [{ checks: [{ progress: { type: 'percent', percent: 75 } }] }] }],
+      expect(parsed).toMatchObject({ counts: { ...NO_COUNTS, passed: 1 }, durationMs: 10 });
     });
   });
 
@@ -465,37 +522,10 @@ describe(formatJsonReport, () => {
         durationMs: 20,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
-        kits: [
-          {
-            checklists: [
-              {
-                checks: [
-                  {
-                    name: 'parent',
-                    checks: [{ name: 'child', checks: [] }],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it('places depth-0 result at the top level of the tree', () => {
-      const report = makeReport({
-        results: [makePassedResult({ name: 'top-check', depth: 0 })],
-        passed: true,
-        durationMs: 10,
-      });
-
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-      expect(parsed).toMatchObject({
-        kits: [{ checklists: [{ checks: [{ name: 'top-check', checks: [] }] }] }],
+        kits: [{ checklists: [{ checks: [{ name: 'parent', checks: [{ name: 'child' }] }] }] }],
       });
     });
 
@@ -512,7 +542,7 @@ describe(formatJsonReport, () => {
         durationMs: 50,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
         kits: [
@@ -520,89 +550,13 @@ describe(formatJsonReport, () => {
             checklists: [
               {
                 checks: [
-                  {
-                    name: 'A',
-                    checks: [
-                      { name: 'A1', checks: [] },
-                      { name: 'A2', checks: [] },
-                    ],
-                  },
-                  {
-                    name: 'B',
-                    checks: [{ name: 'B1', checks: [] }],
-                  },
+                  { name: 'A', checks: [{ name: 'A1' }, { name: 'A2' }] },
+                  { name: 'B', checks: [{ name: 'B1' }] },
                 ],
               },
             ],
           },
         ],
-      });
-    });
-
-    it('produces empty checks array for leaf entries', () => {
-      const report = makeReport({
-        results: [makePassedResult({ name: 'leaf', depth: 0 })],
-        passed: true,
-        durationMs: 10,
-      });
-
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-      expect(parsed).toMatchObject({
-        kits: [{ checklists: [{ checks: [{ name: 'leaf', checks: [] }] }] }],
-      });
-    });
-
-    it('includes n/a subtrees in JSON output', () => {
-      const report = makeReport({
-        results: [
-          makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
-          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 1 }),
-        ],
-        passed: true,
-        durationMs: 0,
-      });
-
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-      expect(parsed).toMatchObject({
-        kits: [
-          {
-            checklists: [
-              {
-                checks: [
-                  {
-                    name: 'na-parent',
-                    checks: [{ name: 'na-child' }],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      });
-    });
-
-    it('counts all results across nesting levels in granular summary', () => {
-      const report = makeReport({
-        results: [
-          makePassedResult({ name: 'parent', depth: 0 }),
-          makePassedResult({ name: 'child-pass', depth: 1 }),
-          makeFailedResult({ name: 'child-fail', depth: 1 }),
-          makeSkippedResult({ name: 'child-skip', depth: 1 }),
-        ],
-        passed: false,
-        durationMs: 30,
-      });
-
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
-
-      expect(parsed).toMatchObject({
-        passed: 2,
-        errors: 1,
-        blocked: 1,
-        worstSeverity: 'error',
-        kits: [{ checklists: [{ passed: 2, errors: 1, blocked: 1, worstSeverity: 'error' }] }],
       });
     });
 
@@ -617,28 +571,26 @@ describe(formatJsonReport, () => {
         durationMs: 30,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report)));
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
 
       expect(parsed).toMatchObject({
-        kits: [
-          {
-            checklists: [
-              {
-                checks: [
-                  {
-                    name: 'L0',
-                    checks: [
-                      {
-                        name: 'L1',
-                        checks: [{ name: 'L2', checks: [] }],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
+        kits: [{ checklists: [{ checks: [{ name: 'L0', checks: [{ name: 'L1', checks: [{ name: 'L2' }] }] }] }] }],
+      });
+    });
+
+    it('includes n/a subtrees in JSON output', () => {
+      const report = makeReport({
+        results: [
+          makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
+          makeSkippedResult({ name: 'na-child', skipReason: 'n/a', depth: 1 }),
         ],
+        passed: true,
+      });
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report)));
+
+      expect(parsed).toMatchObject({
+        kits: [{ checklists: [{ checks: [{ name: 'na-parent', checks: [{ name: 'na-child' }] }] }] }],
       });
     });
   });
@@ -654,11 +606,9 @@ describe(formatJsonReport, () => {
         durationMs: 20,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report), { reportOn: 'error' }));
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report), { reportOn: 'error' }));
 
-      expect(parsed).toMatchObject({
-        kits: [{ checklists: [{ checks: [{ name: 'error-check' }] }] }],
-      });
+      expect(parsed).toMatchObject({ kits: [{ checklists: [{ checks: [{ name: 'error-check' }] }] }] });
     });
 
     it('counts every result in granular buckets, including results pruned from the tree', () => {
@@ -671,15 +621,10 @@ describe(formatJsonReport, () => {
         durationMs: 15,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report), { reportOn: 'error' }));
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report), { reportOn: 'error' }));
 
       expect(parsed).toMatchObject({
-        passed: 1,
-        errors: 0,
-        warnings: 0,
-        recommendations: 1,
-        blocked: 0,
-        optional: 0,
+        counts: { passed: 1, errors: 0, warnings: 0, recommendations: 1, blocked: 0, optional: 0 },
         worstSeverity: 'recommend',
       });
     });
@@ -694,14 +639,115 @@ describe(formatJsonReport, () => {
         durationMs: 15,
       });
 
-      const parsed: unknown = JSON.parse(formatJsonReport(singleKit('deploy', report), { reportOn: 'error' }));
+      const output = formatReport(singleKit('deploy', report), { reportOn: 'error' });
+      const parsed: unknown = JSON.parse(output);
 
       expect(parsed).toMatchObject({
-        warnings: 1,
+        counts: { warnings: 1 },
         worstSeverity: 'warn',
-        kits: [{ warnings: 1, checklists: [{ warnings: 1, checks: [{ name: 'error-pass' }] }] }],
+        kits: [
+          {
+            counts: { warnings: 1 },
+            checklists: [{ counts: { warnings: 1 }, checks: [{ name: 'error-pass' }] }],
+          },
+        ],
       });
-      expect(JSON.stringify(parsed)).not.toContain('warn-fail');
+      expect(output).not.toContain('warn-fail');
+    });
+  });
+
+  describe('detail projection', () => {
+    const report = makeReport({
+      results: [
+        makePassedResult({ name: 'clean', depth: 0 }),
+        makeFailedResult({ name: 'broken', fix: 'run install', detail: 'missing dependency', depth: 0 }),
+        makeFailedResult({ name: 'nested-break', fix: 'rebuild', depth: 1 }),
+        makeSkippedResult({ name: 'blocked', depth: 0 }),
+      ],
+      passed: false,
+      durationMs: 20,
+    });
+
+    it('keeps every result in the tree under `full`', () => {
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report), { detail: 'full' }));
+
+      expect(parsed).toMatchObject({
+        kits: [
+          {
+            checklists: [
+              {
+                checks: [
+                  { name: 'clean' },
+                  { name: 'broken', detail: 'missing dependency', checks: [{ name: 'nested-break' }] },
+                  { name: 'blocked' },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('reduces the tree to failed checks and their fixes under `summary`', () => {
+      const counts = { passed: 1, errors: 2, warnings: 0, recommendations: 0, blocked: 1, optional: 0 };
+
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report), { detail: 'summary' }));
+
+      expect(parsed).toStrictEqual({
+        schemaVersion: 1,
+        readyupVersion: VERSION,
+        passed: false,
+        counts,
+        worstSeverity: 'error',
+        failOn: 'error',
+        reportOn: 'recommend',
+        detail: 'summary',
+        durationMs: 20,
+        kits: [
+          {
+            name: 'deploy',
+            passed: false,
+            counts,
+            worstSeverity: 'error',
+            durationMs: 20,
+            checklists: [
+              {
+                name: 'deploy',
+                passed: false,
+                counts,
+                worstSeverity: 'error',
+                durationMs: 20,
+                checks: [
+                  { name: 'broken', status: 'failed', ok: false, severity: 'error', durationMs: 5, fix: 'run install' },
+                  {
+                    name: 'nested-break',
+                    status: 'failed',
+                    ok: false,
+                    severity: 'error',
+                    durationMs: 5,
+                    fix: 'rebuild',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('omits the checks property when no check failed', () => {
+      const clean = makeReport({ results: [makePassedResult({ name: 'a' })], passed: true });
+
+      const output = formatReport(singleKit('deploy', clean), { detail: 'summary' });
+
+      expect(output).not.toContain('checks');
+    });
+
+    it('produces a payload the schema accepts in both projections', () => {
+      for (const detail of ['full', 'summary'] as const) {
+        const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', report), { detail }));
+        expect(() => ReportSchema.parse(parsed)).not.toThrow();
+      }
     });
   });
 });

--- a/packages/readyup/__tests__/helpers/formatReport.ts
+++ b/packages/readyup/__tests__/helpers/formatReport.ts
@@ -1,0 +1,11 @@
+import { formatJsonReport, type FormatJsonReportOptions, type KitInput } from '../../src/formatJsonReport.ts';
+
+/**
+ * Serialize a report with the run settings a bare `rdy run --json` would resolve.
+ *
+ * The serializer takes these as required values because no unresolved state reaches it; tests that
+ * are not about the settings themselves say so by omitting the override.
+ */
+export function formatReport(kitInputs: KitInput[], overrides: Partial<FormatJsonReportOptions> = {}): string {
+  return formatJsonReport(kitInputs, { detail: 'full', failOn: 'error', reportOn: 'recommend', ...overrides });
+}

--- a/packages/readyup/__tests__/helpers/formatReport.ts
+++ b/packages/readyup/__tests__/helpers/formatReport.ts
@@ -1,11 +1,34 @@
-import { formatJsonReport, type FormatJsonReportOptions, type KitInput } from '../../src/formatJsonReport.ts';
+import {
+  formatJsonReport,
+  type FormatJsonReportOptions,
+  type KitInput,
+  type KitResultInput,
+} from '../../src/formatJsonReport.ts';
+import type { JsonKitErrorEntry } from '../../src/schemas/index.ts';
+
+/** A kit input as a test writes it: thresholds optional, filled in from the invocation's flags. */
+export type TestKitInput =
+  | JsonKitErrorEntry
+  | (Omit<KitResultInput, 'failOn' | 'reportOn'> & Partial<Pick<KitResultInput, 'failOn' | 'reportOn'>>);
 
 /**
- * Serialize a report with the run settings a bare `rdy run --json` would resolve.
+ * Serialize a report the way the CLI would for an invocation carrying the given flags.
  *
- * The serializer takes these as required values because no unresolved state reaches it; tests that
- * are not about the settings themselves say so by omitting the override.
+ * An override stands in for its CLI flag: it reaches the top level only when supplied, and resolves
+ * against the default to give each kit the threshold that governs it. A kit input that names its own
+ * thresholds keeps them, which is how a test expresses a kit that declared one for itself.
  */
-export function formatReport(kitInputs: KitInput[], overrides: Partial<FormatJsonReportOptions> = {}): string {
-  return formatJsonReport(kitInputs, { detail: 'full', failOn: 'error', reportOn: 'recommend', ...overrides });
+export function formatReport(kitInputs: TestKitInput[], overrides: Partial<FormatJsonReportOptions> = {}): string {
+  const { detail = 'full', failOn, reportOn, ...rest } = overrides;
+
+  const resolved: KitInput[] = kitInputs.map((input) =>
+    'error' in input ? input : { failOn: failOn ?? 'error', reportOn: reportOn ?? 'recommend', ...input },
+  );
+
+  return formatJsonReport(resolved, {
+    detail,
+    ...(failOn !== undefined && { failOn }),
+    ...(reportOn !== undefined && { reportOn }),
+    ...rest,
+  });
 }

--- a/packages/readyup/__tests__/helpers/payloadFixtures.ts
+++ b/packages/readyup/__tests__/helpers/payloadFixtures.ts
@@ -85,6 +85,17 @@ export const minimalReportPayload = {
   kits: [],
 };
 
+/**
+ * A report carrying an advisory this readyup does not know about.
+ *
+ * Stands in for a payload from a later version: the open warning-code set is what keeps a consumer
+ * pinned to `report.v1.json` validating it rather than rejecting it.
+ */
+export const unknownWarningReportPayload = {
+  ...minimalReportPayload,
+  warnings: [{ code: 'kit-deprecated', message: 'kit uses a retired API', remedy: 'Regenerate the kit.' }],
+};
+
 export const errorEnvelopePayload = {
   schemaVersion: 1,
   error: { code: 'usage', message: "Unknown option '--bogus'" },

--- a/packages/readyup/__tests__/helpers/payloadFixtures.ts
+++ b/packages/readyup/__tests__/helpers/payloadFixtures.ts
@@ -1,0 +1,108 @@
+/**
+ * Representative payloads for each published JSON contract.
+ *
+ * Shared by the zod-schema suite and the generated-JSON-Schema suite so both judge the same
+ * documents: a payload the zod schema accepts but the published schema rejects is exactly the
+ * divergence the generation step could introduce.
+ */
+
+/** A report exercising every optional field, three levels of nesting, and both kit-entry shapes. */
+export const reportPayload = {
+  schemaVersion: 1,
+  readyupVersion: '0.21.2',
+  passed: false,
+  counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
+  worstSeverity: 'error',
+  failOn: 'error',
+  reportOn: 'recommend',
+  detail: 'full',
+  durationMs: 42,
+  warnings: [{ code: 'version-skew', message: 'kit is stale', remedy: 'Run `rdy compile` to refresh.' }],
+  kits: [
+    {
+      name: 'deploy',
+      passed: false,
+      counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
+      worstSeverity: 'error',
+      durationMs: 42,
+      checklists: [
+        {
+          name: 'preflight',
+          passed: false,
+          counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
+          worstSeverity: 'error',
+          durationMs: 42,
+          checks: [
+            {
+              name: 'gate',
+              status: 'passed',
+              ok: true,
+              severity: 'error',
+              durationMs: 3,
+              progress: { type: 'fraction', passedCount: 3, count: 5 },
+              checks: [
+                {
+                  name: 'child',
+                  status: 'failed',
+                  ok: false,
+                  severity: 'error',
+                  durationMs: 1,
+                  detail: 'missing dependency',
+                  fix: 'run install',
+                  error: 'ENOENT',
+                  checks: [{ name: 'grandchild', status: 'skipped', ok: null, severity: 'error', durationMs: 0 }],
+                },
+              ],
+            },
+            { name: 'optional', status: 'skipped', ok: null, severity: 'warn', durationMs: 0, skipReason: 'n/a' },
+          ],
+        },
+      ],
+    },
+    { name: 'release', error: { code: 'kit-load', message: 'Cannot find release.js' } },
+  ],
+};
+
+/** The smallest report the schema accepts: every optional field absent. */
+export const minimalReportPayload = {
+  schemaVersion: 1,
+  readyupVersion: '0.21.2',
+  passed: true,
+  counts: { passed: 0, errors: 0, warnings: 0, recommendations: 0, blocked: 0, optional: 0 },
+  failOn: 'error',
+  reportOn: 'recommend',
+  detail: 'summary',
+  durationMs: 0,
+  kits: [],
+};
+
+export const errorEnvelopePayload = {
+  schemaVersion: 1,
+  error: { code: 'usage', message: "Unknown option '--bogus'" },
+};
+
+export const listPayload = {
+  schemaVersion: 1,
+  kits: [
+    { name: 'deploy', kind: 'compiled', path: 'deploy.js', readyupVersion: '0.21.2', checklists: ['preflight'] },
+    { name: 'draft', kind: 'internal' },
+  ],
+};
+
+export const verifyPayload = {
+  schemaVersion: 1,
+  passed: false,
+  kits: [
+    { name: 'deploy', status: 'ok' },
+    { name: 'release', status: 'drift', expected: 'abc123', actual: 'def456' },
+  ],
+};
+
+export const compilePayload = {
+  schemaVersion: 1,
+  passed: false,
+  kits: [
+    { name: 'deploy', status: 'compiled' },
+    { name: 'release', status: 'failed', error: 'Kit must export a default RdyKit' },
+  ],
+};

--- a/packages/readyup/__tests__/helpers/payloadFixtures.ts
+++ b/packages/readyup/__tests__/helpers/payloadFixtures.ts
@@ -6,7 +6,12 @@
  * divergence the generation step could introduce.
  */
 
-/** A report exercising every optional field, three levels of nesting, and both kit-entry shapes. */
+/**
+ * A report exercising every optional field, three levels of nesting, and both kit-entry shapes.
+ *
+ * The kit's effective `failOn` differs from the requested one, which is the case the split exists
+ * for: a kit declaring its own threshold cannot be described by the run-level value.
+ */
 export const reportPayload = {
   schemaVersion: 1,
   readyupVersion: '0.21.2',
@@ -24,6 +29,8 @@ export const reportPayload = {
       passed: false,
       counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
       worstSeverity: 'error',
+      failOn: 'warn',
+      reportOn: 'recommend',
       durationMs: 42,
       checklists: [
         {
@@ -63,14 +70,16 @@ export const reportPayload = {
   ],
 };
 
-/** The smallest report the schema accepts: every optional field absent. */
+/**
+ * The smallest report the schema accepts: every optional field absent.
+ *
+ * The thresholds are among them, since a bare invocation requests neither.
+ */
 export const minimalReportPayload = {
   schemaVersion: 1,
   readyupVersion: '0.21.2',
   passed: true,
   counts: { passed: 0, errors: 0, warnings: 0, recommendations: 0, blocked: 0, optional: 0 },
-  failOn: 'error',
-  reportOn: 'recommend',
   detail: 'summary',
   durationMs: 0,
   kits: [],

--- a/packages/readyup/__tests__/list/listCommand.integration.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.integration.test.ts
@@ -1,0 +1,150 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { listCommand } from '../../src/list/listCommand.ts';
+import { ListOutputSchema } from '../../src/schemas/index.ts';
+import { captureRdyError } from '../helpers/captureRdyError.ts';
+
+/**
+ * Integration test: exercises `listCommand` against real directories, without mocking the manifest
+ * reader or the filesystem enumerator. The unit tests cover each mode's branches; this locks in the
+ * wiring the manifest-less fallback depends on — that `list --from` looks where `run --from` loads.
+ */
+describe('listCommand (integration)', () => {
+  let tempDir: string;
+  let stdout: string[];
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'list-integ-'));
+    stdout = [];
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /** Create a kit directory holding compiled kits, with no manifest beside them. */
+  function writeKitsDir(dirName: string, kitNames: string[]): string {
+    const dir = path.join(tempDir, dirName);
+    mkdirSync(dir, { recursive: true });
+    for (const name of kitNames) {
+      writeFileSync(path.join(dir, `${name}.js`), 'export default { checklists: [] };\n');
+    }
+    return dir;
+  }
+
+  describe('--from fallback when no manifest is present', () => {
+    it('lists the compiled kits on disk in human mode', async () => {
+      writeKitsDir('kits', ['alpha', 'beta']);
+
+      const exitCode = await listCommand(['--from', 'dir:kits']);
+
+      expect(exitCode).toBe(0);
+      expect(stdout.join('')).toContain('alpha');
+      expect(stdout.join('')).toContain('beta');
+    });
+
+    it('lists them in JSON mode with a name and a path and nothing the manifest would have added', async () => {
+      writeKitsDir('kits', ['alpha']);
+
+      const exitCode = await listCommand(['--from', 'dir:kits', '--json']);
+
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(stdout.join(''))).toStrictEqual({
+        schemaVersion: 1,
+        kits: [{ name: 'alpha', kind: 'compiled', path: path.join('kits', 'alpha.js') }],
+      });
+    });
+
+    it('resolves a local repo path to the same directory run --from would load from', async () => {
+      writeKitsDir(path.join('repo', '.readyup', 'kits'), ['deploy']);
+
+      await listCommand(['--from', 'repo', '--json']);
+
+      expect(JSON.parse(stdout.join(''))).toMatchObject({
+        kits: [{ name: 'deploy', path: path.join('repo', '.readyup', 'kits', 'deploy.js') }],
+      });
+    });
+
+    it('ignores files that are not compiled kits', async () => {
+      const dir = writeKitsDir('kits', ['alpha']);
+      writeFileSync(path.join(dir, 'notes.md'), '# not a kit\n');
+      writeFileSync(path.join(dir, 'alpha.ts'), 'export default {};\n');
+
+      await listCommand(['--from', 'dir:kits', '--json']);
+
+      expect(JSON.parse(stdout.join(''))).toMatchObject({ kits: [{ name: 'alpha' }] });
+    });
+
+    it('reports a source with neither a manifest nor a kit directory as a config error', async () => {
+      const error = await captureRdyError(() => listCommand(['--from', 'dir:absent']));
+
+      expect(error.code).toBe('config');
+      expect(error.message).toContain('no kit directory');
+    });
+  });
+
+  describe('--from with a manifest present', () => {
+    it('prefers the manifest and carries the fields only it knows', async () => {
+      writeKitsDir('kits', ['deploy']);
+      writeFileSync(
+        path.join(tempDir, 'kits', 'manifest.json'),
+        JSON.stringify({
+          version: 1,
+          kits: [
+            {
+              name: 'deploy',
+              path: 'deploy.js',
+              checklists: ['preflight', 'release'],
+              description: 'Deploy checks',
+              readyupVersion: '0.21.2',
+            },
+          ],
+        }),
+      );
+
+      await listCommand(['--from', 'dir:kits', '--json']);
+
+      expect(JSON.parse(stdout.join(''))).toStrictEqual({
+        schemaVersion: 1,
+        kits: [
+          {
+            name: 'deploy',
+            kind: 'compiled',
+            path: path.join('kits', 'deploy.js'),
+            checklists: ['preflight', 'release'],
+            description: 'Deploy checks',
+            readyupVersion: '0.21.2',
+          },
+        ],
+      });
+    });
+  });
+
+  describe('stdout purity', () => {
+    it('emits exactly one JSON document and sends the human view to stderr', async () => {
+      writeKitsDir('kits', ['alpha']);
+
+      await listCommand(['--from', 'dir:kits', '--json']);
+
+      expect(stdoutSpy).toHaveBeenCalledTimes(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('alpha'));
+      expect(() => ListOutputSchema.parse(JSON.parse(stdout.join('')))).not.toThrow();
+    });
+  });
+});

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -262,6 +262,68 @@ describe(listCommand, () => {
     });
   });
 
+  describe('--json', () => {
+    /** Read the single JSON document the command wrote to stdout. */
+    function parseStdout(): unknown {
+      return JSON.parse(stdoutSpy.mock.calls.map((c) => String(c[0])).join(''));
+    }
+
+    it('distinguishes internal sources from compiled kits in owner mode', async () => {
+      mockEnumerateKits.mockReturnValue(['draft']);
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'deploy', path: 'kits/deploy.js', checklists: ['preflight'] }],
+      });
+
+      const exitCode = await listCommand(['--json']);
+
+      expect(exitCode).toBe(0);
+      expect(parseStdout()).toMatchObject({
+        schemaVersion: 1,
+        kits: [
+          { name: 'draft', kind: 'internal', path: expect.stringContaining('draft.ts') },
+          { name: 'deploy', kind: 'compiled', checklists: ['preflight'] },
+        ],
+      });
+    });
+
+    it('sends the human view to stderr so stdout carries one document', async () => {
+      mockEnumerateKits.mockReturnValue(['draft']);
+      mockReadManifest.mockReturnValue({ version: 1, kits: [] });
+
+      await listCommand(['--json']);
+
+      expect(stdoutSpy).toHaveBeenCalledTimes(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Internal:'));
+    });
+
+    it('reports an empty kit list rather than the empty-owner prose', async () => {
+      mockEnumerateKits.mockReturnValue([]);
+      mockReadManifest.mockImplementation(() => {
+        throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
+      });
+
+      await listCommand(['--json']);
+
+      expect(parseStdout()).toStrictEqual({ schemaVersion: 1, kits: [] });
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('No kits found.'));
+    });
+
+    it('carries the manifest fields in manifest mode', async () => {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'deploy', description: 'Deploy checks', readyupVersion: '0.21.2' }],
+      });
+
+      await listCommand(['--manifest', '.readyup/manifest.json', '--json']);
+
+      expect(parseStdout()).toStrictEqual({
+        schemaVersion: 1,
+        kits: [{ name: 'deploy', kind: 'compiled', description: 'Deploy checks', readyupVersion: '0.21.2' }],
+      });
+    });
+  });
+
   it('reports a usage error for unknown flags', async () => {
     const error = await captureRdyError(() => listCommand(['--unknown']));
 

--- a/packages/readyup/__tests__/partialResults.test.ts
+++ b/packages/readyup/__tests__/partialResults.test.ts
@@ -60,9 +60,9 @@ describe('partial results when a kit fails after dispatch', () => {
       expect(exitCode).toBe(2);
       expect(JSON.parse(readStdout())).toMatchObject({
         kits: [
-          { name: 'passing', passed: 1, errors: 0 },
+          { name: 'passing', passed: true, counts: { passed: 1, errors: 0 } },
           { name: 'absent', error: { code: 'kit-load', message: expect.any(String) } },
-          { name: 'failing', passed: 0, errors: 1 },
+          { name: 'failing', passed: false, counts: { passed: 0, errors: 1 } },
         ],
       });
     });
@@ -71,14 +71,15 @@ describe('partial results when a kit fails after dispatch', () => {
       await routeCommand(['passing', 'absent', '--json']);
 
       expect(JSON.parse(readStdout())).toMatchObject({
-        passed: 1,
-        errors: 0,
-        warnings: 0,
-        recommendations: 0,
-        blocked: 0,
-        optional: 0,
-        worstSeverity: null,
+        counts: { passed: 1, errors: 0, warnings: 0, recommendations: 0, blocked: 0, optional: 0 },
       });
+      expect(JSON.parse(readStdout())).not.toHaveProperty('worstSeverity');
+    });
+
+    it('reports the run as failed when a kit never ran, even though what ran passed', async () => {
+      await routeCommand(['passing', 'absent', '--json']);
+
+      expect(JSON.parse(readStdout())).toMatchObject({ passed: false });
     });
 
     it('emits a report rather than an envelope when the only kit fails', async () => {

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -517,7 +517,10 @@ describe(routeCommand, () => {
       const exitCode = await routeCommand(['--json', '--bogus']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout()).toStrictEqual({ error: { code: 'usage', message: "Unknown option '--bogus'" } });
+      expect(parseStdout()).toStrictEqual({
+        schemaVersion: 1,
+        error: { code: 'usage', message: "Unknown option '--bogus'" },
+      });
       expect(stderrSpy).not.toHaveBeenCalled();
     });
 

--- a/packages/readyup/__tests__/schemas/generateSchemas.test.ts
+++ b/packages/readyup/__tests__/schemas/generateSchemas.test.ts
@@ -1,0 +1,160 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { Ajv2020, type ValidateFunction } from 'ajv/dist/2020.js';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { buildSchemaDocuments, SCHEMA_BASE_URL, writeSchemaFiles } from '../../config/buildSchemas.ts';
+import { isRecord } from '../../src/isRecord.ts';
+import {
+  compilePayload,
+  errorEnvelopePayload,
+  listPayload,
+  minimalReportPayload,
+  reportPayload,
+  verifyPayload,
+} from '../helpers/payloadFixtures.ts';
+
+const documents = new Map(buildSchemaDocuments().map(({ fileName, document }) => [fileName, document]));
+
+/** Look up a generated document by file name, failing loudly rather than returning undefined. */
+function documentFor(fileName: string): Record<string, unknown> {
+  const document = documents.get(fileName);
+  if (document === undefined) throw new Error(`No generated schema named ${fileName}`);
+  return document;
+}
+
+/** Read a nested object property, failing when the path does not lead to an object. */
+function objectAt(root: Record<string, unknown>, ...keys: string[]): Record<string, unknown> {
+  let current: unknown = root;
+  for (const key of keys) {
+    if (!isRecord(current)) throw new TypeError(`Expected an object at ${keys.join('.')}`);
+    current = current[key];
+  }
+  if (!isRecord(current)) throw new TypeError(`Expected an object at ${keys.join('.')}`);
+  return current;
+}
+
+/** Compile a generated document into a validator. */
+function validatorFor(fileName: string): ValidateFunction {
+  return new Ajv2020({ strict: true }).compile(documentFor(fileName));
+}
+
+describe('generated JSON Schemas', () => {
+  it('emits one document per published payload', () => {
+    expect(documents.keys().toArray()).toStrictEqual([
+      'compile.v1.json',
+      'error-envelope.v1.json',
+      'list.v1.json',
+      'report.v1.json',
+      'verify.v1.json',
+    ]);
+  });
+
+  it('gives each document an $id matching its published location', () => {
+    for (const [fileName, document] of documents) {
+      expect(document.$id).toBe(`${SCHEMA_BASE_URL}/${fileName}`);
+    }
+  });
+
+  it('declares the draft each document is written against', () => {
+    for (const document of documents.values()) {
+      expect(document.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    }
+  });
+
+  describe('report document', () => {
+    const report = documentFor('report.v1.json');
+
+    it('requires exactly the fields every report carries', () => {
+      expect(report.required).toStrictEqual([
+        'schemaVersion',
+        'readyupVersion',
+        'passed',
+        'counts',
+        'failOn',
+        'reportOn',
+        'detail',
+        'durationMs',
+        'kits',
+      ]);
+    });
+
+    it('requires all six buckets of the counts object', () => {
+      expect(objectAt(report, '$defs', 'Counts').required).toStrictEqual([
+        'passed',
+        'errors',
+        'warnings',
+        'recommendations',
+        'blocked',
+        'optional',
+      ]);
+    });
+
+    it('expresses the check tree as a self-reference rather than a fixed depth', () => {
+      expect(objectAt(report, '$defs', 'CheckEntry', 'properties', 'checks', 'items').$ref).toBe('#/$defs/CheckEntry');
+    });
+
+    it('offers both kit-entry shapes as alternatives', () => {
+      expect(objectAt(report, '$defs', 'KitEntry').anyOf).toStrictEqual([
+        { $ref: '#/$defs/KitErrorEntry' },
+        { $ref: '#/$defs/KitResultEntry' },
+      ]);
+    });
+
+    it('leaves objects open so an added optional field does not invalidate the version', () => {
+      expect(report).not.toHaveProperty('additionalProperties');
+      expect(objectAt(report, '$defs', 'CheckEntry')).not.toHaveProperty('additionalProperties');
+    });
+  });
+
+  describe('validating real payloads', () => {
+    it.each([
+      ['report.v1.json', reportPayload],
+      ['report.v1.json', minimalReportPayload],
+      ['error-envelope.v1.json', errorEnvelopePayload],
+      ['list.v1.json', listPayload],
+      ['verify.v1.json', verifyPayload],
+      ['compile.v1.json', compilePayload],
+    ])('accepts a representative payload for %s', (fileName, payload) => {
+      const validate = validatorFor(fileName);
+
+      expect(validate(payload), JSON.stringify(validate.errors)).toBe(true);
+    });
+
+    it('rejects a report whose counts are still flat', () => {
+      const { counts, ...withoutCounts } = minimalReportPayload;
+
+      expect(validatorFor('report.v1.json')({ ...withoutCounts, ...counts })).toBe(false);
+    });
+
+    it('rejects a report carrying the old numeric warnings field', () => {
+      expect(validatorFor('report.v1.json')({ ...minimalReportPayload, warnings: 2 })).toBe(false);
+    });
+
+    it('accepts a report carrying a field it has never heard of', () => {
+      expect(validatorFor('report.v1.json')({ ...minimalReportPayload, addedLater: 'ok' })).toBe(true);
+    });
+  });
+
+  describe('writing the files', () => {
+    const outDir = mkdtempSync(path.join(tmpdir(), 'readyup-schemas-'));
+
+    afterAll(() => {
+      rmSync(outDir, { recursive: true, force: true });
+    });
+
+    it('writes every document as parseable JSON under the given directory', () => {
+      const written = writeSchemaFiles(outDir);
+
+      expect(written).toHaveLength(5);
+      expect(readdirSync(outDir).toSorted()).toStrictEqual(documents.keys().toArray());
+      for (const filePath of written) {
+        expect(() => {
+          JSON.parse(readFileSync(filePath, 'utf8'));
+        }).not.toThrow();
+      }
+    });
+  });
+});

--- a/packages/readyup/__tests__/schemas/generateSchemas.test.ts
+++ b/packages/readyup/__tests__/schemas/generateSchemas.test.ts
@@ -13,6 +13,7 @@ import {
   listPayload,
   minimalReportPayload,
   reportPayload,
+  unknownWarningReportPayload,
   verifyPayload,
 } from '../helpers/payloadFixtures.ts';
 
@@ -84,6 +85,12 @@ describe('generated JSON Schemas', () => {
       expect(objectAt(report, '$defs', 'KitResultEntry').required).toContain('reportOn');
     });
 
+    it('publishes the warning vocabulary as an open set that still names its known codes', () => {
+      const warningCode = objectAt(report, '$defs', 'WarningCode');
+
+      expect(warningCode.anyOf).toStrictEqual([{ type: 'string', enum: ['version-skew'] }, { type: 'string' }]);
+    });
+
     it('requires all six buckets of the counts object', () => {
       expect(objectAt(report, '$defs', 'Counts').required).toStrictEqual([
         'passed',
@@ -116,6 +123,9 @@ describe('generated JSON Schemas', () => {
     it.each([
       ['report.v1.json', reportPayload],
       ['report.v1.json', minimalReportPayload],
+      // The forward-compatibility promise is made to a consumer running a JSON Schema validator, so
+      // it has to be checked through one rather than through zod alone.
+      ['report.v1.json', unknownWarningReportPayload],
       ['error-envelope.v1.json', errorEnvelopePayload],
       ['list.v1.json', listPayload],
       ['verify.v1.json', verifyPayload],

--- a/packages/readyup/__tests__/schemas/generateSchemas.test.ts
+++ b/packages/readyup/__tests__/schemas/generateSchemas.test.ts
@@ -73,12 +73,15 @@ describe('generated JSON Schemas', () => {
         'readyupVersion',
         'passed',
         'counts',
-        'failOn',
-        'reportOn',
         'detail',
         'durationMs',
         'kits',
       ]);
+    });
+
+    it('requires the effective thresholds on a kit that ran, where the top level leaves them optional', () => {
+      expect(objectAt(report, '$defs', 'KitResultEntry').required).toContain('failOn');
+      expect(objectAt(report, '$defs', 'KitResultEntry').required).toContain('reportOn');
     });
 
     it('requires all six buckets of the counts object', () => {

--- a/packages/readyup/__tests__/schemas/schemas.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.test.ts
@@ -10,114 +10,24 @@ import {
   VerifyOutputSchema,
 } from '../../src/schemas/index.ts';
 import type { Severity } from '../../src/types.ts';
-
-/** A report exercising every optional field, three levels of nesting, and both kit-entry shapes. */
-const report = {
-  schemaVersion: 1,
-  readyupVersion: '0.21.2',
-  passed: false,
-  counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
-  worstSeverity: 'error',
-  failOn: 'error',
-  reportOn: 'recommend',
-  detail: 'full',
-  durationMs: 42,
-  warnings: [{ code: 'version-skew', message: 'kit is stale', remedy: 'Run `rdy compile` to refresh.' }],
-  kits: [
-    {
-      name: 'deploy',
-      passed: false,
-      counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
-      worstSeverity: 'error',
-      durationMs: 42,
-      checklists: [
-        {
-          name: 'preflight',
-          passed: false,
-          counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
-          worstSeverity: 'error',
-          durationMs: 42,
-          checks: [
-            {
-              name: 'gate',
-              status: 'passed',
-              ok: true,
-              severity: 'error',
-              durationMs: 3,
-              progress: { type: 'fraction', passedCount: 3, count: 5 },
-              checks: [
-                {
-                  name: 'child',
-                  status: 'failed',
-                  ok: false,
-                  severity: 'error',
-                  durationMs: 1,
-                  detail: 'missing dependency',
-                  fix: 'run install',
-                  error: 'ENOENT',
-                  checks: [{ name: 'grandchild', status: 'skipped', ok: null, severity: 'error', durationMs: 0 }],
-                },
-              ],
-            },
-            { name: 'optional', status: 'skipped', ok: null, severity: 'warn', durationMs: 0, skipReason: 'n/a' },
-          ],
-        },
-      ],
-    },
-    { name: 'release', error: { code: 'kit-load', message: 'Cannot find release.js' } },
-  ],
-};
-
-/** The smallest report the schema accepts: every optional field absent. */
-const minimalReport = {
-  schemaVersion: 1,
-  readyupVersion: '0.21.2',
-  passed: true,
-  counts: { passed: 0, errors: 0, warnings: 0, recommendations: 0, blocked: 0, optional: 0 },
-  failOn: 'error',
-  reportOn: 'recommend',
-  detail: 'summary',
-  durationMs: 0,
-  kits: [],
-};
-
-const errorEnvelope = { schemaVersion: 1, error: { code: 'usage', message: "Unknown option '--bogus'" } };
-
-const listOutput = {
-  schemaVersion: 1,
-  kits: [
-    { name: 'deploy', kind: 'compiled', path: 'deploy.js', readyupVersion: '0.21.2', checklists: ['preflight'] },
-    { name: 'draft', kind: 'internal' },
-  ],
-};
-
-const verifyOutput = {
-  schemaVersion: 1,
-  passed: false,
-  kits: [
-    { name: 'deploy', status: 'ok' },
-    { name: 'release', status: 'drift', expected: 'abc123', actual: 'def456' },
-  ],
-};
-
-const compileOutput = {
-  schemaVersion: 1,
-  passed: false,
-  kits: [
-    { name: 'deploy', status: 'compiled' },
-    { name: 'release', status: 'failed', error: 'Kit must export a default RdyKit' },
-  ],
-};
+import {
+  compilePayload,
+  errorEnvelopePayload,
+  listPayload,
+  minimalReportPayload,
+  reportPayload,
+  verifyPayload,
+} from '../helpers/payloadFixtures.ts';
 
 describe('JSON payload schemas', () => {
   describe('representative payloads', () => {
     it.each([
-      ['report', ReportSchema, report],
-      ['minimal report', ReportSchema, minimalReport],
-      ['error envelope', ErrorEnvelopeSchema, errorEnvelope],
-      ['list', ListOutputSchema, listOutput],
-      ['verify', VerifyOutputSchema, verifyOutput],
-      ['compile', CompileOutputSchema, compileOutput],
+      ['report', ReportSchema, reportPayload],
+      ['minimal report', ReportSchema, minimalReportPayload],
+      ['error envelope', ErrorEnvelopeSchema, errorEnvelopePayload],
+      ['list', ListOutputSchema, listPayload],
+      ['verify', VerifyOutputSchema, verifyPayload],
+      ['compile', CompileOutputSchema, compilePayload],
     ])('accepts a representative %s payload', (_label, schema, payload) => {
       expect(() => schema.parse(payload)).not.toThrow();
     });
@@ -127,7 +37,7 @@ describe('JSON payload schemas', () => {
     it.each(['schemaVersion', 'readyupVersion', 'passed', 'counts', 'failOn', 'reportOn', 'detail', 'kits'])(
       'rejects a report missing %s',
       (field) => {
-        const incomplete = Object.fromEntries(Object.entries(minimalReport).filter(([key]) => key !== field));
+        const incomplete = Object.fromEntries(Object.entries(minimalReportPayload).filter(([key]) => key !== field));
 
         expect(() => ReportSchema.parse(incomplete)).toThrow();
       },
@@ -136,13 +46,13 @@ describe('JSON payload schemas', () => {
     it('rejects a counts object missing one of its six buckets', () => {
       const counts = { passed: 0, errors: 0, warnings: 0, recommendations: 0, blocked: 0 };
 
-      expect(() => ReportSchema.parse({ ...minimalReport, counts })).toThrow();
+      expect(() => ReportSchema.parse({ ...minimalReportPayload, counts })).toThrow();
     });
   });
 
   describe('collision fields', () => {
     it('reads `passed` as a verdict at every level and as a count only under `counts`', () => {
-      const parsed = ReportSchema.parse(report);
+      const parsed = ReportSchema.parse(reportPayload);
       const kit = parsed.kits[0];
       if (kit === undefined || 'error' in kit) throw new Error('expected a kit that ran');
 
@@ -153,7 +63,7 @@ describe('JSON payload schemas', () => {
     });
 
     it('reads `warnings` as advisory entries at the top level and as a count only under `counts`', () => {
-      const parsed = ReportSchema.parse(report);
+      const parsed = ReportSchema.parse(reportPayload);
 
       expect(parsed.warnings).toStrictEqual([
         { code: 'version-skew', message: 'kit is stale', remedy: 'Run `rdy compile` to refresh.' },
@@ -162,7 +72,7 @@ describe('JSON payload schemas', () => {
     });
 
     it('rejects a numeric `warnings` at the top level, where the old flat shape put the count', () => {
-      expect(() => ReportSchema.parse({ ...minimalReport, warnings: 3 })).toThrow();
+      expect(() => ReportSchema.parse({ ...minimalReportPayload, warnings: 3 })).toThrow();
     });
   });
 
@@ -170,11 +80,11 @@ describe('JSON payload schemas', () => {
     it('accepts a counts-free error entry', () => {
       const kits = [{ name: 'release', error: { code: 'config', message: 'boom' } }];
 
-      expect(() => ReportSchema.parse({ ...minimalReport, kits })).not.toThrow();
+      expect(() => ReportSchema.parse({ ...minimalReportPayload, kits })).not.toThrow();
     });
 
     it('rejects a kit that carries neither results nor an error', () => {
-      expect(() => ReportSchema.parse({ ...minimalReport, kits: [{ name: 'orphan' }] })).toThrow();
+      expect(() => ReportSchema.parse({ ...minimalReportPayload, kits: [{ name: 'orphan' }] })).toThrow();
     });
   });
 

--- a/packages/readyup/__tests__/schemas/schemas.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import type { RdyErrorCode } from '../../src/errors.ts';
-import type { JsonErrorCode, JsonSeverity } from '../../src/schemas/index.ts';
+import type {
+  JsonErrorCode,
+  JsonSeverity,
+  JsonWarning,
+  JsonWarningCode,
+  RaisedWarning,
+} from '../../src/schemas/index.ts';
 import {
   CompileOutputSchema,
   ErrorEnvelopeSchema,
@@ -16,6 +22,7 @@ import {
   listPayload,
   minimalReportPayload,
   reportPayload,
+  unknownWarningReportPayload,
   verifyPayload,
 } from '../helpers/payloadFixtures.ts';
 
@@ -99,6 +106,18 @@ describe('JSON payload schemas', () => {
     });
   });
 
+  describe('warning codes', () => {
+    it('accepts an advisory code this version does not know', () => {
+      expect(() => ReportSchema.parse(unknownWarningReportPayload)).not.toThrow();
+    });
+
+    it('rejects an error code this version does not know, which selects a consumer branch', () => {
+      const kits = [{ name: 'release', error: { code: 'kit-retired', message: 'boom' } }];
+
+      expect(() => ReportSchema.parse({ ...minimalReportPayload, kits })).toThrow();
+    });
+  });
+
   describe('kit entries', () => {
     it('accepts a counts-free error entry', () => {
       const kits = [{ name: 'release', error: { code: 'config', message: 'boom' } }];
@@ -118,6 +137,19 @@ describe('JSON payload schemas', () => {
 
     it('keeps the wire error taxonomy in step with RdyErrorCode', () => {
       expectTypeOf<JsonErrorCode>().toEqualTypeOf<RdyErrorCode>();
+    });
+
+    it('binds a producer to the vocabulary this version declares while the wire stays open', () => {
+      expectTypeOf<RaisedWarning['code']>().toEqualTypeOf<'version-skew'>();
+      expectTypeOf<JsonWarning['code']>().not.toEqualTypeOf<'version-skew'>();
+    });
+
+    it('publishes the known warning codes as distinguishable members of an open set', () => {
+      // A union of a literal and `string` collapses to `string`, which would still accept both
+      // assignments below while offering a consumer no vocabulary at all.
+      expectTypeOf<JsonWarningCode>().not.toEqualTypeOf<string>();
+      expectTypeOf<'version-skew'>().toExtend<JsonWarningCode>();
+      expectTypeOf<'kit-deprecated'>().toExtend<JsonWarningCode>();
     });
   });
 });

--- a/packages/readyup/__tests__/schemas/schemas.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.test.ts
@@ -34,7 +34,7 @@ describe('JSON payload schemas', () => {
   });
 
   describe('required fields', () => {
-    it.each(['schemaVersion', 'readyupVersion', 'passed', 'counts', 'failOn', 'reportOn', 'detail', 'kits'])(
+    it.each(['schemaVersion', 'readyupVersion', 'passed', 'counts', 'detail', 'kits'])(
       'rejects a report missing %s',
       (field) => {
         const incomplete = Object.fromEntries(Object.entries(minimalReportPayload).filter(([key]) => key !== field));
@@ -42,6 +42,18 @@ describe('JSON payload schemas', () => {
         expect(() => ReportSchema.parse(incomplete)).toThrow();
       },
     );
+
+    it.each(['failOn', 'reportOn'])('accepts a report whose invocation requested no %s', (field) => {
+      expect(minimalReportPayload).not.toHaveProperty(field);
+      expect(() => ReportSchema.parse(minimalReportPayload)).not.toThrow();
+    });
+
+    it.each(['failOn', 'reportOn'])('rejects a kit that ran without its effective %s', (field) => {
+      const kit = reportPayload.kits[0];
+      const stripped = Object.fromEntries(Object.entries(kit ?? {}).filter(([key]) => key !== field));
+
+      expect(() => ReportSchema.parse({ ...reportPayload, kits: [stripped] })).toThrow();
+    });
 
     it('rejects a counts object missing one of its six buckets', () => {
       const counts = { passed: 0, errors: 0, warnings: 0, recommendations: 0, blocked: 0 };
@@ -73,6 +85,17 @@ describe('JSON payload schemas', () => {
 
     it('rejects a numeric `warnings` at the top level, where the old flat shape put the count', () => {
       expect(() => ReportSchema.parse({ ...minimalReportPayload, warnings: 3 })).toThrow();
+    });
+  });
+
+  describe('thresholds', () => {
+    it('carries the kit-declared threshold that governed a kit, not the one the run requested', () => {
+      const parsed = ReportSchema.parse(reportPayload);
+      const kit = parsed.kits[0];
+      if (kit === undefined || 'error' in kit) throw new Error('expected a kit that ran');
+
+      expect(parsed.failOn).toBe('error');
+      expect(kit.failOn).toBe('warn');
     });
   });
 

--- a/packages/readyup/__tests__/schemas/schemas.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import type { RdyErrorCode } from '../../src/errors.ts';
+import type { JsonErrorCode, JsonSeverity } from '../../src/schemas/index.ts';
+import {
+  CompileOutputSchema,
+  ErrorEnvelopeSchema,
+  ListOutputSchema,
+  ReportSchema,
+  VerifyOutputSchema,
+} from '../../src/schemas/index.ts';
+import type { Severity } from '../../src/types.ts';
+
+/** A report exercising every optional field, three levels of nesting, and both kit-entry shapes. */
+const report = {
+  schemaVersion: 1,
+  readyupVersion: '0.21.2',
+  passed: false,
+  counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
+  worstSeverity: 'error',
+  failOn: 'error',
+  reportOn: 'recommend',
+  detail: 'full',
+  durationMs: 42,
+  warnings: [{ code: 'version-skew', message: 'kit is stale', remedy: 'Run `rdy compile` to refresh.' }],
+  kits: [
+    {
+      name: 'deploy',
+      passed: false,
+      counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
+      worstSeverity: 'error',
+      durationMs: 42,
+      checklists: [
+        {
+          name: 'preflight',
+          passed: false,
+          counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
+          worstSeverity: 'error',
+          durationMs: 42,
+          checks: [
+            {
+              name: 'gate',
+              status: 'passed',
+              ok: true,
+              severity: 'error',
+              durationMs: 3,
+              progress: { type: 'fraction', passedCount: 3, count: 5 },
+              checks: [
+                {
+                  name: 'child',
+                  status: 'failed',
+                  ok: false,
+                  severity: 'error',
+                  durationMs: 1,
+                  detail: 'missing dependency',
+                  fix: 'run install',
+                  error: 'ENOENT',
+                  checks: [{ name: 'grandchild', status: 'skipped', ok: null, severity: 'error', durationMs: 0 }],
+                },
+              ],
+            },
+            { name: 'optional', status: 'skipped', ok: null, severity: 'warn', durationMs: 0, skipReason: 'n/a' },
+          ],
+        },
+      ],
+    },
+    { name: 'release', error: { code: 'kit-load', message: 'Cannot find release.js' } },
+  ],
+};
+
+/** The smallest report the schema accepts: every optional field absent. */
+const minimalReport = {
+  schemaVersion: 1,
+  readyupVersion: '0.21.2',
+  passed: true,
+  counts: { passed: 0, errors: 0, warnings: 0, recommendations: 0, blocked: 0, optional: 0 },
+  failOn: 'error',
+  reportOn: 'recommend',
+  detail: 'summary',
+  durationMs: 0,
+  kits: [],
+};
+
+const errorEnvelope = { schemaVersion: 1, error: { code: 'usage', message: "Unknown option '--bogus'" } };
+
+const listOutput = {
+  schemaVersion: 1,
+  kits: [
+    { name: 'deploy', kind: 'compiled', path: 'deploy.js', readyupVersion: '0.21.2', checklists: ['preflight'] },
+    { name: 'draft', kind: 'internal' },
+  ],
+};
+
+const verifyOutput = {
+  schemaVersion: 1,
+  passed: false,
+  kits: [
+    { name: 'deploy', status: 'ok' },
+    { name: 'release', status: 'drift', expected: 'abc123', actual: 'def456' },
+  ],
+};
+
+const compileOutput = {
+  schemaVersion: 1,
+  passed: false,
+  kits: [
+    { name: 'deploy', status: 'compiled' },
+    { name: 'release', status: 'failed', error: 'Kit must export a default RdyKit' },
+  ],
+};
+
+describe('JSON payload schemas', () => {
+  describe('representative payloads', () => {
+    it.each([
+      ['report', ReportSchema, report],
+      ['minimal report', ReportSchema, minimalReport],
+      ['error envelope', ErrorEnvelopeSchema, errorEnvelope],
+      ['list', ListOutputSchema, listOutput],
+      ['verify', VerifyOutputSchema, verifyOutput],
+      ['compile', CompileOutputSchema, compileOutput],
+    ])('accepts a representative %s payload', (_label, schema, payload) => {
+      expect(() => schema.parse(payload)).not.toThrow();
+    });
+  });
+
+  describe('required fields', () => {
+    it.each(['schemaVersion', 'readyupVersion', 'passed', 'counts', 'failOn', 'reportOn', 'detail', 'kits'])(
+      'rejects a report missing %s',
+      (field) => {
+        const incomplete = Object.fromEntries(Object.entries(minimalReport).filter(([key]) => key !== field));
+
+        expect(() => ReportSchema.parse(incomplete)).toThrow();
+      },
+    );
+
+    it('rejects a counts object missing one of its six buckets', () => {
+      const counts = { passed: 0, errors: 0, warnings: 0, recommendations: 0, blocked: 0 };
+
+      expect(() => ReportSchema.parse({ ...minimalReport, counts })).toThrow();
+    });
+  });
+
+  describe('collision fields', () => {
+    it('reads `passed` as a verdict at every level and as a count only under `counts`', () => {
+      const parsed = ReportSchema.parse(report);
+      const kit = parsed.kits[0];
+      if (kit === undefined || 'error' in kit) throw new Error('expected a kit that ran');
+
+      expect(parsed.passed).toBe(false);
+      expect(parsed.counts.passed).toBe(2);
+      expect(kit.passed).toBe(false);
+      expect(kit.checklists[0]?.passed).toBe(false);
+    });
+
+    it('reads `warnings` as advisory entries at the top level and as a count only under `counts`', () => {
+      const parsed = ReportSchema.parse(report);
+
+      expect(parsed.warnings).toStrictEqual([
+        { code: 'version-skew', message: 'kit is stale', remedy: 'Run `rdy compile` to refresh.' },
+      ]);
+      expect(parsed.counts.warnings).toBe(0);
+    });
+
+    it('rejects a numeric `warnings` at the top level, where the old flat shape put the count', () => {
+      expect(() => ReportSchema.parse({ ...minimalReport, warnings: 3 })).toThrow();
+    });
+  });
+
+  describe('kit entries', () => {
+    it('accepts a counts-free error entry', () => {
+      const kits = [{ name: 'release', error: { code: 'config', message: 'boom' } }];
+
+      expect(() => ReportSchema.parse({ ...minimalReport, kits })).not.toThrow();
+    });
+
+    it('rejects a kit that carries neither results nor an error', () => {
+      expect(() => ReportSchema.parse({ ...minimalReport, kits: [{ name: 'orphan' }] })).toThrow();
+    });
+  });
+
+  describe('derived types', () => {
+    it('keeps the wire severity vocabulary in step with the runner type', () => {
+      expectTypeOf<JsonSeverity>().toEqualTypeOf<Severity>();
+    });
+
+    it('keeps the wire error taxonomy in step with RdyErrorCode', () => {
+      expectTypeOf<JsonErrorCode>().toEqualTypeOf<RdyErrorCode>();
+    });
+  });
+});

--- a/packages/readyup/__tests__/verify/verifyCommand.integration.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.integration.test.ts
@@ -14,13 +14,18 @@ import { verifyCommand } from '../../src/verify/verifyCommand.ts';
  */
 describe('verifyCommand (integration)', () => {
   let tempDir: string;
+  let stdout: string[];
   let stdoutSpy: MockInstance;
   let stderrSpy: MockInstance;
   let originalCwd: string;
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'verify-integ-'));
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stdout = [];
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    });
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     originalCwd = process.cwd();
     process.chdir(tempDir);
@@ -67,5 +72,82 @@ describe('verifyCommand (integration)', () => {
     expect(exitCode).toBe(1);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('⚠️  demo — drift'));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('expected deadbeef'));
+  });
+
+  describe('--json', () => {
+    /** Write a manifest naming one matching kit, one drifted kit, and one with no recorded hash. */
+    function writeMixedManifest(): void {
+      const clean = Buffer.from('export default { checks: [] };\n');
+      writeFileSync(path.join(tempDir, 'clean.js'), clean);
+      writeFileSync(path.join(tempDir, 'edited.js'), 'export default { edited: true };\n');
+      writeFileSync(
+        path.join(tempDir, 'manifest.json'),
+        JSON.stringify({
+          version: 1,
+          kits: [
+            { name: 'clean', path: 'clean.js', targetHash: hashBytes(clean) },
+            { name: 'edited', path: 'edited.js', targetHash: 'deadbeef' },
+            { name: 'gone', path: 'gone.js', targetHash: 'abcd1234' },
+            { name: 'unhashed', path: 'clean.js' },
+          ],
+        }),
+      );
+    }
+
+    it('reports every kit status with the hashes only a drift verdict compared', () => {
+      writeMixedManifest();
+
+      const exitCode = verifyCommand(['--manifest', 'manifest.json', '--json']);
+
+      expect(exitCode).toBe(1);
+      expect(JSON.parse(stdout.join(''))).toStrictEqual({
+        schemaVersion: 1,
+        passed: false,
+        kits: [
+          { name: 'clean', status: 'ok' },
+          { name: 'edited', status: 'drift', expected: 'deadbeef', actual: expect.any(String) },
+          { name: 'gone', status: 'missing' },
+          { name: 'unhashed', status: 'unverified' },
+        ],
+      });
+    });
+
+    it('emits exactly one JSON document and sends the per-kit prose to stderr', () => {
+      writeMixedManifest();
+
+      verifyCommand(['--manifest', 'manifest.json', '--json']);
+
+      expect(stdoutSpy).toHaveBeenCalledTimes(1);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('clean — ok'));
+    });
+
+    it('passes when every kit is ok or unverified', () => {
+      const compiled = Buffer.from('export default { checks: [] };\n');
+      writeFileSync(path.join(tempDir, 'demo.js'), compiled);
+      writeFileSync(
+        path.join(tempDir, 'manifest.json'),
+        JSON.stringify({
+          version: 1,
+          kits: [
+            { name: 'demo', path: 'demo.js', targetHash: hashBytes(compiled) },
+            { name: 'unhashed', path: 'demo.js' },
+          ],
+        }),
+      );
+
+      const exitCode = verifyCommand(['--manifest', 'manifest.json', '--json']);
+
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(stdout.join(''))).toMatchObject({ passed: true });
+    });
+
+    it('reports an empty manifest as a passing run with no kits', () => {
+      writeFileSync(path.join(tempDir, 'manifest.json'), JSON.stringify({ version: 1, kits: [] }));
+
+      const exitCode = verifyCommand(['--manifest', 'manifest.json', '--json']);
+
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(stdout.join(''))).toStrictEqual({ schemaVersion: 1, passed: true, kits: [] });
+    });
   });
 });

--- a/packages/readyup/config/buildSchemas.ts
+++ b/packages/readyup/config/buildSchemas.ts
@@ -1,0 +1,69 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { z } from 'zod';
+
+import { CompileOutputSchema, SCHEMA_VERSION as COMPILE_VERSION } from '../src/schemas/compileOutputSchema.ts';
+import { ErrorEnvelopeSchema, SCHEMA_VERSION as ENVELOPE_VERSION } from '../src/schemas/errorEnvelopeSchema.ts';
+import { ListOutputSchema, SCHEMA_VERSION as LIST_VERSION } from '../src/schemas/listOutputSchema.ts';
+import { ReportSchema, SCHEMA_VERSION as REPORT_VERSION } from '../src/schemas/reportSchema.ts';
+import { SCHEMA_VERSION as VERIFY_VERSION, VerifyOutputSchema } from '../src/schemas/verifyOutputSchema.ts';
+
+/** Where a published schema answers from once the package is on npm. */
+export const SCHEMA_BASE_URL = 'https://unpkg.com/readyup/schemas';
+
+/** One payload's published schema: what to call the file and what to put in it. */
+export interface SchemaDocument {
+  fileName: string;
+  document: Record<string, unknown>;
+}
+
+/** A payload paired with the version it publishes under. */
+interface Payload {
+  name: string;
+  version: number;
+  schema: z.ZodType;
+}
+
+/**
+ * The five published payloads.
+ *
+ * Each versions independently, so a change to the report leaves a consumer pinned to `list.v1.json`
+ * untouched.
+ */
+const PAYLOADS: Payload[] = [
+  { name: 'compile', version: COMPILE_VERSION, schema: CompileOutputSchema },
+  { name: 'error-envelope', version: ENVELOPE_VERSION, schema: ErrorEnvelopeSchema },
+  { name: 'list', version: LIST_VERSION, schema: ListOutputSchema },
+  { name: 'report', version: REPORT_VERSION, schema: ReportSchema },
+  { name: 'verify', version: VERIFY_VERSION, schema: VerifyOutputSchema },
+];
+
+/**
+ * Render every payload as a JSON Schema document.
+ *
+ * Rendered in `input` mode, which leaves objects open. The evolution policy promises that adding an
+ * optional field does not bump `schemaVersion`, and a closed schema would break that promise the
+ * first time it was exercised: a consumer pinned to v1 would reject every payload carrying the new
+ * field. No payload uses a transform or a default, so the input and output renderings are otherwise
+ * the same document.
+ */
+export function buildSchemaDocuments(): SchemaDocument[] {
+  return PAYLOADS.map(({ name, version, schema }) => {
+    const fileName = `${name}.v${version}.json`;
+    const { $schema, ...body } = z.toJSONSchema(schema, { target: 'draft-2020-12', io: 'input' });
+
+    return { fileName, document: { $schema, $id: `${SCHEMA_BASE_URL}/${fileName}`, ...body } };
+  });
+}
+
+/** Write every payload schema into `outDir`, creating it if needed, and return the paths written. */
+export function writeSchemaFiles(outDir: string): string[] {
+  mkdirSync(outDir, { recursive: true });
+
+  return buildSchemaDocuments().map(({ fileName, document }) => {
+    const filePath = path.join(outDir, fileName);
+    writeFileSync(filePath, `${JSON.stringify(document, null, 2)}\n`);
+    return filePath;
+  });
+}

--- a/packages/readyup/config/generateSchemas.ts
+++ b/packages/readyup/config/generateSchemas.ts
@@ -1,0 +1,8 @@
+/** Generate `schemas/*.json` from the zod schemas that define readyup's JSON payloads. */
+
+import path from 'node:path';
+import process from 'node:process';
+
+import { writeSchemaFiles } from './buildSchemas.ts';
+
+writeSchemaFiles(path.join(process.cwd(), 'schemas'));

--- a/packages/readyup/package.json
+++ b/packages/readyup/package.json
@@ -36,7 +36,8 @@
     "./readyupResolverHook": {
       "import": "./dist/esm/readyupResolverHook.js",
       "types": "./dist/esm/readyupResolverHook.d.ts"
-    }
+    },
+    "./schemas/*.json": "./schemas/*.json"
   },
   "bin": {
     "rdy": "bin/rdy.js",
@@ -44,10 +45,11 @@
   },
   "files": [
     "bin",
-    "dist"
+    "dist",
+    "schemas"
   ],
   "scripts": {
-    "prepare": "tsx ../../config/generateVersion.ts && nmr-compile"
+    "prepare": "tsx ../../config/generateVersion.ts && tsx config/generateSchemas.ts && nmr-compile"
   },
   "dependencies": {
     "jiti": "2.7.0",
@@ -56,7 +58,8 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@types/picomatch": "4.0.3"
+    "@types/picomatch": "4.0.3",
+    "ajv": "8.20.0"
   },
   "peerDependencies": {
     "esbuild": ">=0.28.1"

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -55,9 +55,15 @@ Exit codes:
 
   list and init use only 0 and 2; neither can find problems to report.
 
-With --json, stdout carries exactly one JSON document: the report when a run produced
-one, otherwise {"error": {"code", "message"}}. Prose goes to stderr. --help and --version
-have no JSON form: their text goes to stderr and stdout stays empty.
+run, compile, list, and verify accept --json; init does not, since scaffolding is
+interactive. With --json, stdout carries exactly one JSON document and all prose goes to
+stderr. For run that document is the report when a run produced one, otherwise the error
+envelope {"schemaVersion", "error": {"code", "message"}}. --help and --version have no
+JSON form: their text goes to stderr and stdout stays empty.
+
+Every payload carries an integer schemaVersion and is specified by a JSON Schema shipped
+with the package, importable as readyup/schemas/<name>.v1.json. Adding an optional field
+does not bump a payload's schemaVersion; removing, renaming, or re-typing one does.
 
 A kit that fails once the run has reached its kits does not discard the kits that ran.
 Under --json it becomes a kits entry carrying "error" in place of results; otherwise it
@@ -125,6 +131,9 @@ Drift detection:
 A sweep runs to completion: a kit that fails to compile is reported and the next kit is
 tried, so every kit's status is known after one run. A kit that failed is left out of the
 manifest rather than recorded as though it had compiled.
+
+Each kit's checklist names are recorded in the manifest so rdy list can report them
+without running the kit. The field is optional, so the manifest format stays at version 1.
 
 Exits 1 when a kit fails to compile or is skipped as drifted, and 2 when the config or
 manifest cannot be read or written.

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -37,6 +37,7 @@ Run options:
   --internal                         Use internal kit directory and infix from config
   --checklists, -c <name,...>        Filter checklists within the selected kit
   --json                             Output results as JSON
+  --detail <summary|full>            How much of the JSON report to emit (default: full); requires --json
   --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
   --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
                                      plus the parent checks of anything shown; summary counts always
@@ -84,6 +85,9 @@ Options:
   --checklists, -c <name,...>        Filter checklists within the selected kit; requires a
                                      single kit and no ":" filter on it
   --json                             Output results as JSON
+  --detail <summary|full>            How much of the JSON report to emit (default: full); requires --json.
+                                     "summary" drops the detail tree to the failed checks and their fixes,
+                                     keeping counts, verdicts, and worst severity intact
   --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
   --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
                                      plus the parent checks of anything shown; summary counts always
@@ -290,6 +294,7 @@ async function handleRun(flags: string[], json: boolean): Promise<number> {
     {
       kitEntries,
       json: parsed.json,
+      ...(parsed.detail !== undefined && { detail: parsed.detail }),
       ...(parsed.failOn !== undefined && { failOn: parsed.failOn }),
       ...(parsed.reportOn !== undefined && { reportOn: parsed.reportOn }),
     },

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -64,6 +64,8 @@ JSON form: their text goes to stderr and stdout stays empty.
 Every payload carries an integer schemaVersion and is specified by a JSON Schema shipped
 with the package, importable as readyup/schemas/<name>.v1.json. Adding an optional field
 does not bump a payload's schemaVersion; removing, renaming, or re-typing one does.
+Warning codes are an open set, so a new advisory never bumps the version and a consumer
+must tolerate a code it does not recognize.
 
 In the report, failOn and reportOn appear at the top level only when the matching flag was
 given, naming what the invocation requested. Each kit that ran carries the thresholds that

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -14,6 +14,7 @@ import { extractMessage } from '../utils/error-handling.ts';
 import { translateParseArgsError } from '../utils/parse-args-error.ts';
 import { verifyCommand } from '../verify/verifyCommand.ts';
 import { VERSION } from '../version.ts';
+import { writeHuman } from '../writeHuman.ts';
 
 const SUBCOMMANDS = ['compile', 'init', 'list', 'verify'];
 const MIN_PREFIX_LENGTH = 3;
@@ -112,6 +113,7 @@ Options:
   --output, -o <path>  Output file path (single-file mode only)
   --manifest <path>    Manifest file path (default: .readyup/manifest.json)
   --force              Overwrite compiled kits even if they have drifted from the manifest
+  --json               Report each kit's status as JSON
   --skip-manifest      Do not read or write the manifest
   --help, -h           Show this help message
 
@@ -119,6 +121,10 @@ Drift detection:
   rdy compile refuses to overwrite a compiled kit whose on-disk hash differs from the
   manifest's recorded targetHash (e.g. someone edited the compiled file directly).
   Drifted kits are reported and skipped; use --force to overwrite anyway.
+
+A sweep runs to completion: a kit that fails to compile is reported and the next kit is
+tried, so every kit's status is known after one run. A kit that failed is left out of the
+manifest rather than recorded as though it had compiled.
 
 Exits 1 when a kit fails to compile or is skipped as drifted, and 2 when the config or
 manifest cannot be read or written.
@@ -328,12 +334,6 @@ function wantsHelp(flags: string[]): boolean {
 function writeHelp(text: string, json: boolean): number {
   writeHuman(`${text}\n`, json);
   return EXIT_OK;
-}
-
-/** Writes human-readable prose, diverting it to stderr when JSON mode owns stdout. */
-function writeHuman(text: string, json: boolean): void {
-  const stream = json ? process.stderr : process.stdout;
-  stream.write(text);
 }
 
 /** Checks whether a positional arg is a close prefix of a known subcommand. */

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -146,6 +146,7 @@ manifest exits 2.
 
 Options:
   --manifest <path>  Manifest file path (default: .readyup/manifest.json)
+  --json             Report each kit's verification status as JSON
   --help, -h         Show this help message
 `;
 
@@ -163,8 +164,15 @@ Modes:
   rdy list --from bitbucket:ws/repo[@ref]   List kits in a remote Bitbucket repository
 
 Options:
-  --from <source>  Kit source (github:org/repo[@ref], bitbucket:ws/repo[@ref], global, dir:path, or local path)
-  --help, -h       Show this help message
+  --from <source>    Kit source (github:org/repo[@ref], bitbucket:ws/repo[@ref], global, dir:path, or local path)
+  --manifest <path>  List the kits a manifest file declares
+  --json             Output the kit list as JSON
+  --help, -h         Show this help message
+
+A local --from source with no manifest beside its kits falls back to listing the compiled
+kits on disk, which are the same kits rdy run --from would resolve. Those rows carry only
+a name and a path; descriptions, checklist names, and versions live in the absent manifest.
+A remote source still requires a manifest.
 
 Examples:
   rdy list                                         Show kits in the current project

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -65,6 +65,10 @@ Every payload carries an integer schemaVersion and is specified by a JSON Schema
 with the package, importable as readyup/schemas/<name>.v1.json. Adding an optional field
 does not bump a payload's schemaVersion; removing, renaming, or re-typing one does.
 
+In the report, failOn and reportOn appear at the top level only when the matching flag was
+given, naming what the invocation requested. Each kit that ran carries the thresholds that
+governed it, so a kit declaring its own is readable from its entry rather than inferred.
+
 A kit that fails once the run has reached its kits does not discard the kits that ran.
 Under --json it becomes a kits entry carrying "error" in place of results; otherwise it
 is reported on stderr, prefixed with the kit's name when more than one kit was

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -135,8 +135,8 @@ Drift detection:
   Drifted kits are reported and skipped; use --force to overwrite anyway.
 
 A sweep runs to completion: a kit that fails to compile is reported and the next kit is
-tried, so every kit's status is known after one run. A kit that failed is left out of the
-manifest rather than recorded as though it had compiled.
+tried, so every kit's status is known after one run. A kit that failed is never recorded as
+though it had compiled, and one that had compiled before keeps the entry it already had.
 
 Each kit's checklist names are recorded in the manifest so rdy list can report them
 without running the kit. The field is optional, so the manifest format stays at version 1.

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -16,6 +16,7 @@ import { resolveBitbucketToken } from './resolveBitbucketToken.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
 import { resolveRequestedNames } from './resolveRequestedNames.ts';
 import { runRdy } from './runRdy.ts';
+import type { JsonDetail, JsonWarning } from './schemas/index.ts';
 import type {
   ChecklistSummary,
   FixLocation,
@@ -380,6 +381,7 @@ function resolveThresholds(
 interface RunCommandOptions {
   kitEntries: ResolvedKitEntry[];
   json: boolean;
+  detail?: JsonDetail;
   failOn?: Severity;
   reportOn?: Severity;
 }
@@ -428,15 +430,18 @@ async function loadKit(source: KitSource, isJit: boolean): Promise<LoadedRdyKit>
  *
  * Silent when the compile-time version is absent (older kit, third-party `--url` source, or
  * uncompiled `.ts` source via `--jit`) and when the comparator returns no-skew.
+ *
+ * The stderr line is written in both modes; the returned entry is what JSON mode captures into the
+ * report, so a consumer that owns only stdout still learns the run was advised of something.
  */
-function warnOnVersionSkew(kitName: string, compileTimeVersion: string | undefined): void {
-  if (compileTimeVersion === undefined) return;
+function warnOnVersionSkew(kitName: string, compileTimeVersion: string | undefined): JsonWarning | undefined {
+  if (compileTimeVersion === undefined) return undefined;
   const result = compareVersionsForSkew(compileTimeVersion, VERSION);
-  if (result.kind === 'no-skew') return;
+  if (result.kind === 'no-skew') return undefined;
   const remedy = result.direction === 'runner-newer' ? 'Run `rdy compile` to refresh.' : 'Upgrade readyup to match.';
-  process.stderr.write(
-    `Warning: kit "${kitName}" was compiled against readyup ${compileTimeVersion}; runner is ${VERSION}. ${remedy}\n`,
-  );
+  const message = `kit "${kitName}" was compiled against readyup ${compileTimeVersion}; runner is ${VERSION}.`;
+  process.stderr.write(`Warning: ${message} ${remedy}\n`);
+  return { code: 'version-skew', message, remedy };
 }
 
 /** Detect module-not-found errors that mention a specific package name. */
@@ -449,11 +454,11 @@ function isModuleNotFoundError(error: unknown, packageName: string): boolean {
 
 /** Run rdy checklists across one or more kits. Returns a numeric exit code. */
 export async function runCommand(
-  { kitEntries, json, failOn, reportOn }: RunCommandOptions,
+  { kitEntries, json, detail, failOn, reportOn }: RunCommandOptions,
   isJit = false,
 ): Promise<number> {
   if (json) {
-    return runMultiKitJsonMode(kitEntries, failOn, reportOn, isJit);
+    return runMultiKitJsonMode(kitEntries, { detail: detail ?? 'full', failOn, reportOn }, isJit);
   }
   return runMultiKitHumanMode(kitEntries, failOn, reportOn, isJit);
 }
@@ -468,11 +473,12 @@ export async function runCommand(
  */
 async function runMultiKitJsonMode(
   kitEntries: ResolvedKitEntry[],
-  failOn: Severity | undefined,
-  reportOn: Severity | undefined,
+  runSettings: { detail: JsonDetail; failOn: Severity | undefined; reportOn: Severity | undefined },
   isJit: boolean,
 ): Promise<number> {
+  const { detail, failOn, reportOn } = runSettings;
   const kitInputs: KitInput[] = [];
+  const warnings: JsonWarning[] = [];
   let allPassed = true;
   let anyKitFailed = false;
 
@@ -480,7 +486,8 @@ async function runMultiKitJsonMode(
     try {
       const { kit, compileTimeVersion } = await loadKit(entry.source, isJit);
 
-      warnOnVersionSkew(entry.name, compileTimeVersion);
+      const warning = warnOnVersionSkew(entry.name, compileTimeVersion);
+      if (warning !== undefined) warnings.push(warning);
 
       const thresholds = resolveThresholds(kit, failOn, reportOn);
       const checklists = selectChecklists(kit, entry.checklists);
@@ -504,8 +511,15 @@ async function runMultiKitJsonMode(
     }
   }
 
-  const resolvedReportOn = reportOn ?? 'recommend';
-  process.stdout.write(formatJsonReport(kitInputs, { reportOn: resolvedReportOn }) + '\n');
+  // The echoed thresholds are the run-level resolution: the CLI flag when given, otherwise the
+  // default. A kit that declares its own `failOn` overrides this for its own checks.
+  const output = formatJsonReport(kitInputs, {
+    detail,
+    failOn: failOn ?? 'error',
+    reportOn: reportOn ?? 'recommend',
+    ...(warnings.length > 0 && { warnings }),
+  });
+  process.stdout.write(output + '\n');
 
   return resolveRunExitCode(anyKitFailed, allPassed);
 }

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -17,7 +17,7 @@ import { resolveBitbucketToken } from './resolveBitbucketToken.ts';
 import { resolveGitHubToken } from './resolveGitHubToken.ts';
 import { resolveRequestedNames } from './resolveRequestedNames.ts';
 import { runRdy } from './runRdy.ts';
-import type { JsonDetail, JsonWarning } from './schemas/index.ts';
+import type { JsonDetail, JsonWarning, RaisedWarning } from './schemas/index.ts';
 import type {
   ChecklistSummary,
   FixLocation,
@@ -452,7 +452,7 @@ async function loadKit(source: KitSource, isJit: boolean): Promise<LoadedRdyKit>
  * The stderr line is written in both modes; the returned entry is what JSON mode captures into the
  * report, so a consumer that owns only stdout still learns the run was advised of something.
  */
-function warnOnVersionSkew(kitName: string, compileTimeVersion: string | undefined): JsonWarning | undefined {
+function warnOnVersionSkew(kitName: string, compileTimeVersion: string | undefined): RaisedWarning | undefined {
   if (compileTimeVersion === undefined) return undefined;
   const result = compareVersionsForSkew(compileTimeVersion, VERSION);
   if (result.kind === 'no-skew') return undefined;

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -8,6 +8,7 @@ import { kitLoadError, toRdyError, usageError } from './errors.ts';
 import { EXIT_OK, EXIT_PROBLEMS_FOUND, EXIT_TOOL_FAILURE } from './exitCodes.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonReport, type KitInput } from './formatJsonReport.ts';
+import { KITS_DIR } from './kitsDir.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { type FromSource, parseFromValue } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
@@ -94,9 +95,6 @@ function parseDetailFlag(value: string): JsonDetail {
   if (value === 'full' || value === 'summary') return value;
   throw usageError(`--detail must be one of: summary, full (got "${value}")`);
 }
-
-/** Convention path for internal kits, relative to the repo root. */
-const KITS_DIR = '.readyup/kits';
 
 /** Build the GitHub raw content URL for a kit. */
 function buildGitHubKitUrl(org: string, repo: string, ref: string, kit: string, extension: string): string {

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -46,6 +46,7 @@ export interface ResolvedKitEntry {
 
 export interface ParsedRunArgs {
   checklists: string[] | undefined;
+  detail?: JsonDetail;
   failOn?: Severity;
   filePath: string | undefined;
   fromValue: string | undefined;
@@ -67,6 +68,7 @@ export interface ParsedRunArgs {
  */
 const runOptions = {
   checklists: { type: 'string', short: 'c' },
+  detail: { type: 'string' },
   'fail-on': { type: 'string' },
   file: { type: 'string', short: 'f' },
   from: { type: 'string' },
@@ -85,6 +87,12 @@ function parseSeverityFlag(flagName: string, value: string): Severity {
   if (value === 'error') return 'error';
   if (value === 'warn') return 'warn';
   return 'recommend';
+}
+
+/** Validate and narrow a string to a detail projection. */
+function parseDetailFlag(value: string): JsonDetail {
+  if (value === 'full' || value === 'summary') return value;
+  throw usageError(`--detail must be one of: summary, full (got "${value}")`);
 }
 
 /** Convention path for internal kits, relative to the repo root. */
@@ -106,6 +114,7 @@ const CHECKLISTS_HINT = '--checklists requires a comma-separated list of checkli
 /** Map generic "requires a value" errors to domain-specific hints for run-subcommand flags. */
 const flagErrorHints: Record<string, string> = {
   '--checklists': CHECKLISTS_HINT,
+  '--detail': '--detail requires a projection (summary, full)',
   '--fail-on': '--fail-on requires a severity level (error, warn, recommend)',
   '--file': '--file requires a path argument',
   '--from': '--from requires a source argument (path, github:org/repo, global, dir:path)',
@@ -116,15 +125,23 @@ const flagErrorHints: Record<string, string> = {
 /** The subset of parsed run flags whose combinations are constrained. */
 interface RunFlagConstraints {
   checklists: string | undefined;
+  detail: string | undefined;
   file: string | undefined;
   from: string | undefined;
   internal: boolean;
   jit: boolean;
+  json: boolean;
   url: string | undefined;
 }
 
 /** Collects the active source flags and enforces mutual exclusivity, mode-flag, and selection constraints. */
 function validateFlagConstraints(parsed: RunFlagConstraints, kitSpecifiers: KitSpecifier[]): string | undefined {
+  // `--detail` selects how much of the JSON payload to emit, so it has nothing to say about the human
+  // report. Erroring beats ignoring it: a caller that passed it meant to change the output.
+  if (parsed.detail !== undefined && !parsed.json) {
+    throw usageError('--detail requires --json; it selects how much of the JSON report to emit');
+  }
+
   const sourceFlags: string[] = [];
   if (parsed.file !== undefined) sourceFlags.push('--file');
   if (parsed.from !== undefined) sourceFlags.push('--from');
@@ -200,6 +217,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
 
   const parsed = {
     checklists: values.checklists,
+    detail: values.detail,
     file: values.file,
     from: values.from,
     internal: values.internal === true,
@@ -228,9 +246,10 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
     throw usageError(CHECKLISTS_HINT);
   }
 
-  // Validate severity flags.
+  // Validate severity and projection flags.
   const failOn = parsed.failOn !== undefined ? parseSeverityFlag('--fail-on', parsed.failOn) : undefined;
   const reportOn = parsed.reportOn !== undefined ? parseSeverityFlag('--report-on', parsed.reportOn) : undefined;
+  const detail = parsed.detail !== undefined ? parseDetailFlag(parsed.detail) : undefined;
 
   const parsedArgs: ParsedRunArgs = {
     checklists,
@@ -242,6 +261,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
     kitSpecifiers,
     urlValue: parsed.url,
   };
+  if (detail !== undefined) parsedArgs.detail = detail;
   if (failOn !== undefined) parsedArgs.failOn = failOn;
   if (reportOn !== undefined) parsedArgs.reportOn = reportOn;
   return parsedArgs;

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -8,7 +8,7 @@ import { kitLoadError, toRdyError, usageError } from './errors.ts';
 import { EXIT_OK, EXIT_PROBLEMS_FOUND, EXIT_TOOL_FAILURE } from './exitCodes.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonReport, type KitInput } from './formatJsonReport.ts';
-import { KITS_DIR } from './kitsDir.ts';
+import { KITS_DIR, resolveHomeDir } from './kitsDir.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { type FromSource, parseFromValue } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
@@ -347,7 +347,7 @@ function resolveFromSource(source: FromSource, specs: KitSpecifier[], extension:
       }));
 
     case 'global': {
-      const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '~';
+      const homeDir = resolveHomeDir();
       return specs.map((spec) => ({
         name: spec.kitName,
         source: { path: path.join(homeDir, KITS_DIR, `${spec.kitName}${extension}`) },

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -521,7 +521,12 @@ async function runMultiKitJsonMode(
         if (!report.passed) allPassed = false;
       }
 
-      kitInputs.push({ name: entry.name, entries });
+      kitInputs.push({
+        name: entry.name,
+        entries,
+        failOn: thresholds.failOn,
+        reportOn: thresholds.reportOn,
+      });
     } catch (error: unknown) {
       const { code, message } = toRdyError(error);
       kitInputs.push({ name: entry.name, error: { code, message } });
@@ -529,12 +534,13 @@ async function runMultiKitJsonMode(
     }
   }
 
-  // The echoed thresholds are the run-level resolution: the CLI flag when given, otherwise the
-  // default. A kit that declares its own `failOn` overrides this for its own checks.
+  // The top-level thresholds say what the invocation asked for, so an absent flag stays absent
+  // rather than being reported as a default nobody requested. What governed each kit, including a
+  // threshold the kit declared for itself, travels on that kit's entry.
   const output = formatJsonReport(kitInputs, {
     detail,
-    failOn: failOn ?? 'error',
-    reportOn: reportOn ?? 'recommend',
+    ...(failOn !== undefined && { failOn }),
+    ...(reportOn !== undefined && { reportOn }),
     ...(warnings.length > 0 && { warnings }),
   });
   process.stdout.write(output + '\n');

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -286,7 +286,12 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
       kitResults.push({ name: kitName, status: 'compiled' });
     } catch (error: unknown) {
       // A kit that fails to compile is a problem with the kit, not with the invocation, so the sweep
-      // carries on and the kit is left out of the manifest rather than recorded as if it had compiled.
+      // carries on. The sweep replaces the whole manifest, so a prior record has to be pushed back to
+      // survive, and it still describes the tree: an esbuild failure leaves the previous output and
+      // its hash intact, and a validation failure deletes the output for `verify` to report missing.
+      const existingKit = existingKitsByName.get(kitName);
+      if (existingKit !== undefined) kitEntries.push(existingKit);
+
       const message = extractMessage(error);
       process.stderr.write(`Error compiling ${fileName}: ${message}\n`);
       kitResults.push({ name: kitName, status: 'failed', error: message });

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -13,17 +13,22 @@ import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { writeManifest } from '../manifest/writeManifest.ts';
 import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../reportRdy.ts';
+import { SCHEMA_VERSION } from '../schemas/compileOutputSchema.ts';
+import type { JsonCompileKitEntry, JsonCompileOutput } from '../schemas/index.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { translateParseArgsError } from '../utils/parse-args-error.ts';
+import { pluralizeWithCount } from '../utils/pluralize.ts';
 import type { DriftStatus } from '../verify/checkDrift.ts';
 import { checkDrift } from '../verify/checkDrift.ts';
 import { VERSION } from '../version.ts';
+import { writeHuman } from '../writeHuman.ts';
 import { compileConfig } from './compileConfig.ts';
 import type { KitMetadata } from './validateCompiledOutput.ts';
 import { validateCompiledOutput } from './validateCompiledOutput.ts';
 
 const compileOptions = {
   force: { type: 'boolean' },
+  json: { type: 'boolean' },
   manifest: { type: 'string' },
   output: { type: 'string', short: 'o' },
   'skip-manifest': { type: 'boolean' },
@@ -57,6 +62,7 @@ export async function compileCommand(args: string[]): Promise<number> {
   }
 
   const force = values.force === true;
+  const json = values.json === true;
   const outputPath = values.output;
   const skipManifest = values['skip-manifest'] === true;
   const manifestPath = resolveManifestPath(values.manifest);
@@ -69,7 +75,7 @@ export async function compileCommand(args: string[]): Promise<number> {
 
   // Explicit input file -- compile just that one
   if (inputPath !== undefined) {
-    return compileSingle({ inputPath, outputPath, skipManifest, force, manifestPath });
+    return compileSingle({ inputPath, outputPath, skipManifest, force, manifestPath, json });
   }
 
   // No input file -- compile all sources from config
@@ -77,7 +83,7 @@ export async function compileCommand(args: string[]): Promise<number> {
     throw usageError('--output requires an input file');
   }
 
-  return compileBatch({ skipManifest, force, manifestPath });
+  return compileBatch({ skipManifest, force, manifestPath, json });
 }
 
 /** Arguments for the single-file compile path. */
@@ -87,26 +93,27 @@ interface CompileSingleArgs {
   skipManifest: boolean;
   force: boolean;
   manifestPath: string;
+  json: boolean;
 }
 
 /** Compile a single explicit input file, applying the drift gate before overwriting. */
 async function compileSingle(args: CompileSingleArgs): Promise<number> {
-  const { inputPath, outputPath, skipManifest, force, manifestPath } = args;
+  const { inputPath, outputPath, skipManifest, force, manifestPath, json } = args;
   const manifestDir = path.dirname(manifestPath);
 
   const resolvedInputPath = path.resolve(inputPath);
   const resolvedOutputPath = path.resolve(outputPath ?? deriveJsPath(resolvedInputPath));
   const kitName = path.basename(resolvedOutputPath, '.js');
+  const relInput = path.relative(process.cwd(), resolvedInputPath);
 
-  process.stdout.write('Compiling kit:\n');
+  writeHuman('Compiling kit:\n', json);
 
   const existingKit = skipManifest ? undefined : loadExistingKitsByName(manifestPath).get(kitName);
   const drift = detectDrift({ skipManifest, force, existingKit, manifestDir });
   if (drift !== undefined) {
-    const relInput = path.relative(process.cwd(), resolvedInputPath);
-    process.stdout.write(formatDriftLine(relInput, drift.status));
-    process.stdout.write('\nRe-run with --force to overwrite, or move edits into the source.\n');
-    return EXIT_PROBLEMS_FOUND;
+    writeHuman(formatDriftLine(relInput, drift.status), json);
+    writeHuman('\nRe-run with --force to overwrite, or move edits into the source.\n', json);
+    return finishCompile([{ name: kitName, status: 'skipped', error: formatDriftReason(drift.status) }], json);
   }
 
   let result;
@@ -116,13 +123,13 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
     metadata = await validateCompiledOutput(result.outputPath);
   } catch (error: unknown) {
     // A kit that fails to compile is a problem with the kit, not with the invocation.
-    process.stderr.write(`Error: ${extractMessage(error)}\n`);
-    return EXIT_PROBLEMS_FOUND;
+    const message = extractMessage(error);
+    process.stderr.write(`Error: ${message}\n`);
+    return finishCompile([{ name: kitName, status: 'failed', error: message }], json);
   }
 
-  const relInput = path.relative(process.cwd(), resolvedInputPath);
   const relOutput = path.relative(process.cwd(), result.outputPath);
-  process.stdout.write(formatResultLine(relInput, relOutput, result.changed));
+  writeHuman(formatResultLine(relInput, relOutput, result.changed), json);
 
   if (!skipManifest) {
     try {
@@ -138,7 +145,29 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
     }
   }
 
-  return EXIT_OK;
+  return finishCompile([{ name: kitName, status: 'compiled' }], json);
+}
+
+/**
+ * Emit the compile payload under `--json` and reduce the run's per-kit statuses to an exit code.
+ *
+ * A kit left alone because it drifted counts against the run just as a failed one does: both mean
+ * the compiled output on disk is not what the source says it should be.
+ */
+function finishCompile(kits: JsonCompileKitEntry[], json: boolean): number {
+  const passed = kits.every((kit) => kit.status === 'compiled');
+
+  if (json) {
+    const output: JsonCompileOutput = { schemaVersion: SCHEMA_VERSION, passed, kits };
+    process.stdout.write(JSON.stringify(output) + '\n');
+  }
+
+  return passed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
+}
+
+/** Describe a drift skip for the JSON payload, where there is no formatted line to read. */
+function formatDriftReason(status: Extract<DriftStatus, { kind: 'drift' }>): string {
+  return `Compiled output has drifted from the manifest (expected ${status.expected}, got ${status.actual})`;
 }
 
 /** Resolve the manifest output path from the optional `--manifest` flag. */
@@ -158,11 +187,19 @@ interface CompileBatchArgs {
   skipManifest: boolean;
   force: boolean;
   manifestPath: string;
+  json: boolean;
 }
 
-/** Compile all matching `.ts` files from the config-driven source directory. */
+/**
+ * Compile all matching `.ts` files from the config-driven source directory.
+ *
+ * The sweep runs to completion: a kit that fails to compile is reported and the next one is tried,
+ * so one broken kit cannot hide the state of every kit that sorts after it. Failures on the way to
+ * the sweep — an unreadable config, an unwritable manifest — still throw, because they say nothing
+ * about any individual kit.
+ */
 async function compileBatch(args: CompileBatchArgs): Promise<number> {
-  const { skipManifest, force, manifestPath } = args;
+  const { skipManifest, force, manifestPath, json } = args;
   let config;
   try {
     config = await loadConfig();
@@ -191,7 +228,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
     const reason = srcDirExists
       ? `No .ts files found in ${relSrc}`
       : `Source directory not found: ${relSrc} — treating as empty`;
-    process.stdout.write(`${reason}\n`);
+    writeHuman(`${reason}\n`, json);
     if (!skipManifest) {
       try {
         writeManifest(manifestPath, { version: 1, kits: [] });
@@ -199,19 +236,21 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
         throw configError(`Error writing manifest: ${extractMessage(error)}`, { cause: error });
       }
     }
-    return EXIT_OK;
+    return finishCompile([], json);
   }
 
   const relSrcDir = path.relative(process.cwd(), srcDir);
   const relOutDir = path.relative(process.cwd(), outDir);
   const header =
     srcDir === outDir ? `Compiling kits in ${relSrcDir}:\n` : `Compiling kits from ${relSrcDir} to ${relOutDir}:\n`;
-  process.stdout.write(header);
+  writeHuman(header, json);
 
   const manifestDir = path.dirname(manifestPath);
   const existingKitsByName = skipManifest ? new Map<string, RdyManifestKit>() : loadExistingKitsByName(manifestPath);
   const kitEntries: RdyManifestKit[] = [];
+  const kitResults: JsonCompileKitEntry[] = [];
   let skippedCount = 0;
+  let failedCount = 0;
 
   for (const fileName of tsFiles) {
     const srcFile = path.join(srcDir, fileName);
@@ -220,8 +259,9 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
 
     const drift = detectDrift({ skipManifest, force, existingKit: existingKitsByName.get(kitName), manifestDir });
     if (drift !== undefined) {
-      process.stdout.write(formatDriftLine(fileName, drift.status));
+      writeHuman(formatDriftLine(fileName, drift.status), json);
       kitEntries.push(drift.existingKit);
+      kitResults.push({ name: kitName, status: 'skipped', error: formatDriftReason(drift.status) });
       skippedCount += 1;
       continue;
     }
@@ -230,7 +270,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
       const result = await compileConfig(srcFile, outFile);
       const metadata = await validateCompiledOutput(result.outputPath);
       const outName = fileName.replace(/\.ts$/, '.js');
-      process.stdout.write(formatResultLine(fileName, outName, result.changed));
+      writeHuman(formatResultLine(fileName, outName, result.changed), json);
 
       const relOutputPath = path.relative(manifestDir, path.resolve(result.outputPath));
       const relSourcePath = path.relative(manifestDir, srcFile);
@@ -240,20 +280,30 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
         readyupVersion: VERSION,
         source: relSourcePath,
         targetHash: result.targetHash,
+        ...(metadata.checklists.length > 0 && { checklists: metadata.checklists }),
         ...(metadata.description !== undefined && { description: metadata.description }),
       });
+      kitResults.push({ name: kitName, status: 'compiled' });
     } catch (error: unknown) {
-      // A kit that fails to compile is a problem with the kit, not with the invocation.
-      process.stderr.write(`Error compiling ${fileName}: ${extractMessage(error)}\n`);
-      return EXIT_PROBLEMS_FOUND;
+      // A kit that fails to compile is a problem with the kit, not with the invocation, so the sweep
+      // carries on and the kit is left out of the manifest rather than recorded as if it had compiled.
+      const message = extractMessage(error);
+      process.stderr.write(`Error compiling ${fileName}: ${message}\n`);
+      kitResults.push({ name: kitName, status: 'failed', error: message });
+      failedCount += 1;
     }
   }
 
   if (skippedCount > 0) {
-    process.stdout.write(
-      `\n${skippedCount} of ${tsFiles.length} kit${tsFiles.length === 1 ? '' : 's'} skipped due to drift.` +
+    writeHuman(
+      `\n${skippedCount} of ${pluralizeWithCount(tsFiles.length, 'kit')} skipped due to drift.` +
         ` Re-run with --force to overwrite, or move edits into the source.\n`,
+      json,
     );
+  }
+
+  if (failedCount > 0) {
+    writeHuman(`\n${failedCount} of ${pluralizeWithCount(tsFiles.length, 'kit')} failed to compile.\n`, json);
   }
 
   if (!skipManifest) {
@@ -265,7 +315,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
     }
   }
 
-  return skippedCount > 0 ? EXIT_PROBLEMS_FOUND : EXIT_OK;
+  return finishCompile(kitResults, json);
 }
 
 /** Location fields for a manifest kit entry. */
@@ -300,6 +350,7 @@ function upsertManifest(
     readyupVersion: VERSION,
     source: location.source,
     targetHash: location.targetHash,
+    ...(metadata.checklists.length > 0 && { checklists: metadata.checklists }),
     ...(metadata.description !== undefined && { description: metadata.description }),
   };
 

--- a/packages/readyup/src/compile/validateCompiledOutput.ts
+++ b/packages/readyup/src/compile/validateCompiledOutput.ts
@@ -10,6 +10,7 @@ import { validateKit } from '../validateKit.ts';
 
 /** Lightweight metadata extracted from a validated kit. */
 export interface KitMetadata {
+  checklists: string[];
   description?: string | undefined;
 }
 
@@ -44,6 +45,7 @@ export async function validateCompiledOutput(outputPath: string): Promise<KitMet
   }
 
   return {
+    checklists: kit.checklists.map((checklist) => checklist.name),
     description: kit.description,
   };
 }

--- a/packages/readyup/src/formatJsonError.ts
+++ b/packages/readyup/src/formatJsonError.ts
@@ -1,6 +1,12 @@
 import type { RdyError } from './errors.ts';
+import { SCHEMA_VERSION } from './schemas/errorEnvelopeSchema.ts';
+import type { JsonErrorEnvelope } from './schemas/index.ts';
 
 /** Serializes a failed invocation as the single-line JSON error envelope. */
 export function formatJsonError(error: RdyError): string {
-  return JSON.stringify({ error: { code: error.code, message: error.message } });
+  const envelope: JsonErrorEnvelope = {
+    schemaVersion: SCHEMA_VERSION,
+    error: { code: error.code, message: error.message },
+  };
+  return JSON.stringify(envelope);
 }

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -2,13 +2,17 @@ import { countResults, emptyCounts, mergeCounts, selectVisibleResults } from './
 import type {
   JsonCheckEntry,
   JsonChecklistEntry,
+  JsonCounts,
+  JsonDetail,
   JsonKitEntry,
   JsonKitErrorEntry,
+  JsonKitResultEntry,
   JsonReport,
-  RdyReport,
-  RdyResult,
-  Severity,
-} from './types.ts';
+  JsonWarning,
+} from './schemas/index.ts';
+import { SCHEMA_VERSION } from './schemas/reportSchema.ts';
+import type { RdyReport, RdyResult, Severity, SummaryCounts } from './types.ts';
+import { VERSION } from './version.ts';
 
 interface ChecklistEntry {
   name: string;
@@ -29,67 +33,151 @@ interface KitResultInput {
  */
 export type KitInput = JsonKitErrorEntry | KitResultInput;
 
-/** Options controlling which results appear in JSON output. */
+/**
+ * The resolved run settings the report echoes back, plus anything it must carry alongside results.
+ *
+ * These are resolved rather than optional: by serialization time every threshold has a value, and a
+ * consumer holding only the payload needs them to tell a clean run from one whose failures were
+ * filtered out of view.
+ */
 export interface FormatJsonReportOptions {
-  reportOn?: Severity;
+  failOn: Severity;
+  reportOn: Severity;
+  detail: JsonDetail;
+  warnings?: JsonWarning[];
 }
 
 /**
- * Build a single checklist entry from a name and report.
+ * A kit that ran, paired with the unrounded figures the report aggregates from it.
  *
- * Counts cover the whole run; the reporting threshold prunes only the serialized detail tree,
- * retaining the ancestors of every result it keeps so the nesting stays intact.
+ * The entry's own `durationMs` is already rounded for the wire; totals are summed from the raw value
+ * so a run of many short kits does not accumulate one rounding error per kit.
  */
-function buildChecklistEntry(name: string, report: RdyReport, reportOn: Severity): JsonChecklistEntry {
-  const counts = countResults(report.results);
-  const visibleResults = selectVisibleResults(report.results, reportOn);
-  const { entries: checks } = buildCheckEntries(visibleResults, 0, 0);
-
-  return {
-    name,
-    durationMs: report.durationMs,
-    ...counts,
-    checks,
-  };
+interface AggregatedKit {
+  entry: JsonKitResultEntry;
+  counts: SummaryCounts;
+  durationMs: number;
 }
 
 /** Transform kit-grouped checklist results into a JSON-serializable report string. */
-export function formatJsonReport(kitInputs: KitInput[], options?: FormatJsonReportOptions): string {
-  const reportOn = options?.reportOn ?? 'recommend';
-  const totals = emptyCounts();
+export function formatJsonReport(kitInputs: KitInput[], options: FormatJsonReportOptions): string {
+  const { failOn, reportOn, detail, warnings } = options;
+  const kits: JsonKitEntry[] = [];
+  const aggregates: AggregatedKit[] = [];
 
-  const kits: JsonKitEntry[] = kitInputs.map((input) => {
+  for (const input of kitInputs) {
     // A kit that never ran contributes nothing to the totals, so they cover only the kits that did.
-    if ('error' in input) return input;
+    if ('error' in input) {
+      kits.push(input);
+      continue;
+    }
+    const aggregate = aggregateKit(input, reportOn, detail);
+    kits.push(aggregate.entry);
+    aggregates.push(aggregate);
+  }
 
-    const { name, entries } = input;
-    const kitCounts = emptyCounts();
-    const checklists: JsonChecklistEntry[] = entries.map(({ name: checklistName, report }) => {
-      const entry = buildChecklistEntry(checklistName, report, reportOn);
-      mergeCounts(kitCounts, entry);
-      return entry;
-    });
+  const totals = emptyCounts();
+  let totalDurationMs = 0;
+  for (const aggregate of aggregates) {
+    mergeCounts(totals, aggregate.counts);
+    totalDurationMs += aggregate.durationMs;
+  }
 
-    const kitDurationMs = checklists.reduce((sum, c) => sum + c.durationMs, 0);
-    mergeCounts(totals, kitCounts);
+  // A kit that never ran leaves the run incomplete, which the verdict must reflect even when
+  // everything that did run passed.
+  const everyKitRan = aggregates.length === kits.length;
 
-    return {
-      name,
-      durationMs: kitDurationMs,
-      ...kitCounts,
-      checklists,
-    };
-  });
-
-  const totalDurationMs = kits.reduce((sum, k) => sum + ('error' in k ? 0 : k.durationMs), 0);
-
-  const output: JsonReport = {
-    ...totals,
-    durationMs: totalDurationMs,
+  const report: JsonReport = {
+    schemaVersion: SCHEMA_VERSION,
+    readyupVersion: VERSION,
+    passed: everyKitRan && aggregates.every(({ entry }) => entry.passed),
+    ...splitCounts(totals),
+    failOn,
+    reportOn,
+    detail,
+    durationMs: Math.round(totalDurationMs),
+    ...(warnings !== undefined && warnings.length > 0 && { warnings }),
     kits,
   };
 
-  return JSON.stringify(output);
+  return JSON.stringify(report);
+}
+
+/** Build one kit's entry and the raw figures the report aggregates from it. */
+function aggregateKit(input: KitResultInput, reportOn: Severity, detail: JsonDetail): AggregatedKit {
+  const counts = emptyCounts();
+  let durationMs = 0;
+
+  const checklists: JsonChecklistEntry[] = input.entries.map(({ name, report }) => {
+    const checklistCounts = countResults(report.results);
+    mergeCounts(counts, checklistCounts);
+    durationMs += report.durationMs;
+
+    return {
+      name,
+      passed: report.passed,
+      ...splitCounts(checklistCounts),
+      durationMs: Math.round(report.durationMs),
+      ...buildDetailTree(report.results, reportOn, detail),
+    };
+  });
+
+  const entry: JsonKitResultEntry = {
+    name: input.name,
+    passed: checklists.every((checklist) => checklist.passed),
+    ...splitCounts(counts),
+    durationMs: Math.round(durationMs),
+    checklists,
+  };
+
+  return { entry, counts, durationMs };
+}
+
+/**
+ * Split the runner's internal tally into the wire shape: six numbers under `counts`, worst severity
+ * beside them.
+ *
+ * `worstSeverity` is derived verdict data rather than a count, so it sits outside the object it
+ * summarizes; a run that failed nothing has no worst severity and omits the field.
+ */
+function splitCounts(counts: SummaryCounts): { counts: JsonCounts; worstSeverity?: Severity } {
+  const { worstSeverity, ...numeric } = counts;
+  return worstSeverity === null ? { counts: numeric } : { counts: numeric, worstSeverity };
+}
+
+/**
+ * Build the `checks` property for a checklist entry, or nothing when the projection leaves it empty.
+ *
+ * The reporting threshold prunes first and the detail projection second, so `summary` shows the same
+ * failures `full` would — just without the checks that passed around them.
+ */
+function buildDetailTree(results: RdyResult[], reportOn: Severity, detail: JsonDetail): { checks?: JsonCheckEntry[] } {
+  const visibleResults = selectVisibleResults(results, reportOn);
+  const checks =
+    detail === 'summary' ? buildSummaryEntries(visibleResults) : buildCheckEntries(visibleResults, 0, 0).entries;
+  return checks.length > 0 ? { checks } : {};
+}
+
+/**
+ * Project visible results down to what `--detail summary` carries: the failures and their remedies.
+ *
+ * Nesting is dropped along with the checks that passed, because what survives is a work list rather
+ * than a trace of the run — the caller wants what to fix, and `full` remains one flag away.
+ */
+function buildSummaryEntries(results: RdyResult[]): JsonCheckEntry[] {
+  return results
+    .filter((result) => result.status === 'failed')
+    .map((result) => {
+      const entry: JsonCheckEntry = {
+        name: result.name,
+        status: result.status,
+        ok: result.ok,
+        severity: result.severity,
+        durationMs: Math.round(result.durationMs),
+      };
+      if (result.fix !== null) entry.fix = result.fix;
+      return entry;
+    });
 }
 
 /**
@@ -131,26 +219,27 @@ function buildCheckEntries(
 }
 
 /**
- * Build a single JSON check entry, normalizing the union to include all fields.
+ * Build a single JSON check entry, omitting every field that carries nothing.
  *
- * Non-skipped results get `skipReason: null` for uniform JSON shape.
- * Error objects are serialized to their message string.
+ * A field is present only when it holds information the consumer could act on: no `null` placeholders,
+ * no empty `checks` array, and no `fix` on a check that has nothing to remediate. Durations are whole
+ * milliseconds, since sub-millisecond precision on a check that took 3ms describes only the scheduler.
  */
-function buildCheckEntry(result: RdyResult, children: JsonCheckEntry[] = []): JsonCheckEntry {
-  const errorString = result.error !== null ? result.error.message : null;
-  const skipReason = result.status === 'skipped' ? result.skipReason : null;
-
-  return {
+function buildCheckEntry(result: RdyResult, children: JsonCheckEntry[]): JsonCheckEntry {
+  const entry: JsonCheckEntry = {
     name: result.name,
     status: result.status,
     ok: result.ok,
     severity: result.severity,
-    skipReason,
-    detail: result.detail,
-    fix: result.fix,
-    error: errorString,
-    progress: result.progress,
-    durationMs: result.durationMs,
-    checks: children,
+    durationMs: Math.round(result.durationMs),
   };
+
+  if (result.status === 'skipped') entry.skipReason = result.skipReason;
+  if (result.detail !== null) entry.detail = result.detail;
+  if (result.status === 'failed' && result.fix !== null) entry.fix = result.fix;
+  if (result.error !== null) entry.error = result.error.message;
+  if (result.progress !== null) entry.progress = result.progress;
+  if (children.length > 0) entry.checks = children;
+
+  return entry;
 }

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -19,10 +19,18 @@ interface ChecklistEntry {
   report: RdyReport;
 }
 
-/** Input for a kit that ran, carrying the reports its checklists produced. */
-interface KitResultInput {
+/**
+ * Input for a kit that ran, carrying the reports its checklists produced and the thresholds that
+ * governed them.
+ *
+ * The thresholds travel with the kit rather than with the run, because a kit may declare its own and
+ * the caller has already resolved the cascade by the time it gets here.
+ */
+export interface KitResultInput {
   name: string;
   entries: ChecklistEntry[];
+  failOn: Severity;
+  reportOn: Severity;
 }
 
 /**
@@ -34,15 +42,15 @@ interface KitResultInput {
 export type KitInput = JsonKitErrorEntry | KitResultInput;
 
 /**
- * The resolved run settings the report echoes back, plus anything it must carry alongside results.
+ * The run settings the report echoes back, plus anything it must carry alongside results.
  *
- * These are resolved rather than optional: by serialization time every threshold has a value, and a
- * consumer holding only the payload needs them to tell a clean run from one whose failures were
- * filtered out of view.
+ * `failOn` and `reportOn` are what the invocation requested, so each is absent when its flag was not
+ * given: a default echoed as though it had been asked for is what made a kit's own threshold
+ * impossible to recover from the payload. `detail` has no per-kit form, so it is always resolved.
  */
 export interface FormatJsonReportOptions {
-  failOn: Severity;
-  reportOn: Severity;
+  failOn?: Severity;
+  reportOn?: Severity;
   detail: JsonDetail;
   warnings?: JsonWarning[];
 }
@@ -71,7 +79,7 @@ export function formatJsonReport(kitInputs: KitInput[], options: FormatJsonRepor
       kits.push(input);
       continue;
     }
-    const aggregate = aggregateKit(input, reportOn, detail);
+    const aggregate = aggregateKit(input, detail);
     kits.push(aggregate.entry);
     aggregates.push(aggregate);
   }
@@ -92,8 +100,8 @@ export function formatJsonReport(kitInputs: KitInput[], options: FormatJsonRepor
     readyupVersion: VERSION,
     passed: everyKitRan && aggregates.every(({ entry }) => entry.passed),
     ...splitCounts(totals),
-    failOn,
-    reportOn,
+    ...(failOn !== undefined && { failOn }),
+    ...(reportOn !== undefined && { reportOn }),
     detail,
     durationMs: Math.round(totalDurationMs),
     ...(warnings !== undefined && warnings.length > 0 && { warnings }),
@@ -104,7 +112,7 @@ export function formatJsonReport(kitInputs: KitInput[], options: FormatJsonRepor
 }
 
 /** Build one kit's entry and the raw figures the report aggregates from it. */
-function aggregateKit(input: KitResultInput, reportOn: Severity, detail: JsonDetail): AggregatedKit {
+function aggregateKit(input: KitResultInput, detail: JsonDetail): AggregatedKit {
   const counts = emptyCounts();
   let durationMs = 0;
 
@@ -118,7 +126,7 @@ function aggregateKit(input: KitResultInput, reportOn: Severity, detail: JsonDet
       passed: report.passed,
       ...splitCounts(checklistCounts),
       durationMs: Math.round(report.durationMs),
-      ...buildDetailTree(report.results, reportOn, detail),
+      ...buildDetailTree(report.results, input.reportOn, detail),
     };
   });
 
@@ -126,6 +134,8 @@ function aggregateKit(input: KitResultInput, reportOn: Severity, detail: JsonDet
     name: input.name,
     passed: checklists.every((checklist) => checklist.passed),
     ...splitCounts(counts),
+    failOn: input.failOn,
+    reportOn: input.reportOn,
     durationMs: Math.round(durationMs),
     checklists,
   };

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -7,12 +7,6 @@ export type {
   FailedResult,
   FixLocation,
   FractionProgress,
-  JsonCheckEntry,
-  JsonChecklistEntry,
-  JsonKitEntry,
-  JsonKitErrorEntry,
-  JsonKitResultEntry,
-  JsonReport,
   LocalRefsCompareResult,
   PassedResult,
   PercentProgress,
@@ -34,6 +28,32 @@ export type {
 
 // Error taxonomy
 export type { RdyErrorCode } from './errors.ts';
+
+// JSON payload types, derived from the zod schemas that also generate the published JSON Schemas
+export type {
+  JsonCheckEntry,
+  JsonChecklistEntry,
+  JsonCompileKitEntry,
+  JsonCompileOutput,
+  JsonCompileStatus,
+  JsonCounts,
+  JsonDetail,
+  JsonDriftStatus,
+  JsonErrorBody,
+  JsonErrorEnvelope,
+  JsonKitEntry,
+  JsonKitErrorEntry,
+  JsonKitKind,
+  JsonKitResultEntry,
+  JsonListKitEntry,
+  JsonListOutput,
+  JsonProgress,
+  JsonReport,
+  JsonVerifyKitEntry,
+  JsonVerifyOutput,
+  JsonWarning,
+  JsonWarningCode,
+} from './schemas/index.ts';
 
 // Type guards
 export { isFlatChecklist, isPercentProgress } from './types.ts';

--- a/packages/readyup/src/kitsDir.ts
+++ b/packages/readyup/src/kitsDir.ts
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 /**
  * Convention directory for kits, relative to a project root or the home directory.
  *
@@ -5,3 +7,8 @@
  * enumerating the same files `run` would load when no manifest sits beside them.
  */
 export const KITS_DIR = '.readyup/kits';
+
+/** Resolve the home directory the `global` kit source is rooted at, across platforms. */
+export function resolveHomeDir(): string {
+  return process.env.HOME ?? process.env.USERPROFILE ?? '~';
+}

--- a/packages/readyup/src/kitsDir.ts
+++ b/packages/readyup/src/kitsDir.ts
@@ -1,0 +1,7 @@
+/**
+ * Convention directory for kits, relative to a project root or the home directory.
+ *
+ * `run --from` and `list --from` both resolve against it, which is what lets `list` fall back to
+ * enumerating the same files `run` would load when no manifest sits beside them.
+ */
+export const KITS_DIR = '.readyup/kits';

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -5,7 +5,7 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 
 import { configError, usageError } from '../errors.ts';
 import { EXIT_OK } from '../exitCodes.ts';
-import { KITS_DIR } from '../kitsDir.ts';
+import { KITS_DIR, resolveHomeDir } from '../kitsDir.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { loadRemoteManifest, RemoteManifestNotFoundError } from '../loadRemoteManifest.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
@@ -15,8 +15,8 @@ import type { DirectorySource, GlobalSource, LocalSource } from '../parseFromVal
 import { parseFromValue } from '../parseFromValue.ts';
 import { resolveBitbucketToken } from '../resolveBitbucketToken.ts';
 import { resolveGitHubToken } from '../resolveGitHubToken.ts';
-import { SCHEMA_VERSION } from '../schemas/listOutputSchema.ts';
 import type { JsonListKitEntry, JsonListOutput } from '../schemas/index.ts';
+import { SCHEMA_VERSION } from '../schemas/listOutputSchema.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { translateParseArgsError } from '../utils/parse-args-error.ts';
 import { writeHuman } from '../writeHuman.ts';
@@ -329,11 +329,6 @@ function resolveFromKitsDir(source: LocalFromSource): string {
 
   // local path
   return path.join(path.resolve(source.path), KITS_DIR);
-}
-
-/** Resolve the home directory across platforms, matching how `run --from global` resolves it. */
-function resolveHomeDir(): string {
-  return process.env.HOME ?? process.env.USERPROFILE ?? '~';
 }
 
 /** Determine the compiled-section display style based on the outDir setting. */

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -1,25 +1,35 @@
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { parseArgs as nodeParseArgs } from 'node:util';
 
 import { configError, usageError } from '../errors.ts';
 import { EXIT_OK } from '../exitCodes.ts';
+import { KITS_DIR } from '../kitsDir.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { loadRemoteManifest, RemoteManifestNotFoundError } from '../loadRemoteManifest.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
-import type { RdyManifest } from '../manifest/manifestSchema.ts';
+import type { RdyManifest, RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
+import type { DirectorySource, GlobalSource, LocalSource } from '../parseFromValue.ts';
 import { parseFromValue } from '../parseFromValue.ts';
 import { resolveBitbucketToken } from '../resolveBitbucketToken.ts';
 import { resolveGitHubToken } from '../resolveGitHubToken.ts';
+import { SCHEMA_VERSION } from '../schemas/listOutputSchema.ts';
+import type { JsonListKitEntry, JsonListOutput } from '../schemas/index.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { translateParseArgsError } from '../utils/parse-args-error.ts';
+import { writeHuman } from '../writeHuman.ts';
 import { enumerateKits } from './enumerateKits.ts';
 import type { CompiledStyle } from './formatList.ts';
 import { formatConsumerView, formatManifestView, formatOwnerView } from './formatList.ts';
 
+/** A local `--from` source, which resolves to a directory on this machine. */
+type LocalFromSource = DirectorySource | GlobalSource | LocalSource;
+
 const listOptions = {
   from: { type: 'string' },
+  json: { type: 'boolean' },
   manifest: { type: 'string' },
 } as const;
 
@@ -44,6 +54,7 @@ export async function listCommand(args: string[]): Promise<number> {
   }
 
   const fromArg = values.from;
+  const json = values.json === true;
   const manifestArg = values.manifest;
 
   if (fromArg !== undefined && manifestArg !== undefined) {
@@ -51,29 +62,32 @@ export async function listCommand(args: string[]): Promise<number> {
   }
 
   if (manifestArg !== undefined) {
-    return runManifestMode(manifestArg);
+    return runManifestMode(manifestArg, json);
   }
 
   if (fromArg !== undefined) {
-    return runFromMode(fromArg);
+    return runFromMode(fromArg, json);
   }
 
-  return runOwnerMode();
+  return runOwnerMode(json);
 }
 
 /** Display kits from a manifest file. */
-function runManifestMode(manifestArg: string): number {
+function runManifestMode(manifestArg: string, json: boolean): number {
   const manifestPath = path.resolve(process.cwd(), manifestArg);
   const manifest = readManifestOrThrow(manifestPath);
 
   const relPath = path.relative(process.cwd(), manifestPath);
-  const output = formatManifestView({ kits: manifest.kits, manifestPath: relPath });
-  process.stdout.write(output + '\n');
-  return EXIT_OK;
+  writeHuman(formatManifestView({ kits: manifest.kits, manifestPath: relPath }) + '\n', json);
+
+  return finishList(
+    manifest.kits.map((kit) => buildManifestEntry(kit, path.dirname(manifestPath))),
+    json,
+  );
 }
 
 /** Resolve the manifest path for a `--from` source and display its kits. */
-async function runFromMode(fromArg: string): Promise<number> {
+async function runFromMode(fromArg: string, json: boolean): Promise<number> {
   let source;
   try {
     source = parseFromValue(fromArg);
@@ -85,32 +99,41 @@ async function runFromMode(fromArg: string): Promise<number> {
     const url = `https://raw.githubusercontent.com/${source.org}/${source.repo}/${source.ref}/.readyup/manifest.json`;
     const token = resolveGitHubToken();
     const headers = token !== undefined ? { Authorization: `token ${token}` } : undefined;
-    return runRemoteFromMode({ url, headers });
+    return runRemoteFromMode({ url, headers, json });
   }
 
   if (source.type === 'bitbucket') {
     const url = `https://api.bitbucket.org/2.0/repositories/${source.workspace}/${source.repo}/src/${source.ref}/.readyup/manifest.json`;
     const token = resolveBitbucketToken();
     const headers = token !== undefined ? { Authorization: `Bearer ${token}` } : undefined;
-    return runRemoteFromMode({ url, headers });
+    return runRemoteFromMode({ url, headers, json });
   }
 
   const manifestPath = resolveFromManifestPath(source);
-  const manifest = readManifestOrThrow(manifestPath);
+  const kitsDir = resolveFromKitsDir(source);
+  const manifest = readLocalManifestIfPresent(manifestPath);
+  const entries =
+    manifest === undefined ? enumerateCompiledKits(kitsDir, manifestPath) : manifestEntries(manifest, manifestPath);
 
-  const kitNames = manifest.kits.map((kit) => kit.name);
-  const output = formatConsumerView({ compiledKits: kitNames, fromArg, kitsDir: path.dirname(manifestPath) });
-  process.stdout.write(output + '\n');
-  return EXIT_OK;
+  const output = formatConsumerView({
+    compiledKits: entries.map((entry) => entry.name),
+    fromArg,
+    kitsDir: path.relative(process.cwd(), kitsDir) || '.',
+  });
+  writeHuman(output + '\n', json);
+
+  return finishList(entries, json);
 }
 
 /** Fetch and display kits from a remote manifest URL. */
 async function runRemoteFromMode({
   url,
   headers,
+  json,
 }: {
   url: string;
   headers?: Record<string, string> | undefined;
+  json: boolean;
 }): Promise<number> {
   let manifest;
   try {
@@ -125,13 +148,18 @@ async function runRemoteFromMode({
     throw configError(detail, { cause: error });
   }
 
-  const output = formatManifestView({ kits: manifest.kits, manifestPath: url });
-  process.stdout.write(output + '\n');
-  return EXIT_OK;
+  writeHuman(formatManifestView({ kits: manifest.kits, manifestPath: url }) + '\n', json);
+
+  // A remote manifest's paths name locations on the host that published it, so they are passed
+  // through rather than rebased onto a directory that does not exist here.
+  return finishList(
+    manifest.kits.map((kit) => buildManifestEntry(kit, undefined)),
+    json,
+  );
 }
 
 /** Enumerate kits using the project config. */
-async function runOwnerMode(): Promise<number> {
+async function runOwnerMode(json: boolean): Promise<number> {
   const cwd = process.cwd();
 
   let config;
@@ -141,7 +169,7 @@ async function runOwnerMode(): Promise<number> {
     throw configError(extractMessage(error), { cause: error });
   }
 
-  const internalDir = path.join(cwd, '.readyup/kits', config.internal.dir);
+  const internalDir = path.join(cwd, KITS_DIR, config.internal.dir);
   const internalExtension = config.internal.infix !== undefined ? `.${config.internal.infix}.ts` : '.ts';
 
   let internalKits;
@@ -152,30 +180,118 @@ async function runOwnerMode(): Promise<number> {
   }
 
   const manifestPath = path.resolve(cwd, DEFAULT_MANIFEST_PATH);
-  let compiledKits: string[] = [];
+  let manifestKits: RdyManifestKit[] = [];
   try {
-    const manifest = readManifest(manifestPath);
-    compiledKits = manifest.kits.map((kit) => kit.name);
+    manifestKits = readManifest(manifestPath).kits;
   } catch (error: unknown) {
     if (error instanceof ManifestNotFoundError) {
       // Missing manifest — show hint only when no internal kits exist either.
       if (internalKits.length === 0) {
-        process.stdout.write(
+        writeHuman(
           'No kits found.\nRun `rdy init` to scaffold an internal kit or `rdy compile` to compile a kit from source.\n',
+          json,
         );
-        return EXIT_OK;
+        return finishList([], json);
       }
     } else {
       // Corrupt or unreadable manifest — warn and continue with empty compiled list.
-      const message = extractMessage(error);
-      process.stderr.write(`Warning: ${message}\n`);
+      process.stderr.write(`Warning: ${extractMessage(error)}\n`);
     }
   }
 
+  const compiledKits = manifestKits.map((kit) => kit.name);
   const compiledStyle = resolveCompiledStyle(cwd, config.compile.outDir);
-  const output = formatOwnerView({ internalKits, compiledKits, compiledStyle });
-  process.stdout.write(output + '\n');
+  writeHuman(formatOwnerView({ internalKits, compiledKits, compiledStyle }) + '\n', json);
+
+  const entries: JsonListKitEntry[] = [
+    ...internalKits.map((name) => buildInternalEntry(name, internalDir, internalExtension)),
+    ...manifestKits.map((kit) => buildManifestEntry(kit, path.dirname(manifestPath))),
+  ];
+  return finishList(entries, json);
+}
+
+/** Emit the list payload under `--json`. Listing succeeds whenever its source could be read. */
+function finishList(kits: JsonListKitEntry[], json: boolean): number {
+  if (json) {
+    const output: JsonListOutput = { schemaVersion: SCHEMA_VERSION, kits };
+    process.stdout.write(JSON.stringify(output) + '\n');
+  }
   return EXIT_OK;
+}
+
+/** Build the rows a manifest declares, rebasing each recorded path onto the current directory. */
+function manifestEntries(manifest: RdyManifest, manifestPath: string): JsonListKitEntry[] {
+  return manifest.kits.map((kit) => buildManifestEntry(kit, path.dirname(manifestPath)));
+}
+
+/**
+ * Build a kit row from a manifest entry.
+ *
+ * Every field but `name` and `kind` comes from the manifest, so a kit compiled by an older readyup
+ * simply carries fewer of them. `checklists` is read here rather than from the kit itself: listing
+ * kits never imports a compiled bundle, so it never runs kit code.
+ *
+ * `manifestDir` rebases the recorded path onto the current directory, so a consumer can hand it
+ * straight to `rdy run --file`. Pass `undefined` for a manifest that is not on this machine.
+ */
+function buildManifestEntry(kit: RdyManifestKit, manifestDir: string | undefined): JsonListKitEntry {
+  const entry: JsonListKitEntry = { name: kit.name, kind: 'compiled' };
+
+  if (kit.path !== undefined) {
+    entry.path =
+      manifestDir === undefined ? kit.path : path.relative(process.cwd(), path.resolve(manifestDir, kit.path));
+  }
+  if (kit.checklists !== undefined) entry.checklists = kit.checklists;
+  if (kit.description !== undefined) entry.description = kit.description;
+  if (kit.readyupVersion !== undefined) entry.readyupVersion = kit.readyupVersion;
+
+  return entry;
+}
+
+/** Build a kit row for a TypeScript source awaiting compilation. */
+function buildInternalEntry(name: string, dir: string, extension: string): JsonListKitEntry {
+  return { name, kind: 'internal', path: path.relative(process.cwd(), path.join(dir, `${name}${extension}`)) };
+}
+
+/**
+ * Enumerate the compiled kits in a directory, for a source that has no manifest beside it.
+ *
+ * `run --from` resolves a kit by filename alone, so a directory it can run from is one `list` must
+ * be able to describe. The rows carry only what the filesystem knows: everything else — description,
+ * checklist names, the readyup version a kit was built against — lives in the manifest that is absent.
+ *
+ * A source with neither a manifest nor a kit directory is still an error. Reporting "no kits" for a
+ * path that does not exist would turn a mistyped `--from` into a clean, empty answer.
+ */
+function enumerateCompiledKits(kitsDir: string, manifestPath: string): JsonListKitEntry[] {
+  if (!existsSync(kitsDir)) {
+    const relManifest = path.relative(process.cwd(), manifestPath);
+    const relKitsDir = path.relative(process.cwd(), kitsDir);
+    throw configError(`No manifest found at ${relManifest}, and no kit directory at ${relKitsDir}.`);
+  }
+
+  let names: string[];
+  try {
+    names = enumerateKits({ dir: kitsDir, extension: '.js' });
+  } catch (error: unknown) {
+    throw configError(extractMessage(error), { cause: error });
+  }
+
+  return names.map((name) => ({
+    name,
+    kind: 'compiled',
+    path: path.relative(process.cwd(), path.join(kitsDir, `${name}.js`)),
+  }));
+}
+
+/** Read a manifest, returning undefined when there is none and reporting any other failure. */
+function readLocalManifestIfPresent(manifestPath: string): RdyManifest | undefined {
+  try {
+    return readManifest(manifestPath);
+  } catch (error: unknown) {
+    if (error instanceof ManifestNotFoundError) return undefined;
+    throw configError(extractMessage(error), { cause: error });
+  }
 }
 
 /** Reads a manifest, reporting an unreadable or invalid one as a config failure. */
@@ -187,13 +303,10 @@ function readManifestOrThrow(manifestPath: string): RdyManifest {
   }
 }
 
-/** Resolve the manifest path for a parsed `--from` source. */
-function resolveFromManifestPath(
-  source: { type: 'global' } | { type: 'directory'; path: string } | { type: 'local'; path: string },
-): string {
+/** Resolve the manifest path for a parsed local `--from` source. */
+function resolveFromManifestPath(source: LocalFromSource): string {
   if (source.type === 'global') {
-    const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '~';
-    return path.join(homeDir, '.readyup/manifest.json');
+    return path.join(resolveHomeDir(), '.readyup/manifest.json');
   }
 
   if (source.type === 'directory') {
@@ -204,10 +317,29 @@ function resolveFromManifestPath(
   return path.join(path.resolve(source.path), '.readyup/manifest.json');
 }
 
+/** Resolve the directory a local `--from` source keeps its compiled kits in, matching `run --from`. */
+function resolveFromKitsDir(source: LocalFromSource): string {
+  if (source.type === 'global') {
+    return path.join(resolveHomeDir(), KITS_DIR);
+  }
+
+  if (source.type === 'directory') {
+    return path.resolve(source.path);
+  }
+
+  // local path
+  return path.join(path.resolve(source.path), KITS_DIR);
+}
+
+/** Resolve the home directory across platforms, matching how `run --from global` resolves it. */
+function resolveHomeDir(): string {
+  return process.env.HOME ?? process.env.USERPROFILE ?? '~';
+}
+
 /** Determine the compiled-section display style based on the outDir setting. */
 function resolveCompiledStyle(cwd: string, outDir: string): CompiledStyle {
   const resolvedOutDir = path.resolve(cwd, outDir);
-  const defaultOutDir = path.resolve(cwd, '.readyup/kits');
+  const defaultOutDir = path.resolve(cwd, KITS_DIR);
 
   if (resolvedOutDir === defaultOutDir) {
     return { kind: 'local-convention' };

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -1,7 +1,15 @@
 import { z } from 'zod';
 
-/** Schema for a single kit entry in the manifest. */
+/**
+ * Schema for a single kit entry in the manifest.
+ *
+ * `checklists` records the names `rdy compile` found in the kit, so `rdy list` can report them
+ * without importing and executing the compiled bundle. It is optional because a manifest written by
+ * an older readyup has no such record; readers strip what they do not recognize, so the field's
+ * arrival leaves `version` at 1.
+ */
 const ManifestKitSchema = z.object({
+  checklists: z.array(z.string()).optional(),
   description: z.string().optional(),
   name: z.string().min(1),
   path: z.string().optional(),

--- a/packages/readyup/src/schemas/common.ts
+++ b/packages/readyup/src/schemas/common.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+/** Severity levels for assertive checks, ordered from most to least urgent. */
+export const SeveritySchema = z.enum(['error', 'warn', 'recommend']).meta({ id: 'Severity' });
+
+/**
+ * Diagnosis of a failure that prevented rdy from completing an invocation.
+ *
+ * Mirrors the `RdyErrorCode` union in `errors.ts`, which is the taxonomy's prose home; a type test
+ * keeps the two in step.
+ */
+export const ErrorCodeSchema = z.enum(['config', 'internal', 'kit-load', 'usage']).meta({ id: 'ErrorCode' });
+
+/** The error body carried by the envelope and, verbatim, by a per-kit error entry inside a report. */
+export const ErrorBodySchema = z
+  .object({
+    code: ErrorCodeSchema,
+    message: z.string(),
+  })
+  .meta({ id: 'ErrorBody' });
+
+/** Every count field is a non-negative integer. */
+const CountSchema = z.int().min(0);
+
+/**
+ * Result tallies for one scope of a run — the whole report, one kit, or one checklist.
+ *
+ * `errors`/`warnings`/`recommendations` bucket failures by severity; `blocked` (precondition-skipped)
+ * and `optional` (n/a-skipped) bucket skips by reason. Counts nest under their own object so they
+ * share no namespace with the verdict and provenance fields beside them: a count added later cannot
+ * collide with a top-level field, which is what makes the additive-evolution policy sound rather
+ * than merely conventional.
+ */
+export const CountsSchema = z
+  .object({
+    passed: CountSchema,
+    errors: CountSchema,
+    warnings: CountSchema,
+    recommendations: CountSchema,
+    blocked: CountSchema,
+    optional: CountSchema,
+  })
+  .meta({ id: 'Counts' });
+
+/** Conditions a run reports as advisory rather than as a failure. */
+export const WarningCodeSchema = z.enum(['version-skew']).meta({ id: 'WarningCode' });
+
+/**
+ * An advisory condition observed during a run.
+ *
+ * Mirrors the error body's `{code, message}` shape and adds `remedy`, the one action that clears the
+ * condition. Warnings reach stderr in both modes; under `--json` they are additionally captured here,
+ * because a consumer that owns only stdout would otherwise never see them.
+ */
+export const WarningSchema = z
+  .object({
+    code: WarningCodeSchema,
+    message: z.string(),
+    remedy: z.string().optional(),
+  })
+  .meta({ id: 'Warning' });
+
+export type JsonSeverity = z.infer<typeof SeveritySchema>;
+export type JsonErrorCode = z.infer<typeof ErrorCodeSchema>;
+export type JsonErrorBody = z.infer<typeof ErrorBodySchema>;
+export type JsonCounts = z.infer<typeof CountsSchema>;
+export type JsonWarningCode = z.infer<typeof WarningCodeSchema>;
+export type JsonWarning = z.infer<typeof WarningSchema>;

--- a/packages/readyup/src/schemas/common.ts
+++ b/packages/readyup/src/schemas/common.ts
@@ -42,8 +42,20 @@ export const CountsSchema = z
   })
   .meta({ id: 'Counts' });
 
-/** Conditions a run reports as advisory rather than as a failure. */
-export const WarningCodeSchema = z.enum(['version-skew']).meta({ id: 'WarningCode' });
+/** The advisory vocabulary this version raises. `RaisedWarning` binds producers to it. */
+export const WarningCodeSchema = z.enum(['version-skew']);
+
+/**
+ * The wire form of a warning code: a known value, or any other string.
+ *
+ * Open where `ErrorCodeSchema` is closed, because the two vocabularies do different jobs. An error
+ * code selects a consumer's branch, so an unknown one leaves the consumer with nothing to dispatch
+ * on and earns its version bump. A warning labels an advisory whose `message` and `remedy` a
+ * consumer can display verbatim, so a code it has never heard of must still validate: closing this
+ * set would make the first new advisory a breaking change. The union keeps the known values visible
+ * in the generated schema's `anyOf` rather than trading them for a bare `string`.
+ */
+const WarningCodeWireSchema = WarningCodeSchema.or(z.string()).meta({ id: 'WarningCode' });
 
 /**
  * An advisory condition observed during a run.
@@ -54,7 +66,7 @@ export const WarningCodeSchema = z.enum(['version-skew']).meta({ id: 'WarningCod
  */
 export const WarningSchema = z
   .object({
-    code: WarningCodeSchema,
+    code: WarningCodeWireSchema,
     message: z.string(),
     remedy: z.string().optional(),
   })
@@ -64,5 +76,20 @@ export type JsonSeverity = z.infer<typeof SeveritySchema>;
 export type JsonErrorCode = z.infer<typeof ErrorCodeSchema>;
 export type JsonErrorBody = z.infer<typeof ErrorBodySchema>;
 export type JsonCounts = z.infer<typeof CountsSchema>;
-export type JsonWarningCode = z.infer<typeof WarningCodeSchema>;
+/**
+ * A warning code: one of the known values, or any other string.
+ *
+ * Assembled rather than inferred from the wire schema, because `z.infer` on a `literal | string`
+ * union collapses to plain `string`, which would drop the known values from the published type.
+ */
+export type JsonWarningCode = z.infer<typeof WarningCodeSchema> | (string & {});
 export type JsonWarning = z.infer<typeof WarningSchema>;
+
+/**
+ * A warning as this version raises it, narrower than `JsonWarning` on `code`.
+ *
+ * The wire type accepts any string so a consumer tolerates an advisory from a later readyup. A
+ * producer may only emit a code this version declares, so a mistyped one fails to compile rather
+ * than entering the published vocabulary.
+ */
+export type RaisedWarning = JsonWarning & { code: z.infer<typeof WarningCodeSchema> };

--- a/packages/readyup/src/schemas/compileOutputSchema.ts
+++ b/packages/readyup/src/schemas/compileOutputSchema.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * Version of the `compile` payload.
+ *
+ * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * What became of one kit in a compile sweep.
+ *
+ * `skipped` means the compiled file had drifted from the manifest and was left alone; `failed` means
+ * the kit itself could not be bundled or validated.
+ */
+export const CompileStatusSchema = z.enum(['compiled', 'failed', 'skipped']).meta({ id: 'CompileStatus' });
+
+/** One kit's compile outcome, carrying the reason only when there is a failure to explain. */
+export const CompileKitEntrySchema = z
+  .object({
+    name: z.string(),
+    status: CompileStatusSchema,
+    error: z.string().optional(),
+  })
+  .meta({ id: 'CompileKitEntry' });
+
+/**
+ * Top-level shape of `rdy compile --json`.
+ *
+ * A sweep runs to completion, so every requested kit appears here whatever happened to the ones
+ * before it. `passed` is true when every kit compiled, agreeing with exit code 0.
+ */
+export const CompileOutputSchema = z
+  .object({
+    schemaVersion: z.int().min(1),
+    passed: z.boolean(),
+    kits: z.array(CompileKitEntrySchema),
+  })
+  .meta({ id: 'CompileOutput' });
+
+export type JsonCompileStatus = z.infer<typeof CompileStatusSchema>;
+export type JsonCompileKitEntry = z.infer<typeof CompileKitEntrySchema>;
+export type JsonCompileOutput = z.infer<typeof CompileOutputSchema>;

--- a/packages/readyup/src/schemas/errorEnvelopeSchema.ts
+++ b/packages/readyup/src/schemas/errorEnvelopeSchema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+import { ErrorBodySchema } from './common.ts';
+
+/**
+ * Version of the error-envelope payload.
+ *
+ * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * The single JSON document stdout carries when an invocation fails before it can produce anything else.
+ *
+ * The envelope covers only failures that precede dispatch. Once a run has reached its kits, a kit
+ * that fails becomes an entry inside the report rather than replacing it, so a consumer that sees an
+ * envelope knows nothing ran.
+ */
+export const ErrorEnvelopeSchema = z
+  .object({
+    schemaVersion: z.int().min(1),
+    error: ErrorBodySchema,
+  })
+  .meta({ id: 'ErrorEnvelope' });
+
+export type JsonErrorEnvelope = z.infer<typeof ErrorEnvelopeSchema>;

--- a/packages/readyup/src/schemas/index.ts
+++ b/packages/readyup/src/schemas/index.ts
@@ -1,0 +1,48 @@
+// Shared building blocks
+export type { JsonCounts, JsonErrorBody, JsonErrorCode, JsonSeverity, JsonWarning, JsonWarningCode } from './common.ts';
+export {
+  CountsSchema,
+  ErrorBodySchema,
+  ErrorCodeSchema,
+  SeveritySchema,
+  WarningCodeSchema,
+  WarningSchema,
+} from './common.ts';
+
+// Run report
+export type {
+  JsonCheckEntry,
+  JsonChecklistEntry,
+  JsonDetail,
+  JsonKitEntry,
+  JsonKitErrorEntry,
+  JsonKitResultEntry,
+  JsonProgress,
+  JsonReport,
+} from './reportSchema.ts';
+export {
+  CheckEntrySchema,
+  ChecklistEntrySchema,
+  DetailSchema,
+  KitEntrySchema,
+  KitErrorEntrySchema,
+  KitResultEntrySchema,
+  ProgressSchema,
+  ReportSchema,
+} from './reportSchema.ts';
+
+// Error envelope
+export type { JsonErrorEnvelope } from './errorEnvelopeSchema.ts';
+export { ErrorEnvelopeSchema } from './errorEnvelopeSchema.ts';
+
+// list
+export type { JsonKitKind, JsonListKitEntry, JsonListOutput } from './listOutputSchema.ts';
+export { KitKindSchema, ListKitEntrySchema, ListOutputSchema } from './listOutputSchema.ts';
+
+// verify
+export type { JsonDriftStatus, JsonVerifyKitEntry, JsonVerifyOutput } from './verifyOutputSchema.ts';
+export { DriftStatusSchema, VerifyKitEntrySchema, VerifyOutputSchema } from './verifyOutputSchema.ts';
+
+// compile
+export type { JsonCompileKitEntry, JsonCompileOutput, JsonCompileStatus } from './compileOutputSchema.ts';
+export { CompileKitEntrySchema, CompileOutputSchema, CompileStatusSchema } from './compileOutputSchema.ts';

--- a/packages/readyup/src/schemas/index.ts
+++ b/packages/readyup/src/schemas/index.ts
@@ -1,5 +1,13 @@
 // Shared building blocks
-export type { JsonCounts, JsonErrorBody, JsonErrorCode, JsonSeverity, JsonWarning, JsonWarningCode } from './common.ts';
+export type {
+  JsonCounts,
+  JsonErrorBody,
+  JsonErrorCode,
+  JsonSeverity,
+  JsonWarning,
+  JsonWarningCode,
+  RaisedWarning,
+} from './common.ts';
 export {
   CountsSchema,
   ErrorBodySchema,

--- a/packages/readyup/src/schemas/listOutputSchema.ts
+++ b/packages/readyup/src/schemas/listOutputSchema.ts
@@ -28,7 +28,15 @@ export const ListKitEntrySchema = z
   })
   .meta({ id: 'ListKitEntry' });
 
-/** Top-level shape of `rdy list --json`. */
+/**
+ * Top-level shape of `rdy list --json`.
+ *
+ * Rows are keyed by `name` and `kind` together, never by `name` alone. Under the default
+ * configuration `internal.dir` and `compile.outDir` both resolve to `.readyup/kits`, so a compiled
+ * source appears twice: once as `internal`, which `rdy run --jit <name>` runs, and once as
+ * `compiled`, which `rdy run <name>` runs. Both rows are meaningful, and a consumer indexing on
+ * `name` alone silently drops one of them.
+ */
 export const ListOutputSchema = z
   .object({
     schemaVersion: z.int().min(1),

--- a/packages/readyup/src/schemas/listOutputSchema.ts
+++ b/packages/readyup/src/schemas/listOutputSchema.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+/**
+ * Version of the `list` payload.
+ *
+ * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ */
+export const SCHEMA_VERSION = 1;
+
+/** Whether a listed kit is TypeScript source awaiting compilation or a compiled bundle. */
+export const KitKindSchema = z.enum(['compiled', 'internal']).meta({ id: 'KitKind' });
+
+/**
+ * One kit row.
+ *
+ * Every field but `name` and `kind` comes from the manifest, so a kit enumerated from the filesystem
+ * without one carries only those two plus `path`. `checklists` is read from the manifest rather than
+ * from the kit itself: listing kits never executes kit code.
+ */
+export const ListKitEntrySchema = z
+  .object({
+    name: z.string(),
+    kind: KitKindSchema,
+    path: z.string().optional(),
+    description: z.string().optional(),
+    readyupVersion: z.string().optional(),
+    checklists: z.array(z.string()).optional(),
+  })
+  .meta({ id: 'ListKitEntry' });
+
+/** Top-level shape of `rdy list --json`. */
+export const ListOutputSchema = z
+  .object({
+    schemaVersion: z.int().min(1),
+    kits: z.array(ListKitEntrySchema),
+  })
+  .meta({ id: 'ListOutput' });
+
+export type JsonKitKind = z.infer<typeof KitKindSchema>;
+export type JsonListKitEntry = z.infer<typeof ListKitEntrySchema>;
+export type JsonListOutput = z.infer<typeof ListOutputSchema>;

--- a/packages/readyup/src/schemas/reportSchema.ts
+++ b/packages/readyup/src/schemas/reportSchema.ts
@@ -65,13 +65,23 @@ export const ChecklistEntrySchema = z
   })
   .meta({ id: 'ChecklistEntry' });
 
-/** A kit that ran, grouping its checklists under a kit-level verdict and tallies. */
+/**
+ * A kit that ran, grouping its checklists under a kit-level verdict and tallies.
+ *
+ * `failOn` and `reportOn` are the thresholds that actually governed this kit, resolved as
+ * `CLI flag > kit field > default`. Both are emitted unconditionally rather than only when they
+ * differ from the run level: `passed` is meaningless without the threshold it was decided against,
+ * and an absent-means-inherit rule would send a consumer elsewhere in the document to read a
+ * six-byte enum.
+ */
 export const KitResultEntrySchema = z
   .object({
     name: z.string(),
     passed: z.boolean(),
     counts: CountsSchema,
     worstSeverity: SeveritySchema.optional(),
+    failOn: SeveritySchema,
+    reportOn: SeveritySchema,
     durationMs: z.int().min(0),
     checklists: z.array(ChecklistEntrySchema),
   })
@@ -96,13 +106,16 @@ export const KitEntrySchema = z.union([KitErrorEntrySchema, KitResultEntrySchema
 /**
  * Top-level shape of `rdy run --json`.
  *
- * `passed` is the run verdict: true when every requested kit produced results and no result at or
- * above `failOn` failed, which makes it agree with exit code 0 in every case. A report is only ever
- * emitted once the run reaches its kits, so `passed: false` means "ran, but incompletely or with
- * failures" and never "could not start" — that failure produces the error envelope instead.
+ * `passed` is the run verdict: true when every requested kit produced results and every kit passed
+ * under its own effective `failOn`, which makes it agree with exit code 0 in every case. A report is
+ * only ever emitted once the run reaches its kits, so `passed: false` means "ran, but incompletely
+ * or with failures" and never "could not start": that failure produces the error envelope instead.
  *
- * `failOn`, `reportOn`, and `detail` echo the thresholds the run resolved, so a consumer holding
- * only the payload can tell a clean run from one whose failures were filtered out of view.
+ * `failOn` and `reportOn` here are what the invocation requested, so each is present only when its
+ * flag was given and absence means "not requested" rather than "defaulted". The thresholds that
+ * governed a kit live on that kit's entry, because a kit may declare its own and one run-level value
+ * cannot describe kits that differ. `detail` has no per-kit resolution, so requested and effective
+ * are the same value and it is always present.
  */
 export const ReportSchema = z
   .object({
@@ -111,8 +124,8 @@ export const ReportSchema = z
     passed: z.boolean(),
     counts: CountsSchema,
     worstSeverity: SeveritySchema.optional(),
-    failOn: SeveritySchema,
-    reportOn: SeveritySchema,
+    failOn: SeveritySchema.optional(),
+    reportOn: SeveritySchema.optional(),
     detail: DetailSchema,
     durationMs: z.int().min(0),
     warnings: z.array(WarningSchema).optional(),

--- a/packages/readyup/src/schemas/reportSchema.ts
+++ b/packages/readyup/src/schemas/reportSchema.ts
@@ -1,0 +1,130 @@
+import { z } from 'zod';
+
+import { CountsSchema, ErrorBodySchema, SeveritySchema, WarningSchema } from './common.ts';
+
+/**
+ * Version of the run-report payload.
+ *
+ * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ */
+export const SCHEMA_VERSION = 1;
+
+/** How much of the detail tree a report carries. */
+export const DetailSchema = z.enum(['summary', 'full']).meta({ id: 'Detail' });
+
+/** Progress a check reported alongside its verdict, discriminated by `type`. */
+export const ProgressSchema = z
+  .discriminatedUnion('type', [
+    z.object({
+      type: z.literal('fraction'),
+      passedCount: z.int().min(0),
+      count: z.int().min(0),
+    }),
+    z.object({
+      type: z.literal('percent'),
+      percent: z.number(),
+    }),
+  ])
+  .meta({ id: 'Progress' });
+
+/**
+ * One check result in a checklist's detail tree.
+ *
+ * `ok` is three-valued rather than optional: `null` is the verdict a skipped check has, not a
+ * missing field. Every other optional field is omitted when it carries nothing, so a passed check
+ * with no detail serializes to five keys. Nesting is recursive — `checks` holds the results of
+ * checks that ran only because this one passed.
+ */
+export const CheckEntrySchema = z
+  .object({
+    name: z.string(),
+    status: z.enum(['passed', 'failed', 'skipped']),
+    ok: z.union([z.boolean(), z.null()]),
+    severity: SeveritySchema,
+    durationMs: z.int().min(0),
+    skipReason: z.enum(['n/a', 'precondition']).optional(),
+    detail: z.string().optional(),
+    fix: z.string().optional(),
+    error: z.string().optional(),
+    progress: ProgressSchema.optional(),
+    get checks() {
+      return z.array(CheckEntrySchema).optional();
+    },
+  })
+  .meta({ id: 'CheckEntry' });
+
+/** One checklist's verdict, tallies, and detail tree. */
+export const ChecklistEntrySchema = z
+  .object({
+    name: z.string(),
+    passed: z.boolean(),
+    counts: CountsSchema,
+    worstSeverity: SeveritySchema.optional(),
+    durationMs: z.int().min(0),
+    checks: z.array(CheckEntrySchema).optional(),
+  })
+  .meta({ id: 'ChecklistEntry' });
+
+/** A kit that ran, grouping its checklists under a kit-level verdict and tallies. */
+export const KitResultEntrySchema = z
+  .object({
+    name: z.string(),
+    passed: z.boolean(),
+    counts: CountsSchema,
+    worstSeverity: SeveritySchema.optional(),
+    durationMs: z.int().min(0),
+    checklists: z.array(ChecklistEntrySchema),
+  })
+  .meta({ id: 'KitResultEntry' });
+
+/**
+ * A kit that produced no results, carrying the same error body as the envelope.
+ *
+ * Deliberately counts-free and verdict-free: a kit that never ran has no `errors: 0` to report and
+ * no verdict to give, and emitting either would misstate the run.
+ */
+export const KitErrorEntrySchema = z
+  .object({
+    name: z.string(),
+    error: ErrorBodySchema,
+  })
+  .meta({ id: 'KitErrorEntry' });
+
+/** One kit's entry, told apart by whether `error` is present. */
+export const KitEntrySchema = z.union([KitErrorEntrySchema, KitResultEntrySchema]).meta({ id: 'KitEntry' });
+
+/**
+ * Top-level shape of `rdy run --json`.
+ *
+ * `passed` is the run verdict: true when every requested kit produced results and no result at or
+ * above `failOn` failed, which makes it agree with exit code 0 in every case. A report is only ever
+ * emitted once the run reaches its kits, so `passed: false` means "ran, but incompletely or with
+ * failures" and never "could not start" — that failure produces the error envelope instead.
+ *
+ * `failOn`, `reportOn`, and `detail` echo the thresholds the run resolved, so a consumer holding
+ * only the payload can tell a clean run from one whose failures were filtered out of view.
+ */
+export const ReportSchema = z
+  .object({
+    schemaVersion: z.int().min(1),
+    readyupVersion: z.string(),
+    passed: z.boolean(),
+    counts: CountsSchema,
+    worstSeverity: SeveritySchema.optional(),
+    failOn: SeveritySchema,
+    reportOn: SeveritySchema,
+    detail: DetailSchema,
+    durationMs: z.int().min(0),
+    warnings: z.array(WarningSchema).optional(),
+    kits: z.array(KitEntrySchema),
+  })
+  .meta({ id: 'Report' });
+
+export type JsonDetail = z.infer<typeof DetailSchema>;
+export type JsonProgress = z.infer<typeof ProgressSchema>;
+export type JsonCheckEntry = z.infer<typeof CheckEntrySchema>;
+export type JsonChecklistEntry = z.infer<typeof ChecklistEntrySchema>;
+export type JsonKitResultEntry = z.infer<typeof KitResultEntrySchema>;
+export type JsonKitErrorEntry = z.infer<typeof KitErrorEntrySchema>;
+export type JsonKitEntry = z.infer<typeof KitEntrySchema>;
+export type JsonReport = z.infer<typeof ReportSchema>;

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+/**
+ * Version of the `verify` payload.
+ *
+ * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ */
+export const SCHEMA_VERSION = 1;
+
+/** Outcome of hashing one compiled kit against the hash the manifest recorded for it. */
+export const DriftStatusSchema = z.enum(['drift', 'missing', 'ok', 'unverified']).meta({ id: 'DriftStatus' });
+
+/**
+ * One kit's drift verdict.
+ *
+ * `expected` and `actual` are the manifest's hash and the on-disk hash; both are present only on a
+ * `drift` verdict, since no other status has two hashes to compare.
+ */
+export const VerifyKitEntrySchema = z
+  .object({
+    name: z.string(),
+    status: DriftStatusSchema,
+    expected: z.string().optional(),
+    actual: z.string().optional(),
+  })
+  .meta({ id: 'VerifyKitEntry' });
+
+/**
+ * Top-level shape of `rdy verify --json`.
+ *
+ * `passed` is true when every kit is `ok` or `unverified`, agreeing with exit code 0. An unreadable
+ * manifest produces the error envelope instead of this payload.
+ */
+export const VerifyOutputSchema = z
+  .object({
+    schemaVersion: z.int().min(1),
+    passed: z.boolean(),
+    kits: z.array(VerifyKitEntrySchema),
+  })
+  .meta({ id: 'VerifyOutput' });
+
+export type JsonDriftStatus = z.infer<typeof DriftStatusSchema>;
+export type JsonVerifyKitEntry = z.infer<typeof VerifyKitEntrySchema>;
+export type JsonVerifyOutput = z.infer<typeof VerifyOutputSchema>;

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -1,5 +1,3 @@
-import type { RdyErrorCode } from './errors.ts';
-
 // -- Ahead/behind --
 
 /** Directional commit counts between two refs. */
@@ -225,6 +223,10 @@ export interface RdyReport {
  * `errors`/`warnings`/`recommendations` replace the coarser `failed` bucket;
  * `blocked` (precondition-skipped) and `optional` (n/a-skipped) replace `skipped`.
  * `worstSeverity` is the highest-severity failed bucket (`null` when nothing failed).
+ *
+ * This is the runner's internal tally, shared by the human report and the combined-summary table.
+ * The JSON layer nests the six numeric fields under `counts` and carries `worstSeverity` beside
+ * them; see `schemas/common.ts`, which is the source of truth for the wire shape.
  */
 export interface SummaryCounts {
   passed: number;
@@ -341,63 +343,4 @@ export interface ResolvedRdyConfig {
     dir: string;
     infix: string | undefined;
   };
-}
-
-// -- JSON output --
-
-/**
- * Serialize a RdyResult for JSON output.
- *
- * All fields are non-optional with explicit `null` for absent values. `skipReason` is
- * present on every entry (not just skipped results) so JSON consumers see a uniform shape.
- */
-export interface JsonCheckEntry {
-  name: string;
-  status: 'passed' | 'failed' | 'skipped';
-  ok: true | false | null;
-  severity: Severity;
-  skipReason: 'n/a' | 'precondition' | null;
-  detail: string | null;
-  fix: string | null;
-  error: string | null;
-  progress: Progress | null;
-  durationMs: number;
-  checks: JsonCheckEntry[];
-}
-
-/** Shape of a single checklist entry in `--json` output. */
-export interface JsonChecklistEntry extends SummaryCounts {
-  name: string;
-  durationMs: number;
-  checks: JsonCheckEntry[];
-}
-
-/** Entry for a kit that ran, grouping its checklists with per-kit summary counts. */
-export interface JsonKitResultEntry extends SummaryCounts {
-  name: string;
-  durationMs: number;
-  checklists: JsonChecklistEntry[];
-}
-
-/**
- * Entry for a kit that produced no results, carrying the same object as the error envelope.
- *
- * Deliberately counts-free: a kit that never ran has no `errors: 0` to report, and emitting
- * zeroes would misstate the run.
- */
-export interface JsonKitErrorEntry {
-  name: string;
-  error: {
-    code: RdyErrorCode;
-    message: string;
-  };
-}
-
-/** Per-kit entry in JSON output, discriminated by the presence of `error`. */
-export type JsonKitEntry = JsonKitErrorEntry | JsonKitResultEntry;
-
-/** Top-level shape of `--json` output. */
-export interface JsonReport extends SummaryCounts {
-  durationMs: number;
-  kits: JsonKitEntry[];
 }

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -7,12 +7,16 @@ import { EXIT_OK, EXIT_PROBLEMS_FOUND } from '../exitCodes.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { readManifest } from '../manifest/readManifest.ts';
+import type { JsonVerifyKitEntry, JsonVerifyOutput } from '../schemas/index.ts';
+import { SCHEMA_VERSION } from '../schemas/verifyOutputSchema.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { translateParseArgsError } from '../utils/parse-args-error.ts';
+import { writeHuman } from '../writeHuman.ts';
 import type { DriftStatus } from './checkDrift.ts';
 import { checkDrift } from './checkDrift.ts';
 
 const verifyOptions = {
+  json: { type: 'boolean' },
   manifest: { type: 'string' },
 } as const;
 
@@ -41,6 +45,7 @@ export function verifyCommand(args: string[]): number {
     }
   }
 
+  const json = values.json === true;
   const manifestPath = path.resolve(process.cwd(), values.manifest ?? DEFAULT_MANIFEST_PATH);
   const manifestDir = path.dirname(manifestPath);
 
@@ -52,27 +57,54 @@ export function verifyCommand(args: string[]): number {
   }
 
   const relManifestPath = path.relative(process.cwd(), manifestPath);
-  process.stdout.write(`Verifying kits against ${relManifestPath}:\n`);
+  writeHuman(`Verifying kits against ${relManifestPath}:\n`, json);
 
   if (manifest.kits.length === 0) {
-    process.stdout.write('  (no kits in manifest)\n');
-    return EXIT_OK;
+    writeHuman('  (no kits in manifest)\n', json);
+    return finishVerify([], json);
   }
 
+  const entries: JsonVerifyKitEntry[] = [];
   let failed = 0;
   for (const kit of manifest.kits) {
     const status = checkDrift(kit, manifestDir);
-    process.stdout.write(formatStatusLine(kit, status));
+    writeHuman(formatStatusLine(kit, status), json);
+    entries.push(buildVerifyEntry(kit.name, status));
     if (status.kind === 'drift' || status.kind === 'missing') {
       failed += 1;
     }
   }
 
   if (failed > 0) {
-    process.stdout.write(`\n${failed} of ${manifest.kits.length} kits failed verification.\n`);
+    writeHuman(`\n${failed} of ${manifest.kits.length} kits failed verification.\n`, json);
   }
 
-  return failed > 0 ? EXIT_PROBLEMS_FOUND : EXIT_OK;
+  return finishVerify(entries, json);
+}
+
+/**
+ * Emit the verify payload under `--json` and reduce the per-kit verdicts to an exit code.
+ *
+ * `unverified` does not fail the run: a manifest entry with no recorded hash predates the feature
+ * or was written with `--skip-manifest`, which says nothing about whether the kit has drifted.
+ */
+function finishVerify(kits: JsonVerifyKitEntry[], json: boolean): number {
+  const passed = kits.every((kit) => kit.status === 'ok' || kit.status === 'unverified');
+
+  if (json) {
+    const output: JsonVerifyOutput = { schemaVersion: SCHEMA_VERSION, passed, kits };
+    process.stdout.write(JSON.stringify(output) + '\n');
+  }
+
+  return passed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
+}
+
+/** Build a kit's JSON entry, carrying the two hashes only on a verdict that compared them. */
+function buildVerifyEntry(name: string, status: DriftStatus): JsonVerifyKitEntry {
+  if (status.kind === 'drift') {
+    return { name, status: 'drift', expected: status.expected, actual: status.actual };
+  }
+  return { name, status: status.kind };
 }
 
 /** Format a single per-kit status line for the verify report. */

--- a/packages/readyup/src/writeHuman.ts
+++ b/packages/readyup/src/writeHuman.ts
@@ -1,0 +1,12 @@
+import process from 'node:process';
+
+/**
+ * Writes human-readable prose, diverting it to stderr when JSON mode owns stdout.
+ *
+ * Under `--json`, stdout carries exactly one JSON document, so every header, progress line, and
+ * summary a command would otherwise print has to go somewhere else.
+ */
+export function writeHuman(text: string, json: boolean): void {
+  const stream = json ? process.stderr : process.stdout;
+  stream.write(text);
+}

--- a/packages/readyup/tsconfig.json
+++ b/packages/readyup/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "__tests__/", "*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "__tests__/", "config/", "*.ts"],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@types/picomatch':
         specifier: 4.0.3
         version: 4.0.3
+      ajv:
+        specifier: 8.20.0
+        version: 8.20.0
 
 packages:
 
@@ -827,6 +830,9 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -1344,6 +1350,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1695,6 +1704,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -3300,6 +3312,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -3989,6 +4008,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.4: {}
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -4347,6 +4368,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4735,8 +4758,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2:
-    optional: true
+  require-from-string@2.0.2: {}
 
   reserved-identifiers@1.2.0: {}
 


### PR DESCRIPTION
## What

The JSON emitted by `readyup` can now be validated against JSON schemas shipped with the package. JSON output now covers `list`, `verify`, and `compile` as well as `run`, and each command puts exactly one document on standard output, with all prose on standard error. Reports are also substantially smaller, and a consumer can now ask for a compact view carrying only the failures and the fixes for them.

Existing consumers of `rdy run --json` must migrate. The result tallies are now grouped under a single object, the pass indicator is now a verdict rather than a tally, and fields carrying nothing are omitted rather than emitted as null.

## Why

Automation could read readyup's JSON but could not depend on it. Nothing declared the shape, so a consumer had to infer it from a sample and hope; nothing signalled when it changed; and only `run` emitted JSON at all, leaving the commands automation uses to orient and gate with no machine-readable form. Agents paid twice over, since the payload ran about three times the size of the human output and most of that bulk was nulls.

Split out of #118 so that ticket could stay reviewable: #118 fixes the machine interface's correctness defects, this one formalizes and slims its contract. readyup is pre-1.0 with no published JSON consumers, which is what makes a breaking reshape cheap now and expensive later.

## Details

### 🎉 Features

- 🚨 **Breaking:** The run report groups its six result tallies under a `counts` object at the report, kit, and checklist levels, and each of those levels gains a `passed` boolean verdict. The flat `passed`, `errors`, `warnings`, `recommendations`, `blocked`, and `optional` fields move under `counts`; `passed` in its old position is now a verdict rather than a tally. `worstSeverity` is omitted when nothing failed, as is every other empty field, so consumers that relied on explicit nulls must handle absence. The error envelope gains `schemaVersion`, and the exported `JsonReport`, `JsonKitEntry`, `JsonChecklistEntry`, and `JsonCheckEntry` types change shape to match.
- Five JSON Schemas ship with the package, resolvable as `readyup/schemas/report.v1.json`, `readyup/schemas/error-envelope.v1.json`, `readyup/schemas/list.v1.json`, `readyup/schemas/verify.v1.json`, and `readyup/schemas/compile.v1.json`, each carrying an `$id` on unpkg so a consumer can validate against the published URL or its own `node_modules` copy. The five version independently, and the schemas are generated from the same definitions the exported `Json*` types derive from, so the published contract and the types cannot drift apart.
- A stability policy states when a payload's `schemaVersion` moves: adding an optional field does not bump it and the schemas accept fields they do not know about, so a validator pinned to v1 keeps working against a later readyup; removing, renaming, or re-typing a field does bump it.
- The report carries `schemaVersion`, `readyupVersion`, the `detail` projection it used, and a structured `warnings[]` array, so version-skew advisories that previously reached only stderr now arrive on stdout as well without losing their stderr line.
- Each kit in a report carries the failure and reporting thresholds that governed it, so a kit declaring its own is interpretable from its own entry. The top-level `failOn` and `reportOn` name only what the invocation requested and are absent when the flag was not given.
- `warnings[].code` is published as an open set, so a later readyup can raise a new advisory without invalidating a consumer pinned to `report.v1.json`. Error codes stay closed, since an unrecognized one leaves a consumer with no branch to take.
- `rdy run --json --detail summary` emits counts, verdicts, and worst severity with only the checks that failed and the fixes they carry. `--detail full` remains the default. Both projections are described by the same schema, and the report's own `detail` field says which one it is. Passing `--detail` without `--json`, or to another command, is a usage error rather than a silently ignored flag.
- `rdy list --json`, `rdy verify --json`, and `rdy compile --json` join `run`. All three send every prose line to stderr so stdout carries exactly one JSON document. `list` and `verify` previously rejected `--json` with a hint about positional arguments.
- Payloads shrink: a field carrying nothing is omitted rather than emitted as null, empty `checks` arrays are dropped, durations are whole milliseconds, and `fix` text appears only on checks that failed.
- `rdy compile` attempts every kit in a batch rather than abandoning the sweep at the first failure, and records each kit's checklist names in the manifest so `rdy list` can report them without importing and running a compiled bundle. The manifest field is optional, so the format stays at version 1 and older readers are unaffected.
- `rdy list --from` falls back to listing the compiled kits on disk when no manifest sits beside them, for a local path, a `dir:` path, or `global`, resolving the same kits `rdy run --from` would load. A source with no kit directory is still an error, and a remote source still requires a manifest.

### 🐛 Bug fixes

- A kit that fails to compile during a `rdy compile` sweep keeps the manifest entry it already had. Previously the sweep rebuilt the manifest from the kits it recorded, so `rdy list` and `rdy verify` stopped mentioning a kit whose stale output stayed runnable, and the next successful compile had no record to check drift against, overwriting hand edits without warning.
- `rdy run --json` honors a kit's declared reporting threshold when pruning that kit's detail tree, matching what human output already did.

### ♻️ Refactoring

- `rdy list --from global` and `rdy run --from global` resolve the home directory through a single definition, so the two cannot drift into listing one set of kits and running another.

### ⚙️ Tooling

- `.readyup/manifest.json` is excluded from Prettier, which disagreed with the manifest writer's own layout once kit entries gained a checklist-name array and left the tracked file dirty after every build.

### 📚 Documentation

- The README and all five `rdy --help` screens describe the machine interface: which commands accept `--json`, where the schemas live and how to import them, what each report field means, the requested-versus-effective distinction on thresholds, and the rule for when a `schemaVersion` changes.


Closes #124
