### PR TITLE
#119 Add remediation hints and improve the first-run experience

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -7,14 +7,14 @@ Run pre-deployment verification checks against your environment and configuratio
 ## Installation
 
 ```bash
-pnpm add -D readyup
+pnpm add --save-dev readyup
 ```
 
 Node 24 or later is required, for the runner and for the kits it compiles.
 
 ## Quick start
 
-Scaffold a starter config and kit:
+Install readyup as shown above, then scaffold a starter config and kit:
 
 ```bash
 rdy init
@@ -56,11 +56,16 @@ export default defineRdyKit({
 });
 ```
 
-Run the checks:
+Compile the kit, then run the checks:
 
 ```bash
+rdy compile
 rdy run
 ```
+
+`rdy compile` bundles `.readyup/kits/default.ts` into `.readyup/kits/default.js`, and `rdy run` loads that compiled kit. Recompile whenever the source changes.
+
+To skip compiling and run straight from the TypeScript source, use `rdy run --jit`. It reads the same `.readyup/kits/default.ts` and needs no compiled bundle, which makes it the faster loop while you are still writing checks. Compiled kits stay the vetted artifact: they are what `rdy verify` hashes and what a consumer running `rdy run --from` gets.
 
 ## CLI reference
 

--- a/packages/readyup/__tests__/config.test.ts
+++ b/packages/readyup/__tests__/config.test.ts
@@ -43,13 +43,25 @@ describe(loadRdyKit, () => {
     );
   });
 
