### PR TITLE
#120 Validate kits, detect staleness, and settle precondition semantics

### DIFF
--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -12,6 +12,7 @@
       "path": "kits/demo.js",
       "readyupVersion": "0.21.2",
       "source": "kits/demo.ts",
+      "sourceHash": "3d21db74",
       "targetHash": "687967f1"
     }
   ]

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -269,7 +269,20 @@ Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `fa
 rdy verify                     Check compiled kits against the manifest's hashes
 ```
 
-Each kit is reported as `ok`, `drift`, `missing`, or `unverified`. Drift and missing fail the run; `unverified` — a manifest entry with no recorded hash — does not, since it says nothing about whether the kit has changed. Under `--json`, a `drift` entry carries the `expected` and `actual` hashes alongside an overall verdict.
+Each kit carries two independent verdicts, because a kit is two artifacts: the TypeScript source and the bundle compiled from it.
+
+The compiled output is reported as `ok`, `drift`, `missing`, or `unverified`. The source is reported as `ok`, `stale`, `missing`, or `unverified`. Both axes are checked for every kit, and a kit can be stale at the source and drifted at the target at once: `drift` means someone edited the bundle by hand, while `stale` means the source moved on and nobody recompiled.
+
+Anything other than `ok` or `unverified` on either axis fails the run. `unverified` does not, since a manifest entry with no recorded hash says nothing about whether the kit has changed; a manifest written before source hashes existed reports `unverified` for the source and still passes.
+
+Under `--json`, each kit reports `status` for the compiled output and `sourceStatus` for the source. A `drift` verdict carries `expected` and `actual`; a `stale` verdict carries `sourceExpected` and `sourceActual`. `sourceStatus` is optional in the published schema, so a consumer pinned to `verify.v1.json` still validates payloads from an earlier readyup.
+
+### The staleness model
+
+Editing a kit's `.ts` without recompiling leaves `rdy run` executing the bundle it was compiled from, which is no longer what the source says. The two commands treat that differently on purpose:
+
+- **`rdy verify` enforces.** A stale source fails the run and exits 1. This is the gate to put in CI.
+- **`rdy run` advises.** It emits a warning and runs anyway, leaving the exit code alone. A verification tool that refused to run because its own bookkeeping was out of date would be worse than one that ran and said so.
 
 ## Authoring API
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -103,6 +103,18 @@ rdy <command> [options]
 
 `--report-on` prunes only the reported detail tree, and keeps the parent checks of anything it shows so nesting stays intact. Summary counts, worst severity, and the exit code always reflect the whole run.
 
+### Advisory warnings
+
+`rdy run` compares each local kit it is about to run against the manifest, and says so when the two disagree. Warnings go to stderr in both output modes and appear under `warnings` in the JSON report; none of them affects the exit code.
+
+| Code           | Raised when                                                                   |
+| -------------- | ----------------------------------------------------------------------------- |
+| `source-stale` | The kit's TypeScript has changed since the compiled bundle was built from it  |
+| `target-drift` | The compiled bundle no longer matches the hash the manifest recorded for it   |
+| `version-skew` | The kit was compiled against a readyup version that differs from the runner's |
+
+The staleness warnings are silent when there is no manifest, when no entry describes the kit being run, or when the entry records no hashes. They do not apply to `--url` sources, which no local manifest describes, or to `--jit`, which runs the source directly. `rdy verify` is the enforcing gate; see [the staleness model](#the-staleness-model).
+
 ### Exit codes
 
 | Code | Meaning                                                                                                                       |

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -113,7 +113,7 @@ rdy <command> [options]
 | `target-drift` | The compiled bundle no longer matches the hash the manifest recorded for it   |
 | `version-skew` | The kit was compiled against a readyup version that differs from the runner's |
 
-The staleness warnings are silent when that manifest is absent, when no entry in it describes the kit being run, or when the entry records no hashes. That one manifest is the only one consulted, so a kit reached through `--from` is outside their scope: it resolves under another root, whose own manifest `rdy run` never reads. Run `rdy verify` in that root to check those kits. The warnings also do not apply to `--url` sources, which no local manifest describes, or to `--jit`, which runs the source directly. `rdy verify` is the enforcing gate; see [the staleness model](#the-staleness-model).
+The staleness warnings are silent when that manifest is absent, when no entry in it describes the kit being run, when the entry records no hashes, or when a file they would hash cannot be read. That one manifest is the only one consulted, so a kit reached through `--from` is outside their scope: it resolves under another root, whose own manifest `rdy run` never reads. Run `rdy verify` in that root to check those kits. The warnings also do not apply to `--url` sources, which no local manifest describes, or to `--jit`, which runs the source directly. `rdy verify` is the enforcing gate; see [the staleness model](#the-staleness-model).
 
 ### Exit codes
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -308,6 +308,17 @@ All helpers are type-safe identity functions that provide editor autocomplete wi
 | `defineRdyStagedChecklist` | Staged checklist (sequential groups) |
 | `defineChecklists`         | Array of checklists                  |
 
+### Preconditions
+
+A checklist's `preconditions` gate the checks that follow it. If any precondition fails, every check in the checklist is skipped, and each skipped result records `precondition` as its reason.
+
+Two rules govern the gate:
+
+- **A failed precondition gates regardless of its severity.** A precondition declared `recommend` gates exactly as one declared `error` does. Severity decides whether the run _fails_; the gate decides whether the checks are worth _running_, and those are separate questions. A `recommend` precondition that fails under the default `--fail-on error` therefore skips the whole checklist and still exits 0.
+- **A precondition skipped `n/a` does not gate.** "The gate does not apply" is not "the gate failed", so the checklist runs in full. To make a whole checklist inapplicable instead, nest its checks under a single parent check whose `skip` returns a reason: an `n/a` skip terminates its own subtree, and nothing beneath it produces a result.
+
+Precondition results and the checks they skip follow the same reporting threshold as everything else: a result appears in the output only when its own severity is at or above `--report-on`.
+
 ### Kit validation
 
 The authoring helpers are type-level only, and neither `rdy compile` nor `rdy run --jit` type-checks the kit it loads, so both commands validate the kit's structure at load time. Validation is the same in both, which means `rdy compile` refuses to publish a kit that `rdy run` would reject.

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -283,6 +283,22 @@ All helpers are type-safe identity functions that provide editor autocomplete wi
 | `defineRdyStagedChecklist` | Staged checklist (sequential groups) |
 | `defineChecklists`         | Array of checklists                  |
 
+### Kit validation
+
+The authoring helpers are type-level only, and neither `rdy compile` nor `rdy run --jit` type-checks the kit it loads, so both commands validate the kit's structure at load time. Validation is the same in both, which means `rdy compile` refuses to publish a kit that `rdy run` would reject.
+
+Every check is validated wherever it appears: in a checklist's `checks`, in a staged checklist's `groups`, in its `preconditions`, and in the `checks` nested under another check. A check must carry a non-empty `name` and a `check` function; `severity` must be one of `error`, `warn`, or `recommend`; `skip` must be a function and `fix` a string when present. Unknown extra keys are allowed, so a kit written for a later readyup still loads.
+
+A typo'd `severity` is the mistake this catches that matters most: before validation reached individual checks, an unrecognized value silently excluded the check from both the failure and the reporting thresholds, and the run passed.
+
+Failures name the kit and the location of each offending value:
+
+```
+Invalid kit at .readyup/kits/default.js:
+  checklists[0].checks[1].severity: expected one of "error", "warn", "recommend", got "info"
+  checklists[0].checks[2].check: expected a function, got string
+```
+
 ## Check utilities
 
 Reusable check functions for common assertions:

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -105,7 +105,7 @@ rdy <command> [options]
 
 ### Advisory warnings
 
-`rdy run` compares each local kit it is about to run against the manifest, and says so when the two disagree. Warnings go to stderr in both output modes and appear under `warnings` in the JSON report; none of them affects the exit code.
+`rdy run` compares the kits it is about to run against `.readyup/manifest.json` in the current working directory, and says so when the two disagree. Warnings go to stderr in both output modes and appear under `warnings` in the JSON report; none of them affects the exit code.
 
 | Code           | Raised when                                                                   |
 | -------------- | ----------------------------------------------------------------------------- |
@@ -113,7 +113,7 @@ rdy <command> [options]
 | `target-drift` | The compiled bundle no longer matches the hash the manifest recorded for it   |
 | `version-skew` | The kit was compiled against a readyup version that differs from the runner's |
 
-The staleness warnings are silent when there is no manifest, when no entry describes the kit being run, or when the entry records no hashes. They do not apply to `--url` sources, which no local manifest describes, or to `--jit`, which runs the source directly. `rdy verify` is the enforcing gate; see [the staleness model](#the-staleness-model).
+The staleness warnings are silent when that manifest is absent, when no entry in it describes the kit being run, or when the entry records no hashes. That one manifest is the only one consulted, so a kit reached through `--from` is outside their scope: it resolves under another root, whose own manifest `rdy run` never reads. Run `rdy verify` in that root to check those kits. The warnings also do not apply to `--url` sources, which no local manifest describes, or to `--jit`, which runs the source directly. `rdy verify` is the enforcing gate; see [the staleness model](#the-staleness-model).
 
 ### Exit codes
 

--- a/packages/readyup/__tests__/assertIsRdyKit.test.ts
+++ b/packages/readyup/__tests__/assertIsRdyKit.test.ts
@@ -39,6 +39,24 @@ describe(assertIsRdyKit, () => {
       );
     });
 
+    // `isFlatChecklist` discriminates on key presence, so a checklist carrying either key explicitly
+    // set to `undefined` is classified by that key whatever its value, and the collection the runner
+    // then iterates is not there.
+    it.each([
+      ['checks is undefined beside a populated groups', { name: 'bad', checks: undefined, groups: [[]] }],
+      ['groups is undefined beside a populated checks', { name: 'bad', checks: [], groups: undefined }],
+    ])('rejects a checklist where %s', (_label, checklist) => {
+      expect(messageFrom({ checklists: [checklist] })).toContain(
+        "checklists[0]: Checklist cannot have both 'checks' and 'groups'",
+      );
+    });
+
+    it('throws when the only collection a checklist declares is undefined', () => {
+      expect(messageFrom({ checklists: [{ name: 'bad', checks: undefined }] })).toContain(
+        "checklists[0]: Checklist must have either 'checks' or 'groups'",
+      );
+    });
+
     it('throws when a checklist entry is not an object', () => {
       expect(messageFrom({ checklists: ['not-an-object'] })).toContain('checklists[0]:');
     });

--- a/packages/readyup/__tests__/assertIsRdyKit.test.ts
+++ b/packages/readyup/__tests__/assertIsRdyKit.test.ts
@@ -1,225 +1,318 @@
 import { describe, expect, it } from 'vitest';
-import { ZodError } from 'zod';
 
 import { assertIsRdyKit } from '../src/assertIsRdyKit.ts';
 
+/** Run the assertion and return the message it threw, failing the test when it accepted the value. */
+function messageFrom(raw: unknown, source?: string): string {
+  try {
+    assertIsRdyKit(raw, source);
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
+    return error.message;
+  }
+  return expect.unreachable('Expected assertIsRdyKit to throw');
+}
+
 describe(assertIsRdyKit, () => {
-  it('throws when input is not an object', () => {
-    expect(() => assertIsRdyKit('string')).toThrow(ZodError);
-  });
+  describe('kit shape', () => {
+    it('throws when input is not an object', () => {
+      expect(() => assertIsRdyKit('string')).toThrow('Invalid kit');
+    });
 
-  it('throws when input is an array', () => {
-    expect(() => assertIsRdyKit([])).toThrow(ZodError);
-  });
+    it('throws when input is an array', () => {
+      expect(() => assertIsRdyKit([])).toThrow('Invalid kit');
+    });
 
-  it('throws when checklists is missing', () => {
-    expect(() => assertIsRdyKit({})).toThrow(ZodError);
-  });
+    it('throws when checklists is missing', () => {
+      expect(messageFrom({})).toContain('checklists:');
+    });
 
-  it('throws when a checklist has neither checks nor groups', () => {
-    expect(() => assertIsRdyKit({ checklists: [{ name: 'bad' }] })).toThrow(ZodError);
-  });
-
-  it('throws when a checklist has both checks and groups', () => {
-    try {
-      assertIsRdyKit({ checklists: [{ name: 'bad', checks: [], groups: [] }] });
-      expect.unreachable('Expected ZodError');
-    } catch (error) {
-      if (!(error instanceof ZodError)) throw error;
-      expect(error.issues).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ message: "Checklist cannot have both 'checks' and 'groups'" }),
-        ]),
+    it('throws when a checklist has neither checks nor groups', () => {
+      expect(messageFrom({ checklists: [{ name: 'bad' }] })).toContain(
+        "checklists[0]: Checklist must have either 'checks' or 'groups'",
       );
-    }
+    });
+
+    it('throws when a checklist has both checks and groups', () => {
+      expect(messageFrom({ checklists: [{ name: 'bad', checks: [], groups: [] }] })).toContain(
+        "checklists[0]: Checklist cannot have both 'checks' and 'groups'",
+      );
+    });
+
+    it('throws when a checklist entry is not an object', () => {
+      expect(messageFrom({ checklists: ['not-an-object'] })).toContain('checklists[0]:');
+    });
+
+    it('throws when a checklist name is missing', () => {
+      expect(messageFrom({ checklists: [{ checks: [] }] })).toContain(
+        'checklists[0].name: expected a non-empty string',
+      );
+    });
+
+    it('throws when a checklist name is empty', () => {
+      expect(messageFrom({ checklists: [{ name: '', checks: [] }] })).toContain(
+        'checklists[0].name: expected a non-empty string',
+      );
+    });
+
+    it('throws when a checklist fixLocation is invalid', () => {
+      expect(messageFrom({ checklists: [{ name: 'test', checks: [], fixLocation: 'INLINE' }] })).toContain(
+        'checklists[0].fixLocation: expected one of "inline", "end", got "INLINE"',
+      );
+    });
   });
 
-  it('throws when a checklist entry is not an object', () => {
-    try {
-      assertIsRdyKit({ checklists: ['not-an-object'] });
-      expect.unreachable('Expected ZodError');
-    } catch (error) {
-      if (!(error instanceof ZodError)) throw error;
-      expect(error.issues[0]?.path).toEqual(expect.arrayContaining(['checklists', 0]));
-    }
+  describe('check validation', () => {
+    it("throws when a flat check has a typo'd severity", () => {
+      const raw = { checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true, severity: 'info' }] }] };
+
+      expect(messageFrom(raw)).toContain(
+        'checklists[0].checks[0].severity: expected one of "error", "warn", "recommend", got "info"',
+      );
+    });
+
+    it('throws when a check name is missing', () => {
+      const raw = { checklists: [{ name: 'test', checks: [{ check: () => true }] }] };
+
+      expect(messageFrom(raw)).toContain('checklists[0].checks[0].name: expected a non-empty string');
+    });
+
+    it('throws when a check name is empty', () => {
+      const raw = { checklists: [{ name: 'test', checks: [{ name: '', check: () => true }] }] };
+
+      expect(messageFrom(raw)).toContain('checklists[0].checks[0].name: expected a non-empty string');
+    });
+
+    it('names the type supplied when check is not a function', () => {
+      const raw = { checklists: [{ name: 'test', checks: [{ name: 'a', check: 'nope' }] }] };
+
+      expect(messageFrom(raw)).toContain('checklists[0].checks[0].check: expected a function, got string');
+    });
+
+    it('names the type supplied when check is null', () => {
+      const raw = { checklists: [{ name: 'test', checks: [{ name: 'a', check: null }] }] };
+
+      expect(messageFrom(raw)).toContain('checklists[0].checks[0].check: expected a function, got null');
+    });
+
+    it('throws when skip is not a function', () => {
+      const raw = { checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true, skip: true }] }] };
+
+      expect(messageFrom(raw)).toContain('checklists[0].checks[0].skip: expected a function, got boolean');
+    });
+
+    it('throws when fix is not a string', () => {
+      const raw = { checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true, fix: 42 }] }] };
+
+      expect(messageFrom(raw)).toContain('checklists[0].checks[0].fix:');
+    });
+
+    it('validates checks nested under a parent check', () => {
+      const raw = {
+        checklists: [
+          {
+            name: 'test',
+            checks: [{ name: 'parent', check: () => true, checks: [{ name: 'child', check: 'nope' }] }],
+          },
+        ],
+      };
+
+      expect(messageFrom(raw)).toContain('checklists[0].checks[0].checks[0].check: expected a function, got string');
+    });
+
+    it('validates checks inside a staged checklist group', () => {
+      const raw = { checklists: [{ name: 'test', groups: [[{ name: 'a', check: () => true }], [{ name: 'b' }]] }] };
+
+      expect(messageFrom(raw)).toContain('checklists[0].groups[1][0].check: expected a function, got undefined');
+    });
+
+    it('validates preconditions', () => {
+      const raw = {
+        checklists: [
+          { name: 'test', preconditions: [{ name: 'gate', check: () => true, severity: 'blocker' }], checks: [] },
+        ],
+      };
+
+      expect(messageFrom(raw)).toContain('checklists[0].preconditions[0].severity:');
+    });
+
+    it('reports every offending check, not only the first', () => {
+      const raw = {
+        checklists: [
+          {
+            name: 'test',
+            checks: [
+              { name: 'a', check: 'nope' },
+              { name: '', check: () => true },
+            ],
+          },
+        ],
+      };
+      const message = messageFrom(raw);
+
+      expect(message).toContain('checklists[0].checks[0].check:');
+      expect(message).toContain('checklists[0].checks[1].name:');
+    });
   });
 
