### PR TITLE
#139 Name bun's install command in a bun-managed project

### DIFF
--- a/packages/readyup/__tests__/utils/install-command.test.ts
+++ b/packages/readyup/__tests__/utils/install-command.test.ts
@@ -79,6 +79,12 @@ describe(buildInstallCommand, () => {
     expect(buildInstallCommand('readyup')).toBe('bun add --dev readyup');
   });
 
+  it('prefers a bun lockfile over a yarn.lock in the same directory', () => {
+    presentFiles(path.join(PACKAGE_DIR, 'bun.lock'), path.join(PACKAGE_DIR, 'yarn.lock'));
+
+    expect(buildInstallCommand('readyup')).toBe('bun add --dev readyup');
+  });
+
   it('falls back to npm when no directory names a package manager', () => {
     expect(buildInstallCommand('readyup')).toBe('npm install --save-dev readyup');
   });

--- a/packages/readyup/__tests__/utils/install-command.test.ts
+++ b/packages/readyup/__tests__/utils/install-command.test.ts
@@ -31,6 +31,8 @@ describe(buildInstallCommand, () => {
   it.each([
     ['pnpm-lock.yaml', 'pnpm add --save-dev readyup'],
     ['yarn.lock', 'yarn add --dev readyup'],
+    ['bun.lock', 'bun add --dev readyup'],
+    ['bun.lockb', 'bun add --dev readyup'],
     ['package-lock.json', 'npm install --save-dev readyup'],
   ])('reads the package manager from %s in the current directory', (lockfile, expected) => {
     presentFiles(path.join(PACKAGE_DIR, lockfile));
@@ -51,6 +53,13 @@ describe(buildInstallCommand, () => {
     expect(buildInstallCommand('readyup')).toBe('pnpm add --save-dev readyup');
   });
 
+  it('resolves bun from a packageManager declaration', () => {
+    presentFiles(path.join(REPO_ROOT, 'package.json'));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'bun@1.2.0' }));
+
+    expect(buildInstallCommand('readyup')).toBe('bun add --dev readyup');
+  });
+
   it('prefers a declared packageManager over a lockfile in the same directory', () => {
     presentFiles(path.join(REPO_ROOT, 'package.json'), path.join(REPO_ROOT, 'package-lock.json'));
     mockReadFileSync.mockReturnValue(JSON.stringify({ packageManager: 'yarn@4.1.0' }));
@@ -62,6 +71,12 @@ describe(buildInstallCommand, () => {
     presentFiles(path.join(PACKAGE_DIR, 'yarn.lock'), path.join(REPO_ROOT, 'pnpm-lock.yaml'));
 
     expect(buildInstallCommand('readyup')).toBe('yarn add --dev readyup');
+  });
+
+  it('prefers a bun lockfile over a package-lock.json left behind by a migration', () => {
+    presentFiles(path.join(PACKAGE_DIR, 'bun.lock'), path.join(PACKAGE_DIR, 'package-lock.json'));
+
+    expect(buildInstallCommand('readyup')).toBe('bun add --dev readyup');
   });
 
   it('falls back to npm when no directory names a package manager', () => {

--- a/packages/readyup/src/utils/install-command.ts
+++ b/packages/readyup/src/utils/install-command.ts
@@ -6,6 +6,7 @@ import { isRecord } from '../isRecord.ts';
 
 /** Dev-dependency install commands, keyed by the package manager that runs them. */
 const INSTALL_COMMANDS = new Map([
+  ['bun', 'bun add --dev'],
   ['npm', 'npm install --save-dev'],
   ['pnpm', 'pnpm add --save-dev'],
   ['yarn', 'yarn add --dev'],
@@ -14,10 +15,18 @@ const INSTALL_COMMANDS = new Map([
 /** Install command used when nothing in the directory chain identifies a package manager. */
 const DEFAULT_COMMAND = 'npm install --save-dev';
 
-/** Lockfiles that identify a package manager, in the order they are probed within one directory. */
+/**
+ * Lockfiles that identify a package manager, in the order they are probed within one directory.
+ *
+ * `package-lock.json` is probed last because it is the likeliest leftover of a migration away from
+ * npm. Bun writes `bun.lock` from 1.2 onward and `bun.lockb` before that; a repo mid-migration can
+ * carry both, so the text format is probed first.
+ */
 const LOCKFILE_MANAGERS = [
   ['pnpm-lock.yaml', 'pnpm'],
   ['yarn.lock', 'yarn'],
+  ['bun.lock', 'bun'],
+  ['bun.lockb', 'bun'],
   ['package-lock.json', 'npm'],
 ] as const;
 

--- a/packages/readyup/src/utils/install-command.ts
+++ b/packages/readyup/src/utils/install-command.ts
@@ -18,15 +18,17 @@ const DEFAULT_COMMAND = 'npm install --save-dev';
 /**
  * Lockfiles that identify a package manager, in the order they are probed within one directory.
  *
- * `package-lock.json` is probed last because it is the likeliest leftover of a migration away from
- * npm. Bun writes `bun.lock` from 1.2 onward and `bun.lockb` before that; a repo mid-migration can
- * carry both, so the text format is probed first.
+ * Order follows how exclusively each file names its own manager. A `bun.lock` or `bun.lockb` is written only by bun,
+ * whereas bun itself can write a `yarn.lock` beside its own (`bun install --yarn`), so a `yarn.lock` does not
+ * establish yarn and the bun entries outrank it. `package-lock.json` is probed last, as the likeliest leftover of a
+ * migration away from npm. Bun takes two entries because it writes `bun.lock` from 1.2 onward and `bun.lockb` before
+ * that.
  */
 const LOCKFILE_MANAGERS = [
   ['pnpm-lock.yaml', 'pnpm'],
-  ['yarn.lock', 'yarn'],
   ['bun.lock', 'bun'],
   ['bun.lockb', 'bun'],
+  ['yarn.lock', 'yarn'],
   ['package-lock.json', 'npm'],
 ] as const;
 


### PR DESCRIPTION
## What

ReadyUp now recognizes bun-managed projects and names bun in the installation instructions. A project that installs with bun is recognized as bun even when it also carries a yarn-format lockfile.

## Why

readyup could identify npm, pnpm, and yarn, and named npm for anything else. Bun is common enough now that the default is a poor guess, and the guess surfaces at the two moments a user is least equipped to second-guess it: first-run setup, and an error reporting a package that is not installed.

## Details

### 🎉 Features

- A `bun.lock` or `bun.lockb` file identifies a bun project, as does a `"packageManager": "bun@<version>"` declaration in `package.json`. The install hint for such a project is `bun add --dev`. Both hint sites draw on the same resolver, so `rdy init` and the missing-dependency error raised when a kit or config imports an uninstalled package are covered together.

- A bun lockfile outranks both a `yarn.lock` and a `package-lock.json` in the same directory. Bun writes a yarn-format lockfile beside its own when run as `bun install --yarn` or configured with `[install.lockfile] print = "yarn"` in `bunfig.toml`, and nothing but bun writes `bun.lock` or `bun.lockb`, so the bun lockfile is the signal that survives the pairing. Resolution between a bun lockfile and `pnpm-lock.yaml` is unchanged: neither manager writes the other's lockfile, so the pair only arises mid-migration, in a direction the files cannot reveal.

### 🧪 Tests

- Five cases cover bun resolution through both detection paths, plus its precedence over a `yarn.lock` and over a `package-lock.json` in the same directory.

Closes #139