-  it("suggests 'rdy init' when the default kit has neither a compiled bundle nor a source", async () => {
+  it("suggests 'rdy init' when the kit directory holds no kits at all", async () => {
     mockExistsSync.mockReturnValue(false);
     mockReaddirSync.mockReturnValue([]);
 
     await expect(loadRdyKit('.readyup/kits/default.js')).rejects.toThrow(
       'Kit "default" not found at .readyup/kits/default.js. Run \'rdy init\' to create one.',
     );
+  });
+
+  it('names the available kits rather than suggesting init when the default kit is missing but others exist', async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockReaddirSync.mockReturnValue(buildDirents('deploy.js', 'release.js'));
+
+    const error = await loadRdyKit('.readyup/kits/default.js').catch((error_: unknown) => error_);
+
+    expect(String(error)).toContain(
+      'Kit "default" not found at .readyup/kits/default.js. Available kits: deploy, release.',
+    );
+    expect(String(error)).not.toContain('rdy init');
   });
 
   it('names the searched path and the available kits for any other missing kit', async () => {

--- a/packages/readyup/__tests__/config.test.ts
+++ b/packages/readyup/__tests__/config.test.ts
@@ -4,9 +4,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockJitiImport = vi.hoisted(() => vi.fn());
+const mockReaddirSync = vi.hoisted(() => vi.fn());
 
 vi.mock(import('node:fs'), () => ({
   existsSync: mockExistsSync,
+  readdirSync: mockReaddirSync,
 }));
 
 vi.mock('jiti', () => ({
@@ -21,32 +23,62 @@ describe(loadRdyKit, () => {
   afterEach(() => {
     mockExistsSync.mockReset();
     mockJitiImport.mockReset();
+    mockReaddirSync.mockReset();
   });
 
-  it('throws when the kit file does not exist', async () => {
-    mockExistsSync.mockReturnValue(false);
+  it('reports an uncompiled kit when only the TypeScript source exists', async () => {
+    mockExistsSync.mockImplementation((target: string) => target.endsWith('.ts'));
 
-    await expect(loadRdyKit('missing/kit.ts')).rejects.toThrow('Kit not found');
-  });
-
-  it('throws with a rdy init hint when a convention-path kit is missing', async () => {
-    mockExistsSync.mockReturnValue(false);
-
-    await expect(loadRdyKit('.readyup/kits/default.ts')).rejects.toThrow(
-      'Kit "default" not found. Run \'rdy init\' to create one.',
+    await expect(loadRdyKit('.readyup/kits/deploy.js')).rejects.toThrow(
+      "Kit \"deploy\" is not compiled. Run 'rdy compile' to compile it, or 'rdy run --jit' to run it from source.",
     );
   });
 
-  it('shows the user-provided path in file-not-found errors', async () => {
-    mockExistsSync.mockReturnValue(false);
+  it('reports a compiled-only kit when its source is requested', async () => {
+    mockExistsSync.mockImplementation((target: string) => target.endsWith('.js'));
 
-    await expect(loadRdyKit('custom/path.ts')).rejects.toThrow('Kit not found: custom/path.ts');
+    await expect(loadRdyKit('.readyup/kits/deploy.ts')).rejects.toThrow(
+      'Kit "deploy" has no source at .readyup/kits/deploy.ts, but a compiled kit exists. ' +
+        "Run 'rdy run' without --jit to use it.",
+    );
   });
 
-  it('includes the path in file-not-found errors for non-convention paths', async () => {
+  it("suggests 'rdy init' when the default kit has neither a compiled bundle nor a source", async () => {
     mockExistsSync.mockReturnValue(false);
+    mockReaddirSync.mockReturnValue([]);
 
-    await expect(loadRdyKit('some/other.ts')).rejects.toThrow('Kit not found: some/other.ts');
+    await expect(loadRdyKit('.readyup/kits/default.js')).rejects.toThrow(
+      'Kit "default" not found at .readyup/kits/default.js. Run \'rdy init\' to create one.',
+    );
+  });
+
+  it('names the searched path and the available kits for any other missing kit', async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockReaddirSync.mockReturnValue(buildDirents('deploy.js', 'release.js'));
+
+    await expect(loadRdyKit('.readyup/kits/deply.js')).rejects.toThrow(
+      'Kit "deply" not found at .readyup/kits/deply.js. Available kits: deploy, release.',
+    );
+  });
+
+  it('names the searched directory when no kits sit beside the missing one', async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockReaddirSync.mockReturnValue([]);
+
+    await expect(loadRdyKit('custom/path.ts')).rejects.toThrow(
+      'Kit "path" not found at custom/path.ts. No kits found in custom.',
+    );
+  });
+
+  it('treats an unreadable kit directory as holding no kits', async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockReaddirSync.mockImplementation(() => {
+      throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    });
+
+    await expect(loadRdyKit('custom/path.ts')).rejects.toThrow(
+      'Kit "path" not found at custom/path.ts. No kits found in custom.',
+    );
   });
 
   it.each(['MODULE_NOT_FOUND', 'ERR_MODULE_NOT_FOUND'])(
@@ -198,3 +230,8 @@ describe(loadRdyKit, () => {
     expect(compileTimeVersion).toBeUndefined();
   });
 });
+
+/** Build the `withFileTypes` entries `readdirSync` returns for a set of regular files. */
+function buildDirents(...names: string[]): Array<{ name: string; isFile: () => boolean }> {
+  return names.map((name) => ({ name, isFile: () => true }));
+}

--- a/packages/readyup/__tests__/initCommand.unit.test.ts
+++ b/packages/readyup/__tests__/initCommand.unit.test.ts
@@ -17,14 +17,14 @@ vi.mock('../src/terminal.ts', () => ({
 }));
 
 const mockBuildInstallCommand = vi.hoisted(() => vi.fn());
-const mockIsPackageResolvable = vi.hoisted(() => vi.fn());
+const mockIsPackageInstalled = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/utils/install-command.ts', () => ({
   buildInstallCommand: mockBuildInstallCommand,
 }));
 
 vi.mock('../src/utils/resolve-package.ts', () => ({
-  isPackageResolvable: mockIsPackageResolvable,
+  isPackageInstalled: mockIsPackageInstalled,
 }));
 
 import { initCommand } from '../src/init/initCommand.ts';
@@ -49,7 +49,7 @@ describe(`${initCommand.name} error handling`, () => {
     mockScaffoldConfig.mockReset();
     mockReportWriteResult.mockReset();
     mockBuildInstallCommand.mockReset();
-    mockIsPackageResolvable.mockReset();
+    mockIsPackageInstalled.mockReset();
   });
 
   it('throws a config error when scaffoldConfig throws', () => {
@@ -119,14 +119,14 @@ describe(`${initCommand.name} next steps`, () => {
     infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     mockScaffoldConfig.mockReturnValue(makeScaffoldResult('created'));
     mockBuildInstallCommand.mockReturnValue('pnpm add --save-dev readyup');
-    mockIsPackageResolvable.mockReturnValue(true);
+    mockIsPackageInstalled.mockReturnValue(true);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     mockScaffoldConfig.mockReset();
     mockBuildInstallCommand.mockReset();
-    mockIsPackageResolvable.mockReset();
+    mockIsPackageInstalled.mockReset();
   });
 
   it('names only rdy commands, never npx readyup', () => {
@@ -137,7 +137,7 @@ describe(`${initCommand.name} next steps`, () => {
     expect(printedSteps(infoSpy)).toContain('rdy run');
   });
 
-  it('omits the install step when readyup already resolves', () => {
+  it('omits the install step when readyup is already installed', () => {
     initCommand({ dryRun: false, force: false });
 
     const steps = printedSteps(infoSpy);
@@ -146,8 +146,8 @@ describe(`${initCommand.name} next steps`, () => {
     expect(steps).toContain('5. Commit the generated files.');
   });
 
-  it('leads with the install step when readyup does not resolve', () => {
-    mockIsPackageResolvable.mockReturnValue(false);
+  it('leads with the install step when readyup is not installed', () => {
+    mockIsPackageInstalled.mockReturnValue(false);
 
     initCommand({ dryRun: false, force: false });
 

--- a/packages/readyup/__tests__/initCommand.unit.test.ts
+++ b/packages/readyup/__tests__/initCommand.unit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 const mockScaffoldConfig = vi.hoisted(() => vi.fn());
 
@@ -14,6 +14,17 @@ vi.mock('../src/terminal.ts', () => ({
   printStep: vi.fn(),
   printSuccess: vi.fn(),
   reportWriteResult: mockReportWriteResult,
+}));
+
+const mockBuildInstallCommand = vi.hoisted(() => vi.fn());
+const mockIsPackageResolvable = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/utils/install-command.ts', () => ({
+  buildInstallCommand: mockBuildInstallCommand,
+}));
+
+vi.mock('../src/utils/resolve-package.ts', () => ({
+  isPackageResolvable: mockIsPackageResolvable,
 }));
 
 import { initCommand } from '../src/init/initCommand.ts';
@@ -37,6 +48,8 @@ describe(`${initCommand.name} error handling`, () => {
     vi.restoreAllMocks();
     mockScaffoldConfig.mockReset();
     mockReportWriteResult.mockReset();
+    mockBuildInstallCommand.mockReset();
+    mockIsPackageResolvable.mockReset();
   });
 
   it('throws a config error when scaffoldConfig throws', () => {
@@ -98,3 +111,60 @@ describe(`${initCommand.name} error handling`, () => {
     expect(mockReportWriteResult).toHaveBeenCalledWith(result.kitResult, dryRun);
   });
 });
+
+describe(`${initCommand.name} next steps`, () => {
+  let infoSpy: MockInstance;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    mockScaffoldConfig.mockReturnValue(makeScaffoldResult('created'));
+    mockBuildInstallCommand.mockReturnValue('pnpm add --save-dev readyup');
+    mockIsPackageResolvable.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockScaffoldConfig.mockReset();
+    mockBuildInstallCommand.mockReset();
+    mockIsPackageResolvable.mockReset();
+  });
+
+  it('names only rdy commands, never npx readyup', () => {
+    initCommand({ dryRun: false, force: false });
+
+    expect(printedSteps(infoSpy)).not.toContain('npx readyup');
+    expect(printedSteps(infoSpy)).toContain('rdy compile');
+    expect(printedSteps(infoSpy)).toContain('rdy run');
+  });
+
+  it('omits the install step when readyup already resolves', () => {
+    initCommand({ dryRun: false, force: false });
+
+    const steps = printedSteps(infoSpy);
+    expect(steps).not.toContain('Install readyup');
+    expect(steps).toContain('1. Customize .config/readyup.config.ts');
+    expect(steps).toContain('5. Commit the generated files.');
+  });
+
+  it('leads with the install step when readyup does not resolve', () => {
+    mockIsPackageResolvable.mockReturnValue(false);
+
+    initCommand({ dryRun: false, force: false });
+
+    const steps = printedSteps(infoSpy);
+    expect(steps).toContain('1. Install readyup as a dev dependency: pnpm add --save-dev readyup');
+    expect(steps).toContain('2. Customize .config/readyup.config.ts');
+    expect(steps).toContain('6. Commit the generated files.');
+  });
+
+  it('prints no next steps in dry-run mode', () => {
+    initCommand({ dryRun: true, force: false });
+
+    expect(printedSteps(infoSpy)).not.toContain('Customize');
+  });
+});
+
+/** Join everything written to `console.info` into one string. */
+function printedSteps(infoSpy: MockInstance): string {
+  return infoSpy.mock.calls.map((call) => String(call[0])).join('\n');
+}

--- a/packages/readyup/__tests__/jitiImport.test.ts
+++ b/packages/readyup/__tests__/jitiImport.test.ts
@@ -1,0 +1,80 @@
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockImport = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  existsSync: mockExistsSync,
+}));
+
+vi.mock('jiti', () => ({
+  createJiti: () => ({ import: mockImport }),
+}));
+
+import { jitiImport } from '../src/jitiImport.ts';
+
+const KIT_PATH = path.resolve(process.cwd(), '.readyup/kits/default.ts');
+const DETAIL = 'Uncompiled kits require the package to be installed as a project dependency.';
+
+describe(jitiImport, () => {
+  afterEach(() => {
+    mockExistsSync.mockReset();
+    mockImport.mockReset();
+  });
+
+  it('names the evaluated file, the caller detail, and the install command', async () => {
+    mockExistsSync.mockImplementation((target: string) => target.endsWith('pnpm-lock.yaml'));
+    mockImport.mockRejectedValue(
+      Object.assign(new Error("Cannot find package 'readyup'"), { code: 'ERR_MODULE_NOT_FOUND' }),
+    );
+
+    await expect(jitiImport(KIT_PATH, DETAIL, 'Kit file')).rejects.toThrow(
+      `Cannot resolve 'readyup' while evaluating .readyup/kits/default.ts. ${DETAIL} ` +
+        'Install it with: pnpm add --save-dev readyup',
+    );
+  });
+
+  it('omits the install command for a specifier that names a file rather than a package', async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockImport.mockRejectedValue(
+      Object.assign(new Error("Cannot find module './helpers.ts'"), { code: 'MODULE_NOT_FOUND' }),
+    );
+
+    const error = await jitiImport(KIT_PATH, DETAIL, 'Kit file').catch((error_: unknown) => error_);
+
+    expect(String(error)).toContain("Cannot resolve './helpers.ts' while evaluating .readyup/kits/default.ts.");
+    expect(String(error)).not.toContain('Install it with');
+  });
+
+  it('omits the install command when the specifier cannot be read from the error', async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockImport.mockRejectedValue(Object.assign(new Error('Module load failed'), { code: 'MODULE_NOT_FOUND' }));
+
+    const error = await jitiImport(KIT_PATH, DETAIL, 'Kit file').catch((error_: unknown) => error_);
+
+    expect(String(error)).toContain("Cannot resolve 'unknown module' while evaluating .readyup/kits/default.ts.");
+    expect(String(error)).not.toContain('Install it with');
+  });
+
+  it('re-throws an error that is not a module-resolution failure', async () => {
+    mockImport.mockRejectedValue(new SyntaxError('Unexpected token'));
+
+    await expect(jitiImport(KIT_PATH, DETAIL, 'Kit file')).rejects.toThrow(SyntaxError);
+  });
+
+  it('rejects a module that does not export an object', async () => {
+    mockImport.mockResolvedValue('not-an-object');
+
+    await expect(jitiImport(KIT_PATH, DETAIL, 'Kit file')).rejects.toThrow(
+      'Kit file must export an object, got string',
+    );
+  });
+
+  it('returns the imported module namespace', async () => {
+    mockImport.mockResolvedValue({ checklists: [] });
+
+    await expect(jitiImport(KIT_PATH, DETAIL, 'Kit file')).resolves.toStrictEqual({ checklists: [] });
+  });
+});

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -15,6 +15,27 @@ describe(formatOwnerView, () => {
     expect(result).toContain('deploy');
   });
 
+  it('omits --internal from the internal hint by default', () => {
+    const result = formatOwnerView({
+      internalKits: ['default'],
+      compiledKits: [],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    expect(result).toContain('Internal: rdy run --jit [<name>]');
+  });
+
+  it('adds --internal to the internal hint when the config makes it necessary', () => {
+    const result = formatOwnerView({
+      internalKits: ['default'],
+      compiledKits: [],
+      compiledStyle: { kind: 'local-convention' },
+      needsInternalFlag: true,
+    });
+
+    expect(result).toContain('Internal: rdy run --jit --internal [<name>]');
+  });
+
   it('renders only the Compiled section when internal kits are empty', () => {
     const result = formatOwnerView({
       internalKits: [],

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -14,9 +14,13 @@ vi.mock('../../src/list/enumerateKits.ts', () => ({
   enumerateKits: mockEnumerateKits,
 }));
 
-vi.mock('../../src/loadConfig.ts', () => ({
-  loadConfig: mockLoadConfig,
-}));
+vi.mock('../../src/loadConfig.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/loadConfig.ts')>();
+  return {
+    DEFAULT_CONFIG: actual.DEFAULT_CONFIG,
+    loadConfig: mockLoadConfig,
+  };
+});
 
 vi.mock('../../src/manifest/readManifest.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/manifest/readManifest.ts')>();

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -176,6 +176,31 @@ describe(listCommand, () => {
       expect(stderrSpy).not.toHaveBeenCalled();
     });
 
+    it.each([
+      ['dir', { dir: 'internal', infix: undefined }],
+      ['infix', { dir: '.', infix: 'internal' }],
+    ])('adds --internal to the internal hint when internal.%s is configured', async (_label, internal) => {
+      mockLoadConfig.mockResolvedValue({
+        compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+        internal,
+      });
+      mockEnumerateKits.mockReturnValue(['default']);
+
+      await listCommand([]);
+
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('Internal: rdy run --jit --internal [<name>]');
+    });
+
+    it('leaves --internal out of the internal hint under the default config', async () => {
+      mockEnumerateKits.mockReturnValue(['default']);
+
+      await listCommand([]);
+
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('Internal: rdy run --jit [<name>]');
+    });
+
     it('writes warning to stderr when manifest read fails with non-missing-file error and internal kits exist', async () => {
       mockEnumerateKits.mockReturnValue(['default']);
       mockReadManifest.mockImplementation(() => {

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -4,9 +4,13 @@ const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockEnumerateKits = vi.hoisted(() => vi.fn());
 const mockReadManifest = vi.hoisted(() => vi.fn());
 
-vi.mock('../src/loadConfig.ts', () => ({
-  loadConfig: mockLoadConfig,
-}));
+vi.mock('../src/loadConfig.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/loadConfig.ts')>();
+  return {
+    DEFAULT_CONFIG: actual.DEFAULT_CONFIG,
+    loadConfig: mockLoadConfig,
+  };
+});
 
 vi.mock('../src/list/enumerateKits.ts', () => ({
   enumerateKits: mockEnumerateKits,
@@ -125,13 +129,24 @@ describe(listCommand, () => {
       expect(output).toContain('No kits found.');
     });
 
-    it('reports a config error when config load fails', async () => {
+    it('warns and lists with default settings when config load fails', async () => {
       mockLoadConfig.mockRejectedValue(new Error('bad config'));
+      mockEnumerateKits.mockReturnValue(['default']);
 
-      const error = await captureRdyError(() => listCommand([]));
+      const exitCode = await listCommand([]);
 
-      expect(error.code).toBe('config');
-      expect(error.message).toContain('bad config');
+      expect(exitCode).toBe(0);
+      expect(stderrSpy).toHaveBeenCalledWith('Warning: bad config. Listing with default settings.\n');
+      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(output).toContain('default');
+    });
+
+    it('does not double the period when the config failure already ends in one', async () => {
+      mockLoadConfig.mockRejectedValue(new Error('bad config.'));
+
+      await listCommand([]);
+
+      expect(stderrSpy).toHaveBeenCalledWith('Warning: bad config. Listing with default settings.\n');
     });
 
     it('reports a config error when enumerateKits throws', async () => {

--- a/packages/readyup/__tests__/loadConfig.test.ts
+++ b/packages/readyup/__tests__/loadConfig.test.ts
@@ -122,6 +122,18 @@ describe(loadConfig, () => {
     },
   );
 
+  it('names the config file and the install command in a module-resolution failure', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockRejectedValue(
+      Object.assign(new Error("Cannot find package 'some-lib'"), { code: 'ERR_MODULE_NOT_FOUND' }),
+    );
+
+    await expect(loadConfig('config.ts')).rejects.toThrow(
+      "Cannot resolve 'some-lib' while evaluating config.ts. External packages imported by the config file " +
+        'must be installed in the project. Install it with: pnpm add --save-dev some-lib',
+    );
+  });
+
   it('falls back to "unknown module" when the error message does not match the expected pattern', async () => {
     mockExistsSync.mockReturnValue(true);
     const moduleError = Object.assign(new Error('Module load failed'), { code: 'MODULE_NOT_FOUND' });

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 const mockRunCommand = vi.hoisted(() => vi.fn());
@@ -37,6 +40,9 @@ vi.mock('../src/version.ts', () => ({
 import { routeCommand } from '../src/bin/route.ts';
 import { usageError } from '../src/errors.ts';
 
+/** Scratch project root for the tests that need a kit file on disk. */
+const TYPO_TEST_DIR = join(import.meta.dirname, '../.test-tmp-route');
+
 describe(routeCommand, () => {
   let stdoutSpy: MockInstance;
   let stderrSpy: MockInstance;
@@ -54,6 +60,7 @@ describe(routeCommand, () => {
   });
 
   afterEach(() => {
+    rmSync(TYPO_TEST_DIR, { recursive: true, force: true });
     vi.restoreAllMocks();
     mockRunCommand.mockReset();
     mockCompileCommand.mockReset();
@@ -616,11 +623,15 @@ describe(routeCommand, () => {
 
   describe('typo detection', () => {
     it.each([
-      ['compil', 'compile'],
-      ['compi', 'compile'],
+      ['co', 'compile'],
       ['comp', 'compile'],
+      ['comple', 'compile'],
+      ['compil', 'compile'],
       ['ini', 'init'],
       ['lis', 'list'],
+      ['lst', 'list'],
+      ['runn', 'run'],
+      ['verfy', 'verify'],
     ])('suggests "%s" -> "%s"', async (input, expected) => {
       const exitCode = await routeCommand([input]);
 
@@ -628,36 +639,41 @@ describe(routeCommand, () => {
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`Did you mean 'rdy ${expected}'?`));
     });
 
-    it('does not suggest for prefixes shorter than 3 characters', async () => {
-      mockParseRunArgs.mockReturnValue({
-        kitSpecifiers: [{ kitName: 'co', checklists: [] }],
-        checklists: undefined,
-        filePath: undefined,
-        fromValue: undefined,
-        urlValue: undefined,
-        jit: false,
-        internal: false,
-        json: false,
-      });
+    it('does not suggest for a word no command is close to', async () => {
+      mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'onboarding', checklists: [] }] }));
       mockRunCommand.mockResolvedValue(0);
 
-      const exitCode = await routeCommand(['co']);
+      const exitCode = await routeCommand(['onboarding']);
 
       expect(exitCode).toBe(0);
       expect(stderrSpy).not.toHaveBeenCalled();
     });
 
+    it('runs a bare word as a kit when a kit by that name exists', async () => {
+      mkdirSync(join(TYPO_TEST_DIR, '.readyup/kits'), { recursive: true });
+      writeFileSync(join(TYPO_TEST_DIR, '.readyup/kits/lst.js'), 'export const checklists = [];', 'utf8');
+      vi.spyOn(process, 'cwd').mockReturnValue(TYPO_TEST_DIR);
+      mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'lst', checklists: [] }] }));
+      mockRunCommand.mockResolvedValue(0);
+
+      const exitCode = await routeCommand(['lst']);
+
+      expect(exitCode).toBe(0);
+      expect(mockParseRunArgs).toHaveBeenCalledWith(['lst']);
+    });
+
+    it('does not suggest after an explicit run subcommand', async () => {
+      mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'lst', checklists: [] }] }));
+      mockRunCommand.mockResolvedValue(0);
+
+      const exitCode = await routeCommand(['run', 'lst']);
+
+      expect(exitCode).toBe(0);
+      expect(mockParseRunArgs).toHaveBeenCalledWith(['lst']);
+    });
+
     it('does not suggest when input matches a subcommand exactly', async () => {
-      mockParseRunArgs.mockReturnValue({
-        kitSpecifiers: [],
-        checklists: undefined,
-        filePath: undefined,
-        fromValue: undefined,
-        urlValue: undefined,
-        jit: false,
-        internal: false,
-        json: false,
-      });
+      mockParseRunArgs.mockReturnValue(parsedRunArgs());
       mockRunCommand.mockResolvedValue(0);
 
       // 'run' is handled before typo detection, so this verifies

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -687,6 +687,39 @@ describe(routeCommand, () => {
       expect(mockParseRunArgs).toHaveBeenCalledWith(['lst']);
     });
 
+    it.each([
+      ['--from', ['lst', '--from', 'global']],
+      ['--from with an inline value', ['lst', '--from=global']],
+      ['--file', ['lst', '--file', 'kit.js']],
+      ['--url', ['lst', '--url', 'https://example.test/kit.js']],
+      ['--internal', ['runn', '--internal']],
+    ])('runs the bare word as a kit when %s names its source', async (_label, args) => {
+      mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: args[0], checklists: [] }] }));
+      mockRunCommand.mockResolvedValue(0);
+
+      const exitCode = await routeCommand(args);
+
+      expect(exitCode).toBe(0);
+      expect(mockParseRunArgs).toHaveBeenCalledWith(args);
+    });
+
+    it('runs a bare word carrying a checklist filter as a kit', async () => {
+      mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'lis', checklists: ['t'] }] }));
+      mockRunCommand.mockResolvedValue(0);
+
+      const exitCode = await routeCommand(['lis:t']);
+
+      expect(exitCode).toBe(0);
+      expect(mockParseRunArgs).toHaveBeenCalledWith(['lis:t']);
+    });
+
+    it('still suggests a command when a source flag follows the -- terminator', async () => {
+      const exitCode = await routeCommand(['lst', '--', '--from']);
+
+      expect(exitCode).toBe(2);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Did you mean 'rdy list'?"));
+    });
+
     it('does not suggest after an explicit run subcommand', async () => {
       mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'lst', checklists: [] }] }));
       mockRunCommand.mockResolvedValue(0);

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -141,6 +141,31 @@ describe(routeCommand, () => {
     expect(output).toContain('(default)');
   });
 
+  it('points at per-command help from top-level help', async () => {
+    await routeCommand(['--help']);
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain("Run 'rdy <command> --help' for command-specific options.");
+  });
+
+  it.each([
+    { label: 'top-level', args: ['--help'] },
+    { label: 'run', args: ['run', '--help'] },
+    { label: 'list', args: ['list', '--help'] },
+  ])('shows examples in $label help', async ({ args }) => {
+    await routeCommand(args);
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('Examples:');
+  });
+
+  it('explains how to escape a positional starting with a dash in run help', async () => {
+    await routeCommand(['run', '--help']);
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('rdy run -- "--odd-kit-name"');
+  });
+
   it('shows run help and returns 0 for run --help', async () => {
     const exitCode = await routeCommand(['run', '--help']);
 

--- a/packages/readyup/__tests__/utils/display-path.test.ts
+++ b/packages/readyup/__tests__/utils/display-path.test.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import process from 'node:process';
+
+import { describe, expect, it } from 'vitest';
+
+import { toDisplayPath } from '../../src/utils/display-path.ts';
+
+describe(toDisplayPath, () => {
+  it('relativizes a path inside the current directory', () => {
+    expect(toDisplayPath(path.join(process.cwd(), '.readyup/kits/default.js'))).toBe('.readyup/kits/default.js');
+  });
+
+  it('resolves a relative path against the current directory', () => {
+    expect(toDisplayPath('.readyup/kits/default.js')).toBe('.readyup/kits/default.js');
+  });
+
+  it('keeps the absolute form for a path outside the current directory', () => {
+    const outside = path.resolve(process.cwd(), '../elsewhere/kit.js');
+
+    expect(toDisplayPath(outside)).toBe(outside);
+  });
+
+  it('keeps the absolute form for the current directory itself', () => {
+    expect(toDisplayPath(process.cwd())).toBe(process.cwd());
+  });
+});

--- a/packages/readyup/__tests__/utils/install-command.test.ts
+++ b/packages/readyup/__tests__/utils/install-command.test.ts
@@ -1,39 +1,90 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
 
 vi.mock(import('node:fs'), () => ({
   existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
 }));
 
 import { buildInstallCommand } from '../../src/utils/install-command.ts';
 
+const PACKAGE_DIR = path.resolve('/repo/packages/readyup');
+const REPO_ROOT = path.resolve('/repo');
+
 describe(buildInstallCommand, () => {
-  afterEach(() => {
-    mockExistsSync.mockReset();
+  beforeEach(() => {
+    vi.spyOn(process, 'cwd').mockReturnValue(PACKAGE_DIR);
+    mockExistsSync.mockReturnValue(false);
+    mockReadFileSync.mockReturnValue('{}');
   });
 
-  it('uses pnpm when a pnpm lockfile is present', () => {
-    mockExistsSync.mockImplementation((target: string) => target.endsWith('pnpm-lock.yaml'));
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockExistsSync.mockReset();
+    mockReadFileSync.mockReset();
+  });
+
+  it.each([
+    ['pnpm-lock.yaml', 'pnpm add --save-dev readyup'],
+    ['yarn.lock', 'yarn add --dev readyup'],
+    ['package-lock.json', 'npm install --save-dev readyup'],
+  ])('reads the package manager from %s in the current directory', (lockfile, expected) => {
+    presentFiles(path.join(PACKAGE_DIR, lockfile));
+
+    expect(buildInstallCommand('readyup')).toBe(expected);
+  });
+
+  it('finds a workspace lockfile above the current directory', () => {
+    presentFiles(path.join(REPO_ROOT, 'pnpm-lock.yaml'));
 
     expect(buildInstallCommand('readyup')).toBe('pnpm add --save-dev readyup');
   });
 
-  it('uses yarn when a yarn lockfile is present', () => {
-    mockExistsSync.mockImplementation((target: string) => target.endsWith('yarn.lock'));
+  it('reads the packageManager field from a package.json above the current directory', () => {
+    presentFiles(path.join(REPO_ROOT, 'package.json'));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'pnpm@11.15.0' }));
+
+    expect(buildInstallCommand('readyup')).toBe('pnpm add --save-dev readyup');
+  });
+
+  it('prefers a declared packageManager over a lockfile in the same directory', () => {
+    presentFiles(path.join(REPO_ROOT, 'package.json'), path.join(REPO_ROOT, 'package-lock.json'));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'yarn@4.1.0' }));
 
     expect(buildInstallCommand('readyup')).toBe('yarn add --dev readyup');
   });
 
-  it('falls back to npm when no lockfile identifies a package manager', () => {
-    mockExistsSync.mockReturnValue(false);
+  it('prefers the nearest signal over one further up the tree', () => {
+    presentFiles(path.join(PACKAGE_DIR, 'yarn.lock'), path.join(REPO_ROOT, 'pnpm-lock.yaml'));
+
+    expect(buildInstallCommand('readyup')).toBe('yarn add --dev readyup');
+  });
+
+  it('falls back to npm when no directory names a package manager', () => {
+    expect(buildInstallCommand('readyup')).toBe('npm install --save-dev readyup');
+  });
+
+  it('falls back to npm when the declared package manager is unrecognized', () => {
+    presentFiles(path.join(REPO_ROOT, 'package.json'));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'somepm@1.0.0' }));
 
     expect(buildInstallCommand('readyup')).toBe('npm install --save-dev readyup');
   });
 
-  it('prefers pnpm when both lockfiles are present', () => {
-    mockExistsSync.mockReturnValue(true);
+  it('falls back to npm when a package.json cannot be parsed', () => {
+    presentFiles(path.join(REPO_ROOT, 'package.json'));
+    mockReadFileSync.mockReturnValue('{ not json');
 
-    expect(buildInstallCommand('readyup')).toBe('pnpm add --save-dev readyup');
+    expect(buildInstallCommand('readyup')).toBe('npm install --save-dev readyup');
   });
 });
+
+/** Make `existsSync` answer true for exactly the given paths. */
+function presentFiles(...paths: string[]): void {
+  const present = new Set(paths);
+  mockExistsSync.mockImplementation((target: string) => present.has(target));
+}

--- a/packages/readyup/__tests__/utils/install-command.test.ts
+++ b/packages/readyup/__tests__/utils/install-command.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  existsSync: mockExistsSync,
+}));
+
+import { buildInstallCommand } from '../../src/utils/install-command.ts';
+
+describe(buildInstallCommand, () => {
+  afterEach(() => {
+    mockExistsSync.mockReset();
+  });
+
+  it('uses pnpm when a pnpm lockfile is present', () => {
+    mockExistsSync.mockImplementation((target: string) => target.endsWith('pnpm-lock.yaml'));
+
+    expect(buildInstallCommand('readyup')).toBe('pnpm add --save-dev readyup');
+  });
+
+  it('uses yarn when a yarn lockfile is present', () => {
+    mockExistsSync.mockImplementation((target: string) => target.endsWith('yarn.lock'));
+
+    expect(buildInstallCommand('readyup')).toBe('yarn add --dev readyup');
+  });
+
+  it('falls back to npm when no lockfile identifies a package manager', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    expect(buildInstallCommand('readyup')).toBe('npm install --save-dev readyup');
+  });
+
+  it('prefers pnpm when both lockfiles are present', () => {
+    mockExistsSync.mockReturnValue(true);
+
+    expect(buildInstallCommand('readyup')).toBe('pnpm add --save-dev readyup');
+  });
+});

--- a/packages/readyup/__tests__/utils/parse-args-error.test.ts
+++ b/packages/readyup/__tests__/utils/parse-args-error.test.ts
@@ -9,6 +9,67 @@ const options = {
   json: { type: 'boolean', short: 'j' },
 } as const;
 
+describe('translateParseArgsError', () => {
+  it('points an unknown option at the command help', () => {
+    const message = translateParseArgsError(captureError(['--nope']), 'list');
+
+    expect(message).toBe("Unknown option '--nope'. Run 'rdy list --help' to see available options.");
+  });
+
+  it('names the command it was given', () => {
+    const message = translateParseArgsError(captureError(['--nope']), 'run');
+
+    expect(message).toBe("Unknown option '--nope'. Run 'rdy run --help' to see available options.");
+  });
+
+  it('reports an unknown short option by the spelling that was given', () => {
+    const message = translateParseArgsError(captureError(['-z']), 'compile');
+
+    expect(message).toBe("Unknown option '-z'. Run 'rdy compile --help' to see available options.");
+  });
+
+  it('leaves out the positional-escape advice Node offers', () => {
+    const message = translateParseArgsError(captureError(['--nope']), 'run');
+
+    expect(message).not.toContain('positional');
+  });
+
+  it('applies the hint when a string flag is missing its value', () => {
+    const message = translateParseArgsError(captureError(['--file']), 'run', {
+      '--file': '--file requires a path argument',
+    });
+
+    expect(message).toBe('--file requires a path argument');
+  });
+
+  it('applies the hint when a string flag is followed by another option (ambiguous)', () => {
+    const message = translateParseArgsError(captureError(['--file', '--json']), 'run', {
+      '--file': '--file requires a path argument',
+    });
+
+    expect(message).toBe('--file requires a path argument');
+  });
+
+  it('falls back to a generic message when no hint matches the missing-value flag', () => {
+    const message = translateParseArgsError(captureError(['--file']), 'run');
+
+    expect(message).toBe('--file requires a value');
+  });
+
+  it('passes a boolean-given-a-value error through instead of claiming a value is required', () => {
+    const message = translateParseArgsError(captureError(['--json=x']), 'run', {
+      '--json': '--json requires a value',
+    });
+
+    expect(message).toContain('does not take an argument');
+    expect(message).not.toContain('requires a value');
+  });
+
+  it('stringifies a non-Error value', () => {
+    expect(translateParseArgsError('raw string', 'run')).toBe('raw string');
+  });
+});
+
 /** Run node:util.parseArgs and return whatever it throws, failing if it unexpectedly succeeds. */
 function captureError(args: string[]): unknown {
   try {
@@ -18,43 +79,3 @@ function captureError(args: string[]): unknown {
   }
   throw new Error('expected parseArgs to throw');
 }
-
-describe('translateParseArgsError', () => {
-  it('passes an unknown-option error through to Node text', () => {
-    const message = translateParseArgsError(captureError(['--nope']));
-
-    expect(message).toContain('--nope');
-    expect(message).toContain('Unknown option');
-  });
-
-  it('applies the hint when a string flag is missing its value', () => {
-    const message = translateParseArgsError(captureError(['--file']), { '--file': '--file requires a path argument' });
-
-    expect(message).toBe('--file requires a path argument');
-  });
-
-  it('applies the hint when a string flag is followed by another option (ambiguous)', () => {
-    const message = translateParseArgsError(captureError(['--file', '--json']), {
-      '--file': '--file requires a path argument',
-    });
-
-    expect(message).toBe('--file requires a path argument');
-  });
-
-  it('falls back to a generic message when no hint matches the missing-value flag', () => {
-    const message = translateParseArgsError(captureError(['--file']));
-
-    expect(message).toBe('--file requires a value');
-  });
-
-  it('passes a boolean-given-a-value error through instead of claiming a value is required', () => {
-    const message = translateParseArgsError(captureError(['--json=x']), { '--json': '--json requires a value' });
-
-    expect(message).toContain('does not take an argument');
-    expect(message).not.toContain('requires a value');
-  });
-
-  it('stringifies a non-Error value', () => {
-    expect(translateParseArgsError('raw string')).toBe('raw string');
-  });
-});

--- a/packages/readyup/__tests__/utils/resolve-package.test.ts
+++ b/packages/readyup/__tests__/utils/resolve-package.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPackageResolvable } from '../../src/utils/resolve-package.ts';
+
+describe(isPackageResolvable, () => {
+  it('reports a package the project depends on as resolvable', () => {
+    expect(isPackageResolvable('zod')).toBe(true);
+  });
+
+  it('reports an uninstalled package as unresolvable', () => {
+    expect(isPackageResolvable('readyup-package-that-does-not-exist')).toBe(false);
+  });
+});

--- a/packages/readyup/__tests__/utils/resolve-package.test.ts
+++ b/packages/readyup/__tests__/utils/resolve-package.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { isPackageResolvable } from '../../src/utils/resolve-package.ts';
+import { isPackageInstalled } from '../../src/utils/resolve-package.ts';
 
-describe(isPackageResolvable, () => {
-  it('reports a package the project depends on as resolvable', () => {
-    expect(isPackageResolvable('zod')).toBe(true);
+describe(isPackageInstalled, () => {
+  it('reports a package the project depends on as installed', () => {
+    expect(isPackageInstalled('zod')).toBe(true);
   });
 
-  it('reports an uninstalled package as unresolvable', () => {
-    expect(isPackageResolvable('readyup-package-that-does-not-exist')).toBe(false);
+  // `readyup` publishes only `import` and `types` conditions, so a require-based resolver reaches its
+  // package.json and then fails on conditions. An ESM-only package is installed all the same.
+  it('reports an import-only package as installed', () => {
+    expect(isPackageInstalled('readyup')).toBe(true);
+  });
+
+  it('reports an uninstalled package as not installed', () => {
+    expect(isPackageInstalled('readyup-package-that-does-not-exist')).toBe(false);
   });
 });

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
 import process from 'node:process';
 import { parseArgs as nodeParseArgs } from 'node:util';
 
@@ -8,6 +10,7 @@ import { EXIT_OK, EXIT_TOOL_FAILURE } from '../exitCodes.ts';
 import { formatJsonError } from '../formatJsonError.ts';
 import { hasJsonFlag } from '../hasJsonFlag.ts';
 import { initCommand } from '../init/initCommand.ts';
+import { KITS_DIR } from '../kitsDir.ts';
 import { listCommand } from '../list/listCommand.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { extractMessage } from '../utils/error-handling.ts';
@@ -16,8 +19,14 @@ import { verifyCommand } from '../verify/verifyCommand.ts';
 import { VERSION } from '../version.ts';
 import { writeHuman } from '../writeHuman.ts';
 
-const SUBCOMMANDS = ['compile', 'init', 'list', 'verify'];
-const MIN_PREFIX_LENGTH = 3;
+/** Command names a mistyped bare word is matched against, including the implicit `run`. */
+const COMMAND_NAMES = ['compile', 'init', 'list', 'run', 'verify'];
+
+/** Edits — insertions, deletions, or substitutions — a word may be from a command and still match it. */
+const MAX_TYPO_DISTANCE = 2;
+
+/** Extensions a kit file can carry, in the order `run` would resolve them. */
+const KIT_EXTENSIONS = ['.js', '.ts'];
 
 const HELP = `
 Usage: rdy [kit[:checklist,...] ...] [options]
@@ -277,9 +286,11 @@ async function dispatchCommand(args: string[], json: boolean): Promise<number> {
     return wantsHelp(flags) ? writeHelp(VERIFY_HELP, json) : verifyCommand(flags);
   }
 
-  // Check for typos before falling through to the default command.
+  // A bare word that names a kit is always run as that kit; only one that names none can be a
+  // mistyped command. The check sits here rather than in `handleRun` so an explicit `rdy run <word>`
+  // never reaches it: naming the subcommand says the word is a kit.
   const typoMatch = findTypoMatch(command);
-  if (typoMatch !== undefined) {
+  if (typoMatch !== undefined && !hasLocalKit(command)) {
     throw usageError(`Unknown command '${command}'. Did you mean 'rdy ${typoMatch}'?`);
   }
 
@@ -359,15 +370,64 @@ function writeHelp(text: string, json: boolean): number {
   return EXIT_OK;
 }
 
-/** Checks whether a positional arg is a close prefix of a known subcommand. */
+/**
+ * Find the command a bare word most likely misspells, or `undefined` when none is close enough.
+ *
+ * A word qualifies by abbreviating a command or by sitting within a couple of edits of one, so a
+ * transposed or wrong letter is caught alongside a truncation. Ties go to the nearest command and
+ * then to the first in alphabetical order. Words starting with `-` are flags, which the argument
+ * parser reports on its own.
+ */
 function findTypoMatch(input: string): string | undefined {
-  if (input.length < MIN_PREFIX_LENGTH || input.startsWith('-')) {
-    return undefined;
-  }
-  for (const cmd of SUBCOMMANDS) {
-    if (cmd !== input && cmd.startsWith(input)) {
-      return cmd;
+  if (input === '' || input.startsWith('-')) return undefined;
+
+  let best: { command: string; distance: number } | undefined;
+  for (const command of COMMAND_NAMES) {
+    const distance = measureEditDistance(input, command);
+    const isCandidate = distance <= MAX_TYPO_DISTANCE || command.startsWith(input);
+    if (isCandidate && (best === undefined || distance < best.distance)) {
+      best = { command, distance };
     }
   }
-  return undefined;
+  return best?.command;
+}
+
+/**
+ * Report whether a bare word names a kit in the conventional kit directory.
+ *
+ * Only the conventional local paths are probed, so a kit reachable solely through `--from` or an
+ * `--internal` directory is invisible here and a near-command name under those sources is still
+ * reported as a typo. That invocation was already failing before the check existed.
+ */
+function hasLocalKit(name: string): boolean {
+  return KIT_EXTENSIONS.some((extension) => existsSync(path.join(process.cwd(), KITS_DIR, `${name}${extension}`)));
+}
+
+/** Compute the Levenshtein edit distance between two words. */
+function measureEditDistance(source: string, target: string): number {
+  const targetCharacters = Array.from(target);
+
+  // Each row holds the distance from one prefix of the source to every non-empty prefix of the
+  // target. Column zero is held in a scalar rather than the row because its value is always the
+  // row's own index, which keeps every read a plain iteration.
+  let previousRow = targetCharacters.map((character, index) => ({ character, distance: index + 1 }));
+
+  for (const [rowIndex, sourceCharacter] of Array.from(source).entries()) {
+    let diagonal = rowIndex;
+    let left = rowIndex + 1;
+    const currentRow: typeof previousRow = [];
+
+    for (const { character, distance: above } of previousRow) {
+      const substitution = diagonal + (sourceCharacter === character ? 0 : 1);
+      const distance = Math.min(above + 1, left + 1, substitution);
+      currentRow.push({ character, distance });
+      diagonal = above;
+      left = distance;
+    }
+
+    previousRow = currentRow;
+  }
+
+  // An empty target leaves every row empty, and the distance is then the source's length alone.
+  return previousRow.at(-1)?.distance ?? source.length;
 }

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -22,7 +22,7 @@ import { writeHuman } from '../writeHuman.ts';
 /** Command names a mistyped bare word is matched against, including the implicit `run`. */
 const COMMAND_NAMES = ['compile', 'init', 'list', 'run', 'verify'];
 
-/** Edits — insertions, deletions, or substitutions — a word may be from a command and still match it. */
+/** Edits (insertions, deletions, or substitutions) a word may be from a command and still match it. */
 const MAX_TYPO_DISTANCE = 2;
 
 /** Extensions a kit file can carry, in the order `run` would resolve them. */
@@ -56,6 +56,17 @@ Run options:
 Global options:
   --help, -h           Show this help message
   --version, -V        Show version number
+
+Run 'rdy <command> --help' for command-specific options.
+
+Examples:
+  rdy                                              Run every checklist in the default kit
+  rdy deploy                                       Run the compiled deploy kit
+  rdy deploy:build,test                            Run two checklists from the deploy kit
+  rdy run --jit deploy                             Run the deploy kit from its TypeScript source
+  rdy init                                         Scaffold a starter config and kit
+  rdy compile                                      Compile every kit source into a bundle
+  rdy list --from github:williamthorsen/workshop   List kits published by a repository
 
 Exit codes:
   0  Ran and found no problems
@@ -118,6 +129,18 @@ Options:
 
 Positional args accept relative paths (e.g., shared/deploy).
 Defaults to .readyup/kits/default.js when no source is given.
+
+To pass a positional argument that starts with a '-', place it at the end of the command
+after '--', as in: rdy run -- "--odd-kit-name"
+
+Examples:
+  rdy run                                Run every checklist in the default kit
+  rdy run deploy                         Run the compiled deploy kit
+  rdy run deploy:build,test              Run two checklists from the deploy kit
+  rdy run --jit deploy                   Run the deploy kit from its TypeScript source
+  rdy run --from global deploy           Run the deploy kit from the global directory
+  rdy run --fail-on warn                 Fail the run on warnings as well as errors
+  rdy run --json --detail summary        Emit a JSON report carrying only failed checks
 `;
 
 const COMPILE_HELP = `

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -353,7 +353,7 @@ function handleInit(flags: string[]): number {
   try {
     parsed = nodeParseArgs({ args: flags, options: initOptions, strict: true, allowPositionals: true });
   } catch (error: unknown) {
-    throw usageError(translateParseArgsError(error), { cause: error });
+    throw usageError(translateParseArgsError(error, 'init'), { cause: error });
   }
 
   return initCommand({ dryRun: parsed.values['dry-run'] === true, force: parsed.values.force === true });

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -28,6 +28,9 @@ const MAX_TYPO_DISTANCE = 2;
 /** Extensions a kit file can carry, in the order `run` would resolve them. */
 const KIT_EXTENSIONS = ['.js', '.ts'];
 
+/** Flags naming where a kit comes from, each of which resolves it somewhere the local probe cannot see. */
+const SOURCE_FLAGS = new Set(['--file', '-f', '--from', '--internal', '--url']);
+
 const HELP = `
 Usage: rdy [kit[:checklist,...] ...] [options]
        rdy <command> [options]
@@ -313,7 +316,7 @@ async function dispatchCommand(args: string[], json: boolean): Promise<number> {
   // mistyped command. The check sits here rather than in `handleRun` so an explicit `rdy run <word>`
   // never reaches it: naming the subcommand says the word is a kit.
   const typoMatch = findTypoMatch(command);
-  if (typoMatch !== undefined && !hasLocalKit(command)) {
+  if (typoMatch !== undefined && !namesAKit(command, args)) {
     throw usageError(`Unknown command '${command}'. Did you mean 'rdy ${typoMatch}'?`);
   }
 
@@ -416,14 +419,34 @@ function findTypoMatch(input: string): string | undefined {
 }
 
 /**
- * Report whether a bare word names a kit in the conventional kit directory.
+ * Report whether a bare word is a kit rather than a candidate command typo.
  *
- * Only the conventional local paths are probed, so a kit reachable solely through `--from` or an
- * `--internal` directory is invisible here and a near-command name under those sources is still
- * reported as a typo. That invocation was already failing before the check existed.
+ * A ':' checklist filter and a source flag are both kit syntax that no command uses, so either
+ * settles the question outright: under them the word is a kit by construction, and the kit it names
+ * lives wherever that source resolves rather than on a path worth probing.
+ *
+ * Everything else is a bare word with no source, which `run` resolves against the conventional kit
+ * directory alone. Probing exactly that directory is what makes the answer match what would run.
  */
-function hasLocalKit(name: string): boolean {
-  return KIT_EXTENSIONS.some((extension) => existsSync(path.join(process.cwd(), KITS_DIR, `${name}${extension}`)));
+function namesAKit(word: string, args: string[]): boolean {
+  if (word.includes(':') || hasSourceFlag(args)) return true;
+
+  return KIT_EXTENSIONS.some((extension) => existsSync(path.join(process.cwd(), KITS_DIR, `${word}${extension}`)));
+}
+
+/**
+ * Detect a kit-source flag by scanning raw argv.
+ *
+ * The scan runs before any flag parsing, so it accepts both `--from value` and `--from=value` and
+ * stops at the `--` terminator, after which arguments are positional rather than flags.
+ */
+function hasSourceFlag(args: string[]): boolean {
+  for (const arg of args) {
+    if (arg === '--') return false;
+    const flag = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg;
+    if (SOURCE_FLAGS.has(flag)) return true;
+  }
+  return false;
 }
 
 /** Compute the Levenshtein edit distance between two words. */

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -197,7 +197,7 @@ function parseRunFlags(flags: string[]) {
   try {
     return nodeParseArgs({ args: flags, options: runOptions, strict: true, allowPositionals: true });
   } catch (error: unknown) {
-    throw usageError(translateParseArgsError(error, flagErrorHints), { cause: error });
+    throw usageError(translateParseArgsError(error, 'run', flagErrorHints), { cause: error });
   }
 }
 

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -49,7 +49,7 @@ export async function compileCommand(args: string[]): Promise<number> {
   try {
     parsed = nodeParseArgs({ args, options: compileOptions, strict: true, allowPositionals: true });
   } catch (error: unknown) {
-    throw usageError(translateParseArgsError(error, compileHints), { cause: error });
+    throw usageError(translateParseArgsError(error, 'compile', compileHints), { cause: error });
   }
   const { values, positionals } = parsed;
 

--- a/packages/readyup/src/config.ts
+++ b/packages/readyup/src/config.ts
@@ -70,11 +70,14 @@ function diagnoseMissingKit(resolvedPath: string): string {
           "Run 'rdy run' without --jit to use it.";
   }
 
-  if (name === 'default' && dir === path.resolve(process.cwd(), KITS_DIR)) {
+  const available = listAvailableKits(dir, extension);
+
+  // Scaffolding is the remedy only for a project that has no kits at all. A directory holding kits
+  // under other names is answered with those names, whichever kit was asked for.
+  if (available.length === 0 && name === 'default' && dir === path.resolve(process.cwd(), KITS_DIR)) {
     return `Kit "default" not found at ${toDisplayPath(resolvedPath)}. Run 'rdy init' to create one.`;
   }
 
-  const available = listAvailableKits(dir, extension);
   const availability =
     available.length > 0 ? `Available kits: ${available.join(', ')}.` : `No kits found in ${toDisplayPath(dir)}.`;
   return `Kit "${name}" not found at ${toDisplayPath(resolvedPath)}. ${availability}`;

--- a/packages/readyup/src/config.ts
+++ b/packages/readyup/src/config.ts
@@ -3,9 +3,15 @@ import path from 'node:path';
 
 import { assertIsRdyKit } from './assertIsRdyKit.ts';
 import { jitiImport } from './jitiImport.ts';
+import { KITS_DIR } from './kitsDir.ts';
+import { enumerateKits } from './list/enumerateKits.ts';
 import { resolveKitExports } from './resolveKitExports.ts';
 import type { RdyKit } from './types.ts';
+import { toDisplayPath } from './utils/display-path.ts';
 import { validateKit } from './validateKit.ts';
+
+/** The extension a kit's counterpart carries, keyed by the extension that was requested. */
+const SIBLING_EXTENSIONS: Record<string, string> = { '.js': '.ts', '.ts': '.js' };
 
 /** Result of loading a rdy kit: the validated kit plus the compile-time readyup version, if embedded. */
 export interface LoadedRdyKit {
@@ -25,11 +31,7 @@ export async function loadRdyKit(kitPath: string): Promise<LoadedRdyKit> {
   const resolvedPath = path.resolve(process.cwd(), kitPath);
 
   if (!existsSync(resolvedPath)) {
-    if (kitPath.startsWith('.readyup/kits/')) {
-      const baseName = path.basename(kitPath, '.ts');
-      throw new Error(`Kit "${baseName}" not found. Run 'rdy init' to create one.`);
-    }
-    throw new Error(`Kit not found: ${kitPath}`);
+    throw new Error(diagnoseMissingKit(resolvedPath));
   }
 
   const imported = await jitiImport(
@@ -46,6 +48,45 @@ export async function loadRdyKit(kitPath: string): Promise<LoadedRdyKit> {
   assertIsRdyKit(resolved);
   validateKit(resolved);
   return { kit: resolved, compileTimeVersion };
+}
+
+/**
+ * Compose the error message for a kit path that does not exist.
+ *
+ * Each branch names the remedy that applies to the state actually found on disk: a source
+ * awaiting compilation, a compiled kit requested as source, a project that was never
+ * initialized, or a name matching nothing in the directory that was searched.
+ */
+function diagnoseMissingKit(resolvedPath: string): string {
+  const extension = path.extname(resolvedPath);
+  const name = path.basename(resolvedPath, extension);
+  const dir = path.dirname(resolvedPath);
+
+  const siblingExtension = SIBLING_EXTENSIONS[extension];
+  if (siblingExtension !== undefined && existsSync(path.join(dir, `${name}${siblingExtension}`))) {
+    return extension === '.js'
+      ? `Kit "${name}" is not compiled. Run 'rdy compile' to compile it, or 'rdy run --jit' to run it from source.`
+      : `Kit "${name}" has no source at ${toDisplayPath(resolvedPath)}, but a compiled kit exists. ` +
+          "Run 'rdy run' without --jit to use it.";
+  }
+
+  if (name === 'default' && dir === path.resolve(process.cwd(), KITS_DIR)) {
+    return `Kit "default" not found at ${toDisplayPath(resolvedPath)}. Run 'rdy init' to create one.`;
+  }
+
+  const available = listAvailableKits(dir, extension);
+  const availability =
+    available.length > 0 ? `Available kits: ${available.join(', ')}.` : `No kits found in ${toDisplayPath(dir)}.`;
+  return `Kit "${name}" not found at ${toDisplayPath(resolvedPath)}. ${availability}`;
+}
+
+/** List the kit names beside a missing kit, treating an unreadable directory as holding none. */
+function listAvailableKits(dir: string, extension: string): string[] {
+  try {
+    return enumerateKits({ dir, extension });
+  } catch {
+    return [];
+  }
 }
 
 /** Narrow `__readyupVersion` from an imported module namespace to a string, or undefined. */

--- a/packages/readyup/src/init/initCommand.ts
+++ b/packages/readyup/src/init/initCommand.ts
@@ -2,7 +2,18 @@ import { configError } from '../errors.ts';
 import { EXIT_OK } from '../exitCodes.ts';
 import { printStep, reportWriteResult } from '../terminal.ts';
 import { extractMessage } from '../utils/error-handling.ts';
+import { buildInstallCommand } from '../utils/install-command.ts';
+import { isPackageResolvable } from '../utils/resolve-package.ts';
 import { scaffoldConfig } from './scaffold.ts';
+
+/** Steps that follow scaffolding regardless of whether readyup is already installed. */
+const STANDARD_NEXT_STEPS = [
+  'Customize .config/readyup.config.ts with your compile settings.',
+  'Add checklists to .readyup/kits/.',
+  'Compile the kits: rdy compile',
+  'Run the checks: rdy run (or rdy run --jit to run straight from the TypeScript source).',
+  'Commit the generated files.',
+];
 
 interface InitOptions {
   dryRun: boolean;
@@ -39,13 +50,23 @@ export function initCommand({ dryRun, force }: InitOptions): number {
 
   if (!dryRun) {
     printStep('Next steps');
-    console.info(`
-  1. Customize .config/readyup.config.ts with your compile settings.
-  2. Add checklists to .readyup/kits/.
-  3. Test by running: npx readyup run
-  4. Commit the generated files.
-`);
+    console.info(`\n${buildNextSteps()}\n`);
   }
 
   return EXIT_OK;
+}
+
+/**
+ * Compose the numbered next steps printed after scaffolding.
+ *
+ * The install step leads when readyup does not resolve from the project, because every later step
+ * depends on it: compiling a kit resolves the kit's readyup import, and running one loads the CLI.
+ * Numbering is computed so the conditional step leaves no gap.
+ */
+function buildNextSteps(): string {
+  const steps = isPackageResolvable('readyup')
+    ? STANDARD_NEXT_STEPS
+    : [`Install readyup as a dev dependency: ${buildInstallCommand('readyup')}`, ...STANDARD_NEXT_STEPS];
+
+  return steps.map((step, index) => `  ${index + 1}. ${step}`).join('\n');
 }

--- a/packages/readyup/src/init/initCommand.ts
+++ b/packages/readyup/src/init/initCommand.ts
@@ -3,7 +3,7 @@ import { EXIT_OK } from '../exitCodes.ts';
 import { printStep, reportWriteResult } from '../terminal.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { buildInstallCommand } from '../utils/install-command.ts';
-import { isPackageResolvable } from '../utils/resolve-package.ts';
+import { isPackageInstalled } from '../utils/resolve-package.ts';
 import { scaffoldConfig } from './scaffold.ts';
 
 /** Steps that follow scaffolding regardless of whether readyup is already installed. */
@@ -64,7 +64,7 @@ export function initCommand({ dryRun, force }: InitOptions): number {
  * Numbering is computed so the conditional step leaves no gap.
  */
 function buildNextSteps(): string {
-  const steps = isPackageResolvable('readyup')
+  const steps = isPackageInstalled('readyup')
     ? STANDARD_NEXT_STEPS
     : [`Install readyup as a dev dependency: ${buildInstallCommand('readyup')}`, ...STANDARD_NEXT_STEPS];
 

--- a/packages/readyup/src/jitiImport.ts
+++ b/packages/readyup/src/jitiImport.ts
@@ -1,11 +1,17 @@
 import { isRecord } from './isRecord.ts';
+import { toDisplayPath } from './utils/display-path.ts';
+import { buildInstallCommand } from './utils/install-command.ts';
+
+/** Prefixes marking a specifier that names a file or an internal import rather than a package. */
+const NON_PACKAGE_PREFIXES = ['.', '/', '#', 'node:'];
 
 /**
  * Import a TypeScript file via jiti with module-resolution error handling.
  *
- * Catches `MODULE_NOT_FOUND` and `ERR_MODULE_NOT_FOUND` errors and rethrows with an
- * actionable message using the caller-provided `moduleErrorDetail`. Validates the imported
- * value is a plain object, using `exportNoun` in the error message if not.
+ * Catches `MODULE_NOT_FOUND` and `ERR_MODULE_NOT_FOUND` errors and rethrows naming the file being
+ * evaluated, the caller-provided `moduleErrorDetail`, and the command that installs the missing
+ * package. Validates the imported value is a plain object, using `exportNoun` in the error message
+ * if not.
  */
 export async function jitiImport(
   resolvedPath: string,
@@ -24,9 +30,7 @@ export async function jitiImport(
       'code' in error &&
       (error.code === 'MODULE_NOT_FOUND' || error.code === 'ERR_MODULE_NOT_FOUND')
     ) {
-      const moduleMatch = error.message.match(/Cannot find (?:module|package) '([^']+)'/);
-      const moduleName = moduleMatch?.[1] ?? 'unknown module';
-      throw new Error(`Cannot resolve '${moduleName}'. ${moduleErrorDetail}`);
+      throw new Error(describeUnresolvedModule(error, resolvedPath, moduleErrorDetail));
     }
     throw error;
   }
@@ -36,4 +40,26 @@ export async function jitiImport(
   }
 
   return imported;
+}
+
+/**
+ * Compose the message for a specifier jiti could not resolve.
+ *
+ * The install command is offered only for a specifier that names a package: installing a relative
+ * import or a builtin is not the remedy, and a specifier jiti did not name cannot be installed at all.
+ */
+function describeUnresolvedModule(error: Error, resolvedPath: string, moduleErrorDetail: string): string {
+  const moduleName = error.message.match(/Cannot find (?:module|package) '([^']+)'/)?.[1];
+  const subject = moduleName ?? 'unknown module';
+  const installHint =
+    moduleName !== undefined && isPackageSpecifier(moduleName)
+      ? ` Install it with: ${buildInstallCommand(moduleName)}`
+      : '';
+
+  return `Cannot resolve '${subject}' while evaluating ${toDisplayPath(resolvedPath)}. ${moduleErrorDetail}${installHint}`;
+}
+
+/** Report whether a specifier names an installable package rather than a file or a builtin. */
+function isPackageSpecifier(specifier: string): boolean {
+  return NON_PACKAGE_PREFIXES.every((prefix) => !specifier.startsWith(prefix));
 }

--- a/packages/readyup/src/jitiImport.ts
+++ b/packages/readyup/src/jitiImport.ts
@@ -30,7 +30,7 @@ export async function jitiImport(
       'code' in error &&
       (error.code === 'MODULE_NOT_FOUND' || error.code === 'ERR_MODULE_NOT_FOUND')
     ) {
-      throw new Error(describeUnresolvedModule(error, resolvedPath, moduleErrorDetail));
+      throw new Error(describeUnresolvedModule(error, resolvedPath, moduleErrorDetail), { cause: error });
     }
     throw error;
   }

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -25,14 +25,24 @@ interface OwnerViewOptions {
   internalKits: string[];
   compiledKits: string[];
   compiledStyle: CompiledStyle;
+  needsInternalFlag?: boolean;
 }
 
 /**
  * Format the owner-mode output showing internal and compiled kit sections.
  *
  * Empty sections are omitted. Returns the empty-owner message when both lists are empty.
+ *
+ * `needsInternalFlag` adds `--internal` to the internal-section hint. The flag is what makes a
+ * configured internal directory or infix reachable, so the hint would name a failing command
+ * without it; the default config needs neither, and omitting it keeps the shorter form.
  */
-export function formatOwnerView({ internalKits, compiledKits, compiledStyle }: OwnerViewOptions): string {
+export function formatOwnerView({
+  internalKits,
+  compiledKits,
+  compiledStyle,
+  needsInternalFlag = false,
+}: OwnerViewOptions): string {
   if (internalKits.length === 0 && compiledKits.length === 0) {
     return formatEmpty('owner');
   }
@@ -40,7 +50,8 @@ export function formatOwnerView({ internalKits, compiledKits, compiledStyle }: O
   const sections: string[] = [];
 
   if (internalKits.length > 0) {
-    const hint = `rdy run --jit ${buildKitHint(internalKits)}`;
+    const internalFlag = needsInternalFlag ? ' --internal' : '';
+    const hint = `rdy run --jit${internalFlag} ${buildKitHint(internalKits)}`;
     sections.push(formatSection('Internal', hint, internalKits, ICON_INTERNAL));
   }
 

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -163,7 +163,7 @@ async function runOwnerMode(json: boolean): Promise<number> {
   const cwd = process.cwd();
 
   // Listing is read-only, so a config that cannot be evaluated costs the caller its settings rather
-  // than the answer — the same warn-and-continue the corrupt-manifest path below takes. `run` still
+  // than the answer, taking the same warn-and-continue the corrupt-manifest path below takes. `run` still
   // fails hard on the same failure: it would otherwise execute against settings nobody chose.
   let config;
   try {

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -43,7 +43,7 @@ export async function listCommand(args: string[]): Promise<number> {
   try {
     parsed = nodeParseArgs({ args, options: listOptions, strict: true, allowPositionals: true });
   } catch (error: unknown) {
-    throw usageError(translateParseArgsError(error), { cause: error });
+    throw usageError(translateParseArgsError(error, 'list'), { cause: error });
   }
   const { values } = parsed;
 

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -6,7 +6,7 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 import { configError, usageError } from '../errors.ts';
 import { EXIT_OK } from '../exitCodes.ts';
 import { KITS_DIR, resolveHomeDir } from '../kitsDir.ts';
-import { loadConfig } from '../loadConfig.ts';
+import { DEFAULT_CONFIG, loadConfig } from '../loadConfig.ts';
 import { loadRemoteManifest, RemoteManifestNotFoundError } from '../loadRemoteManifest.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifest, RdyManifestKit } from '../manifest/manifestSchema.ts';
@@ -162,11 +162,16 @@ async function runRemoteFromMode({
 async function runOwnerMode(json: boolean): Promise<number> {
   const cwd = process.cwd();
 
+  // Listing is read-only, so a config that cannot be evaluated costs the caller its settings rather
+  // than the answer — the same warn-and-continue the corrupt-manifest path below takes. `run` still
+  // fails hard on the same failure: it would otherwise execute against settings nobody chose.
   let config;
   try {
     config = await loadConfig();
   } catch (error: unknown) {
-    throw configError(extractMessage(error), { cause: error });
+    const detail = extractMessage(error).replace(/\.$/, '');
+    process.stderr.write(`Warning: ${detail}. Listing with default settings.\n`);
+    config = { ...DEFAULT_CONFIG };
   }
 
   const internalDir = path.join(cwd, KITS_DIR, config.internal.dir);

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -206,7 +206,8 @@ async function runOwnerMode(json: boolean): Promise<number> {
 
   const compiledKits = manifestKits.map((kit) => kit.name);
   const compiledStyle = resolveCompiledStyle(cwd, config.compile.outDir);
-  writeHuman(formatOwnerView({ internalKits, compiledKits, compiledStyle }) + '\n', json);
+  const needsInternalFlag = config.internal.dir !== '.' || config.internal.infix !== undefined;
+  writeHuman(formatOwnerView({ internalKits, compiledKits, compiledStyle, needsInternalFlag }) + '\n', json);
 
   const entries: JsonListKitEntry[] = [
     ...internalKits.map((name) => buildInternalEntry(name, internalDir, internalExtension)),

--- a/packages/readyup/src/loadConfig.ts
+++ b/packages/readyup/src/loadConfig.ts
@@ -7,8 +7,8 @@ import { isRecord } from './isRecord.ts';
 import { jitiImport } from './jitiImport.ts';
 import type { RdyConfig, ResolvedRdyConfig } from './types.ts';
 
-/** Default config values when no config file is found. */
-const DEFAULT_CONFIG: ResolvedRdyConfig = {
+/** Default config values when no config file is found, or when one cannot be evaluated. */
+export const DEFAULT_CONFIG: ResolvedRdyConfig = {
   compile: {
     srcDir: '.readyup/kits',
     outDir: '.readyup/kits',

--- a/packages/readyup/src/utils/display-path.ts
+++ b/packages/readyup/src/utils/display-path.ts
@@ -1,0 +1,17 @@
+import path from 'node:path';
+import process from 'node:process';
+
+/**
+ * Render a path for display, relative to the current directory when it sits inside it.
+ *
+ * A path outside the current directory keeps its absolute form: a chain of `..` segments is
+ * harder to act on than the path the reader would have typed.
+ */
+export function toDisplayPath(targetPath: string): string {
+  const absolutePath = path.resolve(process.cwd(), targetPath);
+  const relativePath = path.relative(process.cwd(), absolutePath);
+  if (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return absolutePath;
+  }
+  return relativePath;
+}

--- a/packages/readyup/src/utils/install-command.ts
+++ b/packages/readyup/src/utils/install-command.ts
@@ -1,23 +1,87 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-/** Dev-dependency install commands keyed by the lockfile that identifies their package manager. */
-const LOCKFILE_COMMANDS = [
-  { lockfile: 'pnpm-lock.yaml', command: 'pnpm add --save-dev' },
-  { lockfile: 'yarn.lock', command: 'yarn add --dev' },
-];
+import { isRecord } from '../isRecord.ts';
 
-/** Install command used when no lockfile identifies a package manager. */
+/** Dev-dependency install commands, keyed by the package manager that runs them. */
+const INSTALL_COMMANDS = new Map([
+  ['npm', 'npm install --save-dev'],
+  ['pnpm', 'pnpm add --save-dev'],
+  ['yarn', 'yarn add --dev'],
+]);
+
+/** Install command used when nothing in the directory chain identifies a package manager. */
 const DEFAULT_COMMAND = 'npm install --save-dev';
+
+/** Lockfiles that identify a package manager, in the order they are probed within one directory. */
+const LOCKFILE_MANAGERS = [
+  ['pnpm-lock.yaml', 'pnpm'],
+  ['yarn.lock', 'yarn'],
+  ['package-lock.json', 'npm'],
+] as const;
 
 /**
  * Build the command that installs a package as a dev dependency of the current project.
  *
- * The package manager is read from the lockfile in the current directory, falling back to npm when
- * none names one.
+ * The package manager comes from the nearest directory that names one, falling back to npm when
+ * none does.
  */
 export function buildInstallCommand(moduleName: string): string {
-  const match = LOCKFILE_COMMANDS.find(({ lockfile }) => existsSync(path.join(process.cwd(), lockfile)));
-  return `${match?.command ?? DEFAULT_COMMAND} ${moduleName}`;
+  return `${findInstallCommand() ?? DEFAULT_COMMAND} ${moduleName}`;
+}
+
+/**
+ * Find the install command for the package manager governing the current directory.
+ *
+ * The search walks up from the current directory because in a workspace the lockfile and the
+ * `packageManager` declaration sit at the repo root while commands run from a package
+ * subdirectory. Within a directory an explicit `packageManager` outranks a lockfile, and the
+ * nearest directory naming a manager wins over any further up.
+ */
+function findInstallCommand(): string | undefined {
+  for (const directory of listSelfAndAncestors(process.cwd())) {
+    const declared = readDeclaredManager(path.join(directory, 'package.json'));
+    if (declared !== undefined) {
+      return INSTALL_COMMANDS.get(declared);
+    }
+
+    for (const [lockfile, manager] of LOCKFILE_MANAGERS) {
+      if (existsSync(path.join(directory, lockfile))) {
+        return INSTALL_COMMANDS.get(manager);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/** Read the package-manager name from a `package.json`, dropping the version Corepack pins. */
+function readDeclaredManager(packageJsonPath: string): string | undefined {
+  if (!existsSync(packageJsonPath)) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+
+  const declared = isRecord(parsed) ? parsed.packageManager : undefined;
+  return typeof declared === 'string' ? /^[a-z]+/.exec(declared)?.[0] : undefined;
+}
+
+/** List a directory and every directory above it, nearest first. */
+function listSelfAndAncestors(from: string): string[] {
+  const directories = [from];
+  let current = from;
+  let parent = path.dirname(current);
+
+  while (parent !== current) {
+    directories.push(parent);
+    current = parent;
+    parent = path.dirname(current);
+  }
+
+  return directories;
 }

--- a/packages/readyup/src/utils/install-command.ts
+++ b/packages/readyup/src/utils/install-command.ts
@@ -1,0 +1,23 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+/** Dev-dependency install commands keyed by the lockfile that identifies their package manager. */
+const LOCKFILE_COMMANDS = [
+  { lockfile: 'pnpm-lock.yaml', command: 'pnpm add --save-dev' },
+  { lockfile: 'yarn.lock', command: 'yarn add --dev' },
+];
+
+/** Install command used when no lockfile identifies a package manager. */
+const DEFAULT_COMMAND = 'npm install --save-dev';
+
+/**
+ * Build the command that installs a package as a dev dependency of the current project.
+ *
+ * The package manager is read from the lockfile in the current directory, falling back to npm when
+ * none names one.
+ */
+export function buildInstallCommand(moduleName: string): string {
+  const match = LOCKFILE_COMMANDS.find(({ lockfile }) => existsSync(path.join(process.cwd(), lockfile)));
+  return `${match?.command ?? DEFAULT_COMMAND} ${moduleName}`;
+}

--- a/packages/readyup/src/utils/parse-args-error.ts
+++ b/packages/readyup/src/utils/parse-args-error.ts
@@ -6,7 +6,7 @@ import { extractMessage } from './error-handling.ts';
  * An unknown option is reported against `command`, pointing at the help that lists what the command
  * accepts. For a string flag missing its value (`--flag`, `--flag=`, or `--flag --other`), returns
  * the matching per-flag hint keyed by long flag, or a generic `<flag> requires a value`.
- * Everything else — a boolean given a value, say — passes through to Node's own text, which is
+ * Everything else, such as a boolean given a value, passes through to Node's own text, which is
  * already clear.
  */
 export function translateParseArgsError(error: unknown, command: string, hints: Record<string, string> = {}): string {

--- a/packages/readyup/src/utils/parse-args-error.ts
+++ b/packages/readyup/src/utils/parse-args-error.ts
@@ -3,21 +3,30 @@ import { extractMessage } from './error-handling.ts';
 /**
  * Translate a caught `node:util.parseArgs` error into a user-facing message.
  *
- * For a string flag missing its value (`--flag`, `--flag=`, or `--flag --other`), returns the matching per-flag hint
- * keyed by long flag, or a generic `<flag> requires a value`.
- * All other errors — unknown options, booleans given a value — pass through to Node's own text, which is already clear.
+ * An unknown option is reported against `command`, pointing at the help that lists what the command
+ * accepts. For a string flag missing its value (`--flag`, `--flag=`, or `--flag --other`), returns
+ * the matching per-flag hint keyed by long flag, or a generic `<flag> requires a value`.
+ * Everything else — a boolean given a value, say — passes through to Node's own text, which is
+ * already clear.
  */
-export function translateParseArgsError(error: unknown, hints: Record<string, string> = {}): string {
-  if (
-    error instanceof Error &&
-    'code' in error &&
-    error.code === 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE' &&
-    !error.message.includes('does not take an argument')
-  ) {
+export function translateParseArgsError(error: unknown, command: string, hints: Record<string, string> = {}): string {
+  if (!(error instanceof Error) || !('code' in error)) {
+    return extractMessage(error);
+  }
+
+  if (error.code === 'ERR_PARSE_ARGS_UNKNOWN_OPTION') {
+    const flag = error.message.match(/Unknown option '([^']+)'/)?.[1];
+    if (flag !== undefined) {
+      return `Unknown option '${flag}'. Run 'rdy ${command} --help' to see available options.`;
+    }
+  }
+
+  if (error.code === 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE' && !error.message.includes('does not take an argument')) {
     const flag = error.message.match(/(--[a-z][\w-]*)/)?.[1];
     if (flag !== undefined) {
       return hints[flag] ?? `${flag} requires a value`;
     }
   }
+
   return extractMessage(error);
 }

--- a/packages/readyup/src/utils/resolve-package.ts
+++ b/packages/readyup/src/utils/resolve-package.ts
@@ -2,17 +2,27 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
 
+/** Resolution failures that mean the package is absent rather than present but unreachable. */
+const NOT_INSTALLED_CODES = new Set(['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND']);
+
 /**
- * Report whether a package resolves from the current project.
+ * Report whether a package is installed in the current project.
  *
  * Resolution is anchored to a notional file in the current directory rather than to this module, so
  * the answer describes the project being worked on and not readyup's own installation.
+ *
+ * Only a not-found code answers false. `createRequire` resolves under the `require` condition, which
+ * an ESM-only package does not publish; that failure reports the package as found and only its
+ * export conditions as unmatched, which is an installed package either way.
  */
-export function isPackageResolvable(packageName: string): boolean {
+export function isPackageInstalled(packageName: string): boolean {
   try {
     createRequire(path.join(process.cwd(), 'noop.js')).resolve(packageName);
     return true;
-  } catch {
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && typeof error.code === 'string') {
+      return !NOT_INSTALLED_CODES.has(error.code);
+    }
     return false;
   }
 }

--- a/packages/readyup/src/utils/resolve-package.ts
+++ b/packages/readyup/src/utils/resolve-package.ts
@@ -1,0 +1,18 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import process from 'node:process';
+
+/**
+ * Report whether a package resolves from the current project.
+ *
+ * Resolution is anchored to a notional file in the current directory rather than to this module, so
+ * the answer describes the project being worked on and not readyup's own installation.
+ */
+export function isPackageResolvable(packageName: string): boolean {
+  try {
+    createRequire(path.join(process.cwd(), 'noop.js')).resolve(packageName);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -31,7 +31,7 @@ export function verifyCommand(args: string[]): number {
   try {
     parsed = nodeParseArgs({ args, options: verifyOptions, strict: true, allowPositionals: true });
   } catch (error: unknown) {
-    throw usageError(translateParseArgsError(error), { cause: error });
+    throw usageError(translateParseArgsError(error, 'verify'), { cause: error });
   }
   const { values, positionals } = parsed;
 


### PR DESCRIPTION
## What

Fixes a set of `rdy` errors that named the wrong problem or the wrong remedy. A kit that has not been compiled is now reported as needing compilation rather than as missing, and a mistyped command is recognized as a typo instead of a missing kit. When a kit genuinely cannot be found, the error now names the directory searched and the kits that are there. A missing dependency is now reported with the file that needed it and the install command for the project's own package manager, and an unknown-option error now points at the command's help. Listing kits no longer fails when the config file cannot be evaluated, and `rdy --help` now shows examples and points to `rdy <command> --help` for per-command detail.

## Why

The advertised quick start could not be completed as written, and the error a newcomer hit on their first run told them to repeat the step they had just done. Agents follow remediation hints literally, so a hint naming the wrong remedy does not merely confuse — it sends the reader to a write command as a fix.

## Details

### 🎉 Features

- Root `rdy --help` gains an Examples section and a footer pointing at per-command help, which is otherwise undiscoverable from the root help alone. `rdy run --help` gains examples in the format `rdy list --help` already used.

### 🐛 Bug fixes

- Kit-not-found errors diagnose what is actually on disk. A missing bundle with a sibling source names `rdy compile` and `--jit`; a source requested with `--jit` when only a bundle exists says so; anything else names the searched path and the kits that do exist. `rdy init` is suggested only for a kit directory holding nothing, and display names no longer report `default.js` where they mean `default`.
- Command-typo detection matches by edit distance rather than by prefix, and covers `run`, so `lst`, `verfy`, and `comple` are recognized. A word that names a reachable kit — by conventional path, by a `:checklist` filter, or under a source flag — still runs as that kit.
- Module-resolution failures name the file being evaluated and the command that installs the missing package, resolved from the nearest package manager in the directory chain rather than from the current directory alone.
- `rdy list` continues with default settings and a warning on stderr when the config cannot be evaluated, matching the warn-and-continue it already applied to a corrupt manifest. `rdy run` still fails hard on the same failure.
- The owner-mode listing includes `--internal` in its hint whenever a configured internal directory or infix makes the flag necessary, so the printed invocation works as printed.
- `rdy init`'s next steps use `rdy` throughout, lead with an install step when readyup is not installed, and number themselves so the conditional step leaves no gap.
- Unknown-option errors are well-formed and point at the offending command's `--help`, rather than leading with positional-escape advice through an unbalanced quote. That advice now lives in `rdy run --help`, the one place it applies.

### 🏗️ Internal features

- A failed module resolution attaches the caught error as its `cause`.

### 📚 Documentation

- The README quick start is the sequence that works: `rdy init`, install readyup, `rdy compile`, `rdy run`. `--jit` is documented as the compile-free alternative, alongside why compiled kits remain the vetted artifact.

Closes #119