-  it('throws when a checklist name is missing', () => {
-    try {
-      assertIsRdyKit({ checklists: [{ checks: [] }] });
-      expect.unreachable('Expected ZodError');
-    } catch (error) {
-      if (!(error instanceof ZodError)) throw error;
-      const nameIssue = error.issues
-        .flatMap((i) => ('errors' in i ? i.errors.flat() : [i]))
-        .find((i) => i.path.includes('name'));
-      expect(nameIssue).toBeDefined();
-    }
+  describe('error message', () => {
+    it('names the kit source when one is supplied', () => {
+      const message = messageFrom({}, '.readyup/kits/default.js');
+
+      expect(message).toContain('Invalid kit at .readyup/kits/default.js:');
+    });
+
+    it('omits the location clause when no source is supplied', () => {
+      expect(messageFrom({})).toContain('Invalid kit:');
+    });
+
+    it('does not expose raw Zod output', () => {
+      const message = messageFrom({ checklists: [{ name: 'test', checks: [{ name: 'a', check: 'nope' }] }] });
+
+      expect(message).not.toContain('"code"');
+      expect(message).not.toContain('invalid_type');
+    });
+
+    it('locates an issue on the kit itself at the root', () => {
+      expect(messageFrom('string')).toContain('(kit root):');
+    });
   });
 
-  it('throws when a checklist name is empty', () => {
-    try {
-      assertIsRdyKit({ checklists: [{ name: '', checks: [] }] });
-      expect.unreachable('Expected ZodError');
-    } catch (error) {
-      if (!(error instanceof ZodError)) throw error;
-      const nameIssue = error.issues
-        .flatMap((i) => ('errors' in i ? i.errors.flat() : [i]))
-        .find((i) => i.path.includes('name'));
-      expect(nameIssue).toBeDefined();
-    }
+  describe('accepted kits', () => {
+    it('accepts a valid kit with flat checklists', () => {
+      expect(() =>
+        assertIsRdyKit({ checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }] }),
+      ).not.toThrow();
+    });
+
+    it('accepts a valid kit with staged checklists', () => {
+      expect(() =>
+        assertIsRdyKit({ checklists: [{ name: 'test', groups: [[{ name: 'a', check: () => true }]] }] }),
+      ).not.toThrow();
+    });
+
+    it('accepts a checklist with preconditions', () => {
+      expect(() =>
+        assertIsRdyKit({
+          checklists: [
+            {
+              name: 'test',
+              preconditions: [{ name: 'gate', check: () => true, severity: 'warn' }],
+              checks: [{ name: 'a', check: () => true }],
+            },
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it('accepts nested checks to arbitrary depth', () => {
+      expect(() =>
+        assertIsRdyKit({
+          checklists: [
+            {
+              name: 'test',
+              checks: [
+                {
+                  name: 'a',
+                  check: () => true,
+                  checks: [
+                    {
+                      name: 'b',
+                      check: () => Promise.resolve({ ok: true }),
+                      checks: [{ name: 'c', check: () => true }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it('accepts a check carrying every optional field', () => {
+      expect(() =>
+        assertIsRdyKit({
+          checklists: [
+            {
+              name: 'test',
+              checks: [{ name: 'a', check: () => true, severity: 'recommend', skip: () => false, fix: 'run it' }],
+            },
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it('accepts unknown extra keys on a check', () => {
+      expect(() =>
+        assertIsRdyKit({ checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true, note: 'why' }] }] }),
+      ).not.toThrow();
+    });
+
+    it('accepts a valid kit with suites', () => {
+      expect(() =>
+        assertIsRdyKit({ checklists: [{ name: 'lint', checks: [] }], suites: { ci: ['lint'] } }),
+      ).not.toThrow();
+    });
+
+    it('accepts a kit without suites', () => {
+      expect(() => assertIsRdyKit({ checklists: [{ name: 'test', checks: [] }] })).not.toThrow();
+    });
+
+    it('accepts a kit with all optional kit fields', () => {
+      expect(() =>
+        assertIsRdyKit({
+          checklists: [{ name: 'test', checks: [] }],
+          defaultSeverity: 'warn',
+          failOn: 'warn',
+          reportOn: 'recommend',
+          fixLocation: 'end',
+        }),
+      ).not.toThrow();
+    });
   });
 
-  it('accepts a valid kit with flat checklists', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true }] }],
-      }),
-    ).not.toThrow();
-  });
+  describe('kit-level fields', () => {
+    it('throws when suites is not an object', () => {
+      expect(messageFrom({ checklists: [{ name: 'test', checks: [] }], suites: 'not-a-record' })).toContain('suites:');
+    });
 
-  it('accepts a valid kit with staged checklists', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', groups: [[{ name: 'a', check: () => true }]] }],
-      }),
-    ).not.toThrow();
-  });
+    it('throws when a suite value is not an array', () => {
+      expect(messageFrom({ checklists: [{ name: 'test', checks: [] }], suites: { ci: 'not-an-array' } })).toContain(
+        'suites.ci:',
+      );
+    });
 
-  it('accepts a valid kit with suites', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'lint', checks: [] }],
-        suites: { ci: ['lint'] },
-      }),
-    ).not.toThrow();
-  });
+    it('throws when a suite contains non-string entries', () => {
+      expect(messageFrom({ checklists: [{ name: 'test', checks: [] }], suites: { ci: [42] } })).toContain(
+        'suites.ci[0]:',
+      );
+    });
 
-  it('accepts a kit without suites', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-      }),
-    ).not.toThrow();
-  });
+    it('throws when fixLocation is invalid', () => {
+      expect(messageFrom({ checklists: [{ name: 'test', checks: [] }], fixLocation: 'WRONG' })).toContain(
+        'fixLocation: expected one of "inline", "end", got "WRONG"',
+      );
+    });
 
-  it('throws when suites is not an object', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        suites: 'not-a-record',
-      }),
-    ).toThrow(ZodError);
-  });
+    it('throws when fixLocation uses old uppercase casing', () => {
+      expect(messageFrom({ checklists: [{ name: 'test', checks: [] }], fixLocation: 'INLINE' })).toContain(
+        'fixLocation:',
+      );
+    });
 
-  it('throws when a suite value is not an array', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        suites: { ci: 'not-an-array' },
-      }),
-    ).toThrow(ZodError);
-  });
+    it('throws when defaultSeverity is invalid', () => {
+      expect(messageFrom({ checklists: [{ name: 'test', checks: [] }], defaultSeverity: 'critical' })).toContain(
+        'defaultSeverity: expected one of "error", "warn", "recommend", got "critical"',
+      );
+    });
 
-  it('throws when a suite contains non-string entries', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        suites: { ci: [42] },
-      }),
-    ).toThrow(ZodError);
-  });
+    it('throws when failOn is invalid', () => {
+      expect(messageFrom({ checklists: [{ name: 'test', checks: [] }], failOn: 'none' })).toContain('failOn:');
+    });
 
-  it('accepts a valid fixLocation', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        fixLocation: 'inline',
-      }),
-    ).not.toThrow();
-  });
-
-  it('throws when fixLocation is invalid', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        fixLocation: 'WRONG',
-      }),
-    ).toThrow(ZodError);
-  });
-
-  it('throws when fixLocation uses old uppercase casing', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        fixLocation: 'INLINE',
-      }),
-    ).toThrow(ZodError);
-  });
-
-  it('accepts valid defaultSeverity', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        defaultSeverity: 'warn',
-      }),
-    ).not.toThrow();
-  });
-
-  it('throws when defaultSeverity is invalid', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        defaultSeverity: 'critical',
-      }),
-    ).toThrow(ZodError);
-  });
-
-  it('accepts valid failOn', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        failOn: 'recommend',
-      }),
-    ).not.toThrow();
-  });
-
-  it('throws when failOn is invalid', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        failOn: 'none',
-      }),
-    ).toThrow(ZodError);
-  });
-
-  it('accepts valid reportOn', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        reportOn: 'error',
-      }),
-    ).not.toThrow();
-  });
-
-  it('throws when reportOn is invalid', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        reportOn: 'verbose',
-      }),
-    ).toThrow(ZodError);
-  });
-
-  it('accepts a kit with all new fields', () => {
-    expect(() =>
-      assertIsRdyKit({
-        checklists: [{ name: 'test', checks: [] }],
-        defaultSeverity: 'warn',
-        failOn: 'warn',
-        reportOn: 'recommend',
-        fixLocation: 'end',
-      }),
-    ).not.toThrow();
+    it('throws when reportOn is invalid', () => {
+      expect(messageFrom({ checklists: [{ name: 'test', checks: [] }], reportOn: 'verbose' })).toContain('reportOn:');
+    });
   });
 });

--- a/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
+++ b/packages/readyup/__tests__/compile/validateCompiledOutput.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -70,5 +70,37 @@ describe(validateCompiledOutput, () => {
     });
 
     await expect(validateCompiledOutput(outputPath)).rejects.toThrow();
+    expect(existsSync(outputPath)).toBe(false);
+  });
+
+  // A check is serialized to JSON here, so `check` arrives as a string rather than a function: the
+  // same authoring mistake a hand-edited bundle would carry, and one compile must not let through.
+  it('rejects a kit whose check is not a function, naming the offending location', async () => {
+    const outputPath = writeTempKit(testDir, 'bad-check.mjs', {
+      checklists: [{ name: 'test', checks: [{ name: 'a', check: 'nope' }] }],
+    });
+
+    await expect(validateCompiledOutput(outputPath)).rejects.toThrow(
+      'checklists[0].checks[0].check: expected a function, got string',
+    );
+    expect(existsSync(outputPath)).toBe(false);
+  });
+
+  it('rejects a kit whose check declares an unknown severity', async () => {
+    const outputPath = writeTempKit(testDir, 'bad-severity.mjs', {
+      checklists: [{ name: 'test', checks: [{ name: 'a', check: 'nope', severity: 'info' }] }],
+    });
+
+    await expect(validateCompiledOutput(outputPath)).rejects.toThrow(
+      'checklists[0].checks[0].severity: expected one of "error", "warn", "recommend", got "info"',
+    );
+  });
+
+  it('names the compiled kit path in a validation failure', async () => {
+    const outputPath = writeTempKit(testDir, 'unnamed-check.mjs', {
+      checklists: [{ name: 'test', checks: [{ check: 'nope' }] }],
+    });
+
+    await expect(validateCompiledOutput(outputPath)).rejects.toThrow(`Invalid kit at ${outputPath}:`);
   });
 });

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -13,6 +13,7 @@ const mockPicomatch = vi.hoisted(() => vi.fn());
 const mockWriteManifest = vi.hoisted(() => vi.fn());
 const mockReadManifest = vi.hoisted(() => vi.fn());
 const mockCheckDrift = vi.hoisted(() => vi.fn());
+const mockHashFile = vi.hoisted(() => vi.fn());
 
 vi.mock('../src/compile/compileConfig.ts', () => ({
   compileConfig: mockCompileConfig,
@@ -51,6 +52,10 @@ vi.mock('../src/verify/checkDrift.ts', () => ({
   checkDrift: mockCheckDrift,
 }));
 
+vi.mock('../src/verify/targetHash.ts', () => ({
+  hashFile: mockHashFile,
+}));
+
 import { compileCommand } from '../src/compile/compileCommand.ts';
 import type { KitMetadata } from '../src/compile/validateCompiledOutput.ts';
 import { ManifestNotFoundError } from '../src/manifest/readManifest.ts';
@@ -72,6 +77,7 @@ describe(compileCommand, () => {
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockCheckDrift.mockReturnValue({ kind: 'unverified' });
+    mockHashFile.mockReturnValue('5c0urce1');
   });
 
   afterEach(() => {
@@ -85,6 +91,7 @@ describe(compileCommand, () => {
     mockWriteManifest.mockReset();
     mockReadManifest.mockReset();
     mockCheckDrift.mockReset();
+    mockHashFile.mockReset();
   });
 
   // Explicit input file tests
@@ -549,8 +556,8 @@ describe(compileCommand, () => {
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
   });
 
-  // Manifest generation tests
-  it('writes manifest after batch compile with kit entries including location fields', async () => {
+  /** A two-kit batch in which both kits compile successfully. */
+  function arrangeTwoKitBatch(): void {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
     });
@@ -559,6 +566,11 @@ describe(compileCommand, () => {
     mockCompileConfig
       .mockResolvedValueOnce({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' })
       .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
+  }
+
+  // Manifest generation tests
+  it('writes manifest after batch compile with kit entries including location fields', async () => {
+    arrangeTwoKitBatch();
     mockValidateCompiledOutput
       .mockResolvedValueOnce(kitMetadata({ description: 'Alpha checks' }))
       .mockResolvedValueOnce(kitMetadata());
@@ -574,6 +586,7 @@ describe(compileCommand, () => {
           path: expect.stringContaining('alpha.js'),
           readyupVersion: VERSION,
           source: expect.stringContaining('alpha.ts'),
+          sourceHash: '5c0urce1',
           targetHash: 'aaaa1111',
         },
         {
@@ -581,6 +594,7 @@ describe(compileCommand, () => {
           path: expect.stringContaining('beta.js'),
           readyupVersion: VERSION,
           source: expect.stringContaining('beta.ts'),
+          sourceHash: '5c0urce1',
           targetHash: 'bbbb2222',
         },
       ],
@@ -644,6 +658,7 @@ describe(compileCommand, () => {
           path: expect.stringContaining('deploy.js'),
           readyupVersion: VERSION,
           source: expect.stringContaining('deploy.ts'),
+          sourceHash: '5c0urce1',
           targetHash: 'deadbeef',
         },
       ],
@@ -667,6 +682,7 @@ describe(compileCommand, () => {
           path: expect.stringContaining('deploy.js'),
           readyupVersion: VERSION,
           source: expect.stringContaining('deploy.ts'),
+          sourceHash: '5c0urce1',
           targetHash: 'deadbeef',
         },
       ],
@@ -692,9 +708,58 @@ describe(compileCommand, () => {
           path: expect.stringContaining('deploy.js'),
           readyupVersion: VERSION,
           source: expect.stringContaining('deploy.ts'),
+          sourceHash: '5c0urce1',
           targetHash: 'deadbeef',
         },
       ],
+    });
+  });
+
+  it('hashes the source that a single-file compile was given', async () => {
+    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
+    mockReadManifest.mockImplementation(() => {
+      throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
+    });
+
+    await compileCommand(['deploy.ts']);
+
+    expect(mockHashFile).toHaveBeenCalledWith(expect.stringContaining('deploy.ts'));
+  });
+
+  it('records a distinct source hash per kit in a batch compile', async () => {
+    arrangeTwoKitBatch();
+    mockHashFile.mockReturnValueOnce('a1a1a1a1').mockReturnValueOnce('b2b2b2b2');
+
+    await compileCommand([]);
+
+    const [writeManifestCall] = mockWriteManifest.mock.calls;
+    assert.ok(writeManifestCall);
+    const writtenManifest: RdyManifest = writeManifestCall[1];
+    expect(writtenManifest.kits.map((kit) => kit.sourceHash)).toStrictEqual(['a1a1a1a1', 'b2b2b2b2']);
+  });
+
+  it('leaves a drift-skipped kit its prior entry, source hash included', async () => {
+    arrangeTwoKitBatch();
+    const recordedAlpha = {
+      name: 'alpha',
+      path: 'alpha.js',
+      readyupVersion: VERSION,
+      source: 'alpha.ts',
+      sourceHash: '0ld50urc',
+      targetHash: 'aaaa1111',
+    };
+    mockReadManifest.mockReturnValue({ version: 1, kits: [recordedAlpha] });
+    mockCheckDrift.mockImplementation((kit: { name: string }) =>
+      kit.name === 'alpha'
+        ? { kind: 'drift', expected: 'aaaa1111', actual: 'ffff9999', resolvedPath: '/abs/alpha.js' }
+        : { kind: 'unverified' },
+    );
+
+    await compileCommand([]);
+
+    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+      version: 1,
+      kits: [recordedAlpha, expect.objectContaining({ name: 'beta' })],
     });
   });
 

--- a/packages/readyup/__tests__/config.test.ts
+++ b/packages/readyup/__tests__/config.test.ts
@@ -160,6 +160,26 @@ describe(loadRdyKit, () => {
     await expect(loadRdyKit(KIT_PATH)).rejects.toThrow('Kit file must export checklists');
   });
 
+  it('rejects a kit whose check declares an unknown severity', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({
+      checklists: [{ name: 'test', checks: [{ name: 'a', check: () => true, severity: 'info' }] }],
+    });
+
+    await expect(loadRdyKit(KIT_PATH)).rejects.toThrow(
+      'checklists[0].checks[0].severity: expected one of "error", "warn", "recommend", got "info"',
+    );
+  });
+
+  it('names the kit path in a validation failure', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockJitiImport.mockResolvedValue({
+      checklists: [{ name: 'test', checks: [{ name: 'a', check: 'not-a-function' }] }],
+    });
+
+    await expect(loadRdyKit(KIT_PATH)).rejects.toThrow(`Invalid kit at ${KIT_PATH}:`);
+  });
+
   it('loads a kit from a default export', async () => {
     const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
     mockExistsSync.mockReturnValue(true);

--- a/packages/readyup/__tests__/helpers/payloadFixtures.ts
+++ b/packages/readyup/__tests__/helpers/payloadFixtures.ts
@@ -113,9 +113,17 @@ export const verifyPayload = {
   schemaVersion: 1,
   passed: false,
   kits: [
-    { name: 'deploy', status: 'ok' },
-    { name: 'release', status: 'drift', expected: 'abc123', actual: 'def456' },
+    { name: 'deploy', status: 'ok', sourceStatus: 'ok' },
+    { name: 'release', status: 'drift', expected: 'abc123', actual: 'def456', sourceStatus: 'unverified' },
+    { name: 'preflight', status: 'ok', sourceStatus: 'stale', sourceExpected: '111aaa', sourceActual: '222bbb' },
   ],
+};
+
+/** A verify payload from a readyup that predates the source verdict, which a v1 consumer still accepts. */
+export const legacyVerifyPayload = {
+  schemaVersion: 1,
+  passed: true,
+  kits: [{ name: 'deploy', status: 'ok' }],
 };
 
 export const compilePayload = {

--- a/packages/readyup/__tests__/manifest/manifestSchema.test.ts
+++ b/packages/readyup/__tests__/manifest/manifestSchema.test.ts
@@ -81,7 +81,7 @@ describe('ManifestSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('strips legacy sourceHash field from kit entries on parse while preserving targetHash', () => {
+  it('preserves both hashes on parse', () => {
     const input = {
       version: 1,
       kits: [
@@ -101,8 +101,29 @@ describe('ManifestSchema', () => {
     assert.ok(result.success);
     const [firstKit] = result.data.kits;
     assert.ok(firstKit);
-    expect(firstKit).not.toHaveProperty('sourceHash');
+    expect(firstKit.sourceHash).toBe('a1b2c3d4');
     expect(firstKit.targetHash).toBe('e5f6a7b8');
+  });
+
+  it('accepts an entry carrying a targetHash but no sourceHash', () => {
+    const input = {
+      version: 1,
+      kits: [{ name: 'deploy', path: 'kits/deploy.js', source: 'kits/deploy.ts', targetHash: 'e5f6a7b8' }],
+    };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+    assert.ok(result.success);
+    expect(result.data.kits[0]?.sourceHash).toBeUndefined();
+  });
+
+  it('rejects a kit whose sourceHash is not a string', () => {
+    const input = { version: 1, kits: [{ name: 'deploy', sourceHash: 42 }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
   });
 
   it('accepts a manifest with readyupVersion as an optional string and preserves it on parse', () => {

--- a/packages/readyup/__tests__/runRdy.test.ts
+++ b/packages/readyup/__tests__/runRdy.test.ts
@@ -3,7 +3,39 @@ import assert from 'node:assert';
 import { describe, expect, it } from 'vitest';
 
 import { meetsThreshold, runRdy } from '../src/runRdy.ts';
-import type { RdyChecklist, RdyStagedChecklist } from '../src/types.ts';
+import type {
+  CheckReturnValue,
+  RdyCheck,
+  RdyChecklist,
+  RdyStagedChecklist,
+  Severity,
+  SkipResult,
+} from '../src/types.ts';
+
+/*
+ * A kit runs as JavaScript, so its functions return whatever their author wrote and its fields hold
+ * whatever they were assigned; neither jiti nor esbuild type-checks any of it. The authoring-error
+ * tests exercise exactly the values the declared types forbid, so the three wrappers below restate
+ * them as the types those declarations promise.
+ */
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+
+/** Wrap a value as a check function that returns it. */
+function returning(value: unknown): RdyCheck['check'] {
+  return () => value as CheckReturnValue;
+}
+
+/** Wrap a value as a skip function that returns it. */
+function skipReturning(value: unknown): NonNullable<RdyCheck['skip']> {
+  return () => value as SkipResult;
+}
+
+/** Restate a string as a severity, standing in for a kit that declared one outside the enum. */
+function asSeverity(value: string): Severity {
+  return value as Severity;
+}
+
+/* eslint-enable @typescript-eslint/consistent-type-assertions */
 
 describe(runRdy, () => {
   describe('flat checklists', () => {
@@ -736,6 +768,139 @@ describe(runRdy, () => {
     });
   });
 
+  describe('authoring errors', () => {
+    it.each([
+      ['a string', 'yes', 'check() returned string "yes"'],
+      ['a number', 1, 'check() returned number 1'],
+      ['an object whose ok is not a boolean', { ok: 'true' }, 'check() returned object {"ok":"true"}'],
+      ['undefined', undefined, 'check() returned undefined'],
+      ['null', null, 'check() returned null'],
+      ['an array', [true], 'check() returned array [true]'],
+    ])('fails a check returning %s, naming what came back', async (_label, value, expected) => {
+      const checklist: RdyChecklist = { name: 'authoring', checks: [{ name: 'broken', check: returning(value) }] };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.error?.message).toContain(expected);
+    });
+
+    it('names what a check was supposed to return', async () => {
+      const checklist: RdyChecklist = { name: 'authoring', checks: [{ name: 'broken', check: returning('yes') }] };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.error?.message).toContain(
+        'expected a boolean or an object with a boolean "ok" property',
+      );
+    });
+
+    it('overrides a declared severity so an uninterpretable return cannot be a soft finding', async () => {
+      const checklist: RdyChecklist = {
+        name: 'authoring',
+        checks: [{ name: 'broken', check: returning('yes'), severity: 'recommend' }],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.severity).toBe('error');
+      expect(report.passed).toBe(false);
+    });
+
+    it('skips descendants of a check that returned an uninterpretable value', async () => {
+      const checklist: RdyChecklist = {
+        name: 'authoring',
+        checks: [{ name: 'broken', check: returning(1), checks: [{ name: 'child', check: () => true }] }],
+      };
+
+      const report = await runRdy(checklist);
+
+      const child = report.results[1];
+      assert.ok(child?.status === 'skipped');
+      expect(child.name).toBe('child');
+      expect(child.skipReason).toBe('precondition');
+    });
+
+    it.each([
+      ['true', true, 'skip() returned boolean true'],
+      ['a number', 0, 'skip() returned number 0'],
+      ['undefined', undefined, 'skip() returned undefined'],
+    ])('fails a check whose skip returns %s, naming what came back', async (_label, value, expected) => {
+      const checklist: RdyChecklist = {
+        name: 'authoring',
+        checks: [{ name: 'broken-skip', check: () => true, skip: skipReturning(value) }],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.status).toBe('failed');
+      expect(report.results[0]?.severity).toBe('error');
+      expect(report.results[0]?.error?.message).toContain(expected);
+    });
+
+    it('names what a skip function was supposed to return', async () => {
+      const checklist: RdyChecklist = {
+        name: 'authoring',
+        checks: [{ name: 'broken-skip', check: () => true, skip: skipReturning(true) }],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[0]?.error?.message).toContain(
+        'expected false to run the check, or a reason string to skip it',
+      );
+    });
+
+    it('does not run the check when skip returned an uninterpretable value', async () => {
+      let checkCalled = false;
+      const checklist: RdyChecklist = {
+        name: 'authoring',
+        checks: [
+          {
+            name: 'broken-skip',
+            check: () => {
+              checkCalled = true;
+              return true;
+            },
+            skip: skipReturning(true),
+          },
+        ],
+      };
+
+      await runRdy(checklist);
+
+      expect(checkCalled).toBe(false);
+    });
+
+    it('skips descendants of a check whose skip returned an uninterpretable value', async () => {
+      const checklist: RdyChecklist = {
+        name: 'authoring',
+        checks: [
+          {
+            name: 'broken-skip',
+            check: () => true,
+            skip: skipReturning(true),
+            checks: [{ name: 'child', check: () => true }],
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.results[1]?.name).toBe('child');
+      expect(report.results[1]?.status).toBe('skipped');
+    });
+
+    it('surfaces a severity outside the enum rather than dropping the check from every threshold', async () => {
+      const checklist: RdyChecklist = {
+        name: 'authoring',
+        checks: [{ name: 'mistyped', check: () => false, severity: asSeverity('info') }],
+      };
+
+      await expect(runRdy(checklist)).rejects.toThrow('Unknown severity "info"');
+    });
+  });
+
   describe('result shape', () => {
     it('sets null for optional fields on passed results', async () => {
       const checklist: RdyChecklist = {
@@ -1058,5 +1223,15 @@ describe(meetsThreshold, () => {
     { severity: 'recommend', threshold: 'recommend', expected: true },
   ] as const)('returns $expected for severity=$severity, threshold=$threshold', ({ severity, threshold, expected }) => {
     expect(meetsThreshold(severity, threshold)).toBe(expected);
+  });
+
+  it('throws on a severity outside the enum', () => {
+    expect(() => meetsThreshold(asSeverity('info'), 'error')).toThrow(
+      'Unknown severity "info". Expected one of: error, warn, recommend.',
+    );
+  });
+
+  it('throws on a threshold outside the enum', () => {
+    expect(() => meetsThreshold('error', asSeverity('info'))).toThrow('Unknown severity threshold "info"');
   });
 });

--- a/packages/readyup/__tests__/runRdy.test.ts
+++ b/packages/readyup/__tests__/runRdy.test.ts
@@ -269,6 +269,89 @@ describe(runRdy, () => {
       assert.ok(target?.status === 'skipped');
       expect(target.skipReason).toBe('precondition');
     });
+
+    describe('gating semantics', () => {
+      it.each(['error', 'warn', 'recommend'] as const)(
+        'gates the checklist when a %s-severity precondition fails',
+        async (severity) => {
+          const checklist: RdyChecklist = {
+            name: 'gated',
+            preconditions: [{ name: 'pre-fail', check: () => false, severity }],
+            checks: [{ name: 'should-skip', check: () => true }],
+          };
+
+          const report = await runRdy(checklist);
+
+          const target = report.results.find((r) => r.name === 'should-skip');
+          assert.ok(target?.status === 'skipped');
+          expect(target.skipReason).toBe('precondition');
+        },
+      );
+
+      // Gating and run failure are separate questions: the gate asks whether the checks are worth
+      // running at all, and the threshold asks whether what happened is worth failing over.
+      it('gates on a precondition whose failure is below the failure threshold, and still passes', async () => {
+        const checklist: RdyChecklist = {
+          name: 'gated',
+          preconditions: [{ name: 'pre-fail', check: () => false, severity: 'recommend' }],
+          checks: [{ name: 'should-skip', check: () => false }],
+        };
+
+        const report = await runRdy(checklist, { failOn: 'error' });
+
+        expect(report.results[1]?.status).toBe('skipped');
+        expect(report.passed).toBe(true);
+      });
+
+      it.each(['error', 'warn', 'recommend'] as const)(
+        'does not gate when a %s-severity precondition is skipped n/a',
+        async (severity) => {
+          const checklist: RdyChecklist = {
+            name: 'gated',
+            preconditions: [{ name: 'pre-na', check: () => false, severity, skip: () => 'not applicable here' }],
+            checks: [{ name: 'runs-anyway', check: () => true }],
+          };
+
+          const report = await runRdy(checklist);
+
+          expect(report.results.find((r) => r.name === 'runs-anyway')?.status).toBe('passed');
+        },
+      );
+
+      it('produces no results for checks nested under an n/a-skipped precondition', async () => {
+        const checklist: RdyChecklist = {
+          name: 'gated',
+          preconditions: [
+            {
+              name: 'pre-na',
+              check: () => true,
+              skip: () => 'not applicable here',
+              checks: [{ name: 'dependent', check: () => true }],
+            },
+          ],
+          checks: [{ name: 'runs-anyway', check: () => true }],
+        };
+
+        const report = await runRdy(checklist);
+
+        expect(report.results.map((r) => r.name)).toStrictEqual(['pre-na', 'runs-anyway']);
+      });
+
+      it('gates a staged checklist the same way a flat one is gated', async () => {
+        const checklist: RdyStagedChecklist = {
+          name: 'gated-stages',
+          preconditions: [{ name: 'pre-fail', check: () => false, severity: 'recommend' }],
+          groups: [[{ name: 'first', check: () => true }], [{ name: 'second', check: () => true }]],
+        };
+
+        const report = await runRdy(checklist);
+
+        expect(report.results.filter((r) => r.status === 'skipped').map((r) => r.name)).toStrictEqual([
+          'first',
+          'second',
+        ]);
+      });
+    });
   });
 
   describe('thrown checks', () => {

--- a/packages/readyup/__tests__/schemas/generateSchemas.test.ts
+++ b/packages/readyup/__tests__/schemas/generateSchemas.test.ts
@@ -88,7 +88,10 @@ describe('generated JSON Schemas', () => {
     it('publishes the warning vocabulary as an open set that still names its known codes', () => {
       const warningCode = objectAt(report, '$defs', 'WarningCode');
 
-      expect(warningCode.anyOf).toStrictEqual([{ type: 'string', enum: ['version-skew'] }, { type: 'string' }]);
+      expect(warningCode.anyOf).toStrictEqual([
+        { type: 'string', enum: ['source-stale', 'target-drift', 'version-skew'] },
+        { type: 'string' },
+      ]);
     });
 
     it('requires all six buckets of the counts object', () => {

--- a/packages/readyup/__tests__/schemas/schemas.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.test.ts
@@ -159,8 +159,8 @@ describe('JSON payload schemas', () => {
     });
 
     it('binds a producer to the vocabulary this version declares while the wire stays open', () => {
-      expectTypeOf<RaisedWarning['code']>().toEqualTypeOf<'version-skew'>();
-      expectTypeOf<JsonWarning['code']>().not.toEqualTypeOf<'version-skew'>();
+      expectTypeOf<RaisedWarning['code']>().toEqualTypeOf<'source-stale' | 'target-drift' | 'version-skew'>();
+      expectTypeOf<JsonWarning['code']>().not.toEqualTypeOf<'source-stale' | 'target-drift' | 'version-skew'>();
     });
 
     it('publishes the known warning codes as distinguishable members of an open set', () => {
@@ -168,6 +168,7 @@ describe('JSON payload schemas', () => {
       // assignments below while offering a consumer no vocabulary at all.
       expectTypeOf<JsonWarningCode>().not.toEqualTypeOf<string>();
       expectTypeOf<'version-skew'>().toExtend<JsonWarningCode>();
+      expectTypeOf<'source-stale'>().toExtend<JsonWarningCode>();
       expectTypeOf<'kit-deprecated'>().toExtend<JsonWarningCode>();
     });
   });

--- a/packages/readyup/__tests__/schemas/schemas.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.test.ts
@@ -19,6 +19,7 @@ import type { Severity } from '../../src/types.ts';
 import {
   compilePayload,
   errorEnvelopePayload,
+  legacyVerifyPayload,
   listPayload,
   minimalReportPayload,
   reportPayload,
@@ -115,6 +116,24 @@ describe('JSON payload schemas', () => {
       const kits = [{ name: 'release', error: { code: 'kit-retired', message: 'boom' } }];
 
       expect(() => ReportSchema.parse({ ...minimalReportPayload, kits })).toThrow();
+    });
+  });
+
+  describe('verify entries', () => {
+    it('accepts a payload from a readyup that predates the source verdict', () => {
+      expect(() => VerifyOutputSchema.parse(legacyVerifyPayload)).not.toThrow();
+    });
+
+    it('rejects a source verdict outside the vocabulary', () => {
+      const kits = [{ name: 'deploy', status: 'ok', sourceStatus: 'drift' }];
+
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow();
+    });
+
+    it('keeps the source vocabulary distinct from the target vocabulary', () => {
+      const kits = [{ name: 'deploy', status: 'stale', sourceStatus: 'ok' }];
+
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow();
     });
   });
 

--- a/packages/readyup/__tests__/stalenessWarning.test.ts
+++ b/packages/readyup/__tests__/stalenessWarning.test.ts
@@ -260,6 +260,19 @@ describe('staleness warnings', () => {
       expect(mockCheckDrift).not.toHaveBeenCalled();
     });
 
+    // A `--from` source resolves under another root, whose manifest this run never reads.
+    it('stays silent for a kit resolved outside the working directory', async () => {
+      arrangeTargetDrift();
+
+      await runCommand({
+        kitEntries: [{ name: 'default', source: { path: '/elsewhere/.readyup/kits/default.js' }, checklists: [] }],
+        json: false,
+      });
+
+      expect(stderrText()).not.toContain('Warning:');
+      expect(mockCheckDrift).not.toHaveBeenCalled();
+    });
+
     it('stays silent for an entry that records no path to match on', async () => {
       arrangeTargetDrift();
       arrangeManifest([{ name: 'default', source: 'kits/default.ts' }]);

--- a/packages/readyup/__tests__/stalenessWarning.test.ts
+++ b/packages/readyup/__tests__/stalenessWarning.test.ts
@@ -114,6 +114,11 @@ describe('staleness warnings', () => {
     return stderrSpy.mock.calls.map((c) => String(c[0])).join('');
   }
 
+  /** Concatenate every stdout write into a single string for substring assertions. */
+  function stdoutText(): string {
+    return stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+  }
+
   /** The warnings the JSON report was handed, or an empty array when it was handed none. */
   function reportedWarnings(): JsonWarning[] {
     const call = mockFormatJsonReport.mock.calls[0];
@@ -137,6 +142,13 @@ describe('staleness warnings', () => {
       expected: '5555bbbb',
       actual: '6666cccc',
       resolvedPath: '/abs/default.ts',
+    });
+  }
+
+  /** Report the source as present but impossible to hash. */
+  function arrangeUnreadableSource(): void {
+    mockCheckSourceDrift.mockImplementation(() => {
+      throw new Error('EACCES: permission denied, open /abs/default.ts');
     });
   }
 
@@ -179,6 +191,30 @@ describe('staleness warnings', () => {
       const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false });
 
       expect(exitCode).toBe(0);
+    });
+
+    it('still advises on the target when the source cannot be hashed', async () => {
+      arrangeTargetDrift();
+      arrangeUnreadableSource();
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      const stderr = stderrText();
+      expect(stderr).toContain('does not match the hash the manifest recorded');
+      expect(stderr).not.toContain('compiled from an older source');
+    });
+
+    it('still advises on the source when the compiled bundle cannot be hashed', async () => {
+      arrangeSourceStale();
+      mockCheckDrift.mockImplementation(() => {
+        throw new Error('EISDIR: illegal operation on a directory, read');
+      });
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      const stderr = stderrText();
+      expect(stderr).toContain('compiled from an older source');
+      expect(stderr).not.toContain('does not match the hash the manifest recorded');
     });
 
     it('stays silent when both artifacts match the manifest', async () => {
@@ -291,6 +327,16 @@ describe('staleness warnings', () => {
       expect(stderrText()).not.toContain('Warning:');
     });
 
+    it('runs the kit and stays silent when a file it would hash cannot be read', async () => {
+      arrangeUnreadableSource();
+
+      const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(exitCode).toBe(0);
+      expect(stdoutText()).toContain('report output');
+      expect(stderrText()).not.toContain('Warning:');
+    });
+
     it('stays silent when a compiled file the manifest names is gone', async () => {
       mockCheckDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/default.js' });
       mockCheckSourceDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/default.ts' });
@@ -336,7 +382,7 @@ describe('staleness warnings', () => {
       await runCommand({ kitEntries: singleKitEntry(), json: true });
 
       expect(reportedWarnings().map((warning) => warning.code)).toStrictEqual(['target-drift', 'source-stale']);
-      expect(stdoutSpy.mock.calls.map((c) => String(c[0])).join('')).toBe('{"kits":[]}\n');
+      expect(stdoutText()).toBe('{"kits":[]}\n');
     });
 
     it('writes the advisory to stderr in JSON mode as well', async () => {

--- a/packages/readyup/__tests__/stalenessWarning.test.ts
+++ b/packages/readyup/__tests__/stalenessWarning.test.ts
@@ -1,0 +1,351 @@
+import process from 'node:process';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import type { RdyManifestKit } from '../src/manifest/manifestSchema.ts';
+import type { JsonWarning } from '../src/schemas/index.ts';
+import type { RdyKit } from '../src/types.ts';
+
+const mockLoadRdyKit = vi.hoisted(() => vi.fn());
+const mockLoadRemoteKit = vi.hoisted(() => vi.fn());
+const mockRunRdy = vi.hoisted(() => vi.fn());
+const mockReportRdy = vi.hoisted(() => vi.fn());
+const mockFormatCombinedSummary = vi.hoisted(() => vi.fn());
+// Typed against the real signature so the captured call exposes `warnings` without an assertion.
+const mockFormatJsonReport = vi.hoisted(() => vi.fn<typeof import('../src/formatJsonReport.ts').formatJsonReport>());
+const mockReadManifest = vi.hoisted(() => vi.fn());
+const mockCheckDrift = vi.hoisted(() => vi.fn());
+const mockCheckSourceDrift = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/config.ts', () => ({
+  loadRdyKit: mockLoadRdyKit,
+}));
+
+vi.mock('../src/loadRemoteKit.ts', () => ({
+  loadRemoteKit: mockLoadRemoteKit,
+}));
+
+vi.mock('../src/runRdy.ts', () => ({
+  meetsThreshold: () => true,
+  runRdy: mockRunRdy,
+}));
+
+vi.mock('../src/reportRdy.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/reportRdy.ts')>('../src/reportRdy.ts');
+  return { ...actual, reportRdy: mockReportRdy };
+});
+
+vi.mock('../src/formatCombinedSummary.ts', () => ({
+  formatCombinedSummary: mockFormatCombinedSummary,
+}));
+
+vi.mock('../src/formatJsonReport.ts', () => ({
+  formatJsonReport: mockFormatJsonReport,
+}));
+
+vi.mock('../src/manifest/readManifest.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/manifest/readManifest.ts')>();
+  return { ManifestNotFoundError: actual.ManifestNotFoundError, readManifest: mockReadManifest };
+});
+
+vi.mock('../src/verify/checkDrift.ts', () => ({
+  checkDrift: mockCheckDrift,
+}));
+
+vi.mock('../src/verify/checkSourceDrift.ts', () => ({
+  checkSourceDrift: mockCheckSourceDrift,
+}));
+
+import { runCommand } from '../src/cli.ts';
+
+/** The compiled path of the kit every test here runs, as `resolveKitSources` would produce it. */
+const KIT_PATH = '.readyup/kits/default.js';
+
+/** The same file as the manifest records it: relative to `.readyup`, where the manifest lives. */
+const MANIFEST_KIT_PATH = 'kits/default.js';
+
+/** Build a minimal kit with one passing checklist. */
+function makeKit(): RdyKit {
+  return { checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }] };
+}
+
+/** Build a single-kit entry pointing at the compiled default kit. */
+function singleKitEntry(name = 'default') {
+  return [{ name, source: { path: KIT_PATH }, checklists: [] }];
+}
+
+/** Seed the manifest with the given entries. */
+function arrangeManifest(kits: RdyManifestKit[]): void {
+  mockReadManifest.mockReturnValue({ version: 1, kits });
+}
+
+describe('staleness warnings', () => {
+  let stdoutSpy: MockInstance;
+  let stderrSpy: MockInstance;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
+    mockReportRdy.mockReturnValue('report output');
+    mockFormatCombinedSummary.mockReturnValue('');
+    mockFormatJsonReport.mockReturnValue('{}');
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+    mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
+    mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555bbbb' });
+    arrangeManifest([{ name: 'default', path: MANIFEST_KIT_PATH, source: 'kits/default.ts' }]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockLoadRdyKit.mockReset();
+    mockLoadRemoteKit.mockReset();
+    mockRunRdy.mockReset();
+    mockReportRdy.mockReset();
+    mockFormatCombinedSummary.mockReset();
+    mockFormatJsonReport.mockReset();
+    mockReadManifest.mockReset();
+    mockCheckDrift.mockReset();
+    mockCheckSourceDrift.mockReset();
+  });
+
+  /** Concatenate every stderr write into a single string for substring assertions. */
+  function stderrText(): string {
+    return stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+  }
+
+  /** The warnings the JSON report was handed, or an empty array when it was handed none. */
+  function reportedWarnings(): JsonWarning[] {
+    const call = mockFormatJsonReport.mock.calls[0];
+    return call?.[1].warnings ?? [];
+  }
+
+  /** Report the compiled bundle as edited by hand. */
+  function arrangeTargetDrift(): void {
+    mockCheckDrift.mockReturnValue({
+      kind: 'drift',
+      expected: 'aaaa1111',
+      actual: 'aaaa9999',
+      resolvedPath: '/abs/default.js',
+    });
+  }
+
+  /** Report the source as edited without a recompile. */
+  function arrangeSourceStale(): void {
+    mockCheckSourceDrift.mockReturnValue({
+      kind: 'stale',
+      expected: '5555bbbb',
+      actual: '6666cccc',
+      resolvedPath: '/abs/default.ts',
+    });
+  }
+
+  describe('human mode', () => {
+    it('warns when the compiled bundle no longer matches the manifest', async () => {
+      arrangeTargetDrift();
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(stderrText()).toContain(
+        'Warning: compiled kit "default" does not match the hash the manifest recorded for it. Run `rdy compile --force` to rebuild it from source.',
+      );
+    });
+
+    it('warns when the source has moved on since the kit was compiled', async () => {
+      arrangeSourceStale();
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(stderrText()).toContain(
+        'Warning: kit "default" was compiled from an older source than the one on disk. Run `rdy compile` to rebuild it.',
+      );
+    });
+
+    it('raises both advisories when both artifacts have parted from the manifest', async () => {
+      arrangeTargetDrift();
+      arrangeSourceStale();
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      const stderr = stderrText();
+      expect(stderr).toContain('does not match the hash the manifest recorded');
+      expect(stderr).toContain('compiled from an older source');
+    });
+
+    it('leaves the exit code alone, since verify is the enforcing gate', async () => {
+      arrangeTargetDrift();
+      arrangeSourceStale();
+
+      const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(exitCode).toBe(0);
+    });
+
+    it('stays silent when both artifacts match the manifest', async () => {
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(stderrText()).not.toContain('Warning:');
+    });
+
+    it('reads the manifest once per invocation, not once per kit', async () => {
+      arrangeManifest([
+        { name: 'alpha', path: 'kits/alpha.js', source: 'kits/alpha.ts' },
+        { name: 'beta', path: 'kits/beta.js', source: 'kits/beta.ts' },
+      ]);
+
+      await runCommand({
+        kitEntries: [
+          { name: 'alpha', source: { path: '.readyup/kits/alpha.js' }, checklists: [] },
+          { name: 'beta', source: { path: '.readyup/kits/beta.js' }, checklists: [] },
+        ],
+        json: false,
+      });
+
+      expect(mockReadManifest).toHaveBeenCalledTimes(1);
+    });
+
+    it('scopes each advisory to the kit whose entry earned it', async () => {
+      arrangeManifest([
+        { name: 'alpha', path: 'kits/alpha.js', source: 'kits/alpha.ts' },
+        { name: 'beta', path: 'kits/beta.js', source: 'kits/beta.ts' },
+      ]);
+      mockCheckDrift
+        .mockReturnValueOnce({ kind: 'drift', expected: 'a', actual: 'b', resolvedPath: '/abs/alpha.js' })
+        .mockReturnValueOnce({ kind: 'ok', targetHash: 'bbbb' });
+
+      await runCommand({
+        kitEntries: [
+          { name: 'alpha', source: { path: '.readyup/kits/alpha.js' }, checklists: [] },
+          { name: 'beta', source: { path: '.readyup/kits/beta.js' }, checklists: [] },
+        ],
+        json: false,
+      });
+
+      const stderr = stderrText();
+      expect(stderr).toContain('compiled kit "alpha"');
+      expect(stderr).not.toContain('compiled kit "beta"');
+    });
+  });
+
+  describe('silence', () => {
+    it('stays silent when no manifest exists', async () => {
+      arrangeTargetDrift();
+      mockReadManifest.mockImplementation(() => {
+        throw new Error('Manifest file not found: /abs/.readyup/manifest.json');
+      });
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(stderrText()).not.toContain('Warning:');
+    });
+
+    it('stays silent when the manifest is unreadable', async () => {
+      arrangeTargetDrift();
+      mockReadManifest.mockImplementation(() => {
+        throw new Error('Manifest file contains invalid JSON: /abs/.readyup/manifest.json');
+      });
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(stderrText()).not.toContain('Warning:');
+    });
+
+    it('stays silent when no manifest entry describes the kit being run', async () => {
+      arrangeTargetDrift();
+      arrangeManifest([{ name: 'other', path: 'kits/other.js', source: 'kits/other.ts' }]);
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(stderrText()).not.toContain('Warning:');
+      expect(mockCheckDrift).not.toHaveBeenCalled();
+    });
+
+    it('stays silent for an entry that records no path to match on', async () => {
+      arrangeTargetDrift();
+      arrangeManifest([{ name: 'default', source: 'kits/default.ts' }]);
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(stderrText()).not.toContain('Warning:');
+    });
+
+    it('stays silent when the manifest entry records no hashes', async () => {
+      mockCheckDrift.mockReturnValue({ kind: 'unverified' });
+      mockCheckSourceDrift.mockReturnValue({ kind: 'unverified' });
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(stderrText()).not.toContain('Warning:');
+    });
+
+    it('stays silent when a compiled file the manifest names is gone', async () => {
+      mockCheckDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/default.js' });
+      mockCheckSourceDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/default.ts' });
+
+      await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+      expect(stderrText()).not.toContain('Warning:');
+    });
+
+    it('does not read the manifest under --jit, which runs from source', async () => {
+      arrangeTargetDrift();
+
+      await runCommand(
+        {
+          kitEntries: [{ name: 'default', source: { path: '.readyup/kits/default.ts' }, checklists: [] }],
+          json: false,
+        },
+        true,
+      );
+
+      expect(mockReadManifest).not.toHaveBeenCalled();
+      expect(stderrText()).not.toContain('Warning:');
+    });
+
+    it('stays silent for a --url kit, which no local manifest describes', async () => {
+      arrangeTargetDrift();
+      mockLoadRemoteKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
+      const url = 'https://example.com/kits/deploy.js';
+
+      await runCommand({ kitEntries: [{ name: url, source: { url }, checklists: [] }], json: false });
+
+      expect(stderrText()).not.toContain('Warning:');
+      expect(mockCheckDrift).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('JSON mode', () => {
+    it('captures both advisories in the report while keeping stdout to the JSON document', async () => {
+      arrangeTargetDrift();
+      arrangeSourceStale();
+      mockFormatJsonReport.mockReturnValue('{"kits":[]}');
+
+      await runCommand({ kitEntries: singleKitEntry(), json: true });
+
+      expect(reportedWarnings().map((warning) => warning.code)).toStrictEqual(['target-drift', 'source-stale']);
+      expect(stdoutSpy.mock.calls.map((c) => String(c[0])).join('')).toBe('{"kits":[]}\n');
+    });
+
+    it('writes the advisory to stderr in JSON mode as well', async () => {
+      arrangeSourceStale();
+
+      await runCommand({ kitEntries: singleKitEntry(), json: true });
+
+      expect(stderrText()).toContain('compiled from an older source');
+    });
+
+    it('carries no warnings when the manifest agrees with what is on disk', async () => {
+      await runCommand({ kitEntries: singleKitEntry(), json: true });
+
+      expect(reportedWarnings()).toStrictEqual([]);
+    });
+
+    it('leaves the exit code alone', async () => {
+      arrangeTargetDrift();
+
+      const exitCode = await runCommand({ kitEntries: singleKitEntry(), json: true });
+
+      expect(exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/readyup/__tests__/utils/describe-value.test.ts
+++ b/packages/readyup/__tests__/utils/describe-value.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { describeType, previewValue } from '../../src/utils/describe-value.ts';
+import { describeType, describeValue, previewValue } from '../../src/utils/describe-value.ts';
 
 describe(describeType, () => {
   it.each([
@@ -39,7 +39,7 @@ describe(previewValue, () => {
   });
 
   it('names a function rather than rendering its source', () => {
-    expect(previewValue(() => true)).toBe('a function');
+    expect(previewValue(() => true)).toBe('function');
   });
 
   it('renders a bigint with its literal suffix', () => {
@@ -62,5 +62,25 @@ describe(previewValue, () => {
     circular.self = circular;
 
     expect(previewValue(circular)).toBe('object');
+  });
+});
+
+describe(describeValue, () => {
+  it.each([
+    ['string "yes"', 'yes'],
+    ['number 1', 1],
+    ['boolean true', true],
+    ['object {"ok":"true"}', { ok: 'true' }],
+    ['array []', []],
+  ])('describes %s', (expected, value) => {
+    expect(describeValue(value)).toBe(expected);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['function', () => true],
+  ])('collapses the type and preview of %s into one word', (expected, value) => {
+    expect(describeValue(value)).toBe(expected);
   });
 });

--- a/packages/readyup/__tests__/utils/describe-value.test.ts
+++ b/packages/readyup/__tests__/utils/describe-value.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeType, previewValue } from '../../src/utils/describe-value.ts';
+
+describe(describeType, () => {
+  it.each([
+    ['string', 'text'],
+    ['number', 42],
+    ['boolean', true],
+    ['undefined', undefined],
+    ['function', () => true],
+    ['object', {}],
+  ])('names a %s', (expected, value) => {
+    expect(describeType(value)).toBe(expected);
+  });
+
+  it('distinguishes null from object', () => {
+    expect(describeType(null)).toBe('null');
+  });
+
+  it('distinguishes an array from object', () => {
+    expect(describeType([1, 2])).toBe('array');
+  });
+});
+
+describe(previewValue, () => {
+  it('keeps quotes on a string so it stays distinguishable from a number', () => {
+    expect(previewValue('1')).toBe('"1"');
+    expect(previewValue(1)).toBe('1');
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['true', true],
+    ['{"ok":true}', { ok: true }],
+  ])('renders %s', (expected, value) => {
+    expect(previewValue(value)).toBe(expected);
+  });
+
+  it('names a function rather than rendering its source', () => {
+    expect(previewValue(() => true)).toBe('a function');
+  });
+
+  it('renders a bigint with its literal suffix', () => {
+    expect(previewValue(10n)).toBe('10n');
+  });
+
+  it('renders a symbol by its description', () => {
+    expect(previewValue(Symbol('tag'))).toBe('Symbol(tag)');
+  });
+
+  it('truncates a long rendering', () => {
+    const preview = previewValue('x'.repeat(200));
+
+    expect(preview).toHaveLength(43);
+    expect(preview.endsWith('...')).toBe(true);
+  });
+
+  it('falls back to the type name for a value with no JSON rendering', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(previewValue(circular)).toBe('object');
+  });
+});

--- a/packages/readyup/__tests__/verify/checkSourceDrift.test.ts
+++ b/packages/readyup/__tests__/verify/checkSourceDrift.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { checkSourceDrift } from '../../src/verify/checkSourceDrift.ts';
+import { hashBytes } from '../../src/verify/targetHash.ts';
+
+describe(checkSourceDrift, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'source-drift-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns ok when the on-disk hash matches the manifest sourceHash', () => {
+    const content = Buffer.from('export default { checklists: [] };');
+    writeFileSync(path.join(tempDir, 'demo.ts'), content);
+
+    const status = checkSourceDrift({ name: 'demo', source: 'demo.ts', sourceHash: hashBytes(content) }, tempDir);
+
+    expect(status.kind).toBe('ok');
+  });
+
+  it('returns stale with both hashes when the source has changed since compile', () => {
+    writeFileSync(path.join(tempDir, 'demo.ts'), 'export default { checklists: [1] };');
+
+    const status = checkSourceDrift({ name: 'demo', source: 'demo.ts', sourceHash: 'deadbeef' }, tempDir);
+
+    expect(status).toMatchObject({
+      kind: 'stale',
+      expected: 'deadbeef',
+      actual: hashBytes(Buffer.from('export default { checklists: [1] };')),
+    });
+  });
+
+  it('returns missing when the recorded source file is gone', () => {
+    const status = checkSourceDrift({ name: 'demo', source: 'demo.ts', sourceHash: 'deadbeef' }, tempDir);
+
+    expect(status.kind).toBe('missing');
+  });
+
+  it('returns unverified when the kit has no sourceHash', () => {
+    writeFileSync(path.join(tempDir, 'demo.ts'), 'content');
+
+    const status = checkSourceDrift({ name: 'demo', source: 'demo.ts' }, tempDir);
+
+    expect(status.kind).toBe('unverified');
+  });
+
+  it('returns unverified when the kit has no source', () => {
+    const status = checkSourceDrift({ name: 'demo', sourceHash: 'deadbeef' }, tempDir);
+
+    expect(status.kind).toBe('unverified');
+  });
+
+  it('resolves the source path relative to the manifest directory', () => {
+    const content = Buffer.from('nested source');
+    mkdirSync(path.join(tempDir, 'kits'), { recursive: true });
+    writeFileSync(path.join(tempDir, 'kits', 'demo.ts'), content);
+
+    const status = checkSourceDrift({ name: 'demo', source: 'kits/demo.ts', sourceHash: hashBytes(content) }, tempDir);
+
+    expect(status.kind).toBe('ok');
+  });
+});

--- a/packages/readyup/__tests__/verify/verifyCommand.integration.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.integration.test.ts
@@ -74,6 +74,87 @@ describe('verifyCommand (integration)', () => {
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('expected deadbeef'));
   });
 
+  describe('source staleness', () => {
+    /**
+     * Write a matching source/output pair and a manifest recording both hashes.
+     *
+     * Returns the source path so a test can edit it, which is the whole scenario: a kit whose
+     * TypeScript moved on while the compiled bundle it was built from stayed put.
+     */
+    function writeCompiledPair(): string {
+      const compiled = Buffer.from('export default { checklists: [] };\n');
+      const source = Buffer.from('export default defineRdyKit({ checklists: [] });\n');
+      const sourcePath = path.join(tempDir, 'demo.ts');
+      writeFileSync(path.join(tempDir, 'demo.js'), compiled);
+      writeFileSync(sourcePath, source);
+      writeFileSync(
+        path.join(tempDir, 'manifest.json'),
+        JSON.stringify({
+          version: 1,
+          kits: [
+            {
+              name: 'demo',
+              path: 'demo.js',
+              source: 'demo.ts',
+              sourceHash: hashBytes(source),
+              targetHash: hashBytes(compiled),
+            },
+          ],
+        }),
+      );
+      return sourcePath;
+    }
+
+    it('returns 0 when both the source and the compiled kit match the manifest', () => {
+      writeCompiledPair();
+
+      const exitCode = verifyCommand(['--manifest', 'manifest.json']);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('✅ demo — ok'));
+    });
+
+    it('returns 1 when the source was edited without a recompile', () => {
+      const sourcePath = writeCompiledPair();
+      writeFileSync(sourcePath, 'export default defineRdyKit({ checklists: [], failOn: "warn" });\n');
+
+      const exitCode = verifyCommand(['--manifest', 'manifest.json']);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('demo — ok; source stale'));
+    });
+
+    it('returns 1 when the recorded source was deleted', () => {
+      const sourcePath = writeCompiledPair();
+      rmSync(sourcePath);
+
+      const exitCode = verifyCommand(['--manifest', 'manifest.json']);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('demo — ok; source file missing'));
+    });
+
+    it('carries both source hashes in the JSON entry for a stale kit', () => {
+      const sourcePath = writeCompiledPair();
+      const edited = Buffer.from('export default defineRdyKit({ checklists: [], failOn: "warn" });\n');
+      writeFileSync(sourcePath, edited);
+
+      verifyCommand(['--manifest', 'manifest.json', '--json']);
+
+      expect(JSON.parse(stdout.join(''))).toMatchObject({
+        passed: false,
+        kits: [
+          {
+            name: 'demo',
+            status: 'ok',
+            sourceStatus: 'stale',
+            sourceActual: hashBytes(edited),
+          },
+        ],
+      });
+    });
+  });
+
   describe('--json', () => {
     /** Write a manifest naming one matching kit, one drifted kit, and one with no recorded hash. */
     function writeMixedManifest(): void {
@@ -104,10 +185,16 @@ describe('verifyCommand (integration)', () => {
         schemaVersion: 1,
         passed: false,
         kits: [
-          { name: 'clean', status: 'ok' },
-          { name: 'edited', status: 'drift', expected: 'deadbeef', actual: expect.any(String) },
-          { name: 'gone', status: 'missing' },
-          { name: 'unhashed', status: 'unverified' },
+          { name: 'clean', status: 'ok', sourceStatus: 'unverified' },
+          {
+            name: 'edited',
+            status: 'drift',
+            expected: 'deadbeef',
+            actual: expect.any(String),
+            sourceStatus: 'unverified',
+          },
+          { name: 'gone', status: 'missing', sourceStatus: 'unverified' },
+          { name: 'unhashed', status: 'unverified', sourceStatus: 'unverified' },
         ],
       });
     });

--- a/packages/readyup/__tests__/verify/verifyCommand.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 
 const mockReadManifest = vi.hoisted(() => vi.fn());
 const mockCheckDrift = vi.hoisted(() => vi.fn());
+const mockCheckSourceDrift = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/manifest/readManifest.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/manifest/readManifest.ts')>();
@@ -15,6 +16,10 @@ vi.mock('../../src/verify/checkDrift.ts', () => ({
   checkDrift: mockCheckDrift,
 }));
 
+vi.mock('../../src/verify/checkSourceDrift.ts', () => ({
+  checkSourceDrift: mockCheckSourceDrift,
+}));
+
 import { verifyCommand } from '../../src/verify/verifyCommand.ts';
 import { captureRdyError } from '../helpers/captureRdyError.ts';
 
@@ -24,12 +29,14 @@ describe(verifyCommand, () => {
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockCheckSourceDrift.mockReturnValue({ kind: 'unverified' });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     mockReadManifest.mockReset();
     mockCheckDrift.mockReset();
+    mockCheckSourceDrift.mockReset();
   });
 
   it('returns 0 when every kit is ok', () => {
@@ -109,6 +116,90 @@ describe(verifyCommand, () => {
     expect(exitCode).toBe(0);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('(no kits in manifest)'));
     expect(mockCheckDrift).not.toHaveBeenCalled();
+  });
+
+  describe('source verdict', () => {
+    /** A manifest naming one kit, with whatever hashes the caller wants to imply. */
+    function arrangeSingleKit(): void {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'alpha', path: 'alpha.js', source: 'alpha.ts', targetHash: 'aaaa1111' }],
+      });
+      mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
+    }
+
+    it('fails a kit whose source changed without a recompile', () => {
+      arrangeSingleKit();
+      mockCheckSourceDrift.mockReturnValue({
+        kind: 'stale',
+        expected: '5555aaaa',
+        actual: '6666bbbb',
+        resolvedPath: '/abs/alpha.ts',
+      });
+
+      const exitCode = verifyCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining('⚠️  alpha — ok; source stale (expected 5555aaaa, got 6666bbbb)'),
+      );
+    });
+
+    it('fails a kit whose recorded source file is gone', () => {
+      arrangeSingleKit();
+      mockCheckSourceDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/alpha.ts' });
+
+      const exitCode = verifyCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining('❓ alpha — ok; source file missing (expected alpha.ts)'),
+      );
+    });
+
+    it('passes a kit whose source matches, leaving the line unchanged', () => {
+      arrangeSingleKit();
+      mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
+
+      const exitCode = verifyCommand([]);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('✅ alpha — ok\n'));
+    });
+
+    it('passes a manifest that records no source hash, leaving the line unchanged', () => {
+      arrangeSingleKit();
+
+      const exitCode = verifyCommand([]);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('✅ alpha — ok\n'));
+    });
+
+    it('reports both verdicts when the source is stale and the target has drifted', () => {
+      arrangeSingleKit();
+      mockCheckDrift.mockReturnValue({
+        kind: 'drift',
+        expected: 'aaaa1111',
+        actual: 'aaaa9999',
+        resolvedPath: '/abs/alpha.js',
+      });
+      mockCheckSourceDrift.mockReturnValue({
+        kind: 'stale',
+        expected: '5555aaaa',
+        actual: '6666bbbb',
+        resolvedPath: '/abs/alpha.ts',
+      });
+
+      const exitCode = verifyCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'alpha — drift (expected aaaa1111, got aaaa9999); source stale (expected 5555aaaa, got 6666bbbb)',
+        ),
+      );
+    });
   });
 
   it('reports a config error when the manifest cannot be read', async () => {

--- a/packages/readyup/src/assertIsRdyKit.ts
+++ b/packages/readyup/src/assertIsRdyKit.ts
@@ -1,27 +1,72 @@
+import type { ZodError } from 'zod';
 import { z } from 'zod';
 
 import type { RdyKit } from './types.ts';
+import { describeType, previewValue } from './utils/describe-value.ts';
 
 /** Schema for valid severity levels. */
-const SeveritySchema = z.enum(['error', 'warn', 'recommend']);
-
-/** Schema for a flat checklist (has `checks`, no `groups`). */
-const FlatChecklistSchema = z.looseObject({
-  name: z.string().min(1),
-  checks: z.array(z.unknown()),
+const SeveritySchema = z.enum(['error', 'warn', 'recommend'], {
+  error: (issue) => `expected one of "error", "warn", "recommend", got ${previewValue(issue.input)}`,
 });
 
-/** Schema for a staged checklist (has `groups`, no `checks`). */
-const StagedChecklistSchema = z.looseObject({
-  name: z.string().min(1),
-  groups: z.array(z.unknown()),
+/** Schema for the placement of fix messages. */
+const FixLocationSchema = z.enum(['inline', 'end'], {
+  error: (issue) => `expected one of "inline", "end", got ${previewValue(issue.input)}`,
 });
 
-const ChecklistSchema = z
-  .union([FlatChecklistSchema, StagedChecklistSchema])
-  .refine((val) => !('checks' in val && 'groups' in val), {
-    message: "Checklist cannot have both 'checks' and 'groups'",
-  });
+/**
+ * Schema for a value that must be a function.
+ *
+ * Zod 4 offers no composable `z.function()`, so the guard is a `z.custom`. A bare `z.custom` reports
+ * "Invalid input", which tells an author nothing, so the message names the type actually supplied.
+ */
+const FunctionSchema = z.custom<(...args: never[]) => unknown>((value) => typeof value === 'function', {
+  error: (issue) => `expected a function, got ${describeType(issue.input)}`,
+});
+
+/** Schema for a display name, which every check and checklist must carry. */
+const NameSchema = z.string('expected a non-empty string').min(1, 'expected a non-empty string');
+
+/**
+ * Schema for a single check, recursing into its dependent checks through a getter.
+ *
+ * `looseObject` lets unknown keys through: a kit authored against a later readyup, or carrying an
+ * annotation this version knows nothing about, is not thereby broken.
+ */
+const CheckSchema = z.looseObject({
+  name: NameSchema,
+  check: FunctionSchema,
+  severity: SeveritySchema.optional(),
+  skip: FunctionSchema.optional(),
+  fix: z.string().optional(),
+  get checks() {
+    return z.array(CheckSchema).optional();
+  },
+});
+
+/**
+ * Fields common to flat and staged checklists.
+ *
+ * Both `checks` and `groups` are optional here and narrowed by the refinements below. Modelling the
+ * two forms as one object rather than a union is what keeps validation errors precise: a union
+ * failure reports that neither branch matched, burying the offending check under an
+ * `invalid_union` issue whose path stops at the checklist.
+ */
+const ChecklistShapeSchema = z.looseObject({
+  name: NameSchema,
+  preconditions: z.array(CheckSchema).optional(),
+  checks: z.array(CheckSchema).optional(),
+  groups: z.array(z.array(CheckSchema)).optional(),
+  fixLocation: FixLocationSchema.optional(),
+});
+
+const ChecklistSchema = ChecklistShapeSchema.refine(
+  (val) => val.checks !== undefined || val.groups !== undefined,
+  "Checklist must have either 'checks' or 'groups'",
+).refine(
+  (val) => !(val.checks !== undefined && val.groups !== undefined),
+  "Checklist cannot have both 'checks' and 'groups'",
+);
 
 /** Structural schema for an RdyKit. */
 const RdyKitSchema = z.looseObject({
@@ -29,18 +74,46 @@ const RdyKitSchema = z.looseObject({
   defaultSeverity: SeveritySchema.optional(),
   description: z.string().optional(),
   failOn: SeveritySchema.optional(),
-  fixLocation: z.enum(['inline', 'end']).optional(),
+  fixLocation: FixLocationSchema.optional(),
   reportOn: SeveritySchema.optional(),
   suites: z.record(z.string(), z.array(z.string())).optional(),
 });
 
 /**
- * Validate that a raw value conforms to the RdyKit shape.
+ * Validate that a raw value conforms to the RdyKit shape, checks included.
  *
- * Throws a ZodError on invalid input. When it returns without throwing, the value is a valid
- * RdyKit. Function-valued properties like `check` are passed through without
- * validation because jiti loads the actual TypeScript module and preserves original types.
+ * Every check is validated wherever it appears, so a typo'd severity or a non-function `check`
+ * fails at load rather than silently changing what the run reports. jiti and esbuild type-check
+ * nothing, so `defineRdyKit`'s type-level guard protects only authors editing in an IDE.
+ *
+ * Throws an Error whose message names one issue per line, each located by a dot path into the kit.
+ * `source` labels the kit the issues belong to, which matters when the caller loaded it on the
+ * author's behalf and the author never named it.
  */
-export function assertIsRdyKit(raw: unknown): asserts raw is RdyKit {
-  RdyKitSchema.parse(raw);
+export function assertIsRdyKit(raw: unknown, source?: string): asserts raw is RdyKit {
+  const result = RdyKitSchema.safeParse(raw);
+  if (result.success) return;
+  throw new Error(formatValidationError(result.error, source));
+}
+
+/** Compose a heading plus one sentence per issue from a failed kit parse. */
+function formatValidationError(error: ZodError, source: string | undefined): string {
+  const heading = source === undefined ? 'Invalid kit:' : `Invalid kit at ${source}:`;
+  const lines = error.issues.map((issue) => `  ${formatIssuePath(issue.path)}: ${issue.message}`);
+  return [heading, ...lines].join('\n');
+}
+
+/**
+ * Render an issue path in the notation an author would use to reach the value.
+ *
+ * Array indices become brackets and keys become dotted segments, so `checklists[0].checks[1].check`
+ * reads as the expression that selects the offending field.
+ */
+function formatIssuePath(path: ReadonlyArray<PropertyKey>): string {
+  if (path.length === 0) return '(kit root)';
+
+  return path.reduce<string>((rendered, segment) => {
+    if (typeof segment === 'number') return `${rendered}[${segment}]`;
+    return rendered === '' ? String(segment) : `${rendered}.${String(segment)}`;
+  }, '');
 }

--- a/packages/readyup/src/assertIsRdyKit.ts
+++ b/packages/readyup/src/assertIsRdyKit.ts
@@ -60,13 +60,19 @@ const ChecklistShapeSchema = z.looseObject({
   fixLocation: FixLocationSchema.optional(),
 });
 
+/**
+ * A checklist carrying exactly one of `checks` and `groups`.
+ *
+ * The two clauses test different things, and each has to. `isFlatChecklist` discriminates on key
+ * presence, so the exclusivity clause does too: a checklist whose `checks` is present but explicitly
+ * `undefined`, beside a populated `groups`, would otherwise validate, classify as flat, and hand the
+ * runner an array that is not there. The requirement clause tests the value instead, so a key set to
+ * `undefined` cannot satisfy the collection it names.
+ */
 const ChecklistSchema = ChecklistShapeSchema.refine(
   (val) => val.checks !== undefined || val.groups !== undefined,
   "Checklist must have either 'checks' or 'groups'",
-).refine(
-  (val) => !(val.checks !== undefined && val.groups !== undefined),
-  "Checklist cannot have both 'checks' and 'groups'",
-);
+).refine((val) => !('checks' in val && 'groups' in val), "Checklist cannot have both 'checks' and 'groups'");
 
 /** Structural schema for an RdyKit. */
 const RdyKitSchema = z.looseObject({

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -10,6 +10,9 @@ import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonReport, type KitInput } from './formatJsonReport.ts';
 import { KITS_DIR, resolveHomeDir } from './kitsDir.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
+import { DEFAULT_MANIFEST_PATH } from './manifest/manifestPath.ts';
+import type { RdyManifest } from './manifest/manifestSchema.ts';
+import { readManifest } from './manifest/readManifest.ts';
 import { type FromSource, parseFromValue } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
 import { countResults, reportRdy } from './reportRdy.ts';
@@ -29,6 +32,8 @@ import type {
 } from './types.ts';
 import { extractMessage } from './utils/error-handling.ts';
 import { translateParseArgsError } from './utils/parse-args-error.ts';
+import { checkDrift } from './verify/checkDrift.ts';
+import { checkSourceDrift } from './verify/checkSourceDrift.ts';
 import { VERSION } from './version.ts';
 import { compareVersionsForSkew } from './versionSkew/compareVersionsForSkew.ts';
 
@@ -462,6 +467,91 @@ function warnOnVersionSkew(kitName: string, compileTimeVersion: string | undefin
   return { code: 'version-skew', message, remedy };
 }
 
+/** The manifest an invocation checks its kits against, read once and shared by every kit in the run. */
+interface ManifestTracking {
+  manifest: RdyManifest;
+  manifestDir: string;
+}
+
+/**
+ * Read the default manifest for the run's advisories, best effort.
+ *
+ * Every failure here answers with no manifest at all: a missing one is the normal state of a
+ * project that never compiled, and an unreadable or unrecognized one says nothing about any kit. A
+ * verification tool that refused to run because its own bookkeeping was unreadable would be worse
+ * than one that runs and stays quiet. `--jit` runs from source, which the manifest does not
+ * describe, so they skip the read entirely.
+ */
+function readManifestTracking(isJit: boolean): ManifestTracking | undefined {
+  if (isJit) return undefined;
+  const manifestPath = path.resolve(process.cwd(), DEFAULT_MANIFEST_PATH);
+  try {
+    return { manifest: readManifest(manifestPath), manifestDir: path.dirname(manifestPath) };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Emit advisory stderr warnings when the manifest disagrees with the kit that is about to run.
+ *
+ * `target-drift` says the compiled bundle is not the one the manifest recorded, so someone edited
+ * it by hand. `source-stale` says the TypeScript it was built from has moved on, so the run is
+ * about to execute checks that no longer match their source. Both can hold at once.
+ *
+ * Advisory by design: `rdy verify` is the enforcing gate, and this never touches the exit code. A
+ * kit no entry describes, an entry recording no hash, and a remote or just-in-time source are all
+ * silent, because none of them is evidence that anything is stale.
+ *
+ * The stderr lines are written in both modes; the returned entries are what JSON mode captures into
+ * the report, so a consumer that owns only stdout still learns the run was advised of something.
+ */
+function warnOnKitStaleness(
+  kitName: string,
+  source: KitSource,
+  tracking: ManifestTracking | undefined,
+): RaisedWarning[] {
+  if (tracking === undefined || 'url' in source) return [];
+
+  const entry = findManifestEntry(source.path, tracking);
+  if (entry === undefined) return [];
+
+  const warnings: RaisedWarning[] = [];
+  if (checkDrift(entry, tracking.manifestDir).kind === 'drift') {
+    warnings.push({
+      code: 'target-drift',
+      message: `compiled kit "${kitName}" does not match the hash the manifest recorded for it.`,
+      remedy: 'Run `rdy compile --force` to rebuild it from source.',
+    });
+  }
+  if (checkSourceDrift(entry, tracking.manifestDir).kind === 'stale') {
+    warnings.push({
+      code: 'source-stale',
+      message: `kit "${kitName}" was compiled from an older source than the one on disk.`,
+      remedy: 'Run `rdy compile` to rebuild it.',
+    });
+  }
+
+  for (const warning of warnings) {
+    process.stderr.write(`Warning: ${warning.message} ${warning.remedy}\n`);
+  }
+  return warnings;
+}
+
+/**
+ * Find the manifest entry describing a kit, matching on resolved compiled path.
+ *
+ * Matching by name instead would misfire wherever a kit's name and its file part company: `--file`
+ * names a kit by an arbitrary path, and a custom `outDir` puts a differently-named entry's output
+ * where this one's would go.
+ */
+function findManifestEntry(kitPath: string, tracking: ManifestTracking): RdyManifest['kits'][number] | undefined {
+  const resolvedKitPath = path.resolve(process.cwd(), kitPath);
+  return tracking.manifest.kits.find(
+    (kit) => kit.path !== undefined && path.resolve(tracking.manifestDir, kit.path) === resolvedKitPath,
+  );
+}
+
 /** Detect module-not-found errors that mention a specific package name. */
 function isModuleNotFoundError(error: unknown, packageName: string): boolean {
   if (!(error instanceof Error)) return false;
@@ -497,6 +587,7 @@ async function runMultiKitJsonMode(
   const { detail, failOn, reportOn } = runSettings;
   const kitInputs: KitInput[] = [];
   const warnings: JsonWarning[] = [];
+  const tracking = readManifestTracking(isJit);
   let allPassed = true;
   let anyKitFailed = false;
 
@@ -506,6 +597,7 @@ async function runMultiKitJsonMode(
 
       const warning = warnOnVersionSkew(entry.name, compileTimeVersion);
       if (warning !== undefined) warnings.push(warning);
+      warnings.push(...warnOnKitStaleness(entry.name, entry.source, tracking));
 
       const thresholds = resolveThresholds(kit, failOn, reportOn);
       const checklists = selectChecklists(kit, entry.checklists);
@@ -562,6 +654,7 @@ async function runMultiKitHumanMode(
   isJit: boolean,
 ): Promise<number> {
   const showKitHeader = kitEntries.length > 1;
+  const tracking = readManifestTracking(isJit);
   let allPassed = true;
   let anyKitFailed = false;
 
@@ -575,6 +668,7 @@ async function runMultiKitHumanMode(
       const { kit, compileTimeVersion } = await loadKit(entry.source, isJit);
 
       warnOnVersionSkew(entry.name, compileTimeVersion);
+      warnOnKitStaleness(entry.name, entry.source, tracking);
 
       const exitCode = await runSingleKitHumanMode(kit, entry.checklists, failOn, reportOn, showKitHeader);
       if (exitCode !== EXIT_OK) allPassed = false;

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -500,8 +500,8 @@ function readManifestTracking(isJit: boolean): ManifestTracking | undefined {
  * about to execute checks that no longer match their source. Both can hold at once.
  *
  * Advisory by design: `rdy verify` is the enforcing gate, and this never touches the exit code. A
- * kit no entry describes, an entry recording no hash, and a remote or just-in-time source are all
- * silent, because none of them is evidence that anything is stale.
+ * kit no entry describes, an entry recording no hash, a remote or just-in-time source, and a file
+ * that cannot be hashed are all silent, because none of them is evidence that anything is stale.
  *
  * The stderr lines are written in both modes; the returned entries are what JSON mode captures into
  * the report, so a consumer that owns only stdout still learns the run was advised of something.
@@ -517,14 +517,14 @@ function warnOnKitStaleness(
   if (entry === undefined) return [];
 
   const warnings: RaisedWarning[] = [];
-  if (checkDrift(entry, tracking.manifestDir).kind === 'drift') {
+  if (hasVerdict(() => checkDrift(entry, tracking.manifestDir), 'drift')) {
     warnings.push({
       code: 'target-drift',
       message: `compiled kit "${kitName}" does not match the hash the manifest recorded for it.`,
       remedy: 'Run `rdy compile --force` to rebuild it from source.',
     });
   }
-  if (checkSourceDrift(entry, tracking.manifestDir).kind === 'stale') {
+  if (hasVerdict(() => checkSourceDrift(entry, tracking.manifestDir), 'stale')) {
     warnings.push({
       code: 'source-stale',
       message: `kit "${kitName}" was compiled from an older source than the one on disk.`,
@@ -550,6 +550,15 @@ function findManifestEntry(kitPath: string, tracking: ManifestTracking): RdyMani
   return tracking.manifest.kits.find(
     (kit) => kit.path !== undefined && path.resolve(tracking.manifestDir, kit.path) === resolvedKitPath,
   );
+}
+
+/** Report whether a staleness predicate reaches the given verdict, treating a file it cannot hash as no. */
+function hasVerdict<TStatus extends { kind: string }>(check: () => TStatus, kind: TStatus['kind']): boolean {
+  try {
+    return check().kind === kind;
+  } catch {
+    return false;
+  }
 }
 
 /** Detect module-not-found errors that mention a specific package name. */

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -20,6 +20,7 @@ import { translateParseArgsError } from '../utils/parse-args-error.ts';
 import { pluralizeWithCount } from '../utils/pluralize.ts';
 import type { DriftStatus } from '../verify/checkDrift.ts';
 import { checkDrift } from '../verify/checkDrift.ts';
+import { hashFile } from '../verify/targetHash.ts';
 import { VERSION } from '../version.ts';
 import { writeHuman } from '../writeHuman.ts';
 import { compileConfig } from './compileConfig.ts';
@@ -138,6 +139,7 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
       upsertManifest(manifestPath, kitName, metadata, {
         path: relOutputPath,
         source: relSourcePath,
+        sourceHash: hashFile(resolvedInputPath),
         targetHash: result.targetHash,
       });
     } catch (error: unknown) {
@@ -279,6 +281,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
         path: relOutputPath,
         readyupVersion: VERSION,
         source: relSourcePath,
+        sourceHash: hashFile(srcFile),
         targetHash: result.targetHash,
         ...(metadata.checklists.length > 0 && { checklists: metadata.checklists }),
         ...(metadata.description !== undefined && { description: metadata.description }),
@@ -327,6 +330,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
 interface KitLocationFields {
   path: string;
   source: string;
+  sourceHash: string;
   targetHash: string;
 }
 
@@ -354,6 +358,7 @@ function upsertManifest(
     path: location.path,
     readyupVersion: VERSION,
     source: location.source,
+    sourceHash: location.sourceHash,
     targetHash: location.targetHash,
     ...(metadata.checklists.length > 0 && { checklists: metadata.checklists }),
     ...(metadata.description !== undefined && { description: metadata.description }),

--- a/packages/readyup/src/compile/validateCompiledOutput.ts
+++ b/packages/readyup/src/compile/validateCompiledOutput.ts
@@ -5,6 +5,7 @@ import { assertIsRdyKit } from '../assertIsRdyKit.ts';
 import { isRecord } from '../isRecord.ts';
 import { resolveKitExports } from '../resolveKitExports.ts';
 import type { RdyKit } from '../types.ts';
+import { toDisplayPath } from '../utils/display-path.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { validateKit } from '../validateKit.ts';
 
@@ -36,7 +37,7 @@ export async function validateCompiledOutput(outputPath: string): Promise<KitMet
   let kit: RdyKit;
   try {
     const resolved = resolveKitExports(moduleRecord);
-    assertIsRdyKit(resolved);
+    assertIsRdyKit(resolved, toDisplayPath(outputPath));
     validateKit(resolved);
     kit = resolved;
   } catch (error: unknown) {

--- a/packages/readyup/src/config.ts
+++ b/packages/readyup/src/config.ts
@@ -45,7 +45,7 @@ export async function loadRdyKit(kitPath: string): Promise<LoadedRdyKit> {
   const compileTimeVersion = readCompileTimeVersion(imported);
 
   const resolved = resolveKitExports(imported);
-  assertIsRdyKit(resolved);
+  assertIsRdyKit(resolved, toDisplayPath(resolvedPath));
   validateKit(resolved);
   return { kit: resolved, compileTimeVersion };
 }

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -49,6 +49,7 @@ export type {
   JsonListOutput,
   JsonProgress,
   JsonReport,
+  JsonSourceStatus,
   JsonVerifyKitEntry,
   JsonVerifyOutput,
   JsonWarning,

--- a/packages/readyup/src/loadRemoteKit.ts
+++ b/packages/readyup/src/loadRemoteKit.ts
@@ -53,7 +53,7 @@ export async function loadRemoteKit({ url, headers = {} }: LoadRemoteKitOptions)
     const versionValue = moduleRecord.__readyupVersion;
     const compileTimeVersion = typeof versionValue === 'string' ? versionValue : undefined;
     const resolved = resolveKitExports(moduleRecord);
-    assertIsRdyKit(resolved);
+    assertIsRdyKit(resolved, url);
     validateKit(resolved);
     return { kit: resolved, compileTimeVersion };
   } finally {

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -7,6 +7,10 @@ import { z } from 'zod';
  * without importing and executing the compiled bundle. It is optional because a manifest written by
  * an older readyup has no such record; readers strip what they do not recognize, so the field's
  * arrival leaves `version` at 1.
+ *
+ * `sourceHash` and `targetHash` are the two ends of the compile: the hash of the `.ts` the kit was
+ * built from and the hash of the `.js` it produced. Comparing each against the file on disk is what
+ * separates a source edited without recompiling from a compiled bundle edited by hand.
  */
 const ManifestKitSchema = z.object({
   checklists: z.array(z.string()).optional(),
@@ -15,6 +19,7 @@ const ManifestKitSchema = z.object({
   path: z.string().optional(),
   readyupVersion: z.string().optional(),
   source: z.string().optional(),
+  sourceHash: z.string().optional(),
   targetHash: z.string().optional(),
 });
 

--- a/packages/readyup/src/runRdy.ts
+++ b/packages/readyup/src/runRdy.ts
@@ -45,9 +45,10 @@ const AUTHORING_ERROR_SEVERITY: Severity = 'error';
 /**
  * Return true if `severity` is at or above (more severe than or equal to) `threshold`.
  *
- * Throws on a value outside the severity enum. Kits are validated at load, so this is the backstop
- * for one that bypassed validation, such as a third-party `--url` source: an unranked value would
- * compare as `undefined <= n`, which is false, silently excluding the check from every threshold.
+ * Throws on a value outside the severity enum. Supplying a validated severity is the caller's
+ * responsibility, and the throw is what makes that a contract rather than an assumption: an unranked
+ * value compares as `undefined <= n`, which is false, so it would silently exclude the check from
+ * both the failure and the reporting thresholds instead of failing loudly.
  */
 export function meetsThreshold(severity: Severity, threshold: Severity): boolean {
   assertRankedSeverity(severity, 'severity');

--- a/packages/readyup/src/runRdy.ts
+++ b/packages/readyup/src/runRdy.ts
@@ -1,6 +1,8 @@
 import { performance } from 'node:perf_hooks';
 
+import { isRecord } from './isRecord.ts';
 import type {
+  CheckOutcome,
   FailedResult,
   PassedResult,
   RdyCheck,
@@ -12,6 +14,7 @@ import type {
   SkippedResult,
 } from './types.ts';
 import { isFlatChecklist } from './types.ts';
+import { describeValue } from './utils/describe-value.ts';
 
 /** Options controlling failure and severity defaults for a run. */
 export interface RunRdyOptions {
@@ -31,15 +34,24 @@ const SEVERITY_RANK: Record<Severity, number> = {
 };
 
 /**
- * Severity assigned to a check whose `check` or `skip` function throws.
+ * Severity assigned to a check that is broken rather than failing.
  *
- * An exception is a defect in the check itself, not a soft finding, so it overrides
- * whatever severity the check declares.
+ * A `check` or `skip` function that throws, or that returns a value the runner cannot interpret, is
+ * a defect in the check itself and not a soft finding, so it overrides whatever severity the check
+ * declares.
  */
-const THROWN_SEVERITY: Severity = 'error';
+const AUTHORING_ERROR_SEVERITY: Severity = 'error';
 
-/** Return true if `severity` is at or above (more severe than or equal to) `threshold`. */
+/**
+ * Return true if `severity` is at or above (more severe than or equal to) `threshold`.
+ *
+ * Throws on a value outside the severity enum. Kits are validated at load, so this is the backstop
+ * for one that bypassed validation, such as a third-party `--url` source: an unranked value would
+ * compare as `undefined <= n`, which is false, silently excluding the check from every threshold.
+ */
 export function meetsThreshold(severity: Severity, threshold: Severity): boolean {
+  assertRankedSeverity(severity, 'severity');
+  assertRankedSeverity(threshold, 'severity threshold');
   return SEVERITY_RANK[severity] <= SEVERITY_RANK[threshold];
 }
 
@@ -113,15 +125,35 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
   if (check.skip !== undefined) {
     const start = performance.now();
     try {
-      const skipResult = await check.skip();
+      // Widened to `unknown`: a kit runs as JavaScript, so its functions return whatever their
+      // author wrote, whatever the declared type promised.
+      const skipResult: unknown = await check.skip();
       if (typeof skipResult === 'string') {
         // An `n/a` skip terminates its subtree: descendants produce no results at all.
         return [buildSkippedResult(check.name, severity, 'n/a', skipResult, fix, depth)];
       }
+      if (skipResult !== false) {
+        const durationMs = performance.now() - start;
+        const error = new Error(
+          `skip() returned ${describeValue(skipResult)}; expected false to run the check, or a reason string to skip it.`,
+        );
+        const result = buildFailedResult(
+          check.name,
+          AUTHORING_ERROR_SEVERITY,
+          durationMs,
+          null,
+          fix,
+          error,
+          null,
+          depth,
+        );
+        const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
+        return [result, ...childResults];
+      }
     } catch (error_: unknown) {
       const durationMs = performance.now() - start;
       const error = error_ instanceof Error ? error_ : new Error(String(error_));
-      const result = buildFailedResult(check.name, THROWN_SEVERITY, durationMs, null, fix, error, null, depth);
+      const result = buildFailedResult(check.name, AUTHORING_ERROR_SEVERITY, durationMs, null, fix, error, null, depth);
       const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
       return [result, ...childResults];
     }
@@ -129,19 +161,26 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
 
   const start = performance.now();
   try {
-    const raw = await check.check();
+    const raw: unknown = await check.check();
     const durationMs = performance.now() - start;
     let result: PassedResult | FailedResult;
     if (typeof raw === 'boolean') {
       result = raw
         ? buildPassedResult(check.name, severity, durationMs, null, fix, null, depth)
         : buildFailedResult(check.name, severity, durationMs, null, fix, null, null, depth);
-    } else {
+    } else if (isCheckOutcome(raw)) {
       const detail = raw.detail ?? null;
       const progress = raw.progress ?? null;
       result = raw.ok
         ? buildPassedResult(check.name, severity, durationMs, detail, fix, progress, depth)
         : buildFailedResult(check.name, severity, durationMs, detail, fix, null, progress, depth);
+    } else {
+      // Reported as a defect rather than as an ordinary failure: the check never expressed a
+      // verdict, so the severity it declared for its subject says nothing about this outcome.
+      const error = new Error(
+        `check() returned ${describeValue(raw)}; expected a boolean or an object with a boolean "ok" property.`,
+      );
+      result = buildFailedResult(check.name, AUTHORING_ERROR_SEVERITY, durationMs, null, fix, error, null, depth);
     }
 
     const childResults = await collectChildResults(result, children, defaultSeverity, depth + 1);
@@ -149,7 +188,7 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
   } catch (error_: unknown) {
     const durationMs = performance.now() - start;
     const error = error_ instanceof Error ? error_ : new Error(String(error_));
-    const result = buildFailedResult(check.name, THROWN_SEVERITY, durationMs, null, fix, error, null, depth);
+    const result = buildFailedResult(check.name, AUTHORING_ERROR_SEVERITY, durationMs, null, fix, error, null, depth);
     const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
     return [result, ...childResults];
   }
@@ -310,4 +349,21 @@ export async function runRdy(
   const passed = results.every((r) => !(r.status === 'failed' && meetsThreshold(r.severity, failOn)));
 
   return { results, passed, durationMs };
+}
+
+/** Throw when a severity carries no rank, naming the role it was supplied in. */
+function assertRankedSeverity(severity: Severity, role: string): void {
+  if (!Object.hasOwn(SEVERITY_RANK, severity)) {
+    throw new Error(`Unknown ${role} "${severity}". Expected one of: error, warn, recommend.`);
+  }
+}
+
+/**
+ * Return true if a check's return value is a structured outcome.
+ *
+ * `ok` must be a boolean: a truthy value of any other type is an authoring mistake, not a pass, and
+ * treating it as one is how a broken check reports success.
+ */
+function isCheckOutcome(raw: unknown): raw is CheckOutcome {
+  return isRecord(raw) && typeof raw.ok === 'boolean';
 }

--- a/packages/readyup/src/schemas/common.ts
+++ b/packages/readyup/src/schemas/common.ts
@@ -43,7 +43,7 @@ export const CountsSchema = z
   .meta({ id: 'Counts' });
 
 /** The advisory vocabulary this version raises. `RaisedWarning` binds producers to it. */
-export const WarningCodeSchema = z.enum(['version-skew']);
+export const WarningCodeSchema = z.enum(['source-stale', 'target-drift', 'version-skew']);
 
 /**
  * The wire form of a warning code: a known value, or any other string.

--- a/packages/readyup/src/schemas/index.ts
+++ b/packages/readyup/src/schemas/index.ts
@@ -48,8 +48,13 @@ export type { JsonKitKind, JsonListKitEntry, JsonListOutput } from './listOutput
 export { KitKindSchema, ListKitEntrySchema, ListOutputSchema } from './listOutputSchema.ts';
 
 // verify
-export type { JsonDriftStatus, JsonVerifyKitEntry, JsonVerifyOutput } from './verifyOutputSchema.ts';
-export { DriftStatusSchema, VerifyKitEntrySchema, VerifyOutputSchema } from './verifyOutputSchema.ts';
+export type { JsonDriftStatus, JsonSourceStatus, JsonVerifyKitEntry, JsonVerifyOutput } from './verifyOutputSchema.ts';
+export {
+  DriftStatusSchema,
+  SourceStatusSchema,
+  VerifyKitEntrySchema,
+  VerifyOutputSchema,
+} from './verifyOutputSchema.ts';
 
 // compile
 export type { JsonCompileKitEntry, JsonCompileOutput, JsonCompileStatus } from './compileOutputSchema.ts';

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -11,10 +11,23 @@ export const SCHEMA_VERSION = 1;
 export const DriftStatusSchema = z.enum(['drift', 'missing', 'ok', 'unverified']).meta({ id: 'DriftStatus' });
 
 /**
- * One kit's drift verdict.
+ * Outcome of hashing one kit's TypeScript source against the hash the manifest recorded for it.
  *
- * `expected` and `actual` are the manifest's hash and the on-disk hash; both are present only on a
- * `drift` verdict, since no other status has two hashes to compare.
+ * A separate vocabulary from `DriftStatus` rather than a widening of it. The two verdicts answer
+ * different questions -- has the bundle been edited, and has the source moved on since it was
+ * built -- and a kit can carry a distinct answer to each. Widening the closed `DriftStatus` enum
+ * would also break a consumer that exhaustively switches on it.
+ */
+export const SourceStatusSchema = z.enum(['missing', 'ok', 'stale', 'unverified']).meta({ id: 'SourceStatus' });
+
+/**
+ * One kit's verdicts.
+ *
+ * `expected` and `actual` are the manifest's hash and the on-disk hash of the compiled bundle; both
+ * are present only on a `drift` verdict, since no other status has two hashes to compare.
+ * `sourceExpected` and `sourceActual` are their counterparts for the source, present only on
+ * `stale`. `sourceStatus` is optional so a consumer pinned to this schema still validates a payload
+ * from the readyup that predates the source verdict.
  */
 export const VerifyKitEntrySchema = z
   .object({
@@ -22,14 +35,17 @@ export const VerifyKitEntrySchema = z
     status: DriftStatusSchema,
     expected: z.string().optional(),
     actual: z.string().optional(),
+    sourceStatus: SourceStatusSchema.optional(),
+    sourceExpected: z.string().optional(),
+    sourceActual: z.string().optional(),
   })
   .meta({ id: 'VerifyKitEntry' });
 
 /**
  * Top-level shape of `rdy verify --json`.
  *
- * `passed` is true when every kit is `ok` or `unverified`, agreeing with exit code 0. An unreadable
- * manifest produces the error envelope instead of this payload.
+ * `passed` is true when both of every kit's verdicts are `ok` or `unverified`, agreeing with exit
+ * code 0. An unreadable manifest produces the error envelope instead of this payload.
  */
 export const VerifyOutputSchema = z
   .object({
@@ -40,5 +56,6 @@ export const VerifyOutputSchema = z
   .meta({ id: 'VerifyOutput' });
 
 export type JsonDriftStatus = z.infer<typeof DriftStatusSchema>;
+export type JsonSourceStatus = z.infer<typeof SourceStatusSchema>;
 export type JsonVerifyKitEntry = z.infer<typeof VerifyKitEntrySchema>;
 export type JsonVerifyOutput = z.infer<typeof VerifyOutputSchema>;

--- a/packages/readyup/src/utils/describe-value.ts
+++ b/packages/readyup/src/utils/describe-value.ts
@@ -1,0 +1,39 @@
+/** Longest preview rendered before truncation, in characters. */
+const MAX_PREVIEW_LENGTH = 40;
+
+/**
+ * Name the runtime type of a value.
+ *
+ * Distinguishes `null` and arrays from plain objects, which `typeof` alone collapses together. Used
+ * in diagnostics that tell an author what they wrote where a specific type was expected.
+ */
+export function describeType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+/**
+ * Render a short, readable preview of a value for a diagnostic message.
+ *
+ * Strings keep their quotes, so `"1"` stays distinguishable from `1`. Anything long is truncated:
+ * the preview is there to identify what was written, and the author has the source. A value with no
+ * JSON rendering falls back to its type name, which is all that a circular structure could tell a
+ * reader anyway.
+ */
+export function previewValue(value: unknown): string {
+  // The types `JSON.stringify` answers with `undefined` or a throw rather than a rendering.
+  if (value === undefined) return 'undefined';
+  if (typeof value === 'function') return 'a function';
+  if (typeof value === 'symbol') return value.toString();
+  if (typeof value === 'bigint') return `${value}n`;
+
+  let rendered: string;
+  try {
+    rendered = JSON.stringify(value);
+  } catch {
+    return describeType(value);
+  }
+
+  return rendered.length > MAX_PREVIEW_LENGTH ? `${rendered.slice(0, MAX_PREVIEW_LENGTH)}...` : rendered;
+}

--- a/packages/readyup/src/utils/describe-value.ts
+++ b/packages/readyup/src/utils/describe-value.ts
@@ -18,13 +18,13 @@ export function describeType(value: unknown): string {
  *
  * Strings keep their quotes, so `"1"` stays distinguishable from `1`. Anything long is truncated:
  * the preview is there to identify what was written, and the author has the source. A value with no
- * JSON rendering falls back to its type name, which is all that a circular structure could tell a
- * reader anyway.
+ * useful rendering falls back to its type name, which is all that a function or a circular structure
+ * could tell a reader anyway.
  */
 export function previewValue(value: unknown): string {
   // The types `JSON.stringify` answers with `undefined` or a throw rather than a rendering.
   if (value === undefined) return 'undefined';
-  if (typeof value === 'function') return 'a function';
+  if (typeof value === 'function') return 'function';
   if (typeof value === 'symbol') return value.toString();
   if (typeof value === 'bigint') return `${value}n`;
 
@@ -36,4 +36,16 @@ export function previewValue(value: unknown): string {
   }
 
   return rendered.length > MAX_PREVIEW_LENGTH ? `${rendered.slice(0, MAX_PREVIEW_LENGTH)}...` : rendered;
+}
+
+/**
+ * Name a value by its type and its content, for a diagnostic that has to convey both.
+ *
+ * The two collapse into one when the preview already names the type, so a value of `undefined`
+ * reads as `undefined` rather than `undefined undefined`.
+ */
+export function describeValue(value: unknown): string {
+  const type = describeType(value);
+  const preview = previewValue(value);
+  return preview === type ? type : `${type} ${preview}`;
 }

--- a/packages/readyup/src/verify/checkSourceDrift.ts
+++ b/packages/readyup/src/verify/checkSourceDrift.ts
@@ -1,0 +1,40 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
+import { hashFile } from './targetHash.ts';
+
+/** Outcome of a per-kit source-staleness check. */
+export type SourceStatus =
+  | { kind: 'ok'; sourceHash: string }
+  | { kind: 'stale'; expected: string; actual: string; resolvedPath: string }
+  | { kind: 'missing'; resolvedPath: string }
+  | { kind: 'unverified' };
+
+/**
+ * Determine whether a kit's on-disk TypeScript source still matches the `sourceHash` the manifest
+ * recorded when the kit was compiled.
+ *
+ * Orthogonal to the target verdict: a kit can be stale at the source and drifted at the target at
+ * the same time, and neither verdict implies the other. Returns `unverified` when the entry records
+ * no source or no hash (it predates the feature, or was written with `--skip-manifest`), `missing`
+ * when the recorded source is gone, `stale` when the hashes differ, and `ok` when they match.
+ */
+export function checkSourceDrift(kit: RdyManifestKit, manifestDir: string): SourceStatus {
+  if (kit.sourceHash === undefined || kit.source === undefined) {
+    return { kind: 'unverified' };
+  }
+
+  const resolvedPath = path.resolve(manifestDir, kit.source);
+
+  if (!existsSync(resolvedPath)) {
+    return { kind: 'missing', resolvedPath };
+  }
+
+  const actual = hashFile(resolvedPath);
+  if (actual !== kit.sourceHash) {
+    return { kind: 'stale', expected: kit.sourceHash, actual, resolvedPath };
+  }
+
+  return { kind: 'ok', sourceHash: actual };
+}

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -72,7 +72,7 @@ export function verifyCommand(args: string[]): number {
 
   if (manifest.kits.length === 0) {
     writeHuman('  (no kits in manifest)\n', json);
-    return finishVerify([], json);
+    return finishVerify([], true, json);
   }
 
   const entries: JsonVerifyKitEntry[] = [];
@@ -81,9 +81,8 @@ export function verifyCommand(args: string[]): number {
     const status = checkDrift(kit, manifestDir);
     const sourceStatus = checkSourceDrift(kit, manifestDir);
     writeHuman(formatStatusLine(kit, status, sourceStatus), json);
-    const entry = buildVerifyEntry(kit.name, status, sourceStatus);
-    entries.push(entry);
-    if (!isPassingEntry(entry)) {
+    entries.push(buildVerifyEntry(kit.name, status, sourceStatus));
+    if (!isPassingVerdict(status, sourceStatus)) {
       failed += 1;
     }
   }
@@ -92,13 +91,11 @@ export function verifyCommand(args: string[]): number {
     writeHuman(`\n${failed} of ${manifest.kits.length} kits failed verification.\n`, json);
   }
 
-  return finishVerify(entries, json);
+  return finishVerify(entries, failed === 0, json);
 }
 
-/** Emit the verify payload under `--json` and reduce the per-kit verdicts to an exit code. */
-function finishVerify(kits: JsonVerifyKitEntry[], json: boolean): number {
-  const passed = kits.every(isPassingEntry);
-
+/** Emit the verify payload under `--json` and turn the run's verdict into an exit code. */
+function finishVerify(kits: JsonVerifyKitEntry[], passed: boolean, json: boolean): number {
   if (json) {
     const output: JsonVerifyOutput = { schemaVersion: SCHEMA_VERSION, passed, kits };
     process.stdout.write(JSON.stringify(output) + '\n');
@@ -110,12 +107,16 @@ function finishVerify(kits: JsonVerifyKitEntry[], json: boolean): number {
 /**
  * Return true when neither of a kit's verdicts reports a mismatch or a missing file.
  *
+ * Reads the verdicts themselves rather than the entry serialized from them. Both are total unions,
+ * so every case is accounted for; the wire shape leaves `sourceStatus` optional for consumers that
+ * predate it, and a verdict derived from an optional field has an absent case to get wrong.
+ *
  * `unverified` passes on either axis: a manifest entry with no recorded hash predates the feature
  * or was written with `--skip-manifest`, which says nothing about whether the kit has changed.
  */
-function isPassingEntry(kit: JsonVerifyKitEntry): boolean {
-  const targetPasses = kit.status === 'ok' || kit.status === 'unverified';
-  const sourcePasses = kit.sourceStatus === 'ok' || kit.sourceStatus === 'unverified';
+function isPassingVerdict(status: DriftStatus, sourceStatus: SourceStatus): boolean {
+  const targetPasses = status.kind === 'ok' || status.kind === 'unverified';
+  const sourcePasses = sourceStatus.kind === 'ok' || sourceStatus.kind === 'unverified';
   return targetPasses && sourcePasses;
 }
 

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -14,17 +14,28 @@ import { translateParseArgsError } from '../utils/parse-args-error.ts';
 import { writeHuman } from '../writeHuman.ts';
 import type { DriftStatus } from './checkDrift.ts';
 import { checkDrift } from './checkDrift.ts';
+import type { SourceStatus } from './checkSourceDrift.ts';
+import { checkSourceDrift } from './checkSourceDrift.ts';
 
 const verifyOptions = {
   json: { type: 'boolean' },
   manifest: { type: 'string' },
 } as const;
 
+// A line's icon is the worse of the kit's two verdicts. The mismatch icon carries a trailing space
+// because its variation selector renders one column narrower than the others.
+const ICON_OK = '✅';
+const ICON_MISMATCH = '⚠️ ';
+const ICON_MISSING = '❓';
+const ICON_UNVERIFIED = '➖';
+
 /**
- * Handle the `verify` subcommand: read the manifest, hash each compiled kit, and report drift.
+ * Handle the `verify` subcommand: read the manifest, hash each kit's source and compiled output,
+ * and report what no longer matches.
  *
- * Returns 0 when every kit is `ok` or `unverified`; 1 when any kit has `drift` or `missing`.
- * An unreadable manifest is a config failure and is thrown rather than reported as drift.
+ * Each kit carries two independent verdicts. Returns 0 when both are `ok` or `unverified` for every
+ * kit; 1 when any kit has drifted, gone stale, or lost a file. An unreadable manifest is a config
+ * failure and is thrown rather than reported as drift.
  */
 export function verifyCommand(args: string[]): number {
   let parsed;
@@ -68,9 +79,11 @@ export function verifyCommand(args: string[]): number {
   let failed = 0;
   for (const kit of manifest.kits) {
     const status = checkDrift(kit, manifestDir);
-    writeHuman(formatStatusLine(kit, status), json);
-    entries.push(buildVerifyEntry(kit.name, status));
-    if (status.kind === 'drift' || status.kind === 'missing') {
+    const sourceStatus = checkSourceDrift(kit, manifestDir);
+    writeHuman(formatStatusLine(kit, status, sourceStatus), json);
+    const entry = buildVerifyEntry(kit.name, status, sourceStatus);
+    entries.push(entry);
+    if (!isPassingEntry(entry)) {
       failed += 1;
     }
   }
@@ -82,14 +95,9 @@ export function verifyCommand(args: string[]): number {
   return finishVerify(entries, json);
 }
 
-/**
- * Emit the verify payload under `--json` and reduce the per-kit verdicts to an exit code.
- *
- * `unverified` does not fail the run: a manifest entry with no recorded hash predates the feature
- * or was written with `--skip-manifest`, which says nothing about whether the kit has drifted.
- */
+/** Emit the verify payload under `--json` and reduce the per-kit verdicts to an exit code. */
 function finishVerify(kits: JsonVerifyKitEntry[], json: boolean): number {
-  const passed = kits.every((kit) => kit.status === 'ok' || kit.status === 'unverified');
+  const passed = kits.every(isPassingEntry);
 
   if (json) {
     const output: JsonVerifyOutput = { schemaVersion: SCHEMA_VERSION, passed, kits };
@@ -99,24 +107,82 @@ function finishVerify(kits: JsonVerifyKitEntry[], json: boolean): number {
   return passed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
 }
 
-/** Build a kit's JSON entry, carrying the two hashes only on a verdict that compared them. */
-function buildVerifyEntry(name: string, status: DriftStatus): JsonVerifyKitEntry {
-  if (status.kind === 'drift') {
-    return { name, status: 'drift', expected: status.expected, actual: status.actual };
-  }
-  return { name, status: status.kind };
+/**
+ * Return true when neither of a kit's verdicts reports a mismatch or a missing file.
+ *
+ * `unverified` passes on either axis: a manifest entry with no recorded hash predates the feature
+ * or was written with `--skip-manifest`, which says nothing about whether the kit has changed.
+ */
+function isPassingEntry(kit: JsonVerifyKitEntry): boolean {
+  const targetPasses = kit.status === 'ok' || kit.status === 'unverified';
+  const sourcePasses = kit.sourceStatus === 'ok' || kit.sourceStatus === 'unverified';
+  return targetPasses && sourcePasses;
 }
 
-/** Format a single per-kit status line for the verify report. */
-function formatStatusLine(kit: RdyManifestKit, status: DriftStatus): string {
+/** Build a kit's JSON entry, carrying a pair of hashes only on a verdict that compared them. */
+function buildVerifyEntry(name: string, status: DriftStatus, sourceStatus: SourceStatus): JsonVerifyKitEntry {
+  return {
+    name,
+    status: status.kind,
+    ...(status.kind === 'drift' && { expected: status.expected, actual: status.actual }),
+    sourceStatus: sourceStatus.kind,
+    ...(sourceStatus.kind === 'stale' && {
+      sourceExpected: sourceStatus.expected,
+      sourceActual: sourceStatus.actual,
+    }),
+  };
+}
+
+/**
+ * Format a single per-kit line, appending the source verdict only when it has news.
+ *
+ * A source that is `ok`, or that no manifest entry describes, leaves the line saying exactly what it
+ * said before the source verdict existed: the reader's attention belongs on whatever changed.
+ */
+function formatStatusLine(kit: RdyManifestKit, status: DriftStatus, sourceStatus: SourceStatus): string {
+  const clauses = [describeDriftStatus(kit, status)];
+  const sourceClause = describeSourceStatus(kit, sourceStatus);
+  if (sourceClause !== undefined) clauses.push(sourceClause);
+  return `  ${resolveIcon(status, sourceStatus)} ${kit.name} — ${clauses.join('; ')}\n`;
+}
+
+/**
+ * Pick the icon for a kit's line from the worse of its two verdicts.
+ *
+ * A missing file outranks a hash mismatch: one of the artifacts the manifest describes is not there
+ * at all. `unverified` shows only when it is the whole story, since a target verified against its
+ * hash is not made less verified by a source the manifest never recorded.
+ */
+function resolveIcon(status: DriftStatus, sourceStatus: SourceStatus): string {
+  if (status.kind === 'missing' || sourceStatus.kind === 'missing') return ICON_MISSING;
+  if (status.kind === 'drift' || sourceStatus.kind === 'stale') return ICON_MISMATCH;
+  if (status.kind === 'unverified') return ICON_UNVERIFIED;
+  return ICON_OK;
+}
+
+/** Describe the compiled-output verdict, the clause every line carries. */
+function describeDriftStatus(kit: RdyManifestKit, status: DriftStatus): string {
   switch (status.kind) {
     case 'ok':
-      return `  ✅ ${kit.name} — ok\n`;
+      return 'ok';
     case 'drift':
-      return `  ⚠️  ${kit.name} — drift (expected ${status.expected}, got ${status.actual})\n`;
+      return `drift (expected ${status.expected}, got ${status.actual})`;
     case 'missing':
-      return `  ❓ ${kit.name} — compiled file missing (expected ${kit.path ?? '<no path>'})\n`;
+      return `compiled file missing (expected ${kit.path ?? '<no path>'})`;
     case 'unverified':
-      return `  ➖ ${kit.name} — unverified (no targetHash in manifest)\n`;
+      return 'unverified (no targetHash in manifest)';
+  }
+}
+
+/** Describe the source verdict, or nothing when it has no news to add. */
+function describeSourceStatus(kit: RdyManifestKit, status: SourceStatus): string | undefined {
+  switch (status.kind) {
+    case 'stale':
+      return `source stale (expected ${status.expected}, got ${status.actual})`;
+    case 'missing':
+      return `source file missing (expected ${kit.source ?? '<no source>'})`;
+    case 'ok':
+    case 'unverified':
+      return undefined;
   }
 }


### PR DESCRIPTION
## What

Kits are now validated when they load, and a malformed check fails the whole kit at both compile and run. Previously such a kit ran, with the bad check silently disabled and unable to fail anything.

readyup now tracks each compiled kit back to the TypeScript source it was built from. `rdy verify` now fails a kit whose source has been edited without a recompile, and `rdy run` warns when the two have parted.

## Why

A kit could be wrong in ways nothing reported. A misspelled severity dropped its check from both the failure and the reporting thresholds, so the check ran, printed, and could never fail a deployment -- precisely the failure a verification tool exists to prevent. Nothing connected a compiled kit back to the TypeScript it came from either, so a run could execute checks that no longer matched the source in the repo, and neither the run nor `rdy verify` would say so.

## Details

### 🎉 Features

- Checks are validated recursively wherever they appear: a checklist's `checks`, a staged checklist's `groups`, its `preconditions`, and the `checks` nested under another check. Unknown extra keys still pass, so a kit written for a later readyup still loads.
- All three load paths share the validator, so `rdy compile` structurally cannot publish a kit `rdy run` would reject.
- A validation failure names the kit and gives one located line per offending value, in place of a raw schema dump.
- `rdy compile` records a hash of each kit's TypeScript source beside the hash of the bundle it produced. The manifest format stays at version 1: the field is optional, and a manifest written by an earlier readyup still loads. A kit skipped for drift, or one that failed to compile, keeps the entry it already had.
- `rdy verify` reports a source verdict per kit, independent of the target verdict, so a kit can be reported stale at the source and drifted at the target at once. Under `--json` each kit gains `sourceStatus` (`ok`, `stale`, `missing`, or `unverified`), with `sourceExpected` and `sourceActual` on a stale verdict. The field is optional and `schemaVersion` stays at 1, so a consumer pinned to `verify.v1.json` still validates payloads from an earlier readyup. A manifest recording no source hash reports `unverified` and passes, so upgrading readyup does not fail a run until the next compile.
- `rdy run` raises `target-drift` and `source-stale` warnings, on stderr in either output mode and under `warnings` in the JSON report. Both are advisory: `rdy verify` remains the enforcing gate, and neither changes the exit code. They are silent when there is no manifest, when no entry describes the kit being run, when the entry records no hashes, when a file they would hash cannot be read, and for `--url` and `--jit` sources.
- Tightened validation is behavior-changing: a kit that previously loaded and ran now fails if it carries a typo'd severity, a non-function `check`, or a `skip` returning `undefined`.

### 🐛 Bug fixes

- A check returning anything other than a boolean or an object with a boolean `ok` reports as a defect in the check, at severity `error`, naming what came back. It previously counted as an ordinary failure carrying no diagnostic, and an object whose `ok` was truthy but not a boolean counted as a pass. A `skip` returning anything other than `false` or a reason string is reported the same way.
- A severity outside `error`, `warn`, and `recommend` stops the run rather than comparing as unranked, which had excluded the check from both thresholds. This reaches only a kit that bypassed validation.
- A checklist carrying `checks: undefined` beside a populated `groups`, or the mirror, is rejected as "cannot have both". It previously passed validation, was classified as flat because that turns on key presence rather than on the value held, and failed the run with `Cannot read properties of undefined` naming neither the kit nor the location.
- `rdy verify` derives each kit's pass verdict from the two verdicts themselves rather than from the entry serialized for the JSON payload, where an absent optional `sourceStatus` would have read as a failure.
- A staleness check that cannot read a file it would hash no longer costs the run its kit. The run completes and reports its results while the advisory stays quiet about that file; `rdy verify` still fails on the same condition.

### 🧪 Tests

- Precondition gating semantics are locked in by severity-parameterized gating tests and not-applicable non-gating tests, flat and staged.
- Source-staleness detection and `rdy verify` are exercised against the real filesystem, writing a matching source/output pair and then editing or deleting the source.
- The advisory's silence suite covers every condition the README claims.

### ⚙️ Tooling

- The repo's own manifest carries the demo kit's source hash, so `rdy verify` reports it as verified rather than unverified.

### 📚 Documentation

- New README sections on kit validation, the staleness model, and advisory warnings; the Verify section is rewritten.
- Precondition semantics are stated with the reasoning behind each rule: a failed precondition gates every check in the checklist regardless of the severity it declares, and a precondition skipped as not applicable does not gate at all. A `recommend` precondition that fails therefore skips the checklist and still exits 0, since severity decides whether the run fails and the gate decides whether the checks are worth running. Authors wanting a conditionally inapplicable checklist are pointed at a single parent check whose `skip` returns a reason.
- The README names the manifest `rdy run` consults, `.readyup/manifest.json` under the current working directory, and states that a kit reached through `--from` resolves under another root whose manifest the run never reads.

Closes #120
