### PR TITLE
#121 Unify command output under one layout engine and vocabulary

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -357,6 +357,7 @@ Each section names the command that runs the kits beneath it, on its own line so
 
 ```
 ── Manifest: .readyup/manifest.json
+
 📦 deploy (readyup v0.22.0) · Pre-deployment checks
 📦 smoke (readyup v0.22.0)
 ```

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -63,6 +63,29 @@ rdy compile
 rdy run
 ```
 
+Compiling reports what it rebuilt:
+
+```
+── Compiling kits in .readyup/kits
+
+🟢 default.ts -> 📦 default.js
+```
+
+Running reports what it found. With `NODE_ENV` unset, the starter check fails and its remediation is recapped at the end, attributed to the check that raised it:
+
+```
+🔴 environment variables set
+
+🔴 1 error (0ms)
+
+── Fixes
+
+💊 environment variables set
+   Set NODE_ENV before deploying
+```
+
+The failed line carries only its claim, because this check reports no reason of its own -- it returns a bare `false`. Returning a `detail` instead is what puts an explanation beneath the claim; see [the `detail` contract](#the-detail-contract).
+
 `rdy compile` bundles `.readyup/kits/default.ts` into `.readyup/kits/default.js`, and `rdy run` loads that compiled kit. Recompile whenever the source changes.
 
 To skip compiling and run straight from the TypeScript source, use `rdy run --jit`. It reads the same `.readyup/kits/default.ts` and needs no compiled bundle, which makes it the faster loop while you are still writing checks. Compiled kits stay the vetted artifact: they are what `rdy verify` hashes and what a consumer running `rdy run --from` gets.
@@ -86,22 +109,82 @@ rdy <command> [options]
 
 ### Run options
 
-| Option                        | Description                                                   |
-| ----------------------------- | ------------------------------------------------------------- |
-| `--from <source>`             | Kit source (see [kit sources](#kit-sources) below)            |
-| `--file, -f <path>`           | Path to a local kit file                                      |
-| `--url <url>`                 | Fetch kit from a URL                                          |
-| `--jit`                       | Run from TypeScript source instead of compiled JS             |
-| `--internal`                  | Use internal kit directory and infix from config              |
-| `--checklists, -c <name,...>` | Filter checklists within the selected kit                     |
-| `--json`                      | Output results as JSON                                        |
-| `--detail <summary\|full>`    | How much of the JSON report to emit (default: `full`)         |
-| `--fail-on <severity>`        | Fail on this severity or above (`error`, `warn`, `recommend`) |
-| `--report-on <severity>`      | Show this severity or above (`error`, `warn`, `recommend`)    |
+| Option                        | Description                                                    |
+| ----------------------------- | -------------------------------------------------------------- |
+| `--from <source>`             | Kit source (see [kit sources](#kit-sources) below)             |
+| `--file, -f <path>`           | Path to a local kit file                                       |
+| `--url <url>`                 | Fetch kit from a URL                                           |
+| `--jit`                       | Run from TypeScript source instead of compiled JS              |
+| `--internal`                  | Use internal kit directory and infix from config               |
+| `--checklists, -c <name,...>` | Filter checklists within the selected kit                      |
+| `--json`                      | Output results as JSON                                         |
+| `--detail <summary\|full>`    | How much of the JSON report to emit (default: `full`)          |
+| `--fail-on <severity>`        | Fail on this severity or above (`error`, `warn`, `recommend`)  |
+| `--quiet`                     | Hide passed checks from the report; incompatible with `--json` |
+| `--report-on <severity>`      | Show this severity or above (`error`, `warn`, `recommend`)     |
 
 `--checklists` selects checklists within one kit. Pair it with a single positional kit, with `--file` or `--url`, or with no kit at all to filter the default kit. Naming two or more kits, or naming one that already carries a `:checklist` filter, is an error rather than a merge.
 
 `--report-on` prunes only the reported detail tree, and keeps the parent checks of anything it shows so nesting stays intact. Summary counts, worst severity, and the exit code always reflect the whole run.
+
+`--quiet` hides passed check lines from the human report, keeping failures, skips, blocks, the fix recap, and every count line. It filters by status where `--report-on` filters by severity, so the two compose rather than override, and both keep the parent checks of anything they show: a failure nested under passing parents stays reachable through them. Counts and the exit code still cover the whole run. Because it changes only the human report, pairing it with `--json` is a usage error rather than a silently ignored flag.
+
+### Reading the output
+
+Every command renders through one layout engine, so a line means the same thing wherever it appears.
+
+| Token | Meaning                                                         |
+| ----- | --------------------------------------------------------------- |
+| 🟢    | passed; `verify` ok; a file created, overwritten, or up to date |
+| 🔴    | failed at `error` severity; `verify` drift or missing           |
+| 🟠    | failed at `warn` severity; a compile drift-skip                 |
+| 🟡    | failed at `recommend` severity                                  |
+| ⚪    | skipped: not applicable, already present, or no work needed     |
+| 🚫    | blocked, because a precondition failed                          |
+| 💊    | a remediation hint                                              |
+
+📄 and 📦 are not statuses. They name a thing -- a TypeScript source and a compiled bundle -- and appear mid-line in `list` and in compile's transformation lines.
+
+A check line reads `token name · detail [progress] (duration)`. The middle dot is the only detail separator, so progress takes brackets rather than a second one, and compile's transformation lines take an ASCII `->`. Durations appear from 100 ms up, never on a check that did not run, and always on a tail or total line.
+
+**A failed line carries only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. A failure that derives from its children carries no reason at all, because the subtree beneath it is already the explanation. Passes and skips keep their detail inline.
+
+Tail and total lines lead with the run's worst severity rather than its passed count, then report the counts in a fixed order -- passed, errors, warnings, recommendations, blocked, skipped -- omitting any field that is zero.
+
+Headings come from one family whose rule weight encodes level: `━━` for a kit, `──` for a checklist, a step, or a summary. When more than one checklist runs, a table follows, its rules sized to the widest row:
+
+```
+── build
+
+🟢 typecheck (343ms)
+🟢 bundle size · 42kB of a 50kB budget [84%]
+
+🟢 2 passed (343ms)
+
+── integration
+
+🟢 database reachable
+🔴 migrations applied (151ms)
+   2 migrations pending: add_users, add_index
+⚪ seed data loaded · seeding is disabled outside CI
+
+🔴 1 passed | 1 error | 1 skipped (151ms)
+
+── Fixes
+
+💊 migrations applied
+   Run `pnpm migrate` against the target database
+
+── Summary
+
+─────────────────────────────────────────────────────
+🟢 build        343ms  2 passed
+🔴 integration  151ms  1 passed | 1 error | 1 skipped
+─────────────────────────────────────────────────────
+🔴 Total: 3 passed | 1 error | 1 skipped (494ms)
+```
+
+Under `--quiet`, that run keeps everything except `typecheck`, `bundle size`, and `database reachable`.
 
 ### Advisory warnings
 
@@ -254,6 +337,30 @@ rdy list --from bitbucket:ws/repo[@ref]    List kits from a Bitbucket manifest
 rdy list --manifest <path>     List the kits a manifest file declares
 ```
 
+Each section names the command that runs the kits beneath it, on its own line so it can be copied without the label:
+
+```
+── Internal
+   rdy run --jit <name>
+
+📄 deploy
+📄 smoke
+
+── Compiled
+   rdy run <name>
+
+📦 deploy
+📦 smoke
+```
+
+`--manifest` reads a manifest instead, reporting each kit's compile-time readyup version and its description:
+
+```
+── Manifest: .readyup/manifest.json
+📦 deploy (readyup v0.22.0) · Pre-deployment checks
+📦 smoke (readyup v0.22.0)
+```
+
 A local `--from` source with no manifest beside its kits falls back to listing the compiled kits on disk, which are the same kits `rdy run --from` would resolve. Those rows carry a name and a path only; descriptions, checklist names, and versions live in the manifest that is absent. A remote source still requires one.
 
 Under `--json`, each row reports `name`, `kind` (`internal` for a TypeScript source, `compiled` for a bundle), `path`, and — for kits a manifest describes — `checklists`, `description`, and `readyupVersion`. Checklist names are read from the manifest, so listing kits never imports a compiled bundle and never runs kit code.
@@ -267,9 +374,30 @@ rdy compile                    Compile every source in the config's srcDir
 rdy compile <file>             Compile a single file
 ```
 
+A rebuilt kit names its output; one whose bundle is already current says so instead:
+
+```
+── Compiling kits in .readyup/kits
+
+🟢 deploy.ts -> 📦 deploy.js
+⚪ smoke.ts · no changes
+```
+
 A sweep runs to completion: a kit that fails to compile is reported and the next kit is tried, so one broken kit cannot hide the state of the kits that sort after it. A kit that failed is never recorded as though it had compiled, and the run exits 1. A kit that had been compiled before keeps the entry it already had, because that entry still describes the tree: a bundling failure leaves the previous output and its recorded hash untouched, and a validation failure deletes the output, which `rdy verify` then reports as missing. Dropping the entry would hide both, and would leave the next successful compile with no record to check drift against.
 
-`rdy compile` refuses to overwrite a compiled kit whose on-disk hash differs from the manifest's recorded `targetHash` — someone edited the compiled file directly. Drifted kits are reported and skipped; `--force` overwrites them anyway.
+`rdy compile` refuses to overwrite a compiled kit whose on-disk hash differs from the manifest's recorded `targetHash`; someone edited the compiled file directly. Drifted kits are reported and skipped, with the mismatch beneath the kit that carries it:
+
+```
+── Compiling kits in .readyup/kits
+
+🟠 deploy.ts
+   drift in deploy.js: expected 6f58905a, got eb104f57
+⚪ smoke.ts · no changes
+
+1 of 2 kits skipped due to drift. Re-run with --force to overwrite, or move edits into the source.
+```
+
+`--force` overwrites them anyway.
 
 Each kit's checklist names are recorded in the manifest so `rdy list` can report them without running the kit. The field is optional and absent from manifests written by earlier versions, so the manifest format stays at version 1.
 
@@ -279,6 +407,18 @@ Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `fa
 
 ```
 rdy verify                     Check compiled kits against the manifest's hashes
+```
+
+A verified kit carries nothing beyond its token; a failing one carries each verdict on the line beneath it:
+
+```
+── Verifying kits against .readyup/manifest.json
+
+🔴 deploy
+   drift (expected 6f58905a, got eb104f57)
+🟢 smoke
+
+1 of 2 kits failed verification.
 ```
 
 Each kit carries two independent verdicts, because a kit is two artifacts: the TypeScript source and the bundle compiled from it.
@@ -307,6 +447,91 @@ All helpers are type-safe identity functions that provide editor autocomplete wi
 | `defineRdyChecklist`       | Flat checklist                       |
 | `defineRdyStagedChecklist` | Staged checklist (sequential groups) |
 | `defineChecklists`         | Array of checklists                  |
+
+### The `detail` contract
+
+A check may return a `CheckOutcome` rather than a bare boolean, carrying a `detail` string and optional `progress`. One rule governs what belongs in `detail`:
+
+> **`detail` answers "why this status".**
+
+Not "what this check asserts" -- the check's `name` already says that, and repeating it in `detail` doubles the line's width without adding a fact. On a pass, `detail` reports the evidence. On a skip, it reports why the check did not apply. On a failure, it reports what went wrong, and it is the text that renders beneath the claim.
+
+Where the detail lands follows from the status, so an author writes one field and the report places it:
+
+| Status  | Where `detail` renders                                  |
+| ------- | ------------------------------------------------------- |
+| passed  | inline, after the middle dot                            |
+| skipped | inline, after the middle dot (return it from `skip`)    |
+| failed  | in a block beneath the claim, above any thrown `Error:` |
+
+Remediation is not detail. It belongs in `fix`, which is recapped at the end of the report against the check that raised it.
+
+This kit exercises all three placements at three levels of nesting:
+
+```ts
+import { defineRdyKit } from 'readyup';
+
+export default defineRdyKit({
+  checklists: [
+    {
+      name: 'release',
+      checks: [
+        {
+          name: 'working tree is clean',
+          check: () => ({ ok: true, detail: 'no uncommitted changes' }),
+        },
+        {
+          name: 'dependencies',
+          check: () => true,
+          checks: [
+            {
+              name: 'lockfile is current',
+              check: () => ({ ok: true, progress: { type: 'fraction', passedCount: 4, count: 4 } }),
+              checks: [
+                {
+                  name: 'no duplicated majors',
+                  check: () => ({ ok: false, detail: 'react resolves to both 18.3.1 and 19.0.0' }),
+                  fix: 'Run `pnpm dedupe`, then commit the lockfile',
+                },
+              ],
+            },
+            {
+              name: 'native modules rebuilt',
+              check: () => true,
+              skip: () => 'no native dependencies in this workspace',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+```
+
+It produces:
+
+```
+🟢 working tree is clean · no uncommitted changes
+🟢 dependencies
+   🟢 lockfile is current [4 of 4]
+      🔴 no duplicated majors
+         react resolves to both 18.3.1 and 19.0.0
+   ⚪ native modules rebuilt · no native dependencies in this workspace
+
+🔴 3 passed | 1 error | 1 skipped (0ms)
+
+── Fixes
+
+💊 no duplicated majors
+   Run `pnpm dedupe`, then commit the lockfile
+```
+
+Four things to read off that output:
+
+- **`dependencies` carries no reason.** It failed only because a descendant did, and the subtree beneath it is the explanation. Authoring a `detail` on a derived failure would restate what the indentation already shows.
+- **`no duplicated majors` sits at the third level, and its reason lines up under its own name** -- one indent step per level, so a reason is never mistaken for a check.
+- **No check line carries a duration.** Every check here returns immediately, and durations appear only from 100 ms up, so a fast report is not littered with `(0ms)`. The tail line shows the run's total regardless.
+- **`progress` needs no `detail`.** `[4 of 4]` is the evidence; a detail restating it would spend the line's one separator to say the same thing twice.
 
 ### Preconditions
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -22,7 +22,7 @@ rdy init
 
 This creates two files:
 
-**`.config/readyup.config.ts`** — repo-level settings:
+**`.config/readyup.config.ts`** -- repo-level settings:
 
 ```ts
 import { defineRdyConfig } from 'readyup';
@@ -35,7 +35,7 @@ export default defineRdyConfig({
 });
 ```
 
-**`.readyup/kits/default.ts`** — starter kit:
+**`.readyup/kits/default.ts`** -- starter kit:
 
 ```ts
 import { defineRdyKit } from 'readyup';
@@ -143,11 +143,11 @@ Every command renders through one layout engine, so a line means the same thing 
 | 🚫    | blocked, because a precondition failed                          |
 | 💊    | a remediation hint                                              |
 
-📄 and 📦 are not statuses. They name a thing -- a TypeScript source and a compiled bundle -- and appear mid-line in `list` and in compile's transformation lines.
+📄 and 📦 are noun glyphs, not statuses: they name a TypeScript source and a compiled bundle. They lead the line in `list`, where a row names a kit instead of reporting an outcome, and sit mid-line in compile's transformation lines. Both declare the same width as every status token, which is what makes the leading position safe.
 
 A check line reads `token name · detail [progress] (duration)`. The middle dot is the only detail separator, so progress takes brackets rather than a second one, and compile's transformation lines take an ASCII `->`. Durations appear from 100 ms up, never on a check that did not run, and always on a tail or total line.
 
-**A failed line carries only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. A failure that derives from its children carries no reason at all, because the subtree beneath it is already the explanation. Passes and skips keep their detail inline.
+**A failed line carries only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. A failed check that authored neither renders no reason block at all. Passes and skips keep their detail inline.
 
 Tail and total lines lead with the run's worst severity rather than its passed count, then report the counts in a fixed order -- passed, errors, warnings, recommendations, blocked, skipped -- omitting any field that is zero.
 
@@ -206,7 +206,7 @@ The staleness warnings are silent when that manifest is absent, when no entry in
 | `1`  | Ran and found problems with the repo or its kits: failed checks, a `verify` drift or missing kit, a kit that fails to compile |
 | `2`  | Could not complete the invocation: a usage, config, kit-load, or internal error                                               |
 
-The distinction is between "fix the repo" (`1`) and "fix the invocation" (`2`), so a pipeline can branch on which is which. `rdy list` and `rdy init` produce only `0` and `2` — neither can find problems to report.
+The distinction is between "fix the repo" (`1`) and "fix the invocation" (`2`), so a pipeline can branch on which is which. `rdy list` and `rdy init` produce only `0` and `2` -- neither can find problems to report.
 
 A run that loses a kit part-way exits `2` even when the kits that ran also found problems, since part of the invocation did not complete. It still reports what it collected.
 
@@ -214,7 +214,7 @@ A run that loses a kit part-way exits `2` even when the kits that ran also found
 
 `run`, `compile`, `list`, and `verify` all accept `--json`. `init` does not: scaffolding is interactive and stays human-only.
 
-With `--json`, stdout carries exactly one JSON document and every human-readable line — headers, progress, warnings, errors — goes to stderr. The exceptions are `--help` and `--version`, which have no JSON form: their text goes to stderr and stdout stays empty.
+With `--json`, stdout carries exactly one JSON document and every human-readable line -- headers, progress, warnings, errors -- goes to stderr. The exceptions are `--help` and `--version`, which have no JSON form: their text goes to stderr and stdout stays empty.
 
 #### Published schemas
 
@@ -235,7 +235,7 @@ The schemas are generated from the same definitions the exported `Json*` TypeScr
 The five payloads version independently: reshaping the report leaves a consumer pinned to `list.v1.json` untouched.
 
 - **Adding an optional field does not bump `schemaVersion`.** The schemas do not constrain properties they have not heard of, so a validator pinned to `v1` keeps accepting payloads from a later readyup that added one.
-- **Removing, renaming, or re-typing a field does bump it**, and publishes a new `vN` file beside the old one. Widening a closed set of values — an error `code`, a check `status` — counts as re-typing.
+- **Removing, renaming, or re-typing a field does bump it**, and publishes a new `vN` file beside the old one. Widening a closed set of values -- an error `code`, a check `status` -- counts as re-typing.
 - **A field is `required` only when every payload carries it.** Omission is reserved for genuinely absent or empty data, so a present field never means "nothing here".
 - **`warnings[].code` is an open set**, exempt from the widening rule above: the schema accepts a known code or any other string, so a newly raised advisory never bumps the version. Consumers must tolerate a code they have not heard of, displaying its `message` and `remedy` as they would any other. `error.code` stays closed, because an unknown error code leaves a consumer with no branch to select, and that is a break worth announcing.
 
@@ -285,7 +285,7 @@ An error entry carries no counts and no verdict, because a kit that never ran ha
 
 - **`passed`** is the run verdict: true when every requested kit produced results and every kit passed under its own `failOn`, so it agrees with exit code 0 in every case. Kit and checklist entries carry their own `passed`, which means the narrower "nothing at or above this kit's `failOn` failed here".
 - **`counts`** holds the six result tallies at the report, kit, and checklist levels. They nest rather than sitting flat so the count names and the verdict names share no namespace, which is what makes the additive-evolution rule above sound rather than merely conventional.
-- **`worstSeverity`** sits beside `counts` — it is derived verdict data, not a count — and is omitted when nothing failed.
+- **`worstSeverity`** sits beside `counts` -- it is derived verdict data, not a count -- and is omitted when nothing failed.
 - **`failOn`** and **`reportOn`** appear in two places, answering two different questions. At the top level they report what the invocation _requested_, so each is present only when you passed the flag: absence means "not requested", never "defaulted". On each kit that ran they report the threshold that _governed_ it, resolved as CLI flag, then the kit's own declaration, then the default, and both are always present there. The two differ whenever a kit declares its own, which is also why a kit's verdict cannot be recomputed from a run-level value and why a multi-kit run needs one threshold per kit rather than one for the report.
 - **`detail`** has no per-kit form, so requested and effective are the same value and it is always present at the top level.
 - **`warnings`** carries any advisory the run raised, as `{ code, message, remedy? }`. Warnings keep their stderr line in both modes; under `--json` they are captured here as well, because a consumer that owns only stdout would otherwise never see them. The field is absent when the run raised none.
@@ -294,7 +294,7 @@ Payloads are slim by construction: a field carrying nothing is omitted rather th
 
 #### Choosing how much detail to receive
 
-`--detail summary` keeps the counts, verdicts, and worst severity but reduces the detail tree to the checks that failed and the fixes they carry — the shape an agent needs to decide what to do next, at a fraction of the tokens. `--detail full` is the default and keeps every reported check.
+`--detail summary` keeps the counts, verdicts, and worst severity but reduces the detail tree to the checks that failed and the fixes they carry -- the shape an agent needs to decide what to do next, at a fraction of the tokens. `--detail full` is the default and keeps every reported check.
 
 ```bash
 rdy run --json --detail summary
@@ -363,7 +363,7 @@ Each section names the command that runs the kits beneath it, on its own line so
 
 A local `--from` source with no manifest beside its kits falls back to listing the compiled kits on disk, which are the same kits `rdy run --from` would resolve. Those rows carry a name and a path only; descriptions, checklist names, and versions live in the manifest that is absent. A remote source still requires one.
 
-Under `--json`, each row reports `name`, `kind` (`internal` for a TypeScript source, `compiled` for a bundle), `path`, and — for kits a manifest describes — `checklists`, `description`, and `readyupVersion`. Checklist names are read from the manifest, so listing kits never imports a compiled bundle and never runs kit code.
+Under `--json`, each row reports `name`, `kind` (`internal` for a TypeScript source, `compiled` for a bundle), `path`, and -- for kits a manifest describes -- `checklists`, `description`, and `readyupVersion`. Checklist names are read from the manifest, so listing kits never imports a compiled bundle and never runs kit code.
 
 Rows are keyed by `name` and `kind` together, not by `name` alone. Under the default configuration both the internal source directory and the compile output directory resolve to `.readyup/kits`, so a compiled source appears twice: once as `internal`, which `rdy run --jit <name>` runs, and once as `compiled`, which `rdy run <name>` runs. Both rows are meaningful, so a consumer indexing on `name` alone silently drops one of them.
 
@@ -528,7 +528,7 @@ It produces:
 
 Four things to read off that output:
 
-- **`dependencies` carries no reason.** It failed only because a descendant did, and the subtree beneath it is the explanation. Authoring a `detail` on a derived failure would restate what the indentation already shows.
+- **`dependencies` passed, which is why anything beneath it ran at all.** A check that fails blocks its descendants, so they report 🚫 without running. The 🔴 on `no duplicated majors` is reachable only because both checks above it passed, and a failing descendant is what turns the tail line red while every ancestor stays green.
 - **`no duplicated majors` sits at the third level, and its reason lines up under its own name** -- one indent step per level, so a reason is never mistaken for a check.
 - **No check line carries a duration.** Every check here returns immediately, and durations appear only from 100 ms up, so a fast report is not littered with `(0ms)`. The tail line shows the run's total regardless.
 - **`progress` needs no `detail`.** `[4 of 4]` is the evidence; a detail restating it would spend the line's one separator to say the same thing twice.
@@ -596,9 +596,9 @@ import { fileExists, fileContains, hasPackageJsonField } from 'readyup/check-uti
 
 ### Discovering workspaces
 
-`discoverWorkspaces()` returns a uniform `Workspace[]` that collapses pnpm, npm, and yarn monorepo conventions — and single-workspace repos — into one iteration shape. Every entry includes `dir` (relative to `cwd`; `'.'` for a single-workspace repo), `absolutePath`, `name`, `isPackage` (true when `package.json.private !== true`), and the parsed `packageJson`.
+`discoverWorkspaces()` returns a uniform `Workspace[]` that collapses pnpm, npm, and yarn monorepo conventions -- and single-workspace repos -- into one iteration shape. Every entry includes `dir` (relative to `cwd`; `'.'` for a single-workspace repo), `absolutePath`, `name`, `isPackage` (true when `package.json.private !== true`), and the parsed `packageJson`.
 
-Common filter pattern — get all publishable workspaces:
+Common filter pattern -- get all publishable workspaces:
 
 ```ts
 import { discoverWorkspaces } from 'readyup/check-utils';
@@ -610,9 +610,9 @@ Note: `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs 
 
 ### Reading runtime alignment
 
-`readTsconfigLanguageLevel(path)` reports what language level a tsconfig actually declares, which may be several `extends` hops away. Alongside `lib` and `target` — lowercased, so comparisons are string equality — it returns `chain`, the configs it read with the entry file first, and `unresolvedExtends`, the references it could not follow. Bare package specifiers such as `@tsconfig/node24/tsconfig.json` are never followed, and a missing or unparseable parent ends that branch of the walk; both land in `unresolvedExtends`, so a check can tell an incomplete answer from a genuinely undeclared setting. A missing or unparseable entry file returns `undefined`. Configs are read as JSONC, so comments and trailing commas are fine.
+`readTsconfigLanguageLevel(path)` reports what language level a tsconfig actually declares, which may be several `extends` hops away. Alongside `lib` and `target` -- lowercased, so comparisons are string equality -- it returns `chain`, the configs it read with the entry file first, and `unresolvedExtends`, the references it could not follow. Bare package specifiers such as `@tsconfig/node24/tsconfig.json` are never followed, and a missing or unparseable parent ends that branch of the walk; both land in `unresolvedExtends`, so a check can tell an incomplete answer from a genuinely undeclared setting. A missing or unparseable entry file returns `undefined`. Configs are read as JSONC, so comments and trailing commas are fine.
 
-`readEnginesNodeFloor(manifest)` recognizes only the range forms from which a single floor follows: `>=24`, `^22.1`, and a bare `24.1.0`. Anything else — a union such as `^20 || ^22`, a hyphen range, a wildcard — comes back as `{ kind: 'unparseable' }` rather than an invented floor. It takes an already-parsed manifest, so it composes with `discoverWorkspaces` without re-reading files.
+`readEnginesNodeFloor(manifest)` recognizes only the range forms from which a single floor follows: `>=24`, `^22.1`, and a bare `24.1.0`. Anything else -- a union such as `^20 || ^22`, a hyphen range, a wildcard -- comes back as `{ kind: 'unparseable' }` rather than an invented floor. It takes an already-parsed manifest, so it composes with `discoverWorkspaces` without re-reading files.
 
 `satisfiesNodeFloor(version, floor)` compares two dotted numeric versions and returns `undefined` for anything else. That matters because `readToolVersionsNode` reports whatever the file names, and `lts`, `latest`, `system`, and `ref:<git ref>` are all valid pins: without the `undefined`, an unreadable pin would be indistinguishable from a runtime that genuinely sits below the floor.
 
@@ -643,7 +643,7 @@ const findings = discoverWorkspaces().flatMap(({ dir, packageJson }) => {
 
 `readyup/check-utils` is the stable, versioned surface for kit-author imports of check utilities. It follows semver: no breaking changes within a major version.
 
-Compiled kits embed nothing of readyup itself — the runner satisfies `readyup` and `readyup/*` imports at runtime via its module-resolution hook. Kits are therefore version-coupled to the runner across breaking boundaries: when you upgrade readyup across a major, recompile your kits with `rdy compile` so any newly-shipped or changed check utilities are picked up.
+Compiled kits embed nothing of readyup itself -- the runner satisfies `readyup` and `readyup/*` imports at runtime via its module-resolution hook. Kits are therefore version-coupled to the runner across breaking boundaries: when you upgrade readyup across a major, recompile your kits with `rdy compile` so any newly-shipped or changed check utilities are picked up.
 
 ## License
 

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -925,8 +925,8 @@ describe(runCommand, () => {
     });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(allOutput).toContain('--- deploy ---');
-    expect(allOutput).toContain('--- infra ---');
+    expect(allOutput).toContain('\u{2500}\u{2500} deploy');
+    expect(allOutput).toContain('\u{2500}\u{2500} infra');
   });
 
   it('does not show checklist headers for a single checklist', async () => {
@@ -959,8 +959,8 @@ describe(runCommand, () => {
     });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(allOutput).toContain('=== kit1 ===');
-    expect(allOutput).toContain('=== kit2 ===');
+    expect(allOutput).toContain('\u{2501}\u{2501} kit1');
+    expect(allOutput).toContain('\u{2501}\u{2501} kit2');
   });
 
   it('does not print combined summary when running multiple kits', async () => {

--- a/packages/readyup/__tests__/cli.test.ts
+++ b/packages/readyup/__tests__/cli.test.ts
@@ -432,6 +432,36 @@ describe(parseRunArgs, () => {
   });
 });
 
+describe('--quiet', () => {
+  it('parses as a boolean', () => {
+    expect(parseRunArgs(['--quiet']).quiet).toBe(true);
+  });
+
+  it('defaults to false', () => {
+    expect(parseRunArgs([]).quiet).toBe(false);
+  });
+
+  it('rejects --quiet with --json rather than ignoring it', () => {
+    expect(() => parseRunArgs(['--quiet', '--json'])).toThrow(
+      '--quiet cannot be combined with --json; it hides passed lines from human output only',
+    );
+  });
+
+  it('composes with --report-on, which filters on a different axis', () => {
+    const parsed = parseRunArgs(['--quiet', '--report-on', 'warn']);
+
+    expect(parsed.quiet).toBe(true);
+    expect(parsed.reportOn).toBe('warn');
+  });
+
+  it('composes with a kit selection', () => {
+    const parsed = parseRunArgs(['--quiet', 'deploy']);
+
+    expect(parsed.quiet).toBe(true);
+    expect(parsed.kitSpecifiers).toStrictEqual([{ kitName: 'deploy', checklists: [] }]);
+  });
+});
+
 describe(resolveKitSources, () => {
   /** Build args with defaults for internal config. */
   function resolve(

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -64,6 +64,9 @@ import { VERSION } from '../src/version.ts';
 import { captureRdyError } from './helpers/captureRdyError.ts';
 
 const ICON_NO_CHANGES = emojiFormatter.tokens.skippedOptional.glyph;
+const ICON_COMPILED = emojiFormatter.tokens.passed.glyph;
+const ICON_DRIFT = emojiFormatter.tokens.failedWarn.glyph;
+const GLYPH_OUTPUT = emojiFormatter.tokens.docCompiled.glyph;
 
 /** Metadata as `validateCompiledOutput` returns it, defaulting to a kit with no checklists to record. */
 function kitMetadata(overrides: Partial<KitMetadata> = {}): KitMetadata {
@@ -97,14 +100,14 @@ describe(compileCommand, () => {
   });
 
   // Explicit input file tests
-  it('returns 0 and writes "Compiling kit:" header for single file', async () => {
+  it('returns 0 and writes a section heading for single file', async () => {
     mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' });
 
     const exitCode = await compileCommand(['input.ts']);
 
     expect(exitCode).toBe(0);
     expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', undefined);
-    expect(stdoutSpy).toHaveBeenCalledWith('Compiling kit:\n');
+    expect(stdoutSpy).toHaveBeenCalledWith('\n\u{2500}\u{2500} Compiling kit\n\n');
   });
 
   it('shows compiled indicator for a changed single file', async () => {
@@ -112,8 +115,8 @@ describe(compileCommand, () => {
 
     await compileCommand(['input.ts']);
 
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('📦'));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('→'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_COMPILED} input.ts -> ${GLYPH_OUTPUT} `));
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('\u{2192}'));
   });
 
   it('shows no-changes indicator for an unchanged single file', async () => {
@@ -234,8 +237,8 @@ describe(compileCommand, () => {
     expect(mockCompileConfig).toHaveBeenCalledTimes(2);
     // Header + 2 status lines
     expect(stdoutSpy).toHaveBeenCalledTimes(3);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('📦 a.ts → a.js'));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_NO_CHANGES} b.ts — no changes`));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_COMPILED} a.ts -> ${GLYPH_OUTPUT} a.js`));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_NO_CHANGES} b.ts \u{00B7} no changes`));
   });
 
   it('reports a usage error when --output is given without an input file', async () => {
@@ -891,9 +894,9 @@ describe(compileCommand, () => {
     expect(exitCode).toBe(1);
     expect(mockCompileConfig).not.toHaveBeenCalled();
     expect(mockWriteManifest).not.toHaveBeenCalled();
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('⚠️'));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('skipped (drift in deploy.js'));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('expected aaaa1111, got bbbb2222'));
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      `${ICON_DRIFT} deploy.ts\n   drift in deploy.js: expected aaaa1111, got bbbb2222\n`,
+    );
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Re-run with --force'));
   });
 
@@ -947,7 +950,7 @@ describe(compileCommand, () => {
 
     expect(exitCode).toBe(1);
     expect(mockCompileConfig).toHaveBeenCalledTimes(1); // only beta compiled
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('⚠️  alpha.ts — skipped'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_DRIFT} alpha.ts\n   drift in alpha.js:`));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2 kits skipped due to drift'));
 
     const [writeManifestCall] = mockWriteManifest.mock.calls;

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -58,10 +58,12 @@ vi.mock('../src/verify/targetHash.ts', () => ({
 
 import { compileCommand } from '../src/compile/compileCommand.ts';
 import type { KitMetadata } from '../src/compile/validateCompiledOutput.ts';
+import { emojiFormatter } from '../src/layout/emojiFormatter.ts';
 import { ManifestNotFoundError } from '../src/manifest/readManifest.ts';
-import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../src/reportRdy.ts';
 import { VERSION } from '../src/version.ts';
 import { captureRdyError } from './helpers/captureRdyError.ts';
+
+const ICON_NO_CHANGES = emojiFormatter.tokens.skippedOptional.glyph;
 
 /** Metadata as `validateCompiledOutput` returns it, defaulting to a kit with no checklists to record. */
 function kitMetadata(overrides: Partial<KitMetadata> = {}): KitMetadata {

--- a/packages/readyup/__tests__/countAgreement.test.ts
+++ b/packages/readyup/__tests__/countAgreement.test.ts
@@ -67,7 +67,6 @@ describe('count agreement across views', () => {
 
     expect(counts).toStrictEqual(expectedCounts);
 
-    // One rendering of the tally now serves both views, so each must carry it verbatim.
     const expectedFields = layout.formatCounts(expectedCounts);
 
     // Human tail line.

--- a/packages/readyup/__tests__/countAgreement.test.ts
+++ b/packages/readyup/__tests__/countAgreement.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatCombinedSummary } from '../src/formatCombinedSummary.ts';
-import { countResults, formatSummaryCounts, formatSummaryCountsPlain, reportRdy } from '../src/reportRdy.ts';
+import { layout } from '../src/layout/engine.ts';
+import { countResults, reportRdy } from '../src/reportRdy.ts';
 import { runRdy } from '../src/runRdy.ts';
 import type { RdyChecklist, SummaryCounts } from '../src/types.ts';
 import { formatReport } from './helpers/formatReport.ts';
@@ -66,13 +67,16 @@ describe('count agreement across views', () => {
 
     expect(counts).toStrictEqual(expectedCounts);
 
+    // One rendering of the tally now serves both views, so each must carry it verbatim.
+    const expectedFields = layout.formatCounts(expectedCounts);
+
     // Human tail line.
     const human = reportRdy(report, { reportOn: 'error' });
-    expect(human).toContain(formatSummaryCounts(expectedCounts));
+    expect(human).toContain(expectedFields);
 
     // Combined-summary table row.
     const table = formatCombinedSummary([{ name: 'deploy', ...counts, durationMs: report.durationMs }]);
-    expect(table).toContain(formatSummaryCountsPlain(expectedCounts));
+    expect(table).toContain(expectedFields);
 
     // JSON payload: the same tally, nested under `counts` with the verdict beside it.
     const { worstSeverity, ...numericCounts } = expectedCounts;

--- a/packages/readyup/__tests__/formatCombinedSummary.test.ts
+++ b/packages/readyup/__tests__/formatCombinedSummary.test.ts
@@ -1,14 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatCombinedSummary } from '../src/formatCombinedSummary.ts';
-import {
-  ICON_ERROR_FAILED,
-  ICON_PASSED,
-  ICON_RECOMMEND_FAILED,
-  ICON_SKIPPED_PRECONDITION,
-  ICON_WARN_FAILED,
-} from '../src/reportRdy.ts';
+import { emojiFormatter } from '../src/layout/emojiFormatter.ts';
 import type { ChecklistSummary } from '../src/types.ts';
+
+const PASSED = emojiFormatter.tokens.passed.glyph;
+const FAILED_ERROR = emojiFormatter.tokens.failedError.glyph;
+const FAILED_WARN = emojiFormatter.tokens.failedWarn.glyph;
+const FAILED_RECOMMEND = emojiFormatter.tokens.failedRecommend.glyph;
 
 function makeSummary(overrides?: Partial<ChecklistSummary>): ChecklistSummary {
   return {
@@ -25,142 +24,125 @@ function makeSummary(overrides?: Partial<ChecklistSummary>): ChecklistSummary {
   };
 }
 
+/** Return the rendered lines, dropping the leading blank the heading contributes. */
+function renderLines(summaries: ChecklistSummary[]): string[] {
+  return formatCombinedSummary(summaries).split('\n');
+}
+
 describe(formatCombinedSummary, () => {
-  it('renders the summary header and footer lines', () => {
-    const output = formatCombinedSummary([makeSummary()]);
-
-    expect(output).toContain('── Summary');
-    expect(output.split('\n').at(-2)).toMatch(/^─+$/);
+  it('leads with a blank line so a caller appends it directly to the report above', () => {
+    expect(renderLines([makeSummary()])[0]).toBe('');
   });
 
-  it('shows passed prefix when worstSeverity is null', () => {
-    const output = formatCombinedSummary([makeSummary({ name: 'deploy' })]);
+  it('renders a section heading rather than a full-width banner', () => {
+    const lines = renderLines([makeSummary()]);
 
-    expect(output).toContain(`${ICON_PASSED} deploy`);
+    expect(lines[1]).toBe('\u{2500}\u{2500} Summary');
   });
 
-  it('shows error prefix when worstSeverity is error', () => {
-    const output = formatCombinedSummary([makeSummary({ name: 'deploy', errors: 1, worstSeverity: 'error' })]);
+  it('encloses the rows in two equal rules', () => {
+    const lines = renderLines([makeSummary()]);
 
-    expect(output).toContain(`${ICON_ERROR_FAILED} deploy`);
+    expect(lines[3]).toMatch(/^\u{2500}+$/u);
+    expect(lines[5]).toBe(lines[3]);
   });
 
-  it('shows warn prefix when worstSeverity is warn', () => {
-    const output = formatCombinedSummary([makeSummary({ name: 'deploy', warnings: 1, worstSeverity: 'warn' })]);
+  it.each([
+    ['nothing failed', {}, PASSED],
+    ['an error failed', { errors: 1, worstSeverity: 'error' as const }, FAILED_ERROR],
+    ['a warning failed', { warnings: 1, worstSeverity: 'warn' as const }, FAILED_WARN],
+    ['a recommendation failed', { recommendations: 1, worstSeverity: 'recommend' as const }, FAILED_RECOMMEND],
+  ])('leads a row with the worst-severity token when %s', (_case, overrides, token) => {
+    const output = formatCombinedSummary([makeSummary({ name: 'deploy', ...overrides })]);
 
-    expect(output).toContain(`${ICON_WARN_FAILED} deploy`);
+    expect(output).toContain(`${token} deploy`);
   });
 
-  it('shows recommend prefix when worstSeverity is recommend', () => {
-    const output = formatCombinedSummary([
-      makeSummary({ name: 'deploy', recommendations: 1, worstSeverity: 'recommend' }),
-    ]);
-
-    expect(output).toContain(`${ICON_RECOMMEND_FAILED} deploy`);
-  });
-
-  it('includes duration and grouped counts in each row', () => {
+  it('renders each row as name, duration, then pipe counts', () => {
     const output = formatCombinedSummary([
       makeSummary({ name: 'infra', passed: 2, errors: 1, worstSeverity: 'error', durationMs: 45 }),
     ]);
 
-    expect(output).toContain(`${ICON_ERROR_FAILED} infra  45ms  2 passed. Failed: 1 error`);
-    expect(output).not.toContain('Skipped:');
+    expect(output).toContain(`${FAILED_ERROR} infra  45ms  2 passed | 1 error`);
   });
 
-  it('omits zero-count categories from row', () => {
+  it('omits zero-count fields from a row', () => {
     const output = formatCombinedSummary([makeSummary({ name: 'deploy', passed: 5, durationMs: 200 })]);
 
-    expect(output).toContain(`${ICON_PASSED} deploy  200ms  5 passed`);
+    expect(output).toContain(`${PASSED} deploy  200ms  5 passed`);
+    expect(output).not.toContain('|');
+  });
+
+  it('includes skip fields in a row when their counts are non-zero', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ name: 'checks', passed: 1, errors: 1, blocked: 2, optional: 1, worstSeverity: 'error' }),
+    ]);
+
+    expect(output).toContain('1 passed | 1 error | 2 blocked | 1 skipped');
+  });
+
+  it('retires the prose count grammar', () => {
+    const output = formatCombinedSummary([
+      makeSummary({ name: 'infra', passed: 2, errors: 1, blocked: 1, worstSeverity: 'error' }),
+    ]);
+
     expect(output).not.toContain('Failed:');
     expect(output).not.toContain('Skipped:');
   });
 
-  it('renders the Total line with icon-prefixed grouped counts and total duration', () => {
-    const output = formatCombinedSummary([
-      makeSummary({ passed: 10, durationMs: 100 }),
-      makeSummary({
-        name: 'other',
-        passed: 5,
-        errors: 2,
-        blocked: 1,
-        worstSeverity: 'error',
-        durationMs: 200,
-      }),
-    ]);
+  describe('total line', () => {
+    it('leads with the aggregate worst severity and sums the durations', () => {
+      const output = formatCombinedSummary([
+        makeSummary({ passed: 10, durationMs: 100 }),
+        makeSummary({ name: 'other', passed: 5, errors: 2, blocked: 1, worstSeverity: 'error', durationMs: 200 }),
+      ]);
 
-    expect(output).toContain(
-      `Total: ${ICON_PASSED} 15 passed. Failed: ${ICON_ERROR_FAILED} 2 errors. Skipped: ${ICON_SKIPPED_PRECONDITION} 1 blocked (300ms)`,
-    );
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 15 passed | 2 errors | 1 blocked (300ms)`);
+    });
+
+    it('leads with the passed token when no checklist failed', () => {
+      const output = formatCombinedSummary([
+        makeSummary({ passed: 3, durationMs: 50 }),
+        makeSummary({ name: 'other', passed: 7, durationMs: 150 }),
+      ]);
+
+      expect(output.split('\n').at(-1)).toBe(`${PASSED} Total: 10 passed (200ms)`);
+    });
+
+    it('escalates to the worst severity across checklists', () => {
+      const output = formatCombinedSummary([
+        makeSummary({ name: 'only-recommend', passed: 0, recommendations: 1, worstSeverity: 'recommend' }),
+        makeSummary({ name: 'has-warn', passed: 0, warnings: 1, worstSeverity: 'warn' }),
+      ]);
+      const totalLine = output.split('\n').at(-1);
+
+      expect(totalLine?.startsWith(FAILED_WARN)).toBe(true);
+      expect(totalLine).toContain('1 warning | 1 recommendation');
+      expect(totalLine).not.toContain('passed');
+    });
+
+    it('carries no per-field tokens', () => {
+      const output = formatCombinedSummary([makeSummary({ passed: 1, errors: 1, worstSeverity: 'error' })]);
+      const totalLine = output.split('\n').at(-1) ?? '';
+
+      expect(totalLine.slice(FAILED_ERROR.length)).not.toContain(PASSED);
+    });
   });
 
-  it('omits zero-count groups from the Total line', () => {
-    const output = formatCombinedSummary([
-      makeSummary({ passed: 3, durationMs: 50 }),
-      makeSummary({ name: 'other', passed: 7, durationMs: 150 }),
-    ]);
-
-    expect(output).toContain(`Total: ${ICON_PASSED} 10 passed (200ms)`);
-    expect(output).not.toContain('Failed:');
-    expect(output).not.toContain('Skipped:');
-  });
-
-  it('right-aligns durations and left-aligns names across rows', () => {
-    const output = formatCombinedSummary([
+  it('left-aligns names and right-aligns durations across rows', () => {
+    const lines = renderLines([
       makeSummary({ name: 'ab', durationMs: 5 }),
       makeSummary({ name: 'cdef', durationMs: 1200 }),
     ]);
 
-    const rows = output.split('\n').filter((l) => l.includes('passed'));
-    // "ab" padded to length of "cdef", "5ms" padded to length of "1200ms"
-    expect(rows[0]).toContain(`${ICON_PASSED} ab       5ms`);
-    expect(rows[1]).toContain(`${ICON_PASSED} cdef  1200ms`);
+    expect(lines[4]).toContain(`${PASSED} ab       5ms`);
+    expect(lines[5]).toContain(`${PASSED} cdef  1200ms`);
   });
 
-  it('includes skip groups in row when counts are non-zero', () => {
-    const output = formatCombinedSummary([
-      makeSummary({
-        name: 'checks',
-        passed: 1,
-        errors: 1,
-        blocked: 2,
-        worstSeverity: 'error',
-        durationMs: 80,
-      }),
-    ]);
+  it('sizes the rules to the widest line rather than a fixed width', () => {
+    const narrow = renderLines([makeSummary({ name: 'a', passed: 1, durationMs: 1 })]);
+    const wide = renderLines([makeSummary({ name: 'a-considerably-longer-checklist-name', passed: 1, durationMs: 1 })]);
 
-    expect(output).toContain('1 passed. Failed: 1 error. Skipped: 2 blocked');
-  });
-
-  it('renders per-row icons reflecting each checklist worst severity', () => {
-    const output = formatCombinedSummary([
-      makeSummary({ name: 'only-recommend', recommendations: 1, worstSeverity: 'recommend', durationMs: 10 }),
-      makeSummary({ name: 'has-warn', warnings: 1, worstSeverity: 'warn', durationMs: 10 }),
-    ]);
-
-    // Per-checklist rows get worst-severity icons; the Total row itself is always
-    // prefixed with "Total:" and uses per-category icons from `formatSummaryCounts`.
-    expect(output).toContain(`${ICON_RECOMMEND_FAILED} only-recommend`);
-    expect(output).toContain(`${ICON_WARN_FAILED} has-warn`);
-  });
-
-  it('aggregates mixed-severity checklists into a single Total line with per-category icons', () => {
-    const output = formatCombinedSummary([
-      makeSummary({
-        name: 'only-recommend',
-        passed: 0,
-        recommendations: 1,
-        worstSeverity: 'recommend',
-        durationMs: 10,
-      }),
-      makeSummary({ name: 'has-warn', passed: 0, warnings: 1, worstSeverity: 'warn', durationMs: 10 }),
-    ]);
-
-    const totalLine = output.split('\n').find((l) => l.startsWith('Total:'));
-    expect(totalLine).toBeDefined();
-    // Both failure categories are summed with their own per-category icons.
-    expect(totalLine).toContain(`Failed: ${ICON_WARN_FAILED} 1 warning, ${ICON_RECOMMEND_FAILED} 1 recommendation`);
-    expect(totalLine).toContain('(20ms)');
-    expect(totalLine).not.toContain('passed');
+    expect(wide[3]?.length).toBeGreaterThan(narrow[3]?.length ?? 0);
   });
 });

--- a/packages/readyup/__tests__/formatCombinedSummary.test.ts
+++ b/packages/readyup/__tests__/formatCombinedSummary.test.ts
@@ -24,7 +24,7 @@ function makeSummary(overrides?: Partial<ChecklistSummary>): ChecklistSummary {
   };
 }
 
-/** Return the rendered lines, dropping the leading blank the heading contributes. */
+/** Returns the table's lines, the leading blank included. */
 function renderLines(summaries: ChecklistSummary[]): string[] {
   return formatCombinedSummary(summaries).split('\n');
 }

--- a/packages/readyup/__tests__/layout/emojiFormatter.test.ts
+++ b/packages/readyup/__tests__/layout/emojiFormatter.test.ts
@@ -3,10 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
 import { TOKEN_NAMES } from '../../src/layout/formatter.ts';
 
-/** The variation selector whose presence makes a glyph's rendered width terminal-dependent. */
 const VARIATION_SELECTOR_16 = '\u{FE0F}';
 
-/** Glyphs the unified vocabulary retired, each stripped of any variation selector. */
+/** Glyphs no token may use, each stripped of any variation selector. */
 const RETIRED_GLYPHS = ['\u{23ED}', '\u{2705}', '\u{26A0}', '\u{274C}', '\u{2753}', '\u{2796}'];
 
 const entries = TOKEN_NAMES.map((name) => ({ name, ...emojiFormatter.tokens[name] }));
@@ -43,9 +42,8 @@ describe('emojiFormatter', () => {
       expect(glyph).not.toContain(VARIATION_SELECTOR_16);
     });
 
-    // `Emoji_Presentation` is precisely the property that makes a code point render as a two-cell
-    // emoji unaided, so matching it proves the declared width rather than merely restating it. The
-    // anchored single-property pattern also rejects any multi-code-point sequence.
+    // `Emoji_Presentation` is the property that makes a code point occupy two cells unaided, so the
+    // match verifies the declared width. Anchoring to one property also rejects multi-code-point sequences.
     it('is one code point that renders wide unaided', () => {
       expect(glyph).toMatch(/^\p{Emoji_Presentation}$/u);
     });

--- a/packages/readyup/__tests__/layout/emojiFormatter.test.ts
+++ b/packages/readyup/__tests__/layout/emojiFormatter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
+import { TOKEN_NAMES } from '../../src/layout/formatter.ts';
+
+/** The variation selector whose presence makes a glyph's rendered width terminal-dependent. */
+const VARIATION_SELECTOR_16 = '\u{FE0F}';
+
+/** Glyphs the unified vocabulary retired, each stripped of any variation selector. */
+const RETIRED_GLYPHS = ['\u{23ED}', '\u{2705}', '\u{26A0}', '\u{274C}', '\u{2753}', '\u{2796}'];
+
+const entries = TOKEN_NAMES.map((name) => ({ name, ...emojiFormatter.tokens[name] }));
+
+describe('emojiFormatter', () => {
+  it('supplies a token for every semantic state and no others', () => {
+    expect(new Set(Object.keys(emojiFormatter.tokens))).toStrictEqual(new Set<string>(TOKEN_NAMES));
+  });
+
+  it('retires the glyphs the unified vocabulary replaced', () => {
+    const glyphs = entries.map((entry) => entry.glyph);
+
+    for (const retired of RETIRED_GLYPHS) {
+      expect(glyphs).not.toContain(retired);
+    }
+  });
+
+  it('distinguishes the heading levels by rule weight', () => {
+    expect(emojiFormatter.rules.kit).not.toBe(emojiFormatter.rules.section);
+  });
+
+  it('leaves room for a separating space after the widest token', () => {
+    const widest = Math.max(...entries.map((entry) => entry.width));
+
+    expect(emojiFormatter.gutter).toBeGreaterThan(widest);
+  });
+
+  describe.each(entries)('$name', ({ glyph, width }) => {
+    it('declares a width of two cells', () => {
+      expect(width).toBe(2);
+    });
+
+    it('carries no variation selector', () => {
+      expect(glyph).not.toContain(VARIATION_SELECTOR_16);
+    });
+
+    // `Emoji_Presentation` is precisely the property that makes a code point render as a two-cell
+    // emoji unaided, so matching it proves the declared width rather than merely restating it. The
+    // anchored single-property pattern also rejects any multi-code-point sequence.
+    it('is one code point that renders wide unaided', () => {
+      expect(glyph).toMatch(/^\p{Emoji_Presentation}$/u);
+    });
+  });
+});

--- a/packages/readyup/__tests__/layout/layoutEngine.test.ts
+++ b/packages/readyup/__tests__/layout/layoutEngine.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it } from 'vitest';
+
+import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
+import { TOKEN_NAMES, type TokenName } from '../../src/layout/formatter.ts';
+import { createLayoutEngine, resolveWorstToken, type SummaryRow } from '../../src/layout/layoutEngine.ts';
+import type { SummaryCounts } from '../../src/types.ts';
+
+/** Tokens naming a check that never ran, which therefore never carry a duration. */
+const SKIPPED_TOKENS: TokenName[] = ['blockedPrecondition', 'skippedOptional'];
+
+const engine = createLayoutEngine(emojiFormatter);
+
+const PASSED = emojiFormatter.tokens.passed.glyph;
+const FAILED_ERROR = emojiFormatter.tokens.failedError.glyph;
+const FAILED_WARN = emojiFormatter.tokens.failedWarn.glyph;
+const SKIPPED = emojiFormatter.tokens.skippedOptional.glyph;
+
+function makeCounts(overrides?: Partial<SummaryCounts>): SummaryCounts {
+  return {
+    passed: 0,
+    errors: 0,
+    warnings: 0,
+    recommendations: 0,
+    blocked: 0,
+    optional: 0,
+    worstSeverity: null,
+    ...overrides,
+  };
+}
+
+function makeRow(overrides?: Partial<SummaryRow>): SummaryRow {
+  return { name: 'checklist', counts: makeCounts({ passed: 1 }), durationMs: 100, ...overrides };
+}
+
+/**
+ * Measure the display column at which a rendered line's name begins.
+ *
+ * Counts terminal cells rather than UTF-16 units, using the formatter's declared widths. An
+ * index-based measurement would report the same number for a one-cell and a two-cell glyph and so
+ * would prove nothing about alignment -- the very confusion the width declarations exist to settle.
+ */
+function measureNameColumn(line: string): number {
+  const match = /^(?<indent> *)(?<glyph>\P{White_Space})(?<pad> +)/u.exec(line);
+  const groups = match?.groups;
+  if (groups === undefined) throw new Error(`Not a token-led line: ${JSON.stringify(line)}`);
+
+  const token = Object.values(emojiFormatter.tokens).find((entry) => entry.glyph === groups.glyph);
+  if (token === undefined) throw new Error(`Unknown glyph: ${JSON.stringify(groups.glyph)}`);
+
+  return (groups.indent?.length ?? 0) + token.width + (groups.pad?.length ?? 0);
+}
+
+/** Measure a line's leading whitespace, which is already one column per character. */
+function measureIndent(line: string): number {
+  return line.length - line.trimStart().length;
+}
+
+describe('formatCheckLine', () => {
+  it('leads with the token and pads to the gutter', () => {
+    expect(engine.formatCheckLine({ token: 'passed', name: 'lockfile' })).toBe(`${PASSED} lockfile`);
+  });
+
+  it('separates an inline detail with a middle dot', () => {
+    const line = engine.formatCheckLine({ token: 'passed', name: 'lockfile', detail: 'up to date' });
+
+    expect(line).toBe(`${PASSED} lockfile \u{00B7} up to date`);
+  });
+
+  it('brackets progress rather than spending a second separator on it', () => {
+    const line = engine.formatCheckLine({ token: 'passed', name: 'suite', progress: '7 of 10' });
+
+    expect(line).toBe(`${PASSED} suite [7 of 10]`);
+  });
+
+  it('carries exactly one separator when both detail and progress are present', () => {
+    const line = engine.formatCheckLine({
+      token: 'failedError',
+      name: 'suite',
+      detail: 'three specs failed',
+      progress: '70%',
+    });
+
+    expect(line).toBe(`${FAILED_ERROR} suite \u{00B7} three specs failed [70%]`);
+    expect(line.match(/\u{00B7}/gu)).toHaveLength(1);
+  });
+
+  it('omits the em dash the middle dot replaced', () => {
+    const line = engine.formatCheckLine({ token: 'passed', name: 'lockfile', detail: 'up to date' });
+
+    expect(line).not.toContain('\u{2014}');
+  });
+
+  describe('duration', () => {
+    it('shows a duration at the floor', () => {
+      expect(engine.formatCheckLine({ token: 'passed', name: 'slow', durationMs: 100 })).toBe(`${PASSED} slow (100ms)`);
+    });
+
+    it('omits a duration below the floor', () => {
+      expect(engine.formatCheckLine({ token: 'passed', name: 'quick', durationMs: 99 })).toBe(`${PASSED} quick`);
+    });
+
+    it('omits a duration of zero', () => {
+      expect(engine.formatCheckLine({ token: 'passed', name: 'instant', durationMs: 0 })).toBe(`${PASSED} instant`);
+    });
+
+    it('rounds a fractional duration', () => {
+      expect(engine.formatCheckLine({ token: 'passed', name: 'slow', durationMs: 140.6 })).toContain('(141ms)');
+    });
+
+    it.each(SKIPPED_TOKENS)('omits the duration on a %s check however long it took', (token) => {
+      expect(engine.formatCheckLine({ token, name: 'skipped', durationMs: 5000 })).not.toContain('ms');
+    });
+
+    it('places the duration after detail and progress', () => {
+      const line = engine.formatCheckLine({
+        token: 'passed',
+        name: 'suite',
+        detail: 'all green',
+        progress: '100%',
+        durationMs: 250,
+      });
+
+      expect(line).toBe(`${PASSED} suite \u{00B7} all green [100%] (250ms)`);
+    });
+  });
+
+  describe('alignment', () => {
+    it('starts each nesting level one gutter right of the level above', () => {
+      const columns = [0, 1, 2, 3].map((depth) =>
+        measureNameColumn(engine.formatCheckLine({ token: 'passed', name: 'check', depth })),
+      );
+
+      expect(columns).toStrictEqual([3, 6, 9, 12]);
+    });
+
+    it('puts a child token under its parent name at every level', () => {
+      for (const depth of [0, 1, 2, 3]) {
+        const parent = engine.formatCheckLine({ token: 'passed', name: 'parent', depth });
+        const child = engine.formatCheckLine({ token: 'failedError', name: 'child', depth: depth + 1 });
+
+        expect(measureIndent(child)).toBe(measureNameColumn(parent));
+      }
+    });
+
+    it('lands the name at one column whichever token leads the line', () => {
+      const columns = TOKEN_NAMES.map((token) =>
+        measureNameColumn(engine.formatCheckLine({ token, name: 'check', depth: 2 })),
+      );
+
+      expect(new Set(columns)).toStrictEqual(new Set([emojiFormatter.gutter * 3]));
+    });
+  });
+});
+
+describe('formatReasonBlock', () => {
+  it('returns one line per reason', () => {
+    expect(engine.formatReasonBlock(['first', 'second'])).toHaveLength(2);
+  });
+
+  it('returns nothing for no reasons', () => {
+    expect(engine.formatReasonBlock([])).toStrictEqual([]);
+  });
+
+  it.each([0, 1, 2, 3])('indents a reason to the name column of the check at depth %i', (depth) => {
+    const check = engine.formatCheckLine({ token: 'failedError', name: 'deps', depth });
+    const [reason] = engine.formatReasonBlock(['lockfile out of date'], depth);
+
+    expect(measureIndent(reason ?? '')).toBe(measureNameColumn(check));
+  });
+
+  it('leads with no token, so a reason never reads as a check of its own', () => {
+    const [reason] = engine.formatReasonBlock(['lockfile out of date']);
+
+    expect(reason).toBe('   lockfile out of date');
+  });
+});
+
+describe('formatHeading', () => {
+  it('sets a kit heading off with blank lines above and below', () => {
+    expect(engine.formatHeading('deploy', 'kit')).toStrictEqual(['', '\u{2501}\u{2501} deploy', '']);
+  });
+
+  it('weights a section heading lighter than a kit heading', () => {
+    expect(engine.formatHeading('build', 'section')).toStrictEqual(['', '\u{2500}\u{2500} build', '']);
+  });
+
+  it('retires the heading grammars it replaced', () => {
+    const rendered = [...engine.formatHeading('deploy', 'kit'), ...engine.formatHeading('build', 'section')].join('\n');
+
+    expect(rendered).not.toContain('===');
+    expect(rendered).not.toContain('---');
+  });
+});
+
+describe('formatCounts', () => {
+  it('joins non-zero fields with pipes in the fixed order', () => {
+    const counts = makeCounts({
+      passed: 14,
+      errors: 1,
+      warnings: 1,
+      recommendations: 2,
+      blocked: 5,
+      optional: 2,
+      worstSeverity: 'error',
+    });
+
+    expect(engine.formatCounts(counts)).toBe(
+      '14 passed | 1 error | 1 warning | 2 recommendations | 5 blocked | 2 skipped',
+    );
+  });
+
+  it('omits zero-count fields', () => {
+    expect(engine.formatCounts(makeCounts({ passed: 3, warnings: 1, worstSeverity: 'warn' }))).toBe(
+      '3 passed | 1 warning',
+    );
+  });
+
+  it('reports zero counts as a statement rather than an empty segment', () => {
+    expect(engine.formatCounts(makeCounts())).toBe('0 passed');
+  });
+
+  it('pluralizes the severity labels', () => {
+    expect(engine.formatCounts(makeCounts({ errors: 2, warnings: 2, recommendations: 2 }))).toBe(
+      '2 errors | 2 warnings | 2 recommendations',
+    );
+  });
+
+  it('leaves the skip labels unchanged for any count', () => {
+    expect(engine.formatCounts(makeCounts({ blocked: 3, optional: 4 }))).toBe('3 blocked | 4 skipped');
+  });
+
+  it('carries no per-field tokens', () => {
+    const counts = makeCounts({ passed: 1, errors: 1, blocked: 1, optional: 1, worstSeverity: 'error' });
+
+    for (const { glyph } of Object.values(emojiFormatter.tokens)) {
+      expect(engine.formatCounts(counts)).not.toContain(glyph);
+    }
+  });
+});
+
+describe('formatCountLine', () => {
+  it('leads with the worst severity rather than the first non-zero field', () => {
+    const counts = makeCounts({ passed: 9, errors: 1, worstSeverity: 'error' });
+
+    expect(engine.formatCountLine(counts, 1200)).toBe(`${FAILED_ERROR} 9 passed | 1 error (1200ms)`);
+  });
+
+  it('leads with the passed token when nothing failed', () => {
+    expect(engine.formatCountLine(makeCounts({ passed: 4 }), 300)).toBe(`${PASSED} 4 passed (300ms)`);
+  });
+
+  it('shows a duration below the check-line floor', () => {
+    expect(engine.formatCountLine(makeCounts({ passed: 1 }), 4)).toContain('(4ms)');
+  });
+
+  it('places an optional label between the token and the counts', () => {
+    expect(engine.formatCountLine(makeCounts({ passed: 2 }), 500, 'Total:')).toBe(`${PASSED} Total: 2 passed (500ms)`);
+  });
+
+  it('leads a blocked-only run with the passed token, since nothing failed', () => {
+    expect(engine.formatCountLine(makeCounts({ blocked: 2 }), 100)).toBe(`${PASSED} 2 blocked (100ms)`);
+  });
+});
+
+describe('formatSummaryTable', () => {
+  const input = {
+    rows: [
+      makeRow({ name: 'build', counts: makeCounts({ passed: 2 }), durationMs: 410 }),
+      makeRow({
+        name: 'integration',
+        counts: makeCounts({ passed: 1, errors: 1, worstSeverity: 'error' }),
+        durationMs: 1400,
+      }),
+    ],
+    totals: makeCounts({ passed: 3, errors: 1, worstSeverity: 'error' }),
+    totalDurationMs: 1810,
+  };
+
+  /**
+   * Measure a rendered table line in display columns.
+   *
+   * The leading token and the space padding it out occupy the gutter between them, so the body's
+   * character count can be added to the gutter directly.
+   */
+  function measureWidth(line: string): number {
+    const glyph = String.fromCodePoint(line.codePointAt(0) ?? 0);
+    const token = Object.values(emojiFormatter.tokens).find((entry) => entry.glyph === glyph);
+    if (token === undefined) return line.length;
+
+    const rendered = glyph + ' '.repeat(emojiFormatter.gutter - token.width);
+    return emojiFormatter.gutter + line.slice(rendered.length).length;
+  }
+
+  it('renders a heading, two rules, one row per checklist, and a total', () => {
+    const lines = engine.formatSummaryTable(input);
+
+    expect(lines[0]).toBe('');
+    expect(lines[1]).toBe('\u{2500}\u{2500} Summary');
+    expect(lines[3]).toMatch(/^\S build\s+410ms {2}2 passed$/u);
+    expect(lines[4]).toMatch(/^\S integration {2}1400ms {2}1 passed \| 1 error$/u);
+    expect(lines.at(-1)).toBe(`${FAILED_ERROR} Total: 3 passed | 1 error (1810ms)`);
+    expect(lines).toHaveLength(7);
+  });
+
+  it('sizes both rules equally', () => {
+    const lines = engine.formatSummaryTable(input);
+
+    expect(lines[2]).toBe(lines[5]);
+    expect(lines[2]).toMatch(/^\u{2500}+$/u);
+  });
+
+  it('sizes the rules to the widest line they enclose', () => {
+    const lines = engine.formatSummaryTable(input);
+    const widest = Math.max(...[lines[3], lines[4], lines[6]].map((line) => measureWidth(line ?? '')));
+
+    expect(lines[2]?.length).toBe(widest);
+  });
+
+  it('sizes the rules to the total line when it is the widest', () => {
+    const lines = engine.formatSummaryTable({
+      rows: [makeRow({ name: 'a', counts: makeCounts({ passed: 1 }), durationMs: 1 })],
+      totals: makeCounts({ passed: 1, errors: 1, warnings: 1, recommendations: 1, worstSeverity: 'error' }),
+      totalDurationMs: 9,
+    });
+
+    expect(lines[2]?.length).toBe(measureWidth(lines.at(-1) ?? ''));
+  });
+
+  it('pads names so the counts column starts at one place in every row', () => {
+    const lines = engine.formatSummaryTable(input);
+
+    expect(lines[3]?.indexOf('2 passed')).toBe(lines[4]?.indexOf('1 passed'));
+  });
+
+  it('right-aligns durations', () => {
+    const lines = engine.formatSummaryTable(input);
+
+    expect(lines[3]).toContain(' 410ms');
+    expect(lines[4]).toContain('1400ms');
+  });
+
+  it('leads each row with the worst severity of that checklist alone', () => {
+    const lines = engine.formatSummaryTable({
+      rows: [
+        makeRow({ name: 'warned', counts: makeCounts({ warnings: 1, worstSeverity: 'warn' }) }),
+        makeRow({ name: 'clean', counts: makeCounts({ passed: 1 }) }),
+      ],
+      totals: makeCounts({ passed: 1, warnings: 1, worstSeverity: 'warn' }),
+      totalDurationMs: 200,
+    });
+
+    expect(lines[3]?.startsWith(FAILED_WARN)).toBe(true);
+    expect(lines[4]?.startsWith(PASSED)).toBe(true);
+  });
+
+  it('handles a single row', () => {
+    const lines = engine.formatSummaryTable({
+      rows: [makeRow({ name: 'only', counts: makeCounts({ passed: 1 }), durationMs: 100 })],
+      totals: makeCounts({ passed: 1 }),
+      totalDurationMs: 100,
+    });
+
+    expect(lines).toHaveLength(6);
+  });
+});
+
+describe(resolveWorstToken, () => {
+  it.each([
+    ['error', 'failedError'],
+    ['warn', 'failedWarn'],
+    ['recommend', 'failedRecommend'],
+  ] as const)('maps %s to %s', (severity, expected) => {
+    expect(resolveWorstToken(severity)).toBe(expected);
+  });
+
+  it('maps a run with no failures to the passed token', () => {
+    expect(resolveWorstToken(null)).toBe('passed');
+  });
+});
+
+describe('token and glyph', () => {
+  it('pads a token to the gutter', () => {
+    expect(engine.token('passed')).toBe(`${PASSED} `);
+  });
+
+  it('returns a bare glyph for mid-line placement', () => {
+    expect(engine.glyph('docCompiled')).toBe(emojiFormatter.tokens.docCompiled.glyph);
+    expect(engine.glyph('skippedOptional')).toBe(SKIPPED);
+  });
+
+  it('indents by one gutter per level', () => {
+    expect(engine.indent(0)).toBe('');
+    expect(engine.indent(3)).toBe(' '.repeat(9));
+  });
+});

--- a/packages/readyup/__tests__/layout/layoutEngine.test.ts
+++ b/packages/readyup/__tests__/layout/layoutEngine.test.ts
@@ -5,7 +5,7 @@ import { TOKEN_NAMES, type TokenName } from '../../src/layout/formatter.ts';
 import { createLayoutEngine, resolveWorstToken, type SummaryRow } from '../../src/layout/layoutEngine.ts';
 import type { SummaryCounts } from '../../src/types.ts';
 
-/** Tokens naming a check that never ran, which therefore never carry a duration. */
+/** Tokens naming a check that did not run. */
 const SKIPPED_TOKENS: TokenName[] = ['blockedPrecondition', 'skippedOptional'];
 
 const engine = createLayoutEngine(emojiFormatter);
@@ -33,11 +33,9 @@ function makeRow(overrides?: Partial<SummaryRow>): SummaryRow {
 }
 
 /**
- * Measure the display column at which a rendered line's name begins.
+ * Returns the display column at which a rendered line's name begins.
  *
- * Counts terminal cells rather than UTF-16 units, using the formatter's declared widths. An
- * index-based measurement would report the same number for a one-cell and a two-cell glyph and so
- * would prove nothing about alignment -- the very confusion the width declarations exist to settle.
+ * Counts terminal cells, taking each glyph's width from the formatter, so a two-cell glyph counts twice.
  */
 function measureNameColumn(line: string): number {
   const match = /^(?<indent> *)(?<glyph>\P{White_Space})(?<pad> +)/u.exec(line);
@@ -50,7 +48,7 @@ function measureNameColumn(line: string): number {
   return (groups.indent?.length ?? 0) + token.width + (groups.pad?.length ?? 0);
 }
 
-/** Measure a line's leading whitespace, which is already one column per character. */
+/** Returns a line's count of leading spaces, one per column. */
 function measureIndent(line: string): number {
   return line.length - line.trimStart().length;
 }
@@ -276,12 +274,7 @@ describe('formatSummaryTable', () => {
     totalDurationMs: 1810,
   };
 
-  /**
-   * Measure a rendered table line in display columns.
-   *
-   * The leading token and the space padding it out occupy the gutter between them, so the body's
-   * character count can be added to the gutter directly.
-   */
+  /** Returns a rendered table line's width in display columns, its leading token counted as one gutter. */
   function measureWidth(line: string): number {
     const glyph = String.fromCodePoint(line.codePointAt(0) ?? 0);
     const token = Object.values(emojiFormatter.tokens).find((entry) => entry.glyph === glyph);

--- a/packages/readyup/__tests__/layout/layoutEngine.test.ts
+++ b/packages/readyup/__tests__/layout/layoutEngine.test.ts
@@ -296,24 +296,25 @@ describe('formatSummaryTable', () => {
 
     expect(lines[0]).toBe('');
     expect(lines[1]).toBe('\u{2500}\u{2500} Summary');
-    expect(lines[3]).toMatch(/^\S build\s+410ms {2}2 passed$/u);
-    expect(lines[4]).toMatch(/^\S integration {2}1400ms {2}1 passed \| 1 error$/u);
+    expect(lines[2]).toBe('');
+    expect(lines[4]).toMatch(/^\S build\s+410ms {2}2 passed$/u);
+    expect(lines[5]).toMatch(/^\S integration {2}1400ms {2}1 passed \| 1 error$/u);
     expect(lines.at(-1)).toBe(`${FAILED_ERROR} Total: 3 passed | 1 error (1810ms)`);
-    expect(lines).toHaveLength(7);
+    expect(lines).toHaveLength(8);
   });
 
   it('sizes both rules equally', () => {
     const lines = engine.formatSummaryTable(input);
 
-    expect(lines[2]).toBe(lines[5]);
-    expect(lines[2]).toMatch(/^\u{2500}+$/u);
+    expect(lines[3]).toBe(lines[6]);
+    expect(lines[3]).toMatch(/^\u{2500}+$/u);
   });
 
   it('sizes the rules to the widest line they enclose', () => {
     const lines = engine.formatSummaryTable(input);
-    const widest = Math.max(...[lines[3], lines[4], lines[6]].map((line) => measureWidth(line ?? '')));
+    const widest = Math.max(...[lines[4], lines[5], lines[7]].map((line) => measureWidth(line ?? '')));
 
-    expect(lines[2]?.length).toBe(widest);
+    expect(lines[3]?.length).toBe(widest);
   });
 
   it('sizes the rules to the total line when it is the widest', () => {
@@ -323,20 +324,20 @@ describe('formatSummaryTable', () => {
       totalDurationMs: 9,
     });
 
-    expect(lines[2]?.length).toBe(measureWidth(lines.at(-1) ?? ''));
+    expect(lines[3]?.length).toBe(measureWidth(lines.at(-1) ?? ''));
   });
 
   it('pads names so the counts column starts at one place in every row', () => {
     const lines = engine.formatSummaryTable(input);
 
-    expect(lines[3]?.indexOf('2 passed')).toBe(lines[4]?.indexOf('1 passed'));
+    expect(lines[4]?.indexOf('2 passed')).toBe(lines[5]?.indexOf('1 passed'));
   });
 
   it('right-aligns durations', () => {
     const lines = engine.formatSummaryTable(input);
 
-    expect(lines[3]).toContain(' 410ms');
-    expect(lines[4]).toContain('1400ms');
+    expect(lines[4]).toContain(' 410ms');
+    expect(lines[5]).toContain('1400ms');
   });
 
   it('leads each row with the worst severity of that checklist alone', () => {
@@ -349,8 +350,8 @@ describe('formatSummaryTable', () => {
       totalDurationMs: 200,
     });
 
-    expect(lines[3]?.startsWith(FAILED_WARN)).toBe(true);
-    expect(lines[4]?.startsWith(PASSED)).toBe(true);
+    expect(lines[4]?.startsWith(FAILED_WARN)).toBe(true);
+    expect(lines[5]?.startsWith(PASSED)).toBe(true);
   });
 
   it('handles a single row', () => {
@@ -360,7 +361,7 @@ describe('formatSummaryTable', () => {
       totalDurationMs: 100,
     });
 
-    expect(lines).toHaveLength(6);
+    expect(lines).toHaveLength(7);
   });
 });
 

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -71,10 +71,27 @@ describe(formatOwnerView, () => {
     });
     const lines = result.split('\n');
 
-    expect(lines[0]).toBe('\u{2500}\u{2500} Internal');
-    expect(lines[1]).toBe('   rdy run --jit <name>');
-    expect(lines[2]).toBe('');
-    expect(lines[3]).toBe(`${INTERNAL} deploy`);
+    expect(lines[0]).toBe('');
+    expect(lines[1]).toBe('\u{2500}\u{2500} Internal');
+    expect(lines[2]).toBe('   rdy run --jit <name>');
+    expect(lines[3]).toBe('');
+    expect(lines[4]).toBe(`${INTERNAL} deploy`);
+  });
+
+  it('sets every section off with a blank line above its title', () => {
+    const lines = formatOwnerView({
+      internalKits: ['deploy'],
+      compiledKits: ['monitor'],
+      compiledStyle: { kind: 'local-convention' },
+    }).split('\n');
+    const titleIndexes = lines
+      .map((line, index) => (line.startsWith('\u{2500}\u{2500} ') ? index : -1))
+      .filter((index) => index !== -1);
+
+    expect(titleIndexes).toHaveLength(2);
+    for (const index of titleIndexes) {
+      expect(lines[index - 1]).toBe('');
+    }
   });
 
   it('fuses neither the command into the title nor the title into the command', () => {

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -6,10 +6,10 @@ import { formatConsumerView, formatEmpty, formatManifestView, formatOwnerView } 
 const INTERNAL = emojiFormatter.tokens.docInternal.glyph;
 
 /**
- * Return the copy-pasteable command a section publishes, which sits on the line beneath its title.
+ * Returns the line beneath a section's title, which is where its command sits.
  *
- * Reading the line after the title is the assertion: a command fused to the title would satisfy a
- * plain `toContain` on the whole output while defeating the point of splitting it out.
+ * Reading that line positionally is the assertion: a command fused into the title would still satisfy a
+ * `toContain` over the whole output.
  */
 function findSectionCommand(output: string, title: string): string | undefined {
   const lines = output.split('\n');

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
+import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
 import { formatConsumerView, formatEmpty, formatManifestView, formatOwnerView } from '../../src/list/formatList.ts';
+
+const INTERNAL = emojiFormatter.tokens.docInternal.glyph;
+
+/**
+ * Return the copy-pasteable command a section publishes, which sits on the line beneath its title.
+ *
+ * Reading the line after the title is the assertion: a command fused to the title would satisfy a
+ * plain `toContain` on the whole output while defeating the point of splitting it out.
+ */
+function findSectionCommand(output: string, title: string): string | undefined {
+  const lines = output.split('\n');
+  const titleIndex = lines.indexOf(`\u{2500}\u{2500} ${title}`);
+  return titleIndex === -1 ? undefined : lines[titleIndex + 1];
+}
 
 describe(formatOwnerView, () => {
   it('renders only the Internal section when compiled kits are empty', () => {
@@ -10,8 +25,8 @@ describe(formatOwnerView, () => {
       compiledStyle: { kind: 'local-convention' },
     });
 
-    expect(result).toContain('Internal:');
-    expect(result).not.toContain('Compiled:');
+    expect(result).toContain('\u{2500}\u{2500} Internal');
+    expect(result).not.toContain('\u{2500}\u{2500} Compiled');
     expect(result).toContain('deploy');
   });
 
@@ -22,7 +37,7 @@ describe(formatOwnerView, () => {
       compiledStyle: { kind: 'local-convention' },
     });
 
-    expect(result).toContain('Internal: rdy run --jit [<name>]');
+    expect(findSectionCommand(result, 'Internal')).toBe('   rdy run --jit [<name>]');
   });
 
   it('adds --internal to the internal hint when the config makes it necessary', () => {
@@ -33,7 +48,7 @@ describe(formatOwnerView, () => {
       needsInternalFlag: true,
     });
 
-    expect(result).toContain('Internal: rdy run --jit --internal [<name>]');
+    expect(findSectionCommand(result, 'Internal')).toBe('   rdy run --jit --internal [<name>]');
   });
 
   it('renders only the Compiled section when internal kits are empty', () => {
@@ -43,9 +58,33 @@ describe(formatOwnerView, () => {
       compiledStyle: { kind: 'local-convention' },
     });
 
-    expect(result).not.toContain('Internal:');
-    expect(result).toContain('Compiled:');
+    expect(result).not.toContain('\u{2500}\u{2500} Internal');
+    expect(result).toContain('\u{2500}\u{2500} Compiled');
     expect(result).toContain('deploy');
+  });
+
+  it('splits the section title from its command onto two lines', () => {
+    const result = formatOwnerView({
+      internalKits: ['deploy'],
+      compiledKits: [],
+      compiledStyle: { kind: 'local-convention' },
+    });
+    const lines = result.split('\n');
+
+    expect(lines[0]).toBe('\u{2500}\u{2500} Internal');
+    expect(lines[1]).toBe('   rdy run --jit <name>');
+    expect(lines[2]).toBe('');
+    expect(lines[3]).toBe(`${INTERNAL} deploy`);
+  });
+
+  it('fuses neither the command into the title nor the title into the command', () => {
+    const result = formatOwnerView({
+      internalKits: ['deploy'],
+      compiledKits: [],
+      compiledStyle: { kind: 'local-convention' },
+    });
+
+    expect(result).not.toContain('Internal: rdy run');
   });
 
   it('uses brackets around positional name in internal hint when default exists', () => {
@@ -55,12 +94,8 @@ describe(formatOwnerView, () => {
       compiledStyle: { kind: 'local-convention' },
     });
 
-    const lines = result.split('\n');
-    const internalHeader = lines.find((l) => l.startsWith('Internal:'));
-    const compiledHeader = lines.find((l) => l.startsWith('Compiled:'));
-
-    expect(internalHeader).toContain('rdy run --jit [<name>]');
-    expect(compiledHeader).toContain('rdy run <name>');
+    expect(findSectionCommand(result, 'Internal')).toBe('   rdy run --jit [<name>]');
+    expect(findSectionCommand(result, 'Compiled')).toBe('   rdy run <name>');
   });
 
   it('uses brackets in compiled hint when default is in compiled kits', () => {
@@ -70,12 +105,8 @@ describe(formatOwnerView, () => {
       compiledStyle: { kind: 'local-convention' },
     });
 
-    const lines = result.split('\n');
-    const internalHeader = lines.find((l) => l.startsWith('Internal:'));
-    const compiledHeader = lines.find((l) => l.startsWith('Compiled:'));
-
-    expect(internalHeader).toContain('rdy run --jit <name>');
-    expect(compiledHeader).toContain('rdy run [<name>]');
+    expect(findSectionCommand(result, 'Internal')).toBe('   rdy run --jit <name>');
+    expect(findSectionCommand(result, 'Compiled')).toBe('   rdy run [<name>]');
   });
 
   it('omits brackets around positional name when no default kit exists', () => {
@@ -96,12 +127,8 @@ describe(formatOwnerView, () => {
       compiledStyle: { kind: 'local-convention' },
     });
 
-    const lines = result.split('\n');
-    const internalHeader = lines.find((l) => l.startsWith('Internal:'));
-    const compiledHeader = lines.find((l) => l.startsWith('Compiled:'));
-
-    expect(internalHeader).toContain('--jit');
-    expect(compiledHeader).not.toContain('--jit');
+    expect(findSectionCommand(result, 'Internal')).toContain('--jit');
+    expect(findSectionCommand(result, 'Compiled')).not.toContain('--jit');
   });
 
   it('renders custom outDir style with file paths', () => {
@@ -135,8 +162,8 @@ describe(formatOwnerView, () => {
       compiledStyle: { kind: 'local-convention' },
     });
 
-    expect(result).toContain('Internal:');
-    expect(result).toContain('Compiled:');
+    expect(result).toContain('\u{2500}\u{2500} Internal');
+    expect(result).toContain('\u{2500}\u{2500} Compiled');
   });
 });
 
@@ -222,7 +249,7 @@ describe(formatManifestView, () => {
       manifestPath: '.readyup/manifest.json',
     });
 
-    expect(result).toContain('Manifest: .readyup/manifest.json');
+    expect(result).toContain('\u{2500}\u{2500} Manifest: .readyup/manifest.json');
     expect(result).toContain('📦 deploy');
     expect(result).toContain('📦 monitor');
   });
@@ -233,7 +260,7 @@ describe(formatManifestView, () => {
       manifestPath: '.readyup/manifest.json',
     });
 
-    expect(result).toContain('📦 default — General project health checks');
+    expect(result).toContain('\u{1F4E6} default \u{00B7} General project health checks');
   });
 
   it('omits description suffix when description is absent', () => {
@@ -244,7 +271,7 @@ describe(formatManifestView, () => {
 
     const lines = result.split('\n');
     const kitLine = lines.find((l) => l.includes('deploy'));
-    expect(kitLine).toBe('  📦 deploy');
+    expect(kitLine).toBe('\u{1F4E6} deploy');
   });
 
   it('returns empty-manifest message when kits array is empty', () => {
@@ -262,7 +289,7 @@ describe(formatManifestView, () => {
       manifestPath: '.readyup/manifest.json',
     });
 
-    expect(result).toContain('📦 default (readyup v0.20.0) — General project health checks');
+    expect(result).toContain('\u{1F4E6} default (readyup v0.20.0) \u{00B7} General project health checks');
   });
 
   it('renders version-only parenthetical when description is absent', () => {
@@ -273,7 +300,7 @@ describe(formatManifestView, () => {
 
     const lines = result.split('\n');
     const kitLine = lines.find((l) => l.includes('deploy'));
-    expect(kitLine).toBe('  📦 deploy (readyup v0.19.2)');
+    expect(kitLine).toBe('\u{1F4E6} deploy (readyup v0.19.2)');
   });
 
   it('omits the version parenthetical entirely when readyupVersion is absent', () => {
@@ -282,7 +309,7 @@ describe(formatManifestView, () => {
       manifestPath: '.readyup/manifest.json',
     });
 
-    expect(result).toContain('📦 legacy — Older kit');
+    expect(result).toContain('\u{1F4E6} legacy \u{00B7} Older kit');
     expect(result).not.toContain('readyup v');
   });
 
@@ -294,7 +321,7 @@ describe(formatManifestView, () => {
 
     const lines = result.split('\n');
     const kitLine = lines.find((l) => l.includes('bare'));
-    expect(kitLine).toBe('  📦 bare');
+    expect(kitLine).toBe('\u{1F4E6} bare');
   });
 });
 

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
 import { formatConsumerView, formatEmpty, formatManifestView, formatOwnerView } from '../../src/list/formatList.ts';
 
+const COMPILED = emojiFormatter.tokens.docCompiled.glyph;
 const INTERNAL = emojiFormatter.tokens.docInternal.glyph;
 
 /**
@@ -269,6 +270,18 @@ describe(formatManifestView, () => {
     expect(result).toContain('\u{2500}\u{2500} Manifest: .readyup/manifest.json');
     expect(result).toContain('📦 deploy');
     expect(result).toContain('📦 monitor');
+  });
+
+  it('sets the heading off with a blank line above and below', () => {
+    const lines = formatManifestView({
+      kits: [{ name: 'deploy' }],
+      manifestPath: '.readyup/manifest.json',
+    }).split('\n');
+
+    expect(lines[0]).toBe('');
+    expect(lines[1]).toBe('\u{2500}\u{2500} Manifest: .readyup/manifest.json');
+    expect(lines[2]).toBe('');
+    expect(lines[3]).toBe(`${COMPILED} deploy`);
   });
 
   it('renders description inline after kit name when present', () => {

--- a/packages/readyup/__tests__/list/listCommand.test.ts
+++ b/packages/readyup/__tests__/list/listCommand.test.ts
@@ -144,7 +144,7 @@ describe(listCommand, () => {
     expect(stdoutCalls).toContain(
       'Manifest: https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json',
     );
-    expect(stdoutCalls).toContain('default — General project health checks');
+    expect(stdoutCalls).toContain('default \u{00B7} General project health checks');
     expect(stdoutCalls).toContain('deploy');
   });
 
@@ -259,7 +259,7 @@ describe(listCommand, () => {
     expect(stdoutCalls).toContain(
       'Manifest: https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json',
     );
-    expect(stdoutCalls).toContain('default — General project health checks');
+    expect(stdoutCalls).toContain('default \u{00B7} General project health checks');
     expect(stdoutCalls).toContain('deploy');
   });
 

--- a/packages/readyup/__tests__/listCommand.test.ts
+++ b/packages/readyup/__tests__/listCommand.test.ts
@@ -69,8 +69,8 @@ describe(listCommand, () => {
         expect.objectContaining({ dir: expect.stringContaining('.readyup/kits'), extension: '.ts' }),
       );
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('Internal:');
-      expect(output).toContain('Compiled:');
+      expect(output).toContain('\u{2500}\u{2500} Internal');
+      expect(output).toContain('\u{2500}\u{2500} Compiled');
     });
 
     it('uses infix-based extension for internal kits when configured', async () => {
@@ -94,8 +94,8 @@ describe(listCommand, () => {
 
       expect(exitCode).toBe(0);
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('Internal:');
-      expect(output).not.toContain('Compiled:');
+      expect(output).toContain('\u{2500}\u{2500} Internal');
+      expect(output).not.toContain('\u{2500}\u{2500} Compiled');
     });
 
     it('uses custom-outDir style when outDir differs from default', async () => {
@@ -171,8 +171,8 @@ describe(listCommand, () => {
 
       expect(exitCode).toBe(0);
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('Internal:');
-      expect(output).not.toContain('Compiled:');
+      expect(output).toContain('\u{2500}\u{2500} Internal');
+      expect(output).not.toContain('\u{2500}\u{2500} Compiled');
       expect(stderrSpy).not.toHaveBeenCalled();
     });
 
@@ -189,7 +189,7 @@ describe(listCommand, () => {
       await listCommand([]);
 
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('Internal: rdy run --jit --internal [<name>]');
+      expect(output).toContain('\u{2500}\u{2500} Internal\n   rdy run --jit --internal [<name>]');
     });
 
     it('leaves --internal out of the internal hint under the default config', async () => {
@@ -198,7 +198,7 @@ describe(listCommand, () => {
       await listCommand([]);
 
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('Internal: rdy run --jit [<name>]');
+      expect(output).toContain('\u{2500}\u{2500} Internal\n   rdy run --jit [<name>]');
     });
 
     it('writes warning to stderr when manifest read fails with non-missing-file error and internal kits exist', async () => {
@@ -211,8 +211,8 @@ describe(listCommand, () => {
 
       expect(exitCode).toBe(0);
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('Internal:');
-      expect(output).not.toContain('Compiled:');
+      expect(output).toContain('\u{2500}\u{2500} Internal');
+      expect(output).not.toContain('\u{2500}\u{2500} Compiled');
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Warning:'));
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'));
     });
@@ -239,7 +239,7 @@ describe(listCommand, () => {
       expect(exitCode).toBe(0);
       expect(mockReadManifest).toHaveBeenCalledWith(expect.stringContaining('.readyup/manifest.json'));
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('Compiled:');
+      expect(output).toContain('\u{2500}\u{2500} Compiled');
       expect(output).toContain('deploy');
     });
 
@@ -277,7 +277,7 @@ describe(listCommand, () => {
       expect(exitCode).toBe(0);
       expect(mockLoadConfig).not.toHaveBeenCalled();
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      expect(output).toContain('Manifest:');
+      expect(output).toContain('\u{2500}\u{2500} Manifest:');
       expect(output).toContain('default');
       expect(output).toContain('Health checks');
       expect(output).toContain('deploy');
@@ -334,7 +334,7 @@ describe(listCommand, () => {
       await listCommand(['--json']);
 
       expect(stdoutSpy).toHaveBeenCalledTimes(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Internal:'));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('\u{2500}\u{2500} Internal'));
     });
 
     it('reports an empty kit list rather than the empty-owner prose', async () => {

--- a/packages/readyup/__tests__/partialResults.test.ts
+++ b/packages/readyup/__tests__/partialResults.test.ts
@@ -108,8 +108,8 @@ describe('partial results when a kit fails after dispatch', () => {
     it('heads every requested kit on stdout, including one that never ran', async () => {
       await routeCommand(['passing', 'absent']);
 
-      expect(readStdout()).toContain('=== passing ===');
-      expect(readStdout()).toContain('=== absent ===');
+      expect(readStdout()).toContain('\u{2501}\u{2501} passing');
+      expect(readStdout()).toContain('\u{2501}\u{2501} absent');
     });
 
     it('keeps the failure off stdout, where a failed check would appear', async () => {

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -12,7 +12,7 @@ const SKIPPED_OPTIONAL = emojiFormatter.tokens.skippedOptional.glyph;
 const BLOCKED = emojiFormatter.tokens.blockedPrecondition.glyph;
 const FIX = emojiFormatter.tokens.fix.glyph;
 
-/** A duration at or above the engine's floor, so a line that may carry one does. */
+/** A duration above the engine's floor, so lines eligible for one show it. */
 const SLOW_MS = 250;
 
 function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
@@ -73,14 +73,14 @@ function makeReport(overrides?: Partial<RdyReport> & { results?: RdyResult[] }):
   };
 }
 
-/** Return the line that names `needle`, for assertions about a specific check's rendering. */
+/** Returns the first output line containing `needle`, throwing when no line does. */
 function lineNaming(output: string, needle: string): string {
   const line = output.split('\n').find((candidate) => candidate.includes(needle));
   if (line === undefined) throw new Error(`No line naming ${JSON.stringify(needle)} in:\n${output}`);
   return line;
 }
 
-/** Return the line index that names `needle`. */
+/** Returns the index of the first output line containing `needle`, or -1. */
 function indexNaming(output: string, needle: string): number {
   return output.split('\n').findIndex((candidate) => candidate.includes(needle));
 }
@@ -488,8 +488,7 @@ describe(reportRdy, () => {
     });
 
     it('renders every result it is given, applying no suppression of its own', () => {
-      // `runRdy` no longer emits descendants of an n/a result, so the renderer must not
-      // second-guess its input: whatever arrives is displayed and counted.
+      // The renderer displays and counts whatever it is given, applying no suppression of its own.
       const output = reportRdy(
         makeReport({
           results: [

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -523,6 +523,139 @@ describe(reportRdy, () => {
     });
   });
 
+  describe('quiet', () => {
+    it('hides a passed check', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makePassedResult({ name: 'quiet-pass' }), makeFailedResult({ name: 'loud-fail' })],
+          passed: false,
+        }),
+        { quiet: true },
+      );
+
+      expect(output).not.toContain('quiet-pass');
+      expect(output).toContain('loud-fail');
+    });
+
+    it('keeps failures, skips, and blocks', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'hidden' }),
+            makeFailedResult({ name: 'failure' }),
+            makeSkippedResult({ name: 'optional-skip', skipReason: 'n/a' }),
+            makeSkippedResult({ name: 'blocked-skip', skipReason: 'precondition' }),
+          ],
+          passed: false,
+        }),
+        { quiet: true },
+      );
+
+      expect(output).not.toContain('hidden');
+      for (const name of ['failure', 'optional-skip', 'blocked-skip']) {
+        expect(output).toContain(name);
+      }
+    });
+
+    it('retains a passed ancestor so a deep failure stays reachable', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'passed-parent' }),
+            makePassedResult({ name: 'passed-child', depth: 1 }),
+            makeFailedResult({ name: 'deep-failure', depth: 2 }),
+          ],
+          passed: false,
+        }),
+        { quiet: true },
+      );
+
+      expect(output.split('\n').slice(0, 3)).toStrictEqual([
+        `${PASSED} passed-parent`,
+        `   ${PASSED} passed-child`,
+        `      ${FAILED_ERROR} deep-failure`,
+      ]);
+    });
+
+    it('drops a wholly passing subtree', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'clean-parent' }),
+            makePassedResult({ name: 'clean-child', depth: 1 }),
+            makeFailedResult({ name: 'failure' }),
+          ],
+          passed: false,
+        }),
+        { quiet: true },
+      );
+
+      expect(output).not.toContain('clean-parent');
+      expect(output).not.toContain('clean-child');
+      expect(output).toContain('failure');
+    });
+
+    it('counts hidden passes, so the tally still covers the whole run', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makePassedResult({ name: 'a' }), makePassedResult({ name: 'b' }), makeFailedResult({ name: 'c' })],
+          passed: false,
+          durationMs: 90,
+        }),
+        { quiet: true },
+      );
+
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} 2 passed | 1 error (90ms)`);
+    });
+
+    it('keeps the fix recap', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makePassedResult({ name: 'hidden' }), makeFailedResult({ name: 'broken', fix: 'Run install' })],
+          passed: false,
+        }),
+        { quiet: true },
+      );
+
+      expect(output).toContain(`${FIX} broken`);
+      expect(output).toContain('   Run install');
+    });
+
+    it('composes with the reporting threshold rather than overriding it', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'passed-error-sev', severity: 'error' }),
+            makeFailedResult({ name: 'warn-failure', severity: 'warn' }),
+            makeFailedResult({ name: 'error-failure', severity: 'error' }),
+          ],
+          passed: false,
+        }),
+        { quiet: true, reportOn: 'error' },
+      );
+
+      // Hidden by quiet (passed), by the threshold (warn), and shown by both (error failure).
+      expect(output).not.toContain('passed-error-sev');
+      expect(output).not.toContain('warn-failure');
+      expect(output).toContain('error-failure');
+    });
+
+    it('shows every passed check when off', () => {
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'visible' })] }), { quiet: false });
+
+      expect(output).toContain('visible');
+    });
+
+    it('leaves an all-passing run with only its count line', () => {
+      const output = reportRdy(
+        makeReport({ results: [makePassedResult({ name: 'a' }), makePassedResult({ name: 'b' })], durationMs: 30 }),
+        { quiet: true },
+      );
+
+      expect(output).toBe(`\n${PASSED} 2 passed (30ms)`);
+    });
+  });
+
   describe('reporting threshold', () => {
     it('excludes results below the reporting threshold', () => {
       const output = reportRdy(

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -652,7 +652,7 @@ describe(reportRdy, () => {
         { quiet: true },
       );
 
-      expect(output).toBe(`\n${PASSED} 2 passed (30ms)`);
+      expect(output).toBe(`${PASSED} 2 passed (30ms)`);
     });
   });
 

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -1,20 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  countResults,
-  formatSummaryCounts,
-  formatSummaryCountsPlain,
-  ICON_ERROR_FAILED,
-  ICON_FIX,
-  ICON_PASSED,
-  ICON_RECOMMEND_FAILED,
-  ICON_SKIPPED_NA,
-  ICON_SKIPPED_PRECONDITION,
-  ICON_WARN_FAILED,
-  reportRdy,
-  selectVisibleResults,
-} from '../src/reportRdy.ts';
+import { emojiFormatter } from '../src/layout/emojiFormatter.ts';
+import { countResults, reportRdy, selectVisibleResults } from '../src/reportRdy.ts';
 import type { FailedResult, PassedResult, RdyReport, RdyResult, SkippedResult, SummaryCounts } from '../src/types.ts';
+
+const PASSED = emojiFormatter.tokens.passed.glyph;
+const FAILED_ERROR = emojiFormatter.tokens.failedError.glyph;
+const FAILED_WARN = emojiFormatter.tokens.failedWarn.glyph;
+const FAILED_RECOMMEND = emojiFormatter.tokens.failedRecommend.glyph;
+const SKIPPED_OPTIONAL = emojiFormatter.tokens.skippedOptional.glyph;
+const BLOCKED = emojiFormatter.tokens.blockedPrecondition.glyph;
+const FIX = emojiFormatter.tokens.fix.glyph;
+
+/** A duration at or above the engine's floor, so a line that may carry one does. */
+const SLOW_MS = 250;
 
 function makePassedResult(overrides?: Partial<PassedResult>): PassedResult {
   return {
@@ -74,512 +73,524 @@ function makeReport(overrides?: Partial<RdyReport> & { results?: RdyResult[] }):
   };
 }
 
+/** Return the line that names `needle`, for assertions about a specific check's rendering. */
+function lineNaming(output: string, needle: string): string {
+  const line = output.split('\n').find((candidate) => candidate.includes(needle));
+  if (line === undefined) throw new Error(`No line naming ${JSON.stringify(needle)} in:\n${output}`);
+  return line;
+}
+
+/** Return the line index that names `needle`. */
+function indexNaming(output: string, needle: string): number {
+  return output.split('\n').findIndex((candidate) => candidate.includes(needle));
+}
+
 describe(reportRdy, () => {
-  it('shows passed checks with green circle icon', () => {
-    const report = makeReport({
-      results: [makePassedResult({ name: 'check-a', durationMs: 10 })],
+  describe('status tokens', () => {
+    it.each([
+      ['passed', makePassedResult({ name: 'target' }), PASSED],
+      ['error-failed', makeFailedResult({ name: 'target', severity: 'error' }), FAILED_ERROR],
+      ['warn-failed', makeFailedResult({ name: 'target', severity: 'warn' }), FAILED_WARN],
+      ['recommend-failed', makeFailedResult({ name: 'target', severity: 'recommend' }), FAILED_RECOMMEND],
+      ['n/a-skipped', makeSkippedResult({ name: 'target', skipReason: 'n/a' }), SKIPPED_OPTIONAL],
+      ['precondition-skipped', makeSkippedResult({ name: 'target', skipReason: 'precondition' }), BLOCKED],
+    ])('leads a %s check with its token', (_case, result, token) => {
+      const output = reportRdy(makeReport({ results: [result], passed: false }));
+
+      expect(lineNaming(output, 'target')).toBe(`${token} target`);
     });
 
-    const output = reportRdy(report);
+    it.each(['\u{23ED}', '\u{2705}', '\u{26A0}', '\u{274C}', '\u{2753}', '\u{2796}', '\u{FE0F}'])(
+      'renders no %s anywhere in the report',
+      (retired) => {
+        const output = reportRdy(
+          makeReport({
+            results: [
+              makePassedResult({ name: 'a' }),
+              makeFailedResult({ name: 'b', detail: 'why', fix: 'do it' }),
+              makeSkippedResult({ name: 'c', skipReason: 'n/a' }),
+              makeSkippedResult({ name: 'd', skipReason: 'precondition' }),
+            ],
+            passed: false,
+          }),
+        );
 
-    expect(output).toContain(`${ICON_PASSED} check-a (10ms)`);
-  });
-
-  it('shows error-failed checks with red circle icon', () => {
-    const report = makeReport({
-      results: [makeFailedResult({ name: 'check-b', severity: 'error' })],
-      passed: false,
-    });
-
-    const output = reportRdy(report);
-
-    expect(output).toContain(`${ICON_ERROR_FAILED} check-b (5ms)`);
-  });
-
-  it('shows warn-failed checks with orange circle icon', () => {
-    const report = makeReport({
-      results: [makeFailedResult({ name: 'check-warn', severity: 'warn' })],
-      passed: false,
-    });
-
-    const output = reportRdy(report);
-
-    expect(output).toContain(`${ICON_WARN_FAILED} check-warn (5ms)`);
-  });
-
-  it('shows recommend-failed checks with yellow circle icon', () => {
-    const report = makeReport({
-      results: [makeFailedResult({ name: 'check-rec', severity: 'recommend' })],
-      passed: false,
-    });
-
-    const output = reportRdy(report);
-
-    expect(output).toContain(`${ICON_RECOMMEND_FAILED} check-rec (5ms)`);
-  });
-
-  it('shows n/a-skipped checks with magnifying glass icon', () => {
-    const report = makeReport({
-      results: [makeSkippedResult({ name: 'check-na', skipReason: 'n/a' })],
-    });
-
-    const output = reportRdy(report);
-
-    expect(output).toContain(`${ICON_SKIPPED_NA} check-na (0ms)`);
-  });
-
-  it('shows precondition-skipped checks with prohibition icon', () => {
-    const report = makeReport({
-      results: [makeSkippedResult({ name: 'check-pre', skipReason: 'precondition' })],
-    });
-
-    const output = reportRdy(report);
-
-    expect(output).toContain(`${ICON_SKIPPED_PRECONDITION} check-pre (0ms)`);
-  });
-
-  it('renders the summary line with granular failure and skip groups', () => {
-    const report = makeReport({
-      results: [
-        makePassedResult({ name: 'a', durationMs: 10 }),
-        makeFailedResult({ name: 'b', durationMs: 20 }),
-        makeSkippedResult({ name: 'c' }),
-      ],
-      passed: false,
-      durationMs: 142,
-    });
-
-    const output = reportRdy(report);
-
-    expect(output).toContain(
-      `${ICON_PASSED} 1 passed. Failed: ${ICON_ERROR_FAILED} 1 error. Skipped: ${ICON_SKIPPED_PRECONDITION} 1 blocked (142ms)`,
+        expect(output).not.toContain(retired);
+      },
     );
   });
 
-  it('omits zero counts from the summary line', () => {
-    const report = makeReport({
-      results: [makePassedResult({ name: 'a', durationMs: 10 }), makePassedResult({ name: 'b', durationMs: 15 })],
-      durationMs: 25,
+  describe('inline detail', () => {
+    it('separates a passed check detail with a middle dot', () => {
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target', detail: 'up to date' })] }));
+
+      expect(lineNaming(output, 'target')).toBe(`${PASSED} target \u{00B7} up to date`);
     });
 
-    const output = reportRdy(report);
+    it('separates a skip reason with a middle dot', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeSkippedResult({ name: 'target', skipReason: 'n/a', detail: 'no lockfile' })] }),
+      );
 
-    expect(output).toContain(`${ICON_PASSED} 2 passed (25ms)`);
-    expect(output).not.toContain('failed');
-    expect(output).not.toContain('skipped');
-  });
-
-  describe('inline mode', () => {
-    it('shows error and fix below failed check', () => {
-      const report = makeReport({
-        results: [
-          makeFailedResult({
-            name: 'broken',
-            error: new Error('Something went wrong'),
-            fix: 'Run npm install',
-          }),
-        ],
-        passed: false,
-      });
-
-      const output = reportRdy(report, { fixLocation: 'inline' });
-      const lines = output.split('\n');
-
-      expect(output).toContain('Error: Something went wrong');
-      expect(output).toContain(`${ICON_FIX} Fix: Run npm install`);
-
-      const checkLineIndex = lines.findIndex((l) => l.includes('broken'));
-      const errorLineIndex = lines.findIndex((l) => l.includes('Error: Something went wrong'));
-      expect(errorLineIndex).toBe(checkLineIndex + 1);
+      expect(lineNaming(output, 'target')).toBe(`${SKIPPED_OPTIONAL} target \u{00B7} no lockfile`);
     });
 
-    it('shows fix without error when error is null', () => {
-      const report = makeReport({
-        results: [makeFailedResult({ name: 'broken', fix: 'Run npm install' })],
-        passed: false,
-      });
+    it('brackets progress', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makePassedResult({ name: 'target', progress: { type: 'fraction', passedCount: 7, count: 10 } })],
+        }),
+      );
 
-      const output = reportRdy(report, { fixLocation: 'inline' });
-
-      expect(output).toContain(`${ICON_FIX} Fix: Run npm install`);
-      expect(output).not.toContain('Error:');
-    });
-
-    it('shows error without fix when fix is null', () => {
-      const report = makeReport({
-        results: [makeFailedResult({ name: 'broken', error: new Error('Missing file') })],
-        passed: false,
-      });
-
-      const output = reportRdy(report, { fixLocation: 'inline' });
-
-      expect(output).toContain('Error: Missing file');
-      expect(output).not.toContain(ICON_FIX);
-    });
-  });
-
-  describe('end mode', () => {
-    it('shows error inline and collects fixes at the bottom', () => {
-      const report = makeReport({
-        results: [
-          makeFailedResult({
-            name: 'broken',
-            error: new Error('Bad config'),
-            fix: 'Update config file',
-          }),
-        ],
-        passed: false,
-      });
-
-      const output = reportRdy(report, { fixLocation: 'end' });
-
-      const lines = output.split('\n');
-      const errorLineIndex = lines.findIndex((l) => l.includes('Error: Bad config'));
-      const checkLineIndex = lines.findIndex((l) => l.includes('broken'));
-      expect(errorLineIndex).toBe(checkLineIndex + 1);
-
-      expect(output).toContain('Fixes:');
-      expect(output).toContain(`  ${ICON_FIX} Update config file`);
-    });
-
-    it('omits Fixes section when no fixes are present', () => {
-      const report = makeReport({
-        results: [makeFailedResult({ name: 'broken', error: new Error('Unknown error') })],
-        passed: false,
-      });
-
-      const output = reportRdy(report, { fixLocation: 'end' });
-
-      expect(output).toContain('Error: Unknown error');
-      expect(output).not.toContain('Fixes:');
-    });
-  });
-
-  describe('detail and progress rendering', () => {
-    it('renders detail inline after duration', () => {
-      const report = makeReport({
-        results: [makePassedResult({ name: 'check-a', durationMs: 10, detail: 'some info' })],
-      });
-
-      const output = reportRdy(report);
-
-      expect(output).toContain(`${ICON_PASSED} check-a (10ms) \u{2014} some info`);
-    });
-
-    it('renders fraction progress', () => {
-      const report = makeReport({
-        results: [
-          makeFailedResult({
-            name: 'check-b',
-            progress: { type: 'fraction', passedCount: 7, count: 10 },
-          }),
-        ],
-        passed: false,
-      });
-
-      const output = reportRdy(report);
-
-      expect(output).toContain(`${ICON_ERROR_FAILED} check-b (5ms) \u{2014} 7 of 10`);
+      expect(lineNaming(output, 'target')).toBe(`${PASSED} target [7 of 10]`);
     });
 
     it('renders percent progress', () => {
-      const report = makeReport({
-        results: [makeFailedResult({ name: 'check-c', durationMs: 3, progress: { type: 'percent', percent: 85 } })],
-        passed: false,
-      });
+      const output = reportRdy(
+        makeReport({ results: [makePassedResult({ name: 'target', progress: { type: 'percent', percent: 85 } })] }),
+      );
 
-      const output = reportRdy(report);
-
-      expect(output).toContain(`${ICON_ERROR_FAILED} check-c (3ms) \u{2014} 85%`);
+      expect(lineNaming(output, 'target')).toBe(`${PASSED} target [85%]`);
     });
 
-    it('renders both detail and progress as separate segments', () => {
-      const report = makeReport({
-        results: [
-          makeFailedResult({
-            name: 'check-d',
-            detail: 'some detail',
-            progress: { type: 'fraction', passedCount: 7, count: 10 },
-          }),
-        ],
-        passed: false,
-      });
+    it('renders detail and progress together with one separator', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({
+              name: 'target',
+              detail: 'all good',
+              progress: { type: 'percent', percent: 100 },
+            }),
+          ],
+        }),
+      );
 
-      const output = reportRdy(report);
-
-      expect(output).toContain(`${ICON_ERROR_FAILED} check-d (5ms) \u{2014} some detail \u{2014} 7 of 10`);
+      expect(lineNaming(output, 'target')).toBe(`${PASSED} target \u{00B7} all good [100%]`);
     });
 
-    it('renders detail and progress on passing checks', () => {
-      const report = makeReport({
-        results: [
-          makePassedResult({
-            name: 'check-e',
-            durationMs: 2,
-            detail: 'all good',
-            progress: { type: 'percent', percent: 100 },
-          }),
-        ],
-      });
+    it('retires the em-dash separator', () => {
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target', detail: 'up to date' })] }));
 
-      const output = reportRdy(report);
-
-      expect(output).toContain(`${ICON_PASSED} check-e (2ms) \u{2014} all good \u{2014} 100%`);
-    });
-
-    it('omits detail segment when detail is null', () => {
-      const report = makeReport({
-        results: [makePassedResult({ name: 'check-f', durationMs: 1 })],
-      });
-
-      const output = reportRdy(report);
-
-      expect(output).toContain(`${ICON_PASSED} check-f (1ms)`);
       expect(output).not.toContain('\u{2014}');
     });
   });
 
-  it('defaults to end mode when no options are provided', () => {
-    const report = makeReport({
-      results: [
-        makeFailedResult({
-          name: 'broken',
-          error: new Error('Oops'),
-          fix: 'Fix it',
-        }),
-      ],
-      passed: false,
+  describe('duration', () => {
+    it('omits a duration below the floor', () => {
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target', durationMs: 10 })] }));
+
+      expect(lineNaming(output, 'target')).toBe(`${PASSED} target`);
     });
 
-    const output = reportRdy(report);
+    it('shows a duration at or above the floor', () => {
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target', durationMs: SLOW_MS })] }));
 
-    expect(output).toContain('Fixes:');
-    expect(output).toContain(`  ${ICON_FIX} Fix it`);
-    expect(output).not.toContain('Fix: Fix it');
+      expect(lineNaming(output, 'target')).toBe(`${PASSED} target (250ms)`);
+    });
+
+    it.each(['n/a', 'precondition'] as const)('omits the duration on a %s-skipped check', (skipReason) => {
+      const output = reportRdy(
+        makeReport({ results: [makeSkippedResult({ name: 'target', skipReason, durationMs: SLOW_MS })] }),
+      );
+
+      expect(lineNaming(output, 'target')).not.toContain('ms');
+    });
+
+    it('always shows the total duration on the count line', () => {
+      const output = reportRdy(makeReport({ results: [makePassedResult()], durationMs: 4 }));
+
+      expect(output.split('\n').at(-1)).toBe(`${PASSED} 1 passed (4ms)`);
+    });
   });
 
-  describe('nested checks', () => {
-    it('indents nested results by depth', () => {
-      const report = makeReport({
-        results: [
-          makePassedResult({ name: 'parent', depth: 0, durationMs: 10 }),
-          makePassedResult({ name: 'child', depth: 1, durationMs: 5 }),
-          makePassedResult({ name: 'grandchild', depth: 2, durationMs: 3 }),
-        ],
-      });
+  describe('failure reasons', () => {
+    it('leaves the failed line carrying only its claim', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'target', detail: 'lockfile is stale' })], passed: false }),
+      );
 
-      const output = reportRdy(report);
+      expect(lineNaming(output, 'target')).toBe(`${FAILED_ERROR} target`);
+    });
+
+    it('renders the authored detail beneath, indented to the name column', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'target', detail: 'lockfile is stale' })], passed: false }),
+      );
       const lines = output.split('\n');
 
-      expect(lines[0]).toBe(`${ICON_PASSED} parent (10ms)`);
-      expect(lines[1]).toBe(`   ${ICON_PASSED} child (5ms)`);
-      expect(lines[2]).toBe(`      ${ICON_PASSED} grandchild (3ms)`);
+      expect(lines[1]).toBe('   lockfile is stale');
     });
 
-    it('renders top-level result at depth 0 with no indentation', () => {
-      const report = makeReport({
-        results: [makePassedResult({ name: 'top-check', depth: 0, durationMs: 7 })],
-      });
-
-      const output = reportRdy(report);
+    it('renders the authored detail before the labeled exception', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makeFailedResult({ name: 'target', detail: 'lockfile is stale', error: new Error('ENOENT') })],
+          passed: false,
+        }),
+      );
       const lines = output.split('\n');
 
-      expect(lines[0]).toBe(`${ICON_PASSED} top-check (7ms)`);
+      expect(lines[1]).toBe('   lockfile is stale');
+      expect(lines[2]).toBe('   Error: ENOENT');
     });
 
-    it('renders an n/a result and the results that follow it', () => {
-      const report = makeReport({
-        results: [
-          makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
-          makePassedResult({ name: 'next-sibling', depth: 0, durationMs: 10 }),
-        ],
-      });
+    it('renders an exception alone when no detail was authored', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'target', error: new Error('boom') })], passed: false }),
+      );
 
-      const output = reportRdy(report);
-
-      expect(output).toContain('na-parent');
-      expect(output).toContain('next-sibling');
+      expect(output.split('\n', 2)[1]).toBe('   Error: boom');
     });
 
-    it('indents inline detail lines at parent depth', () => {
-      const report = makeReport({
-        results: [
-          makePassedResult({ name: 'parent', depth: 0 }),
-          makeFailedResult({
-            name: 'child',
-            depth: 1,
-            error: new Error('child error'),
-            fix: 'fix child',
-          }),
-        ],
-        passed: false,
-      });
+    it('renders no block for a failure deriving from its children', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makeFailedResult({ name: 'parent' }), makeFailedResult({ name: 'child', depth: 1 })],
+          passed: false,
+        }),
+      );
 
-      const output = reportRdy(report, { fixLocation: 'inline' });
+      expect(output.split('\n').slice(0, 2)).toStrictEqual([`${FAILED_ERROR} parent`, `   ${FAILED_ERROR} child`]);
+    });
+
+    it('indents a nested failure reason to that check\u{2019}s own name column', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'parent' }),
+            makePassedResult({ name: 'child', depth: 1 }),
+            makeFailedResult({ name: 'grandchild', depth: 2, detail: 'went wrong' }),
+          ],
+          passed: false,
+        }),
+      );
+
+      expect(output.split('\n', 4)[3]).toBe('         went wrong');
+    });
+  });
+
+  describe('count line', () => {
+    it('leads with the worst severity rather than the passed count', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makePassedResult({ name: 'a' }), makeFailedResult({ name: 'b', severity: 'warn' })],
+          passed: false,
+          durationMs: 142,
+        }),
+      );
+
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_WARN} 1 passed | 1 warning (142ms)`);
+    });
+
+    it('orders the fields by decreasing severity and omits zeros', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'a' }),
+            makeFailedResult({ name: 'b', severity: 'error' }),
+            makeFailedResult({ name: 'c', severity: 'recommend' }),
+            makeSkippedResult({ name: 'd', skipReason: 'precondition' }),
+            makeSkippedResult({ name: 'e', skipReason: 'n/a' }),
+          ],
+          passed: false,
+          durationMs: 500,
+        }),
+      );
+
+      expect(output.split('\n').at(-1)).toBe(
+        `${FAILED_ERROR} 1 passed | 1 error | 1 recommendation | 1 blocked | 1 skipped (500ms)`,
+      );
+    });
+
+    it('counts results pruned from the tree by the reporting threshold', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'shown', severity: 'error' }),
+            makePassedResult({ name: 'pruned', severity: 'recommend' }),
+          ],
+        }),
+        { reportOn: 'error' },
+      );
+
+      expect(output).not.toContain('pruned');
+      expect(output.split('\n').at(-1)).toContain('2 passed');
+    });
+
+    it('separates the count line from the tree with a blank line', () => {
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] }));
+
+      expect(output.split('\n', 2)[1]).toBe('');
+    });
+  });
+
+  describe('fix recap in end mode', () => {
+    it('attributes each fix to the check that raised it', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run pnpm install' })], passed: false }),
+      );
+      const lines = output.split('\n');
+      const heading = indexNaming(output, 'Fixes');
+
+      expect(lines[heading]).toBe('\u{2500}\u{2500} Fixes');
+      expect(lines[heading + 2]).toBe(`${FIX} broken`);
+      expect(lines[heading + 3]).toBe('   Run pnpm install');
+    });
+
+    it('recaps a fix from each failed check', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makeFailedResult({ name: 'first', fix: 'fix one' }),
+            makeFailedResult({ name: 'second', fix: 'fix two' }),
+          ],
+          passed: false,
+        }),
+      );
+
+      expect(output).toContain(`${FIX} first`);
+      expect(output).toContain(`${FIX} second`);
+    });
+
+    it('keeps the fix out of the reason block', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makeFailedResult({ name: 'broken', error: new Error('bad'), fix: 'Update config' })],
+          passed: false,
+        }),
+      );
+      const checkLine = indexNaming(output, 'broken');
+
+      expect(output.split('\n')[checkLine + 1]).toBe('   Error: bad');
+      expect(output.split('\n')[checkLine + 2]).not.toContain('Update config');
+    });
+
+    it('omits the recap when no failed check carries a fix', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'broken', error: new Error('bad') })], passed: false }),
+      );
+
+      expect(output).not.toContain('Fixes');
+      expect(output).not.toContain(FIX);
+    });
+
+    it('recaps a nested check by name', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'parent' }),
+            makeFailedResult({ name: 'child', depth: 1, fix: 'fix child' }),
+          ],
+          passed: false,
+        }),
+      );
+
+      expect(output).toContain(`${FIX} child`);
+      expect(output).toContain('   fix child');
+    });
+
+    it('is the default when no options are given', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Fix it' })], passed: false }),
+      );
+
+      expect(output).toContain('\u{2500}\u{2500} Fixes');
+    });
+  });
+
+  describe('fix in inline mode', () => {
+    it('joins the fix to the reason block beneath the check', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makeFailedResult({ name: 'broken', error: new Error('Something went wrong'), fix: 'Run install' })],
+          passed: false,
+        }),
+        { fixLocation: 'inline' },
+      );
+
+      expect(output.split('\n').slice(0, 3)).toStrictEqual([
+        `${FAILED_ERROR} broken`,
+        '   Error: Something went wrong',
+        `   ${FIX} Run install`,
+      ]);
+    });
+
+    it('renders a fix without an exception', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run install' })], passed: false }),
+        { fixLocation: 'inline' },
+      );
+
+      expect(output.split('\n', 2)[1]).toBe(`   ${FIX} Run install`);
+      expect(output).not.toContain('Error:');
+    });
+
+    it('renders an exception without a fix', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makeFailedResult({ name: 'broken', error: new Error('Missing file') })],
+          passed: false,
+        }),
+        { fixLocation: 'inline' },
+      );
+
+      expect(output).toContain('Error: Missing file');
+      expect(output).not.toContain(FIX);
+    });
+
+    it('adds no end-of-report recap', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run install' })], passed: false }),
+        { fixLocation: 'inline' },
+      );
+
+      expect(output).not.toContain('Fixes');
+    });
+
+    it('indents a nested fix to that check\u{2019}s own name column', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'parent' }),
+            makeFailedResult({ name: 'child', depth: 1, error: new Error('child error'), fix: 'fix child' }),
+          ],
+          passed: false,
+        }),
+        { fixLocation: 'inline' },
+      );
       const lines = output.split('\n');
 
-      const childLine = lines.findIndex((l) => l.includes('child'));
-      expect(lines[childLine]).toMatch(/^ {3}/);
-      expect(lines[childLine + 1]).toBe('      Error: child error');
-      expect(lines[childLine + 2]).toBe(`      ${ICON_FIX} Fix: fix child`);
+      expect(lines[2]).toBe('      Error: child error');
+      expect(lines[3]).toBe(`      ${FIX} fix child`);
     });
+  });
 
-    it('collects fixes from nested failed checks in end mode', () => {
-      const report = makeReport({
-        results: [
-          makePassedResult({ name: 'parent', depth: 0 }),
-          makeFailedResult({
-            name: 'child',
-            depth: 1,
-            error: new Error('child error'),
-            fix: 'fix the child',
-          }),
-        ],
-        passed: false,
-      });
+  describe('nesting', () => {
+    it('indents each level by one gutter', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'parent', depth: 0 }),
+            makePassedResult({ name: 'child', depth: 1 }),
+            makePassedResult({ name: 'grandchild', depth: 2 }),
+            makePassedResult({ name: 'great-grandchild', depth: 3 }),
+          ],
+        }),
+      );
 
-      const output = reportRdy(report, { fixLocation: 'end' });
-      const lines = output.split('\n');
-
-      const childLine = lines.findIndex((l) => l.includes('child'));
-      expect(lines[childLine + 1]).toBe('      Error: child error');
-      expect(output).toContain('Fixes:');
-      expect(output).toContain(`  ${ICON_FIX} fix the child`);
-      // Fix should not appear inline after the error line.
-      expect(lines[childLine + 2]).not.toContain('fix the child');
-    });
-
-    it('includes nested results in summary counts', () => {
-      const report = makeReport({
-        results: [
-          makePassedResult({ name: 'parent', depth: 0 }),
-          makePassedResult({ name: 'child', depth: 1 }),
-          makeFailedResult({ name: 'child-fail', depth: 1 }),
-        ],
-        passed: false,
-        durationMs: 50,
-      });
-
-      const output = reportRdy(report);
-
-      expect(output).toContain(`${ICON_PASSED} 2 passed. Failed: ${ICON_ERROR_FAILED} 1 error`);
-    });
-
-    it('counts an n/a result as an optional skip', () => {
-      const report = makeReport({
-        results: [
-          makeSkippedResult({ name: 'na-parent', skipReason: 'n/a', depth: 0 }),
-          makePassedResult({ name: 'sibling', depth: 0, durationMs: 10 }),
-        ],
-        durationMs: 50,
-      });
-
-      const output = reportRdy(report);
-
-      expect(output).toContain(`${ICON_PASSED} 1 passed`);
-      expect(output).toContain(`${ICON_SKIPPED_NA} 1 optional`);
+      expect(output.split('\n').slice(0, 4)).toStrictEqual([
+        `${PASSED} parent`,
+        `   ${PASSED} child`,
+        `      ${PASSED} grandchild`,
+        `         ${PASSED} great-grandchild`,
+      ]);
     });
 
     it('renders every result it is given, applying no suppression of its own', () => {
       // `runRdy` no longer emits descendants of an n/a result, so the renderer must not
       // second-guess its input: whatever arrives is displayed and counted.
-      const report = makeReport({
-        results: [
-          makeSkippedResult({ name: 'na-check', skipReason: 'n/a', depth: 1 }),
-          makeSkippedResult({ name: 'deeper', skipReason: 'precondition', depth: 2 }),
-          makePassedResult({ name: 'sibling', depth: 1, durationMs: 5 }),
-        ],
-      });
-
-      const output = reportRdy(report);
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makeSkippedResult({ name: 'na-check', skipReason: 'n/a', depth: 1 }),
+            makeSkippedResult({ name: 'deeper', skipReason: 'precondition', depth: 2 }),
+            makePassedResult({ name: 'sibling', depth: 1 }),
+          ],
+        }),
+      );
 
       expect(output).toContain('na-check');
       expect(output).toContain('deeper');
       expect(output).toContain('sibling');
-      expect(output).toContain(`${ICON_SKIPPED_PRECONDITION} 1 blocked`);
+      expect(output.split('\n').at(-1)).toContain('1 blocked');
+    });
+
+    it('includes nested results in the counts', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'parent', depth: 0 }),
+            makePassedResult({ name: 'child', depth: 1 }),
+            makeFailedResult({ name: 'child-fail', depth: 1 }),
+          ],
+          passed: false,
+          durationMs: 50,
+        }),
+      );
+
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} 2 passed | 1 error (50ms)`);
     });
   });
 
   describe('reporting threshold', () => {
     it('excludes results below the reporting threshold', () => {
-      const report = makeReport({
-        results: [
-          makeFailedResult({ name: 'error-check', severity: 'error' }),
-          makeFailedResult({ name: 'recommend-check', severity: 'recommend' }),
-        ],
-        passed: false,
-      });
-
-      const output = reportRdy(report, { reportOn: 'error' });
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makeFailedResult({ name: 'error-check', severity: 'error' }),
+            makeFailedResult({ name: 'recommend-check', severity: 'recommend' }),
+          ],
+          passed: false,
+        }),
+        { reportOn: 'error' },
+      );
 
       expect(output).toContain('error-check');
       expect(output).not.toContain('recommend-check');
     });
 
-    it('counts every result in the summary, including results pruned from the tree', () => {
-      const report = makeReport({
-        results: [
-          makePassedResult({ name: 'error-pass', severity: 'error' }),
-          makePassedResult({ name: 'recommend-pass', severity: 'recommend' }),
-        ],
-      });
-
-      const output = reportRdy(report, { reportOn: 'error' });
-
-      expect(output).toContain(`${ICON_PASSED} 2 passed`);
-      expect(output).not.toContain('recommend-pass');
-    });
-
     it('reports a below-threshold failure in the counts and worst severity', () => {
-      const report = makeReport({
-        results: [
-          makePassedResult({ name: 'error-pass', severity: 'error' }),
-          makeFailedResult({ name: 'warn-fail', severity: 'warn' }),
-        ],
-        passed: false,
-      });
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makePassedResult({ name: 'error-pass', severity: 'error' }),
+            makeFailedResult({ name: 'warn-fail', severity: 'warn' }),
+          ],
+          passed: false,
+        }),
+        { reportOn: 'error' },
+      );
 
-      const output = reportRdy(report, { reportOn: 'error' });
-
-      expect(output).toContain(`${ICON_WARN_FAILED} 1 warning`);
+      expect(output.split('\n').at(-1)).toContain(`${FAILED_WARN} 1 passed | 1 warning`);
       expect(output).not.toContain('warn-fail');
     });
 
-    it('hides precondition result when its severity is below the reporting threshold', () => {
-      const report = makeReport({
-        results: [
-          makeSkippedResult({ name: 'precond', severity: 'recommend', skipReason: 'precondition' }),
-          makeFailedResult({ name: 'error-check', severity: 'error' }),
-        ],
-        passed: false,
-      });
-
-      const output = reportRdy(report, { reportOn: 'error' });
+    it('hides a precondition result whose severity is below the threshold', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makeSkippedResult({ name: 'precond', severity: 'recommend', skipReason: 'precondition' }),
+            makeFailedResult({ name: 'error-check', severity: 'error' }),
+          ],
+          passed: false,
+        }),
+        { reportOn: 'error' },
+      );
 
       expect(output).toContain('error-check');
       expect(output).not.toContain('precond');
     });
 
-    it('shows only skipped dependents whose severity meets the reporting threshold', () => {
-      const report = makeReport({
-        results: [
-          makeSkippedResult({ name: 'high-sev-dep', severity: 'error', skipReason: 'precondition' }),
-          makeSkippedResult({ name: 'low-sev-dep', severity: 'recommend', skipReason: 'precondition' }),
-        ],
-      });
-
-      const output = reportRdy(report, { reportOn: 'warn' });
+    it('shows only skipped dependents whose severity meets the threshold', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [
+            makeSkippedResult({ name: 'high-sev-dep', severity: 'error', skipReason: 'precondition' }),
+            makeSkippedResult({ name: 'low-sev-dep', severity: 'recommend', skipReason: 'precondition' }),
+          ],
+        }),
+        { reportOn: 'warn' },
+      );
 
       expect(output).toContain('high-sev-dep');
       expect(output).not.toContain('low-sev-dep');
     });
 
-    it('defaults reportOn to recommend (show all)', () => {
-      const report = makeReport({
-        results: [makePassedResult({ name: 'recommend-check', severity: 'recommend' })],
-      });
-
-      const output = reportRdy(report);
+    it('defaults reportOn to recommend, showing everything', () => {
+      const output = reportRdy(
+        makeReport({ results: [makePassedResult({ name: 'recommend-check', severity: 'recommend' })] }),
+      );
 
       expect(output).toContain('recommend-check');
     });
@@ -598,159 +609,6 @@ function makeCounts(overrides?: Partial<SummaryCounts>): SummaryCounts {
     ...overrides,
   };
 }
-
-describe(formatSummaryCounts, () => {
-  it('includes all non-zero counts with icons across all three groups', () => {
-    const counts = makeCounts({
-      passed: 14,
-      errors: 1,
-      warnings: 1,
-      recommendations: 2,
-      blocked: 5,
-      optional: 2,
-      worstSeverity: 'error',
-    });
-
-    expect(formatSummaryCounts(counts)).toBe(
-      `${ICON_PASSED} 14 passed. Failed: ${ICON_ERROR_FAILED} 1 error, ${ICON_WARN_FAILED} 1 warning, ${ICON_RECOMMEND_FAILED} 2 recommendations. Skipped: ${ICON_SKIPPED_PRECONDITION} 5 blocked, ${ICON_SKIPPED_NA} 2 optional`,
-    );
-  });
-
-  it('pluralizes errors correctly for counts of 1 and 2', () => {
-    expect(formatSummaryCounts(makeCounts({ errors: 1, worstSeverity: 'error' }))).toBe(
-      `Failed: ${ICON_ERROR_FAILED} 1 error`,
-    );
-    expect(formatSummaryCounts(makeCounts({ errors: 2, worstSeverity: 'error' }))).toBe(
-      `Failed: ${ICON_ERROR_FAILED} 2 errors`,
-    );
-  });
-
-  it('pluralizes warnings correctly for counts of 1 and 2', () => {
-    expect(formatSummaryCounts(makeCounts({ warnings: 1, worstSeverity: 'warn' }))).toBe(
-      `Failed: ${ICON_WARN_FAILED} 1 warning`,
-    );
-    expect(formatSummaryCounts(makeCounts({ warnings: 2, worstSeverity: 'warn' }))).toBe(
-      `Failed: ${ICON_WARN_FAILED} 2 warnings`,
-    );
-  });
-
-  it('pluralizes recommendations correctly for counts of 1 and 2', () => {
-    expect(formatSummaryCounts(makeCounts({ recommendations: 1, worstSeverity: 'recommend' }))).toBe(
-      `Failed: ${ICON_RECOMMEND_FAILED} 1 recommendation`,
-    );
-    expect(formatSummaryCounts(makeCounts({ recommendations: 2, worstSeverity: 'recommend' }))).toBe(
-      `Failed: ${ICON_RECOMMEND_FAILED} 2 recommendations`,
-    );
-  });
-
-  it('keeps `blocked` and `optional` labels unchanged for any count', () => {
-    expect(formatSummaryCounts(makeCounts({ blocked: 1, optional: 1 }))).toBe(
-      `Skipped: ${ICON_SKIPPED_PRECONDITION} 1 blocked, ${ICON_SKIPPED_NA} 1 optional`,
-    );
-    expect(formatSummaryCounts(makeCounts({ blocked: 3, optional: 4 }))).toBe(
-      `Skipped: ${ICON_SKIPPED_PRECONDITION} 3 blocked, ${ICON_SKIPPED_NA} 4 optional`,
-    );
-  });
-
-  it('omits the Failed group when no failure categories have counts', () => {
-    expect(formatSummaryCounts(makeCounts({ passed: 5 }))).toBe(`${ICON_PASSED} 5 passed`);
-  });
-
-  it('omits the Skipped group when no skip categories have counts', () => {
-    expect(formatSummaryCounts(makeCounts({ passed: 5, errors: 1, worstSeverity: 'error' }))).toBe(
-      `${ICON_PASSED} 5 passed. Failed: ${ICON_ERROR_FAILED} 1 error`,
-    );
-  });
-
-  it('omits zero-count categories within an otherwise non-empty group', () => {
-    expect(formatSummaryCounts(makeCounts({ errors: 2, recommendations: 1, worstSeverity: 'error' }))).toBe(
-      `Failed: ${ICON_ERROR_FAILED} 2 errors, ${ICON_RECOMMEND_FAILED} 1 recommendation`,
-    );
-  });
-
-  it('returns empty string when all counts are zero', () => {
-    expect(formatSummaryCounts(makeCounts())).toBe('');
-  });
-});
-
-describe(formatSummaryCountsPlain, () => {
-  it('formats passed count without inline icons', () => {
-    expect(formatSummaryCountsPlain(makeCounts({ passed: 3 }))).toBe('3 passed');
-  });
-
-  it('formats Failed segment without per-count severity icons', () => {
-    const counts = makeCounts({
-      errors: 1,
-      warnings: 2,
-      recommendations: 3,
-      worstSeverity: 'error',
-    });
-
-    const output = formatSummaryCountsPlain(counts);
-
-    expect(output).toBe('Failed: 1 error, 2 warnings, 3 recommendations');
-    expect(output).not.toContain(ICON_ERROR_FAILED);
-    expect(output).not.toContain(ICON_WARN_FAILED);
-    expect(output).not.toContain(ICON_RECOMMEND_FAILED);
-  });
-
-  it('formats Skipped segment without per-count reason icons', () => {
-    const counts = makeCounts({ blocked: 2, optional: 3 });
-
-    const output = formatSummaryCountsPlain(counts);
-
-    expect(output).toBe('Skipped: 2 blocked, 3 optional');
-    expect(output).not.toContain(ICON_SKIPPED_PRECONDITION);
-    expect(output).not.toContain(ICON_SKIPPED_NA);
-  });
-
-  it('joins all three groups with icon-free counts', () => {
-    const counts = makeCounts({
-      passed: 14,
-      errors: 1,
-      warnings: 1,
-      recommendations: 2,
-      blocked: 5,
-      optional: 2,
-      worstSeverity: 'error',
-    });
-
-    expect(formatSummaryCountsPlain(counts)).toBe(
-      '14 passed. Failed: 1 error, 1 warning, 2 recommendations. Skipped: 5 blocked, 2 optional',
-    );
-  });
-
-  it('omits the 🟢 prefix from the passed count', () => {
-    expect(formatSummaryCountsPlain(makeCounts({ passed: 5 }))).not.toContain(ICON_PASSED);
-  });
-
-  it('returns empty string when all counts are zero', () => {
-    expect(formatSummaryCountsPlain(makeCounts())).toBe('');
-  });
-
-  it('matches formatSummaryCounts except for the absence of per-count icon prefixes', () => {
-    const counts = makeCounts({
-      passed: 2,
-      errors: 1,
-      warnings: 1,
-      recommendations: 1,
-      blocked: 1,
-      optional: 1,
-      worstSeverity: 'error',
-    });
-
-    // Strip every known severity/skip icon (and the trailing space) from the iconed output.
-    const iconStripped = formatSummaryCounts(counts)
-      .replaceAll(`${ICON_PASSED} `, '')
-      .replaceAll(`${ICON_ERROR_FAILED} `, '')
-      .replaceAll(`${ICON_WARN_FAILED} `, '')
-      .replaceAll(`${ICON_RECOMMEND_FAILED} `, '')
-      .replaceAll(`${ICON_SKIPPED_PRECONDITION} `, '')
-      .replaceAll(`${ICON_SKIPPED_NA} `, '');
-
-    expect(formatSummaryCountsPlain(counts)).toBe(iconStripped);
-  });
-});
 
 describe(countResults, () => {
   it('returns zeroed counts for an empty result list', () => {
@@ -813,12 +671,6 @@ describe(countResults, () => {
     expect(counts.optional).toBe(1);
     expect(counts.blocked).toBe(0);
     expect(counts.worstSeverity).toBeNull();
-  });
-
-  it('escalates worstSeverity from null to recommend on first recommend failure', () => {
-    const counts = countResults([makeFailedResult({ severity: 'recommend' })]);
-
-    expect(counts.worstSeverity).toBe('recommend');
   });
 
   it('escalates worstSeverity from recommend to warn', () => {
@@ -952,11 +804,5 @@ describe(selectVisibleResults, () => {
     selectVisibleResults(results, 'error');
 
     expect(results.map((r) => r.name)).toStrictEqual(['parent', 'child']);
-  });
-});
-
-describe('status icons', () => {
-  it('marks skipped-N/A outcomes with the skip-forward emoji, not the magnifying glass', () => {
-    expect(ICON_SKIPPED_NA).toBe('\u{23ED}\u{FE0F}');
   });
 });

--- a/packages/readyup/__tests__/terminal.test.ts
+++ b/packages/readyup/__tests__/terminal.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { emojiFormatter } from '../src/layout/emojiFormatter.ts';
+import { printStep, reportWriteResult } from '../src/terminal.ts';
+import type { WriteResult } from '../src/writeFileWithCheck.ts';
+
+const PASSED = emojiFormatter.tokens.passed.glyph;
+const SKIPPED = emojiFormatter.tokens.skippedOptional.glyph;
+const WARNED = emojiFormatter.tokens.failedWarn.glyph;
+const FAILED = emojiFormatter.tokens.failedError.glyph;
+
+const PATH = '.config/readyup.config.ts';
+
+function makeResult(overrides: Partial<WriteResult> = {}): WriteResult {
+  return { filePath: PATH, outcome: 'created', ...overrides };
+}
+
+describe(printStep, () => {
+  let infoSpy: MockInstance;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a step label as a section heading set off by blank lines', () => {
+    printStep('Scaffolding config');
+
+    expect(infoSpy).toHaveBeenCalledWith('\n\u{2500}\u{2500} Scaffolding config\n');
+  });
+
+  it('retires the arrow-prefixed step grammar', () => {
+    printStep('Next steps');
+
+    expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('> Next steps'));
+  });
+});
+
+describe(reportWriteResult, () => {
+  let infoSpy: MockInstance;
+  let errorSpy: MockInstance;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe.each([
+    ['created', { outcome: 'created' as const }, `${PASSED} ${PATH} \u{00B7} created`],
+    ['overwrote', { outcome: 'overwritten' as const }, `${PASSED} ${PATH} \u{00B7} overwrote`],
+    ['up to date', { outcome: 'up-to-date' as const }, `${PASSED} ${PATH} \u{00B7} up to date`],
+    ['already exists', { outcome: 'skipped' as const }, `${SKIPPED} ${PATH} \u{00B7} already exists`],
+  ])('%s', (_case, overrides, expected) => {
+    it('renders the ratified token with the outcome as inline detail', () => {
+      reportWriteResult(makeResult(overrides), false);
+
+      expect(infoSpy).toHaveBeenCalledWith(expected);
+    });
+
+    it('writes to stdout', () => {
+      reportWriteResult(makeResult(overrides), false);
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe.each([
+    ['created', { outcome: 'created' as const }, 'would create'],
+    ['overwritten', { outcome: 'overwritten' as const }, 'would overwrite'],
+  ])('%s under dry run', (_case, overrides, expected) => {
+    it('states what would happen rather than what did', () => {
+      reportWriteResult(makeResult(overrides), true);
+
+      expect(infoSpy).toHaveBeenCalledWith(`${PASSED} ${PATH} \u{00B7} ${expected}`);
+    });
+  });
+
+  describe('unreadable for comparison', () => {
+    const result = makeResult({ outcome: 'skipped', error: 'EACCES' });
+
+    it('warns rather than reporting a benign skip', () => {
+      reportWriteResult(result, false);
+
+      expect(infoSpy).toHaveBeenCalledWith(`${WARNED} ${PATH}\n   could not read for comparison: EACCES`);
+    });
+
+    it('puts the reason in a block rather than inline', () => {
+      reportWriteResult(result, false);
+
+      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining(`${PATH} \u{00B7}`));
+    });
+  });
+
+  describe('failed', () => {
+    it('renders a claim with the cause in a block beneath', () => {
+      reportWriteResult(makeResult({ outcome: 'failed', error: 'ENOSPC' }), false);
+
+      expect(errorSpy).toHaveBeenCalledWith(`${FAILED} ${PATH}\n   failed to write: ENOSPC`);
+    });
+
+    it('states the failure without a cause when none was captured', () => {
+      reportWriteResult(makeResult({ outcome: 'failed' }), false);
+
+      expect(errorSpy).toHaveBeenCalledWith(`${FAILED} ${PATH}\n   failed to write`);
+    });
+
+    it('routes to stderr so a caller redirecting stdout still sees it', () => {
+      reportWriteResult(makeResult({ outcome: 'failed', error: 'ENOSPC' }), false);
+
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each(['\u{2705}', '\u{26A0}', '\u{274C}', '\u{FE0F}'])('renders no %s for any outcome', (retired) => {
+    const outcomes: WriteResult[] = [
+      makeResult({ outcome: 'created' }),
+      makeResult({ outcome: 'overwritten' }),
+      makeResult({ outcome: 'up-to-date' }),
+      makeResult({ outcome: 'skipped' }),
+      makeResult({ outcome: 'skipped', error: 'EACCES' }),
+      makeResult({ outcome: 'failed', error: 'ENOSPC' }),
+    ];
+
+    for (const result of outcomes) {
+      reportWriteResult(result, false);
+    }
+
+    const written = [...infoSpy.mock.calls, ...errorSpy.mock.calls].flat().join('\n');
+    expect(written).not.toContain(retired);
+  });
+});

--- a/packages/readyup/__tests__/verify/verifyCommand.integration.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.integration.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
+import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
 import { hashBytes } from '../../src/verify/targetHash.ts';
 import { verifyCommand } from '../../src/verify/verifyCommand.ts';
 
@@ -12,6 +13,9 @@ import { verifyCommand } from '../../src/verify/verifyCommand.ts';
  * against real files in a tempdir, without mocking the drift helper. Unit tests cover the branches;
  * this locks in the wiring (e.g., that `manifestDir` is threaded through correctly).
  */
+const OK = emojiFormatter.tokens.passed.glyph;
+const FAILED = emojiFormatter.tokens.failedError.glyph;
+
 describe('verifyCommand (integration)', () => {
   let tempDir: string;
   let stdout: string[];
@@ -52,7 +56,7 @@ describe('verifyCommand (integration)', () => {
     const exitCode = verifyCommand(['--manifest', 'manifest.json']);
 
     expect(exitCode).toBe(0);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('✅ demo — ok'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
     expect(stderrSpy).not.toHaveBeenCalled();
   });
 
@@ -70,7 +74,7 @@ describe('verifyCommand (integration)', () => {
     const exitCode = verifyCommand(['--manifest', 'manifest.json']);
 
     expect(exitCode).toBe(1);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('⚠️  demo — drift'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} demo\n   drift`));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('expected deadbeef'));
   });
 
@@ -111,7 +115,7 @@ describe('verifyCommand (integration)', () => {
       const exitCode = verifyCommand(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('✅ demo — ok'));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
     });
 
     it('returns 1 when the source was edited without a recompile', () => {
@@ -121,7 +125,7 @@ describe('verifyCommand (integration)', () => {
       const exitCode = verifyCommand(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('demo — ok; source stale'));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} demo\n   source stale`));
     });
 
     it('returns 1 when the recorded source was deleted', () => {
@@ -131,7 +135,7 @@ describe('verifyCommand (integration)', () => {
       const exitCode = verifyCommand(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('demo — ok; source file missing'));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} demo\n   source file missing`));
     });
 
     it('carries both source hashes in the JSON entry for a stale kit', () => {
@@ -205,7 +209,7 @@ describe('verifyCommand (integration)', () => {
       verifyCommand(['--manifest', 'manifest.json', '--json']);
 
       expect(stdoutSpy).toHaveBeenCalledTimes(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('clean — ok'));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} clean`));
     });
 
     it('passes when every kit is ok or unverified', () => {

--- a/packages/readyup/__tests__/verify/verifyCommand.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.test.ts
@@ -234,7 +234,7 @@ describe(verifyCommand, () => {
   });
 
   describe('unified vocabulary', () => {
-    /** Every verdict pairing, so one sweep covers each line the command can produce. */
+    /** Every verdict the command can report, so one sweep covers each line it produces. */
     const verdicts = [
       { kind: 'ok', targetHash: 'aaaa1111' },
       { kind: 'drift', expected: 'aaaa1111', actual: 'aaaa9999', resolvedPath: '/abs/alpha.js' },

--- a/packages/readyup/__tests__/verify/verifyCommand.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.test.ts
@@ -20,8 +20,13 @@ vi.mock('../../src/verify/checkSourceDrift.ts', () => ({
   checkSourceDrift: mockCheckSourceDrift,
 }));
 
+import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
 import { verifyCommand } from '../../src/verify/verifyCommand.ts';
 import { captureRdyError } from '../helpers/captureRdyError.ts';
+
+const OK = emojiFormatter.tokens.passed.glyph;
+const FAILED = emojiFormatter.tokens.failedError.glyph;
+const UNVERIFIED = emojiFormatter.tokens.skippedOptional.glyph;
 
 describe(verifyCommand, () => {
   let stdoutSpy: MockInstance;
@@ -52,8 +57,8 @@ describe(verifyCommand, () => {
     const exitCode = verifyCommand([]);
 
     expect(exitCode).toBe(0);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('✅ alpha — ok'));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('✅ beta — ok'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha`));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} beta`));
     expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('failed verification'));
   });
 
@@ -77,7 +82,7 @@ describe(verifyCommand, () => {
     const exitCode = verifyCommand([]);
 
     expect(exitCode).toBe(1);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('⚠️  alpha — drift'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} alpha\n   drift`));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('expected aaaa1111, got aaaa9999'));
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2 kits failed verification'));
   });
@@ -92,7 +97,7 @@ describe(verifyCommand, () => {
     const exitCode = verifyCommand([]);
 
     expect(exitCode).toBe(1);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('❓ alpha — compiled file missing'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} alpha\n   compiled file missing`));
   });
 
   it('returns 0 when a kit is unverified (no targetHash)', () => {
@@ -105,7 +110,7 @@ describe(verifyCommand, () => {
     const exitCode = verifyCommand([]);
 
     expect(exitCode).toBe(0);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('➖ alpha — unverified'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${UNVERIFIED} alpha \u{00B7} unverified`));
   });
 
   it('returns 0 and reports no-kits message when the manifest is empty', () => {
@@ -141,7 +146,7 @@ describe(verifyCommand, () => {
 
       expect(exitCode).toBe(1);
       expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining('⚠️  alpha — ok; source stale (expected 5555aaaa, got 6666bbbb)'),
+        expect.stringContaining(`${FAILED} alpha\n   source stale (expected 5555aaaa, got 6666bbbb)`),
       );
     });
 
@@ -153,7 +158,7 @@ describe(verifyCommand, () => {
 
       expect(exitCode).toBe(1);
       expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining('❓ alpha — ok; source file missing (expected alpha.ts)'),
+        expect.stringContaining(`${FAILED} alpha\n   source file missing (expected alpha.ts)`),
       );
     });
 
@@ -164,7 +169,7 @@ describe(verifyCommand, () => {
       const exitCode = verifyCommand([]);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('✅ alpha — ok\n'));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha\n`));
     });
 
     it('passes a manifest that records no source hash, leaving the line unchanged', () => {
@@ -173,7 +178,7 @@ describe(verifyCommand, () => {
       const exitCode = verifyCommand([]);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('✅ alpha — ok\n'));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha\n`));
     });
 
     it('reports both verdicts when the source is stale and the target has drifted', () => {
@@ -196,7 +201,7 @@ describe(verifyCommand, () => {
       expect(exitCode).toBe(1);
       expect(stdoutSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          'alpha — drift (expected aaaa1111, got aaaa9999); source stale (expected 5555aaaa, got 6666bbbb)',
+          `${FAILED} alpha\n   drift (expected aaaa1111, got aaaa9999)\n   source stale (expected 5555aaaa, got 6666bbbb)`,
         ),
       );
     });
@@ -226,5 +231,53 @@ describe(verifyCommand, () => {
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain('does not accept positional arguments');
+  });
+
+  describe('unified vocabulary', () => {
+    /** Every verdict pairing, so one sweep covers each line the command can produce. */
+    const verdicts = [
+      { kind: 'ok', targetHash: 'aaaa1111' },
+      { kind: 'drift', expected: 'aaaa1111', actual: 'aaaa9999', resolvedPath: '/abs/alpha.js' },
+      { kind: 'missing', resolvedPath: '/abs/alpha.js' },
+      { kind: 'unverified' },
+    ];
+
+    it.each(['\u{2705}', '\u{26A0}', '\u{2753}', '\u{2796}', '\u{FE0F}', '\u{2014}'])(
+      'renders no %s for any verdict',
+      (retired) => {
+        for (const verdict of verdicts) {
+          mockReadManifest.mockReturnValue({
+            version: 1,
+            kits: [{ name: 'alpha', path: 'alpha.js', targetHash: 'aaaa1111', source: 'alpha.ts' }],
+          });
+          mockCheckDrift.mockReturnValue(verdict);
+          verifyCommand([]);
+        }
+
+        const written = stdoutSpy.mock.calls.flat().join('\n');
+        expect(written).not.toContain(retired);
+      },
+    );
+
+    it('renders a section heading rather than a colon-terminated header', () => {
+      mockReadManifest.mockReturnValue({ version: 1, kits: [] });
+
+      verifyCommand([]);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('\u{2500}\u{2500} Verifying kits against '));
+    });
+
+    it('leaves a wholly verified kit carrying nothing beyond its token', () => {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'alpha', path: 'alpha.js', targetHash: 'aaaa1111', source: 'alpha.ts', sourceHash: '5555aaaa' }],
+      });
+      mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
+      mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
+
+      verifyCommand([]);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+    });
   });
 });

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -52,6 +52,7 @@ Run options:
   --json                             Output results as JSON
   --detail <summary|full>            How much of the JSON report to emit (default: full); requires --json
   --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
+  --quiet                            Hide passed checks from the report; incompatible with --json
   --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
                                      plus the parent checks of anything shown; summary counts always
                                      cover the whole run
@@ -125,6 +126,10 @@ Options:
                                      "summary" drops the detail tree to the failed checks and their fixes,
                                      keeping counts, verdicts, and worst severity intact
   --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
+  --quiet                            Hide passed checks from the report, keeping failures, skips, the
+                                     fix recap, and every count line. Human output only, so it cannot
+                                     be combined with --json; counts and the exit code still cover the
+                                     whole run
   --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
                                      plus the parent checks of anything shown; summary counts always
                                      cover the whole run
@@ -143,6 +148,7 @@ Examples:
   rdy run --jit deploy                   Run the deploy kit from its TypeScript source
   rdy run --from global deploy           Run the deploy kit from the global directory
   rdy run --fail-on warn                 Fail the run on warnings as well as errors
+  rdy run --quiet                        Report only what is not passing
   rdy run --json --detail summary        Emit a JSON report carrying only failed checks
 `;
 
@@ -190,6 +196,8 @@ Each kit is reported as one of:
   drift       on-disk hash differs from the manifest's targetHash
   missing     compiled file is absent
   unverified  manifest entry has no targetHash (predates the feature)
+
+A failing kit carries its name alone, with each verdict on the line beneath it.
 
 Exits 1 when any kit is in drift or missing; unverified kits do not fail. An unreadable
 manifest exits 2.

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -360,6 +360,7 @@ async function handleRun(flags: string[], json: boolean): Promise<number> {
     {
       kitEntries,
       json: parsed.json,
+      quiet: parsed.quiet,
       ...(parsed.detail !== undefined && { detail: parsed.detail }),
       ...(parsed.failOn !== undefined && { failOn: parsed.failOn }),
       ...(parsed.reportOn !== undefined && { reportOn: parsed.reportOn }),

--- a/packages/readyup/src/check-utils/git/factories.ts
+++ b/packages/readyup/src/check-utils/git/factories.ts
@@ -67,7 +67,7 @@ export function makeRemoteRefSyncCheck(options: RemoteRefSyncCheckOptions): RdyC
     async skip() {
       const result = await getProbe();
       if (result.status === 'unreachable') {
-        return `remote '${remote}' is unreachable — skipping network check`;
+        return `remote '${remote}' is unreachable; skipping network check`;
       }
       return false;
     },
@@ -107,7 +107,7 @@ function formatLocalResult(
     return `${refA} and ${refB} have diverged, with ${ahead} and ${behind} different commits each`;
   }
   if (behind > 0) {
-    return `${refA} is behind ${refB} by ${behind} commit${behind === 1 ? '' : 's'} — run 'git merge ${refB}' in ${path}`;
+    return `${refA} is behind ${refB} by ${behind} commit${behind === 1 ? '' : 's'}; run 'git merge ${refB}' in ${path}`;
   }
   return `${refA} is ahead of ${refB} by ${ahead} commit${ahead === 1 ? '' : 's'}`;
 }
@@ -136,7 +136,7 @@ function formatRemoteResult(
     return `${ref} and ${remote}/${ref} have diverged, with ${ahead} and ${behind} different commits each`;
   }
   if (behind > 0) {
-    return `${ref} is behind ${remote}/${ref} by ${behind} commit${behind === 1 ? '' : 's'} — run 'git pull' in ${path}`;
+    return `${ref} is behind ${remote}/${ref} by ${behind} commit${behind === 1 ? '' : 's'}; run 'git pull' in ${path}`;
   }
   return `${ref} is ahead of ${remote}/${ref} by ${ahead} commit${ahead === 1 ? '' : 's'}`;
 }

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -149,8 +149,7 @@ function validateFlagConstraints(parsed: RunFlagConstraints, kitSpecifiers: KitS
     throw usageError('--detail requires --json; it selects how much of the JSON report to emit');
   }
 
-  // `--quiet` thins the human detail tree, which `--json` does not emit. Erroring beats ignoring it,
-  // for the same reason `--detail` errors without `--json`.
+  // `--quiet` thins the human detail tree, which `--json` does not emit.
   if (parsed.quiet && parsed.json) {
     throw usageError('--quiet cannot be combined with --json; it hides passed lines from human output only');
   }
@@ -422,7 +421,6 @@ interface RunCommandOptions {
   reportOn?: Severity;
 }
 
-/** Threshold and verbosity settings governing every kit in a human-mode run. */
 interface HumanRunSettings {
   failOn: Severity | undefined;
   quiet: boolean;

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -60,6 +60,7 @@ export interface ParsedRunArgs {
   jit: boolean;
   json: boolean;
   kitSpecifiers: KitSpecifier[];
+  quiet: boolean;
   reportOn?: Severity;
   urlValue: string | undefined;
 }
@@ -81,6 +82,7 @@ const runOptions = {
   internal: { type: 'boolean' },
   jit: { type: 'boolean' },
   json: { type: 'boolean' },
+  quiet: { type: 'boolean' },
   'report-on': { type: 'string' },
   url: { type: 'string' },
 } as const;
@@ -134,6 +136,7 @@ interface RunFlagConstraints {
   internal: boolean;
   jit: boolean;
   json: boolean;
+  quiet: boolean;
   url: string | undefined;
 }
 
@@ -143,6 +146,12 @@ function validateFlagConstraints(parsed: RunFlagConstraints, kitSpecifiers: KitS
   // report. Erroring beats ignoring it: a caller that passed it meant to change the output.
   if (parsed.detail !== undefined && !parsed.json) {
     throw usageError('--detail requires --json; it selects how much of the JSON report to emit');
+  }
+
+  // `--quiet` thins the human detail tree, which `--json` does not emit. Erroring beats ignoring it,
+  // for the same reason `--detail` errors without `--json`.
+  if (parsed.quiet && parsed.json) {
+    throw usageError('--quiet cannot be combined with --json; it hides passed lines from human output only');
   }
 
   const sourceFlags: string[] = [];
@@ -226,6 +235,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
     internal: values.internal === true,
     jit: values.jit === true,
     json: values.json === true,
+    quiet: values.quiet === true,
     url: values.url,
     failOn: values['fail-on'],
     reportOn: values['report-on'],
@@ -262,6 +272,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
     jit: parsed.jit,
     json: parsed.json,
     kitSpecifiers,
+    quiet: parsed.quiet,
     urlValue: parsed.url,
   };
   if (detail !== undefined) parsedArgs.detail = detail;
@@ -406,7 +417,15 @@ interface RunCommandOptions {
   json: boolean;
   detail?: JsonDetail;
   failOn?: Severity;
+  quiet?: boolean;
   reportOn?: Severity;
+}
+
+/** Threshold and verbosity settings governing every kit in a human-mode run. */
+interface HumanRunSettings {
+  failOn: Severity | undefined;
+  quiet: boolean;
+  reportOn: Severity | undefined;
 }
 
 /** Load a rdy kit from a path or URL source. */
@@ -571,13 +590,13 @@ function isModuleNotFoundError(error: unknown, packageName: string): boolean {
 
 /** Run rdy checklists across one or more kits. Returns a numeric exit code. */
 export async function runCommand(
-  { kitEntries, json, detail, failOn, reportOn }: RunCommandOptions,
+  { kitEntries, json, detail, failOn, quiet, reportOn }: RunCommandOptions,
   isJit = false,
 ): Promise<number> {
   if (json) {
     return runMultiKitJsonMode(kitEntries, { detail: detail ?? 'full', failOn, reportOn }, isJit);
   }
-  return runMultiKitHumanMode(kitEntries, failOn, reportOn, isJit);
+  return runMultiKitHumanMode(kitEntries, { failOn, quiet: quiet === true, reportOn }, isJit);
 }
 
 /**
@@ -658,8 +677,7 @@ async function runMultiKitJsonMode(
  */
 async function runMultiKitHumanMode(
   kitEntries: ResolvedKitEntry[],
-  failOn: Severity | undefined,
-  reportOn: Severity | undefined,
+  settings: HumanRunSettings,
   isJit: boolean,
 ): Promise<number> {
   const showKitHeader = kitEntries.length > 1;
@@ -679,7 +697,7 @@ async function runMultiKitHumanMode(
       warnOnVersionSkew(entry.name, compileTimeVersion);
       warnOnKitStaleness(entry.name, entry.source, tracking);
 
-      const exitCode = await runSingleKitHumanMode(kit, entry.checklists, failOn, reportOn, showKitHeader);
+      const exitCode = await runSingleKitHumanMode(kit, entry.checklists, settings, showKitHeader);
       if (exitCode !== EXIT_OK) allPassed = false;
     } catch (error: unknown) {
       // A lone kit needs no label: nothing to disambiguate, and its source is already in the message.
@@ -696,12 +714,11 @@ async function runMultiKitHumanMode(
 async function runSingleKitHumanMode(
   kit: RdyKit,
   checklistFilter: string[],
-  failOn: Severity | undefined,
-  reportOn: Severity | undefined,
+  settings: HumanRunSettings,
   isMultiKit: boolean,
 ): Promise<number> {
   const checklists = selectChecklists(kit, checklistFilter);
-  const thresholds = resolveThresholds(kit, failOn, reportOn);
+  const thresholds = resolveThresholds(kit, settings.failOn, settings.reportOn);
   const showChecklistHeader = checklists.length > 1;
   let allPassed = true;
   const summaries: ChecklistSummary[] = [];
@@ -716,7 +733,7 @@ async function runSingleKitHumanMode(
       failOn: thresholds.failOn,
     });
     const fixLocation = resolveFixLocation(checklist, kit.fixLocation);
-    const output = reportRdy(report, { fixLocation, reportOn: thresholds.reportOn });
+    const output = reportRdy(report, { fixLocation, quiet: settings.quiet, reportOn: thresholds.reportOn });
     process.stdout.write(output + '\n');
 
     if (!report.passed) {

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -9,6 +9,7 @@ import { EXIT_OK, EXIT_PROBLEMS_FOUND, EXIT_TOOL_FAILURE } from './exitCodes.ts'
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonReport, type KitInput } from './formatJsonReport.ts';
 import { KITS_DIR, resolveHomeDir } from './kitsDir.ts';
+import { layout } from './layout/engine.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { DEFAULT_MANIFEST_PATH } from './manifest/manifestPath.ts';
 import type { RdyManifest } from './manifest/manifestSchema.ts';
@@ -688,7 +689,7 @@ async function runMultiKitHumanMode(
   for (const entry of kitEntries) {
     // Precedes the load so stdout lists every requested kit, including one that never ran.
     if (showKitHeader) {
-      process.stdout.write(`\n=== ${entry.name} ===\n`);
+      process.stdout.write(layout.formatHeading(entry.name, 'kit').join('\n') + '\n');
     }
 
     try {
@@ -725,7 +726,7 @@ async function runSingleKitHumanMode(
 
   for (const checklist of checklists) {
     if (showChecklistHeader) {
-      process.stdout.write(`\n--- ${checklist.name} ---\n\n`);
+      process.stdout.write(layout.formatHeading(checklist.name, 'section').join('\n') + '\n');
     }
 
     const report = await runRdy(checklist, {

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -729,7 +729,7 @@ async function runSingleKitHumanMode(
   }
 
   if (summaries.length > 1 && !isMultiKit) {
-    process.stdout.write('\n' + formatCombinedSummary(summaries) + '\n');
+    process.stdout.write(formatCombinedSummary(summaries) + '\n');
   }
 
   return allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND;

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -35,6 +35,14 @@ const compileOptions = {
   'skip-manifest': { type: 'boolean' },
 } as const;
 
+/**
+ * Separator between a compiled kit's source and its output.
+ *
+ * ASCII rather than U+2192: two fixed cells in every terminal, and ligature fonts still draw it as
+ * an arrow. The middle dot is reserved for detail, so a transformation line spends neither.
+ */
+const TRANSFORM_ARROW = '->';
+
 /** Domain-specific hints for compile flags that require a value. */
 const compileHints: Record<string, string> = {
   '--output': '--output requires a path argument',
@@ -107,7 +115,7 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
   const kitName = path.basename(resolvedOutputPath, '.js');
   const relInput = path.relative(process.cwd(), resolvedInputPath);
 
-  writeHuman('Compiling kit:\n', json);
+  writeHuman(formatSectionHeading('Compiling kit'), json);
 
   const existingKit = skipManifest ? undefined : loadExistingKitsByName(manifestPath).get(kitName);
   const drift = detectDrift({ skipManifest, force, existingKit, manifestDir });
@@ -229,7 +237,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
     const relSrc = path.relative(process.cwd(), srcDir);
     const reason = srcDirExists
       ? `No .ts files found in ${relSrc}`
-      : `Source directory not found: ${relSrc} — treating as empty`;
+      : `Source directory not found: ${relSrc}; treating as empty`;
     writeHuman(`${reason}\n`, json);
     if (!skipManifest) {
       try {
@@ -243,9 +251,9 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
 
   const relSrcDir = path.relative(process.cwd(), srcDir);
   const relOutDir = path.relative(process.cwd(), outDir);
-  const header =
-    srcDir === outDir ? `Compiling kits in ${relSrcDir}:\n` : `Compiling kits from ${relSrcDir} to ${relOutDir}:\n`;
-  writeHuman(header, json);
+  const label =
+    srcDir === outDir ? `Compiling kits in ${relSrcDir}` : `Compiling kits from ${relSrcDir} to ${relOutDir}`;
+  writeHuman(formatSectionHeading(label), json);
 
   const manifestDir = path.dirname(manifestPath);
   const existingKitsByName = skipManifest ? new Map<string, RdyManifestKit>() : loadExistingKitsByName(manifestPath);
@@ -349,7 +357,7 @@ function upsertManifest(
     // Missing manifest is expected for first compile; other failures should surface.
     if (!(error instanceof ManifestNotFoundError)) {
       const message = extractMessage(error);
-      process.stderr.write(`Warning: ${message} — starting with empty manifest\n`);
+      process.stderr.write(`Warning: ${message}; starting with empty manifest\n`);
     }
   }
 
@@ -382,7 +390,7 @@ function loadExistingKitsByName(manifestPath: string): Map<string, RdyManifestKi
   } catch (error: unknown) {
     if (!(error instanceof ManifestNotFoundError)) {
       const message = extractMessage(error);
-      process.stderr.write(`Warning: ${message} — drift gate skipped\n`);
+      process.stderr.write(`Warning: ${message}; drift gate skipped\n`);
     }
   }
   return map;
@@ -423,13 +431,36 @@ function detectDrift(args: DetectDriftArgs): DriftSkip | undefined {
   return { status, existingKit };
 }
 
-/** Format a single compile-result line with a change indicator. */
+/**
+ * Format a compile-result line.
+ *
+ * A rebuilt kit names its output after an ASCII arrow; an untouched one says so as inline detail. The
+ * leading tokens are what preserve the rebuilt-versus-untouched scan down the left edge, which frees
+ * the box glyph to name the output rather than report a status.
+ */
 function formatResultLine(srcName: string, outName: string, changed: boolean): string {
-  return changed ? `  📦 ${srcName} → ${outName}\n` : `  ${layout.glyph('skippedOptional')} ${srcName} — no changes\n`;
+  if (!changed) {
+    return layout.formatCheckLine({ token: 'skippedOptional', name: srcName, detail: 'no changes' }) + '\n';
+  }
+
+  const claim = layout.formatCheckLine({ token: 'passed', name: srcName });
+  return `${claim} ${TRANSFORM_ARROW} ${layout.glyph('docCompiled')} ${outName}\n`;
 }
 
-/** Format a drift-skip status line. Requires a `drift` status; other statuses never produce this line. */
+/**
+ * Format a drift-skip line: a warning claim with the hash mismatch in a block beneath.
+ *
+ * Requires a `drift` status; other statuses never produce this line.
+ */
 function formatDriftLine(srcName: string, status: Extract<DriftStatus, { kind: 'drift' }>): string {
   const target = path.basename(status.resolvedPath);
-  return `  ⚠️  ${srcName} — skipped (drift in ${target}; expected ${status.expected}, got ${status.actual})\n`;
+  const claim = layout.formatCheckLine({ token: 'failedWarn', name: srcName });
+  const reason = `drift in ${target}: expected ${status.expected}, got ${status.actual}`;
+
+  return [claim, ...layout.formatReasonBlock([reason])].join('\n') + '\n';
+}
+
+/** Build a section heading together with the blank line that follows it, ready to write. */
+function formatSectionHeading(label: string): string {
+  return layout.formatHeading(label, 'section').join('\n') + '\n';
 }

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -35,12 +35,7 @@ const compileOptions = {
   'skip-manifest': { type: 'boolean' },
 } as const;
 
-/**
- * Separator between a compiled kit's source and its output.
- *
- * ASCII rather than U+2192: two fixed cells in every terminal, and ligature fonts still draw it as
- * an arrow. The middle dot is reserved for detail, so a transformation line spends neither.
- */
+/** Separator between a compiled kit's source and its output. ASCII, so its width is two cells everywhere. */
 const TRANSFORM_ARROW = '->';
 
 /** Domain-specific hints for compile flags that require a value. */
@@ -431,13 +426,7 @@ function detectDrift(args: DetectDriftArgs): DriftSkip | undefined {
   return { status, existingKit };
 }
 
-/**
- * Format a compile-result line.
- *
- * A rebuilt kit names its output after an ASCII arrow; an untouched one says so as inline detail. The
- * leading tokens are what preserve the rebuilt-versus-untouched scan down the left edge, which frees
- * the box glyph to name the output rather than report a status.
- */
+/** Returns a line naming the output a rebuilt kit produced, or reporting an unchanged one as skipped. */
 function formatResultLine(srcName: string, outName: string, changed: boolean): string {
   if (!changed) {
     return layout.formatCheckLine({ token: 'skippedOptional', name: srcName, detail: 'no changes' }) + '\n';
@@ -447,11 +436,7 @@ function formatResultLine(srcName: string, outName: string, changed: boolean): s
   return `${claim} ${TRANSFORM_ARROW} ${layout.glyph('docCompiled')} ${outName}\n`;
 }
 
-/**
- * Format a drift-skip line: a warning claim with the hash mismatch in a block beneath.
- *
- * Requires a `drift` status; other statuses never produce this line.
- */
+/** Returns a warning line for a source, with the hash mismatch from `status` in a block beneath. */
 function formatDriftLine(srcName: string, status: Extract<DriftStatus, { kind: 'drift' }>): string {
   const target = path.basename(status.resolvedPath);
   const claim = layout.formatCheckLine({ token: 'failedWarn', name: srcName });
@@ -460,7 +445,7 @@ function formatDriftLine(srcName: string, status: Extract<DriftStatus, { kind: '
   return [claim, ...layout.formatReasonBlock([reason])].join('\n') + '\n';
 }
 
-/** Build a section heading together with the blank line that follows it, ready to write. */
+/** Returns a section heading as a single writable string, newline-terminated. */
 function formatSectionHeading(label: string): string {
   return layout.formatHeading(label, 'section').join('\n') + '\n';
 }

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -7,12 +7,12 @@ import picomatch from 'picomatch';
 
 import { configError, usageError } from '../errors.ts';
 import { EXIT_OK, EXIT_PROBLEMS_FOUND } from '../exitCodes.ts';
+import { layout } from '../layout/engine.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { writeManifest } from '../manifest/writeManifest.ts';
-import { ICON_SKIPPED_NA as ICON_NO_CHANGES } from '../reportRdy.ts';
 import { SCHEMA_VERSION } from '../schemas/compileOutputSchema.ts';
 import type { JsonCompileKitEntry, JsonCompileOutput } from '../schemas/index.ts';
 import { extractMessage } from '../utils/error-handling.ts';
@@ -425,7 +425,7 @@ function detectDrift(args: DetectDriftArgs): DriftSkip | undefined {
 
 /** Format a single compile-result line with a change indicator. */
 function formatResultLine(srcName: string, outName: string, changed: boolean): string {
-  return changed ? `  📦 ${srcName} → ${outName}\n` : `  ${ICON_NO_CHANGES} ${srcName} — no changes\n`;
+  return changed ? `  📦 ${srcName} → ${outName}\n` : `  ${layout.glyph('skippedOptional')} ${srcName} — no changes\n`;
 }
 
 /** Format a drift-skip status line. Requires a `drift` status; other statuses never produce this line. */

--- a/packages/readyup/src/formatCombinedSummary.ts
+++ b/packages/readyup/src/formatCombinedSummary.ts
@@ -2,11 +2,7 @@ import { layout } from './layout/engine.ts';
 import { emptyCounts, mergeCounts } from './reportRdy.ts';
 import type { ChecklistSummary, SummaryCounts } from './types.ts';
 
-/**
- * Format the combined summary table shown after multiple checklists run.
- *
- * Leads with the heading's own blank line, so a caller appends it directly to the report above.
- */
+/** Returns the summary table for `summaries`, one row each, opening with a blank line. */
 export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
   const rows = summaries.map((summary) => ({
     name: summary.name,
@@ -23,7 +19,7 @@ export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
     .join('\n');
 }
 
-/** Sum granular counts across multiple summaries, propagating the worst severity. */
+/** Returns the sum of every summary's counts, carrying the worst severity among them. */
 function aggregateCounts(summaries: ChecklistSummary[]): SummaryCounts {
   const totals = emptyCounts();
   for (const summary of summaries) {

--- a/packages/readyup/src/formatCombinedSummary.ts
+++ b/packages/readyup/src/formatCombinedSummary.ts
@@ -1,26 +1,26 @@
-import {
-  emptyCounts,
-  formatSummaryCounts,
-  formatSummaryCountsPlain,
-  ICON_ERROR_FAILED,
-  ICON_PASSED,
-  ICON_RECOMMEND_FAILED,
-  ICON_WARN_FAILED,
-  mergeCounts,
-} from './reportRdy.ts';
-import type { ChecklistSummary, Severity, SummaryCounts } from './types.ts';
+import { layout } from './layout/engine.ts';
+import { emptyCounts, mergeCounts } from './reportRdy.ts';
+import type { ChecklistSummary, SummaryCounts } from './types.ts';
 
-/** Format a duration in milliseconds for display. */
-function formatDuration(ms: number): string {
-  return `${Math.round(ms)}ms`;
-}
+/**
+ * Format the combined summary table shown after multiple checklists run.
+ *
+ * Leads with the heading's own blank line, so a caller appends it directly to the report above.
+ */
+export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
+  const rows = summaries.map((summary) => ({
+    name: summary.name,
+    counts: summary,
+    durationMs: summary.durationMs,
+  }));
 
-/** Return the row-level icon reflecting the worst failed severity in a summary. */
-function getRowIcon(worstSeverity: Severity | null): string {
-  if (worstSeverity === 'error') return ICON_ERROR_FAILED;
-  if (worstSeverity === 'warn') return ICON_WARN_FAILED;
-  if (worstSeverity === 'recommend') return ICON_RECOMMEND_FAILED;
-  return ICON_PASSED;
+  return layout
+    .formatSummaryTable({
+      rows,
+      totals: aggregateCounts(summaries),
+      totalDurationMs: summaries.reduce((sum, summary) => sum + summary.durationMs, 0),
+    })
+    .join('\n');
 }
 
 /** Sum granular counts across multiple summaries, propagating the worst severity. */
@@ -30,33 +30,4 @@ function aggregateCounts(summaries: ChecklistSummary[]): SummaryCounts {
     mergeCounts(totals, summary);
   }
   return totals;
-}
-
-/** Format the combined summary table shown after multiple checklists run. */
-export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
-  const HEADER =
-    '\u{2500}\u{2500} Summary \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}';
-  const lines: string[] = [HEADER];
-
-  const maxNameLen = Math.max(...summaries.map((s) => s.name.length));
-  const maxDurationLen = Math.max(...summaries.map((s) => formatDuration(s.durationMs).length));
-
-  for (const summary of summaries) {
-    const icon = getRowIcon(summary.worstSeverity);
-    const name = summary.name.padEnd(maxNameLen);
-    const duration = formatDuration(summary.durationMs).padStart(maxDurationLen);
-    const counts = formatSummaryCountsPlain(summary);
-    lines.push(`${icon} ${name}  ${duration}  ${counts}`);
-  }
-
-  lines.push(
-    '\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}',
-  );
-
-  const totals = aggregateCounts(summaries);
-  const totalDuration = summaries.reduce((sum, s) => sum + s.durationMs, 0);
-
-  lines.push(`Total: ${formatSummaryCounts(totals)} (${formatDuration(totalDuration)})`);
-
-  return lines.join('\n');
 }

--- a/packages/readyup/src/init/initCommand.ts
+++ b/packages/readyup/src/init/initCommand.ts
@@ -50,7 +50,7 @@ export function initCommand({ dryRun, force }: InitOptions): number {
 
   if (!dryRun) {
     printStep('Next steps');
-    console.info(`\n${buildNextSteps()}\n`);
+    console.info(`${buildNextSteps()}\n`);
   }
 
   return EXIT_OK;

--- a/packages/readyup/src/layout/emojiFormatter.ts
+++ b/packages/readyup/src/layout/emojiFormatter.ts
@@ -1,12 +1,11 @@
 import type { Formatter } from './formatter.ts';
 
 /**
- * The emoji vocabulary: nine glyphs that each occupy two terminal cells with no variation selector.
+ * A formatter whose tokens are emoji.
  *
- * Every glyph has `Emoji_Presentation=Yes`, so it renders wide on its own and the gutter is a fixed
- * three columns everywhere. A glyph needing U+FE0F to render as emoji is two cells in some terminals
- * and one in others, which is why the retired `⏭️` and `⚠️` tokens each needed a hand-placed
- * compensating space at their call site. Escapes rather than literals keep that property auditable.
+ * Every glyph carries `Emoji_Presentation=Yes`, so it occupies two terminal cells without a U+FE0F
+ * variation selector. A glyph lacking that property renders one cell wide in some terminals and two in
+ * others, so its declared width would be wrong somewhere.
  */
 export const emojiFormatter: Formatter = {
   gutter: 3,

--- a/packages/readyup/src/layout/emojiFormatter.ts
+++ b/packages/readyup/src/layout/emojiFormatter.ts
@@ -1,0 +1,28 @@
+import type { Formatter } from './formatter.ts';
+
+/**
+ * The emoji vocabulary: nine glyphs that each occupy two terminal cells with no variation selector.
+ *
+ * Every glyph has `Emoji_Presentation=Yes`, so it renders wide on its own and the gutter is a fixed
+ * three columns everywhere. A glyph needing U+FE0F to render as emoji is two cells in some terminals
+ * and one in others, which is why the retired `⏭️` and `⚠️` tokens each needed a hand-placed
+ * compensating space at their call site. Escapes rather than literals keep that property auditable.
+ */
+export const emojiFormatter: Formatter = {
+  gutter: 3,
+  rules: {
+    kit: '\u{2501}',
+    section: '\u{2500}',
+  },
+  tokens: {
+    blockedPrecondition: { glyph: '\u{1F6AB}', width: 2 },
+    docCompiled: { glyph: '\u{1F4E6}', width: 2 },
+    docInternal: { glyph: '\u{1F4C4}', width: 2 },
+    failedError: { glyph: '\u{1F534}', width: 2 },
+    failedRecommend: { glyph: '\u{1F7E1}', width: 2 },
+    failedWarn: { glyph: '\u{1F7E0}', width: 2 },
+    fix: { glyph: '\u{1F48A}', width: 2 },
+    passed: { glyph: '\u{1F7E2}', width: 2 },
+    skippedOptional: { glyph: '\u{26AA}', width: 2 },
+  },
+};

--- a/packages/readyup/src/layout/engine.ts
+++ b/packages/readyup/src/layout/engine.ts
@@ -1,0 +1,11 @@
+import { emojiFormatter } from './emojiFormatter.ts';
+import { createLayoutEngine, type LayoutEngine } from './layoutEngine.ts';
+
+/**
+ * The engine every command renders through.
+ *
+ * One shared instance because emoji is the only vocabulary the CLI can currently select. The
+ * follow-up that adds a text formatter replaces this constant with a per-invocation choice, which is
+ * why call sites take their geometry from the engine rather than reaching for a formatter directly.
+ */
+export const layout: LayoutEngine = createLayoutEngine(emojiFormatter);

--- a/packages/readyup/src/layout/engine.ts
+++ b/packages/readyup/src/layout/engine.ts
@@ -1,11 +1,5 @@
 import { emojiFormatter } from './emojiFormatter.ts';
 import { createLayoutEngine, type LayoutEngine } from './layoutEngine.ts';
 
-/**
- * The engine every command renders through.
- *
- * One shared instance because emoji is the only vocabulary the CLI can currently select. The
- * follow-up that adds a text formatter replaces this constant with a per-invocation choice, which is
- * why call sites take their geometry from the engine rather than reaching for a formatter directly.
- */
+/** The layout engine bound to the emoji formatter. */
 export const layout: LayoutEngine = createLayoutEngine(emojiFormatter);

--- a/packages/readyup/src/layout/formatter.ts
+++ b/packages/readyup/src/layout/formatter.ts
@@ -1,10 +1,4 @@
-/**
- * Every semantic state a status token can name.
- *
- * The set is closed, which is what lets a formatter declare each token's cell width instead of
- * measuring it: a new state is a deliberate addition here, not something a caller invents. Declared
- * as data so a formatter's token map can be checked against it at runtime, not only by the compiler.
- */
+/** Every semantic state a status token can name. */
 export const TOKEN_NAMES = [
   'blockedPrecondition',
   'docCompiled',
@@ -17,7 +11,6 @@ export const TOKEN_NAMES = [
   'skippedOptional',
 ] as const;
 
-/** A semantic state a status token can name. */
 export type TokenName = (typeof TOKEN_NAMES)[number];
 
 /** A glyph together with the number of terminal cells it occupies. */
@@ -26,20 +19,11 @@ export interface LayoutToken {
   width: number;
 }
 
-/** Heading weights, each naming a nesting level rather than a specific command's vocabulary. */
 export type HeadingLevel = 'kit' | 'section';
 
-/**
- * A token vocabulary and rule characters. Formatters own only these; the layout engine owns every
- * geometric decision made from them, so two formatters cannot disagree about spacing or alignment.
- */
+/** A vocabulary of status tokens and heading rule characters, from which the layout engine derives geometry. */
 export interface Formatter {
-  /**
-   * Columns from the start of a status token to the start of the name beside it.
-   *
-   * Doubles as the indent unit, which is what puts each child's token under its parent's name. It
-   * must exceed every token's width, since the difference is the separating space.
-   */
+  /** Columns from the start of a status token to the start of the name beside it. Exceeds every token's width. */
   gutter: number;
 
   rules: Record<HeadingLevel, string>;

--- a/packages/readyup/src/layout/formatter.ts
+++ b/packages/readyup/src/layout/formatter.ts
@@ -1,0 +1,48 @@
+/**
+ * Every semantic state a status token can name.
+ *
+ * The set is closed, which is what lets a formatter declare each token's cell width instead of
+ * measuring it: a new state is a deliberate addition here, not something a caller invents. Declared
+ * as data so a formatter's token map can be checked against it at runtime, not only by the compiler.
+ */
+export const TOKEN_NAMES = [
+  'blockedPrecondition',
+  'docCompiled',
+  'docInternal',
+  'failedError',
+  'failedRecommend',
+  'failedWarn',
+  'fix',
+  'passed',
+  'skippedOptional',
+] as const;
+
+/** A semantic state a status token can name. */
+export type TokenName = (typeof TOKEN_NAMES)[number];
+
+/** A glyph together with the number of terminal cells it occupies. */
+export interface LayoutToken {
+  glyph: string;
+  width: number;
+}
+
+/** Heading weights, each naming a nesting level rather than a specific command's vocabulary. */
+export type HeadingLevel = 'kit' | 'section';
+
+/**
+ * A token vocabulary and rule characters. Formatters own only these; the layout engine owns every
+ * geometric decision made from them, so two formatters cannot disagree about spacing or alignment.
+ */
+export interface Formatter {
+  /**
+   * Columns from the start of a status token to the start of the name beside it.
+   *
+   * Doubles as the indent unit, which is what puts each child's token under its parent's name. It
+   * must exceed every token's width, since the difference is the separating space.
+   */
+  gutter: number;
+
+  rules: Record<HeadingLevel, string>;
+
+  tokens: Record<TokenName, LayoutToken>;
+}

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -162,7 +162,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
     const rule = formatter.rules.section.repeat(formatter.gutter + bodyWidth);
 
     return [
-      ...formatHeading(SUMMARY_HEADING, 'section').slice(0, 2),
+      ...formatHeading(SUMMARY_HEADING, 'section'),
       rule,
       ...entries.map((entry) => `${token(entry.token)}${entry.body}`),
       rule,

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -1,0 +1,245 @@
+import type { Severity, SummaryCounts } from '../types.ts';
+import { pluralizeWithCount } from '../utils/pluralize.ts';
+import type { Formatter, HeadingLevel, TokenName } from './formatter.ts';
+
+/** Milliseconds below which a line omits its duration, leaving only timings worth reading. */
+const DURATION_FLOOR_MS = 100;
+
+/** The one separator a line may carry between a name and its inline detail (U+00B7). */
+const DETAIL_SEPARATOR = '\u{00B7}';
+
+/** Rule characters in a heading's leading sigil. */
+const HEADING_SIGIL_WIDTH = 2;
+
+/** Columns between one summary-table cell and the next. */
+const TABLE_CELL_GAP = '  ';
+
+/** Label leading the combined summary table's final line. */
+const TOTAL_LABEL = 'Total:';
+
+/** Heading over the combined summary table. */
+const SUMMARY_HEADING = 'Summary';
+
+/** Statement a count line makes when there is nothing at all to report. */
+const EMPTY_COUNTS = '0 passed';
+
+/** Tokens naming a check that never ran, so no elapsed time describes it. */
+const SKIPPED_TOKENS: ReadonlySet<TokenName> = new Set<TokenName>(['blockedPrecondition', 'skippedOptional']);
+
+/** One tallied field of a count line, with the labels its count selects between. */
+interface CountField {
+  key: keyof Omit<SummaryCounts, 'worstSeverity'>;
+  plural: string;
+  singular: string;
+}
+
+/**
+ * Count fields in the order every count line presents them.
+ *
+ * Ordered by decreasing severity rather than alphabetically: the reader scans left to right for the
+ * worst news, and a fixed order is what lets them find a field without reading every label.
+ */
+const COUNT_FIELDS: readonly CountField[] = [
+  { key: 'passed', singular: 'passed', plural: 'passed' },
+  { key: 'errors', singular: 'error', plural: 'errors' },
+  { key: 'warnings', singular: 'warning', plural: 'warnings' },
+  { key: 'recommendations', singular: 'recommendation', plural: 'recommendations' },
+  { key: 'blocked', singular: 'blocked', plural: 'blocked' },
+  { key: 'optional', singular: 'skipped', plural: 'skipped' },
+];
+
+/** A check line's content. Every geometric decision made from it belongs to the engine. */
+export interface CheckLineInput {
+  token: TokenName;
+  name: string;
+  depth?: number | undefined;
+  detail?: string | undefined;
+  durationMs?: number | undefined;
+  progress?: string | undefined;
+}
+
+/** One checklist's row in the combined summary table. */
+export interface SummaryRow {
+  counts: SummaryCounts;
+  durationMs: number;
+  name: string;
+}
+
+/** The combined summary table's rows alongside the totals its final line reports. */
+export interface SummaryTableInput {
+  rows: SummaryRow[];
+  totalDurationMs: number;
+  totals: SummaryCounts;
+}
+
+/** Pure string builders composing a formatter's vocabulary into laid-out lines. */
+export interface LayoutEngine {
+  formatCheckLine(input: CheckLineInput): string;
+  formatCountLine(counts: SummaryCounts, durationMs: number, label?: string): string;
+  formatCounts(counts: SummaryCounts): string;
+  formatHeading(name: string, level: HeadingLevel): string[];
+  formatReasonBlock(reasons: string[], depth?: number): string[];
+  formatSummaryTable(input: SummaryTableInput): string[];
+  glyph(token: TokenName): string;
+  indent(depth: number): string;
+  token(token: TokenName): string;
+}
+
+/**
+ * Build the layout engine for a formatter.
+ *
+ * Every function it returns is a pure string builder: no I/O, no `process`, no ambient state. Stream
+ * selection and the decision of what to render stay with the caller, so one geometry serves the run
+ * report, the summary table, and every other command's lines.
+ */
+export function createLayoutEngine(formatter: Formatter): LayoutEngine {
+  /**
+   * Compose a check line as `token name · detail [progress] (duration)`.
+   *
+   * The middle dot is the only detail separator, so progress takes brackets rather than a second one.
+   * A failed check passes no `detail`: its reason belongs in the block beneath, where a multi-clause
+   * explanation has room an inline tail does not.
+   */
+  function formatCheckLine(input: CheckLineInput): string {
+    const segments = [`${indent(input.depth ?? 0)}${token(input.token)}${input.name}`];
+    if (input.detail !== undefined) segments.push(`${DETAIL_SEPARATOR} ${input.detail}`);
+    if (input.progress !== undefined) segments.push(`[${input.progress}]`);
+
+    const duration = resolveDuration(input.token, input.durationMs);
+    if (duration !== undefined) segments.push(`(${duration})`);
+
+    return segments.join(' ');
+  }
+
+  /**
+   * Compose a tail or total line: the worst severity's token, the pipe counts, then the duration.
+   *
+   * Leading with the worst severity is what makes a failed run legible at a glance; the counts say
+   * how much of each kind. The duration is unconditional here, unlike on a check line -- how long a
+   * whole run took is worth reading however small it is.
+   */
+  function formatCountLine(counts: SummaryCounts, durationMs: number, label?: string): string {
+    return token(resolveWorstToken(counts.worstSeverity)) + buildCountBody(counts, durationMs, label);
+  }
+
+  /** Build a heading and the blank lines setting it off, as separate lines for the caller to join. */
+  function formatHeading(name: string, level: HeadingLevel): string[] {
+    return ['', `${formatter.rules[level].repeat(HEADING_SIGIL_WIDTH)} ${name}`, ''];
+  }
+
+  /**
+   * Indent reason lines to the name column of a check at `depth`.
+   *
+   * The indent unit is the gutter, so one further level of indent is exactly where the name above
+   * starts -- the reason then reads as continuation of that name rather than as a check of its own.
+   */
+  function formatReasonBlock(reasons: string[], depth = 0): string[] {
+    return reasons.map((reason) => `${indent(depth + 1)}${reason}`);
+  }
+
+  /**
+   * Build the combined summary table: heading, rules, one row per checklist, then the total line.
+   *
+   * Names are padded and durations right-aligned so every row's counts start at one column, and both
+   * rules are sized to the widest line they enclose -- including the total, which a rule stopping
+   * short of would read as unrelated to the table above it.
+   */
+  function formatSummaryTable({ rows, totalDurationMs, totals }: SummaryTableInput): string[] {
+    const nameWidth = Math.max(...rows.map((row) => row.name.length));
+    const durationWidth = Math.max(...rows.map((row) => formatDuration(row.durationMs).length));
+
+    const entries = rows.map((row) => ({
+      token: resolveWorstToken(row.counts.worstSeverity),
+      body: [
+        row.name.padEnd(nameWidth),
+        formatDuration(row.durationMs).padStart(durationWidth),
+        formatCounts(row.counts),
+      ].join(TABLE_CELL_GAP),
+    }));
+    const totalBody = buildCountBody(totals, totalDurationMs, TOTAL_LABEL);
+
+    const bodyWidth = Math.max(...entries.map((entry) => entry.body.length), totalBody.length);
+    const rule = formatter.rules.section.repeat(formatter.gutter + bodyWidth);
+
+    return [
+      ...formatHeading(SUMMARY_HEADING, 'section').slice(0, 2),
+      rule,
+      ...entries.map((entry) => `${token(entry.token)}${entry.body}`),
+      rule,
+      `${token(resolveWorstToken(totals.worstSeverity))}${totalBody}`,
+    ];
+  }
+
+  /** Return a token's bare glyph, for mid-line placement where it names a thing rather than a status. */
+  function glyph(name: TokenName): string {
+    return formatter.tokens[name].glyph;
+  }
+
+  /** Build the leading whitespace for a given nesting depth. */
+  function indent(depth: number): string {
+    return ' '.repeat(formatter.gutter * depth);
+  }
+
+  /** Return a token padded to the gutter, so the name beside it starts at one column every time. */
+  function token(name: TokenName): string {
+    const { glyph: character, width } = formatter.tokens[name];
+    return character + ' '.repeat(formatter.gutter - width);
+  }
+
+  // -- Helpers --
+
+  /** Build everything a count line carries after its leading token. */
+  function buildCountBody(counts: SummaryCounts, durationMs: number, label?: string): string {
+    const prefix = label === undefined ? '' : `${label} `;
+    return `${prefix}${formatCounts(counts)} (${formatDuration(durationMs)})`;
+  }
+
+  return {
+    formatCheckLine,
+    formatCountLine,
+    formatCounts,
+    formatHeading,
+    formatReasonBlock,
+    formatSummaryTable,
+    glyph,
+    indent,
+    token,
+  };
+}
+
+/** Map the worst failed severity to its token, falling back to `passed` when nothing failed. */
+export function resolveWorstToken(worstSeverity: Severity | null): TokenName {
+  if (worstSeverity === 'error') return 'failedError';
+  if (worstSeverity === 'warn') return 'failedWarn';
+  if (worstSeverity === 'recommend') return 'failedRecommend';
+  return 'passed';
+}
+
+/**
+ * Join the non-zero counts with pipes, in the fixed field order.
+ *
+ * A run with nothing to report still says `0 passed` rather than collapsing to an empty segment,
+ * which would leave a bare token and duration with no statement between them.
+ */
+function formatCounts(counts: SummaryCounts): string {
+  const fields = COUNT_FIELDS.filter((field) => counts[field.key] > 0).map((field) =>
+    pluralizeWithCount(counts[field.key], field.singular, field.plural),
+  );
+  return fields.length > 0 ? fields.join(' | ') : EMPTY_COUNTS;
+}
+
+/**
+ * Resolve a line's duration text, or nothing when the timing is not worth a reader's attention.
+ *
+ * A skipped check carries none however long its skip predicate took: the check itself never ran.
+ * Below the floor, a duration is noise on every line of a healthy report.
+ */
+function resolveDuration(token: TokenName, durationMs: number | undefined): string | undefined {
+  if (durationMs === undefined || SKIPPED_TOKENS.has(token)) return undefined;
+  return durationMs >= DURATION_FLOOR_MS ? formatDuration(durationMs) : undefined;
+}
+
+/** Format a duration in milliseconds for display. */
+function formatDuration(ms: number): string {
+  return `${Math.round(ms)}ms`;
+}

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -78,6 +78,7 @@ export interface LayoutEngine {
   formatCountLine(counts: SummaryCounts, durationMs: number, label?: string): string;
   formatCounts(counts: SummaryCounts): string;
   formatHeading(name: string, level: HeadingLevel): string[];
+  formatHeadingLine(name: string, level: HeadingLevel): string;
   formatReasonBlock(reasons: string[], depth?: number): string[];
   formatSummaryTable(input: SummaryTableInput): string[];
   glyph(token: TokenName): string;
@@ -124,7 +125,17 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
 
   /** Build a heading and the blank lines setting it off, as separate lines for the caller to join. */
   function formatHeading(name: string, level: HeadingLevel): string[] {
-    return ['', `${formatter.rules[level].repeat(HEADING_SIGIL_WIDTH)} ${name}`, ''];
+    return ['', formatHeadingLine(name, level), ''];
+  }
+
+  /**
+   * Build a heading line alone, for a caller that attaches its own content directly beneath.
+   *
+   * `list` needs this: its copy-pasteable command belongs against the title it qualifies, so the
+   * blank line `formatHeading` supplies would separate the two.
+   */
+  function formatHeadingLine(name: string, level: HeadingLevel): string {
+    return `${formatter.rules[level].repeat(HEADING_SIGIL_WIDTH)} ${name}`;
   }
 
   /**
@@ -199,6 +210,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
     formatCountLine,
     formatCounts,
     formatHeading,
+    formatHeadingLine,
     formatReasonBlock,
     formatSummaryTable,
     glyph,

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -5,7 +5,7 @@ import type { Formatter, HeadingLevel, TokenName } from './formatter.ts';
 /** Milliseconds below which a line omits its duration, leaving only timings worth reading. */
 const DURATION_FLOOR_MS = 100;
 
-/** The one separator a line may carry between a name and its inline detail (U+00B7). */
+/** Middle dot, U+00B7. */
 const DETAIL_SEPARATOR = '\u{00B7}';
 
 /** Rule characters in a heading's leading sigil. */
@@ -23,7 +23,7 @@ const SUMMARY_HEADING = 'Summary';
 /** Statement a count line makes when there is nothing at all to report. */
 const EMPTY_COUNTS = '0 passed';
 
-/** Tokens naming a check that never ran, so no elapsed time describes it. */
+/** Tokens naming a check that did not run. */
 const SKIPPED_TOKENS: ReadonlySet<TokenName> = new Set<TokenName>(['blockedPrecondition', 'skippedOptional']);
 
 /** One tallied field of a count line, with the labels its count selects between. */
@@ -72,7 +72,7 @@ export interface SummaryTableInput {
   totals: SummaryCounts;
 }
 
-/** Pure string builders composing a formatter's vocabulary into laid-out lines. */
+/** String builders that lay out a formatter's tokens. */
 export interface LayoutEngine {
   formatCheckLine(input: CheckLineInput): string;
   formatCountLine(counts: SummaryCounts, durationMs: number, label?: string): string;
@@ -86,21 +86,9 @@ export interface LayoutEngine {
   token(token: TokenName): string;
 }
 
-/**
- * Build the layout engine for a formatter.
- *
- * Every function it returns is a pure string builder: no I/O, no `process`, no ambient state. Stream
- * selection and the decision of what to render stay with the caller, so one geometry serves the run
- * report, the summary table, and every other command's lines.
- */
+/** Returns string builders bound to `formatter`, each deriving its spacing from the formatter's gutter. */
 export function createLayoutEngine(formatter: Formatter): LayoutEngine {
-  /**
-   * Compose a check line as `token name · detail [progress] (duration)`.
-   *
-   * The middle dot is the only detail separator, so progress takes brackets rather than a second one.
-   * A failed check passes no `detail`: its reason belongs in the block beneath, where a multi-clause
-   * explanation has room an inline tail does not.
-   */
+  /** Returns one line, `token name · detail [progress] (duration)`, dropping the segments it lacks. */
   function formatCheckLine(input: CheckLineInput): string {
     const segments = [`${indent(input.depth ?? 0)}${token(input.token)}${input.name}`];
     if (input.detail !== undefined) segments.push(`${DETAIL_SEPARATOR} ${input.detail}`);
@@ -113,47 +101,34 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   }
 
   /**
-   * Compose a tail or total line: the worst severity's token, the pipe counts, then the duration.
+   * Returns `token label counts (duration)`, led by the token for `counts.worstSeverity`.
    *
-   * Leading with the worst severity is what makes a failed run legible at a glance; the counts say
-   * how much of each kind. The duration is unconditional here, unlike on a check line -- how long a
-   * whole run took is worth reading however small it is.
+   * The duration always appears, whatever its magnitude.
    */
   function formatCountLine(counts: SummaryCounts, durationMs: number, label?: string): string {
     return token(resolveWorstToken(counts.worstSeverity)) + buildCountBody(counts, durationMs, label);
   }
 
-  /** Build a heading and the blank lines setting it off, as separate lines for the caller to join. */
+  /** Returns the heading line preceded and followed by a blank line. */
   function formatHeading(name: string, level: HeadingLevel): string[] {
     return ['', formatHeadingLine(name, level), ''];
   }
 
-  /**
-   * Build a heading line alone, for a caller that attaches its own content directly beneath.
-   *
-   * `list` needs this: its copy-pasteable command belongs against the title it qualifies, so the
-   * blank line `formatHeading` supplies would separate the two.
-   */
+  /** Returns `name` behind a two-character rule whose weight comes from `level`. */
   function formatHeadingLine(name: string, level: HeadingLevel): string {
     return `${formatter.rules[level].repeat(HEADING_SIGIL_WIDTH)} ${name}`;
   }
 
-  /**
-   * Indent reason lines to the name column of a check at `depth`.
-   *
-   * The indent unit is the gutter, so one further level of indent is exactly where the name above
-   * starts -- the reason then reads as continuation of that name rather than as a check of its own.
-   */
+  /** Returns each reason indented to the name column of a check at `depth`, one gutter further in. */
   function formatReasonBlock(reasons: string[], depth = 0): string[] {
     return reasons.map((reason) => `${indent(depth + 1)}${reason}`);
   }
 
   /**
-   * Build the combined summary table: heading, rules, one row per checklist, then the total line.
+   * Returns the summary table's lines: a heading, a rule, one line per row, a closing rule, and a total.
    *
-   * Names are padded and durations right-aligned so every row's counts start at one column, and both
-   * rules are sized to the widest line they enclose -- including the total, which a rule stopping
-   * short of would read as unrelated to the table above it.
+   * Names are padded and durations right-aligned, so every row's counts begin at the same column. Both
+   * rules span the widest line they enclose, the total included.
    */
   function formatSummaryTable({ rows, totalDurationMs, totals }: SummaryTableInput): string[] {
     const nameWidth = Math.max(...rows.map((row) => row.name.length));
@@ -181,17 +156,17 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
     ];
   }
 
-  /** Return a token's bare glyph, for mid-line placement where it names a thing rather than a status. */
+  /** Returns a token's glyph unpadded. */
   function glyph(name: TokenName): string {
     return formatter.tokens[name].glyph;
   }
 
-  /** Build the leading whitespace for a given nesting depth. */
+  /** Returns `depth` gutters' worth of spaces. */
   function indent(depth: number): string {
     return ' '.repeat(formatter.gutter * depth);
   }
 
-  /** Return a token padded to the gutter, so the name beside it starts at one column every time. */
+  /** Returns a token's glyph padded to the gutter, so what follows starts at a fixed column. */
   function token(name: TokenName): string {
     const { glyph: character, width } = formatter.tokens[name];
     return character + ' '.repeat(formatter.gutter - width);
@@ -199,7 +174,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
 
   // -- Helpers --
 
-  /** Build everything a count line carries after its leading token. */
+  /** Returns everything a count line carries after its leading token. */
   function buildCountBody(counts: SummaryCounts, durationMs: number, label?: string): string {
     const prefix = label === undefined ? '' : `${label} `;
     return `${prefix}${formatCounts(counts)} (${formatDuration(durationMs)})`;
@@ -219,7 +194,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   };
 }
 
-/** Map the worst failed severity to its token, falling back to `passed` when nothing failed. */
+/** Returns the token for a severity, or the `passed` token for `null`. */
 export function resolveWorstToken(worstSeverity: Severity | null): TokenName {
   if (worstSeverity === 'error') return 'failedError';
   if (worstSeverity === 'warn') return 'failedWarn';
@@ -227,12 +202,7 @@ export function resolveWorstToken(worstSeverity: Severity | null): TokenName {
   return 'passed';
 }
 
-/**
- * Join the non-zero counts with pipes, in the fixed field order.
- *
- * A run with nothing to report still says `0 passed` rather than collapsing to an empty segment,
- * which would leave a bare token and duration with no statement between them.
- */
+/** Returns the non-zero counts pipe-joined in field order, or `0 passed` when every count is zero. */
 function formatCounts(counts: SummaryCounts): string {
   const fields = COUNT_FIELDS.filter((field) => counts[field.key] > 0).map((field) =>
     pluralizeWithCount(counts[field.key], field.singular, field.plural),
@@ -240,18 +210,13 @@ function formatCounts(counts: SummaryCounts): string {
   return fields.length > 0 ? fields.join(' | ') : EMPTY_COUNTS;
 }
 
-/**
- * Resolve a line's duration text, or nothing when the timing is not worth a reader's attention.
- *
- * A skipped check carries none however long its skip predicate took: the check itself never ran.
- * Below the floor, a duration is noise on every line of a healthy report.
- */
+/** Returns the formatted duration, or nothing for a skipped token or a duration under the floor. */
 function resolveDuration(token: TokenName, durationMs: number | undefined): string | undefined {
   if (durationMs === undefined || SKIPPED_TOKENS.has(token)) return undefined;
   return durationMs >= DURATION_FLOOR_MS ? formatDuration(durationMs) : undefined;
 }
 
-/** Format a duration in milliseconds for display. */
+/** Returns a whole number of milliseconds with its unit. */
 function formatDuration(ms: number): string {
   return `${Math.round(ms)}ms`;
 }

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -114,7 +114,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
     return ['', formatHeadingLine(name, level), ''];
   }
 
-  /** Returns `name` behind a two-character rule whose weight comes from `level`. */
+  /** Returns `name` behind a two-character rule whose weight comes from `level`, with no surrounding blanks. */
   function formatHeadingLine(name: string, level: HeadingLevel): string {
     return `${formatter.rules[level].repeat(HEADING_SIGIL_WIDTH)} ${name}`;
   }

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -1,7 +1,7 @@
 import { layout } from '../layout/engine.ts';
 import type { TokenName } from '../layout/formatter.ts';
 
-/** Build the positional name hint, bracketed when a default kit exists. */
+/** Returns the positional-name placeholder, bracketed when `kits` contains a default. */
 function buildKitHint(kits: string[]): string {
   return kits.includes('default') ? '[<name>]' : '<name>';
 }
@@ -109,12 +109,11 @@ interface ManifestViewOptions {
 }
 
 /**
- * Format a view of kits loaded from a manifest file.
+ * Returns a heading naming the manifest, then one line per kit.
  *
- * Kit names carry the compiled-output glyph. When a kit's `readyupVersion` is present, it appears as
- * a parenthetical between the name and the description, which follows the middle dot. The literal
- * `readyup` label is load-bearing: it disambiguates the version from a hypothetical kit-own version.
- * Descriptions appear inline when present; both fields are omitted independently.
+ * A kit's line carries its version as a parenthetical and its description as inline detail, each present
+ * only when the manifest records it. The `readyup` label distinguishes the runner's version from a
+ * version the kit might declare for itself.
  */
 export function formatManifestView({ kits, manifestPath }: ManifestViewOptions): string {
   if (kits.length === 0) {
@@ -135,13 +134,7 @@ export function formatManifestView({ kits, manifestPath }: ManifestViewOptions):
 
 // -- Helpers --
 
-/**
- * Build a titled section: the title, the copy-pasteable command beneath it, then the kits.
- *
- * Splitting the command onto its own line is what makes it copy-pasteable. Fused to the title, it
- * could not be selected without also taking the label, and the title could not be scanned without
- * reading past the command.
- */
+/** Returns a titled section: the title, `hint` indented beneath it on its own line, then one line per kit. */
 function formatSection(title: string, hint: string, kits: string[], token: TokenName): string {
   const items = kits.map((name) => layout.formatCheckLine({ token, name }));
   return [layout.formatHeadingLine(title, 'section'), ...layout.formatReasonBlock([hint]), '', ...items].join('\n');

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -1,5 +1,5 @@
-const ICON_INTERNAL = '📄';
-const ICON_COMPILED = '📦';
+import { layout } from '../layout/engine.ts';
+import type { TokenName } from '../layout/formatter.ts';
 
 /** Build the positional name hint, bracketed when a default kit exists. */
 function buildKitHint(kits: string[]): string {
@@ -52,17 +52,17 @@ export function formatOwnerView({
   if (internalKits.length > 0) {
     const internalFlag = needsInternalFlag ? ' --internal' : '';
     const hint = `rdy run --jit${internalFlag} ${buildKitHint(internalKits)}`;
-    sections.push(formatSection('Internal', hint, internalKits, ICON_INTERNAL));
+    sections.push(formatSection('Internal', hint, internalKits, 'docInternal'));
   }
 
   if (compiledKits.length > 0) {
     if (compiledStyle.kind === 'local-convention') {
       const hint = `rdy run ${buildKitHint(compiledKits)}`;
-      sections.push(formatSection('Compiled', hint, compiledKits, ICON_COMPILED));
+      sections.push(formatSection('Compiled', hint, compiledKits, 'docCompiled'));
     } else {
       const hint = `rdy run --file <file path>`;
       const pathItems = compiledKits.map((name) => `${compiledStyle.outDirRel}/${name}.js`);
-      sections.push(formatSection('Compiled', hint, pathItems, ICON_COMPILED));
+      sections.push(formatSection('Compiled', hint, pathItems, 'docCompiled'));
     }
   }
 
@@ -88,7 +88,7 @@ export function formatConsumerView({ compiledKits, fromArg, kitsDir }: ConsumerV
   }
 
   const hint = `rdy run --from ${fromArg} ${buildKitHint(compiledKits)}`;
-  return formatSection('Compiled', hint, compiledKits, ICON_COMPILED);
+  return formatSection('Compiled', hint, compiledKits, 'docCompiled');
 }
 
 // -- Empty messages --
@@ -111,10 +111,10 @@ interface ManifestViewOptions {
 /**
  * Format a view of kits loaded from a manifest file.
  *
- * Kit names are displayed with the compiled icon. When a kit's `readyupVersion` is present, it
- * appears as a parenthetical between the name and the description — `📦 <name> (readyup v<X>) — <description>`.
- * The literal `readyup` label is load-bearing: it disambiguates the version from a hypothetical
- * kit-own version. Descriptions appear inline when present; both fields are omitted independently.
+ * Kit names carry the compiled-output glyph. When a kit's `readyupVersion` is present, it appears as
+ * a parenthetical between the name and the description, which follows the middle dot. The literal
+ * `readyup` label is load-bearing: it disambiguates the version from a hypothetical kit-own version.
+ * Descriptions appear inline when present; both fields are omitted independently.
  */
 export function formatManifestView({ kits, manifestPath }: ManifestViewOptions): string {
   if (kits.length === 0) {
@@ -123,17 +123,26 @@ export function formatManifestView({ kits, manifestPath }: ManifestViewOptions):
 
   const items = kits.map((kit) => {
     const versionSegment = kit.readyupVersion !== undefined ? ` (readyup v${kit.readyupVersion})` : '';
-    const descriptionSegment = kit.description !== undefined ? ` — ${kit.description}` : '';
-    return `  ${ICON_COMPILED} ${kit.name}${versionSegment}${descriptionSegment}`;
+    return layout.formatCheckLine({
+      token: 'docCompiled',
+      name: `${kit.name}${versionSegment}`,
+      ...(kit.description !== undefined && { detail: kit.description }),
+    });
   });
 
-  return `Manifest: ${manifestPath}\n${items.join('\n')}`;
+  return [layout.formatHeadingLine(`Manifest: ${manifestPath}`, 'section'), ...items].join('\n');
 }
 
 // -- Helpers --
 
-/** Build a titled section with a usage hint and indented item list. */
-function formatSection(title: string, hint: string, kits: string[], icon: string): string {
-  const items = kits.map((name) => `  ${icon} ${name}`);
-  return `${title}: ${hint}\n${items.join('\n')}`;
+/**
+ * Build a titled section: the title, the copy-pasteable command beneath it, then the kits.
+ *
+ * Splitting the command onto its own line is what makes it copy-pasteable. Fused to the title, it
+ * could not be selected without also taking the label, and the title could not be scanned without
+ * reading past the command.
+ */
+function formatSection(title: string, hint: string, kits: string[], token: TokenName): string {
+  const items = kits.map((name) => layout.formatCheckLine({ token, name }));
+  return [layout.formatHeadingLine(title, 'section'), ...layout.formatReasonBlock([hint]), '', ...items].join('\n');
 }

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -66,7 +66,7 @@ export function formatOwnerView({
     }
   }
 
-  return sections.join('\n\n');
+  return sections.join('\n');
 }
 
 // -- Consumer view --
@@ -129,13 +129,17 @@ export function formatManifestView({ kits, manifestPath }: ManifestViewOptions):
     });
   });
 
-  return [layout.formatHeadingLine(`Manifest: ${manifestPath}`, 'section'), ...items].join('\n');
+  return [...layout.formatHeading(`Manifest: ${manifestPath}`, 'section'), ...items].join('\n');
 }
 
 // -- Helpers --
 
-/** Returns a titled section: the title, `hint` indented beneath it on its own line, then one line per kit. */
+/**
+ * Returns a titled section, opening with a blank line: the title, `hint` indented beneath it, then the kits.
+ *
+ * `hint` sits against the title with no blank between them, so the command reads as part of the heading.
+ */
 function formatSection(title: string, hint: string, kits: string[], token: TokenName): string {
   const items = kits.map((name) => layout.formatCheckLine({ token, name }));
-  return [layout.formatHeadingLine(title, 'section'), ...layout.formatReasonBlock([hint]), '', ...items].join('\n');
+  return ['', layout.formatHeadingLine(title, 'section'), `${layout.indent(1)}${hint}`, '', ...items].join('\n');
 }

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -40,8 +40,10 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
   const visibleResults = selectReportedResults(report.results, reportOn, options?.quiet === true);
   const lines = visibleResults.flatMap((result) => renderResult(result, fixLocation));
 
-  const counts = countResults(report.results);
-  lines.push('', layout.formatCountLine(counts, report.durationMs));
+  // The blank line separates the count line from the tree, so an empty tree needs none: the heading
+  // above already supplies one, and a second would open a gap under every fully-hidden checklist.
+  if (lines.length > 0) lines.push('');
+  lines.push(layout.formatCountLine(countResults(report.results), report.durationMs));
 
   if (fixLocation === 'end') {
     const fixes = collectFixes(visibleResults);

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -18,6 +18,7 @@ interface AttributedFix {
 /** Options controlling how the report is formatted. */
 export interface ReportRdyOptions {
   fixLocation?: FixLocation;
+  quiet?: boolean;
   reportOn?: Severity;
 }
 
@@ -29,13 +30,14 @@ export interface ReportRdyOptions {
  * check that raised it; in `inline` mode the fix joins that check's reason block instead.
  *
  * Results below the reporting threshold are omitted from the detail tree unless they are an ancestor
- * of a result that is shown; the summary counts always reflect the whole run.
+ * of a result that is shown, and `quiet` drops passed checks from what survives that. The summary
+ * counts always reflect the whole run regardless of either.
  */
 export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string {
   const fixLocation = options?.fixLocation ?? 'end';
   const reportOn = options?.reportOn ?? 'recommend';
 
-  const visibleResults = selectVisibleResults(report.results, reportOn);
+  const visibleResults = selectReportedResults(report.results, reportOn, options?.quiet === true);
   const lines = visibleResults.flatMap((result) => renderResult(result, fixLocation));
 
   const counts = countResults(report.results);
@@ -83,24 +85,12 @@ export function countResults(results: RdyResult[]): SummaryCounts {
  * Selects the results a reporting threshold leaves visible, retaining the ancestors of every survivor.
  *
  * A result is visible when its own severity meets the threshold or when any of its descendants is visible, so a
- * surviving check is never rendered under a pruned parent. Assumes the contiguous depth-first ordering `runRdy`
- * produces: a result's descendants are exactly the run of deeper results that follows it.
+ * surviving check is never rendered under a pruned parent.
  *
  * Visible results are returned in their original order.
  */
 export function selectVisibleResults(results: RdyResult[], reportOn: Severity): RdyResult[] {
-  const visible: RdyResult[] = [];
-  // Scanning right to left, the nearest visible result is a descendant exactly when it is deeper, so its
-  // depth alone decides whether the current result must be retained as an ancestor.
-  let nearestVisibleDepth = -Infinity;
-
-  for (const result of results.toReversed()) {
-    if (!meetsThreshold(result.severity, reportOn) && nearestVisibleDepth <= result.depth) continue;
-    visible.push(result);
-    nearestVisibleDepth = result.depth;
-  }
-
-  return visible.toReversed();
+  return retainWithAncestors(results, (result) => meetsThreshold(result.severity, reportOn));
 }
 
 /** Aggregates `source` counts into `target` in place, propagating the worse severity. */
@@ -115,6 +105,41 @@ export function mergeCounts(target: SummaryCounts, source: SummaryCounts): void 
 }
 
 // -- Helpers --
+
+/**
+ * Selects what the detail tree shows: the severity threshold first, then `quiet` over what survives.
+ *
+ * The two are orthogonal -- one filters by severity, the other by status -- so they compose rather
+ * than override. Both run through the same ancestor-retaining walk, which is what keeps a lone deep
+ * failure reachable through its passed parents under either.
+ */
+function selectReportedResults(results: RdyResult[], reportOn: Severity, quiet: boolean): RdyResult[] {
+  const reported = selectVisibleResults(results, reportOn);
+  if (!quiet) return reported;
+  return retainWithAncestors(reported, (result) => result.status !== 'passed');
+}
+
+/**
+ * Filters results to those `isVisible` accepts, retaining the ancestors of every survivor.
+ *
+ * Assumes the contiguous depth-first ordering `runRdy` produces: a result's descendants are exactly
+ * the run of deeper results that follows it. Retaining whole ancestor chains preserves that property,
+ * so the output of one pass is valid input to the next.
+ */
+function retainWithAncestors(results: RdyResult[], isVisible: (result: RdyResult) => boolean): RdyResult[] {
+  const visible: RdyResult[] = [];
+  // Scanning right to left, the nearest visible result is a descendant exactly when it is deeper, so its
+  // depth alone decides whether the current result must be retained as an ancestor.
+  let nearestVisibleDepth = -Infinity;
+
+  for (const result of results.toReversed()) {
+    if (!isVisible(result) && nearestVisibleDepth <= result.depth) continue;
+    visible.push(result);
+    nearestVisibleDepth = result.depth;
+  }
+
+  return visible.toReversed();
+}
 
 /** Render one result: its check line, plus the reason block a failure carries beneath it. */
 function renderResult(result: RdyResult, fixLocation: FixLocation): string[] {

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -1,16 +1,19 @@
+import { layout } from './layout/engine.ts';
+import type { TokenName } from './layout/formatter.ts';
+import { resolveWorstToken } from './layout/layoutEngine.ts';
 import { meetsThreshold } from './runRdy.ts';
 import type { FixLocation, Progress, RdyReport, RdyResult, Severity, SummaryCounts } from './types.ts';
 import { isPercentProgress } from './types.ts';
-import { pluralizeWithCount } from './utils/pluralize.ts';
 import { worseSeverity } from './utils/severity.ts';
 
-export const ICON_PASSED = '\u{1F7E2}';
-export const ICON_ERROR_FAILED = '\u{1F534}';
-export const ICON_WARN_FAILED = '\u{1F7E0}';
-export const ICON_RECOMMEND_FAILED = '\u{1F7E1}';
-export const ICON_SKIPPED_NA = '\u{23ED}\u{FE0F}';
-export const ICON_SKIPPED_PRECONDITION = '\u{1F6AB}';
-export const ICON_FIX = '\u{1F48A}';
+/** Heading over the end-of-report fix recap. */
+const FIXES_HEADING = 'Fixes';
+
+/** A remediation message together with the check that raised it. */
+interface AttributedFix {
+  fix: string;
+  name: string;
+}
 
 /** Options controlling how the report is formatted. */
 export interface ReportRdyOptions {
@@ -18,112 +21,34 @@ export interface ReportRdyOptions {
   reportOn?: Severity;
 }
 
-/** Format a duration in milliseconds for display. */
-function formatDuration(ms: number): string {
-  return `${Math.round(ms)}ms`;
-}
-
-/** Return the status icon for a result based on status, severity, and skip reason. */
-function getIcon(result: RdyResult): string {
-  if (result.status === 'passed') return ICON_PASSED;
-  if (result.status === 'skipped') {
-    return result.skipReason === 'precondition' ? ICON_SKIPPED_PRECONDITION : ICON_SKIPPED_NA;
-  }
-  // Failed result: icon depends on severity.
-  if (result.severity === 'warn') return ICON_WARN_FAILED;
-  if (result.severity === 'recommend') return ICON_RECOMMEND_FAILED;
-  return ICON_ERROR_FAILED;
-}
-
-/** Format a progress value for display. */
-function formatProgress(progress: Progress): string {
-  if (isPercentProgress(progress)) {
-    return `${progress.percent}%`;
-  }
-  return `${progress.passedCount} of ${progress.count}`;
-}
-
-/** Build a "Failed: ..." segment with per-severity counts. Returns null when nothing failed. */
-function formatFailedSegment(counts: SummaryCounts, withIcons: boolean): string | null {
-  const parts: string[] = [];
-  if (counts.errors > 0) {
-    const label = pluralizeWithCount(counts.errors, 'error');
-    parts.push(withIcons ? `${ICON_ERROR_FAILED} ${label}` : label);
-  }
-  if (counts.warnings > 0) {
-    const label = pluralizeWithCount(counts.warnings, 'warning');
-    parts.push(withIcons ? `${ICON_WARN_FAILED} ${label}` : label);
-  }
-  if (counts.recommendations > 0) {
-    const label = pluralizeWithCount(counts.recommendations, 'recommendation');
-    parts.push(withIcons ? `${ICON_RECOMMEND_FAILED} ${label}` : label);
-  }
-  if (parts.length === 0) return null;
-  return `Failed: ${parts.join(', ')}`;
-}
-
-/** Build a "Skipped: ..." segment with per-reason counts. Returns null when nothing was skipped. */
-function formatSkippedSegment(counts: SummaryCounts, withIcons: boolean): string | null {
-  const parts: string[] = [];
-  if (counts.blocked > 0) {
-    const label = pluralizeWithCount(counts.blocked, 'blocked', 'blocked');
-    parts.push(withIcons ? `${ICON_SKIPPED_PRECONDITION} ${label}` : label);
-  }
-  if (counts.optional > 0) {
-    const label = pluralizeWithCount(counts.optional, 'optional', 'optional');
-    parts.push(withIcons ? `${ICON_SKIPPED_NA} ${label}` : label);
-  }
-  if (parts.length === 0) return null;
-  return `Skipped: ${parts.join(', ')}`;
-}
-
 /**
- * Build an icon-prefixed summary string with per-severity failure counts and per-reason skip counts.
+ * Format a readyup report as a human-readable string for terminal output.
  *
- * Each segment is icon-prefixed and joined with `. `. Zero-count entries and empty groups are omitted.
+ * A failed check's line carries only its claim; the reason renders in a block beneath, indented to
+ * the name column. In `end` mode (default) fixes are recapped at the bottom, each attributed to the
+ * check that raised it; in `inline` mode the fix joins that check's reason block instead.
+ *
+ * Results below the reporting threshold are omitted from the detail tree unless they are an ancestor
+ * of a result that is shown; the summary counts always reflect the whole run.
  */
-export function formatSummaryCounts(counts: SummaryCounts): string {
-  return formatCounts(counts, true);
-}
+export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string {
+  const fixLocation = options?.fixLocation ?? 'end';
+  const reportOn = options?.reportOn ?? 'recommend';
 
-/**
- * Build a summary string with the same granular format as `formatSummaryCounts` but
- * without inline severity icons, for use in combined-summary table rows.
- */
-export function formatSummaryCountsPlain(counts: SummaryCounts): string {
-  return formatCounts(counts, false);
-}
+  const visibleResults = selectVisibleResults(report.results, reportOn);
+  const lines = visibleResults.flatMap((result) => renderResult(result, fixLocation));
 
-/** Shared implementation for formatting granular summary counts, with or without icons. */
-function formatCounts(counts: SummaryCounts, withIcons: boolean): string {
-  const segments: string[] = [];
+  const counts = countResults(report.results);
+  lines.push('', layout.formatCountLine(counts, report.durationMs));
 
-  if (counts.passed > 0) {
-    const passedLabel = pluralizeWithCount(counts.passed, 'passed', 'passed');
-    segments.push(withIcons ? `${ICON_PASSED} ${passedLabel}` : passedLabel);
+  if (fixLocation === 'end') {
+    const fixes = collectFixes(visibleResults);
+    if (fixes.length > 0) {
+      lines.push(...layout.formatHeading(FIXES_HEADING, 'section'), ...renderFixRecap(fixes));
+    }
   }
 
-  const failedSegment = formatFailedSegment(counts, withIcons);
-  if (failedSegment !== null) segments.push(failedSegment);
-
-  const skippedSegment = formatSkippedSegment(counts, withIcons);
-  if (skippedSegment !== null) segments.push(skippedSegment);
-
-  return segments.join('. ');
-}
-
-/** Collect inline detail lines (error and/or fix) for a failed result. */
-function collectInlineDetails(result: RdyResult, includeFix: boolean): string[] {
-  const details: string[] = [];
-  // The 3-space lead-in matches the icon+space width on the check line above,
-  // so continuation text lands directly under the check name column.
-  if (result.error !== null) {
-    details.push(`   Error: ${result.error.message}`);
-  }
-  if (includeFix && result.fix !== null) {
-    details.push(`   ${ICON_FIX} Fix: ${result.fix}`);
-  }
-  return details;
+  return lines.join('\n');
 }
 
 /** Create a zeroed `SummaryCounts` object. */
@@ -189,6 +114,70 @@ export function mergeCounts(target: SummaryCounts, source: SummaryCounts): void 
   target.worstSeverity = worseSeverity(target.worstSeverity, source.worstSeverity);
 }
 
+// -- Helpers --
+
+/** Render one result: its check line, plus the reason block a failure carries beneath it. */
+function renderResult(result: RdyResult, fixLocation: FixLocation): string[] {
+  const isFailed = result.status === 'failed';
+  const checkLine = layout.formatCheckLine({
+    token: resolveResultToken(result),
+    name: result.name,
+    depth: result.depth,
+    durationMs: result.durationMs,
+    // A failed check's detail is its reason, which belongs in the block beneath rather than inline.
+    ...(!isFailed && result.detail !== null && { detail: result.detail }),
+    ...(result.progress !== null && { progress: formatProgress(result.progress) }),
+  });
+
+  if (!isFailed) return [checkLine];
+
+  return [checkLine, ...layout.formatReasonBlock(collectReasons(result, fixLocation === 'inline'), result.depth)];
+}
+
+/**
+ * Collect the reason lines beneath a failed check: the authored detail, then the thrown exception.
+ *
+ * A failure deriving from its children has neither, and so contributes no block at all -- the subtree
+ * beneath it is already the explanation, and a restatement would only push the checks further apart.
+ */
+function collectReasons(result: RdyResult, includeFix: boolean): string[] {
+  const reasons: string[] = [];
+  if (result.detail !== null) reasons.push(result.detail);
+  if (result.error !== null) reasons.push(`Error: ${result.error.message}`);
+  if (includeFix && result.fix !== null) reasons.push(`${layout.token('fix')}${result.fix}`);
+  return reasons;
+}
+
+/** Gather every fix a failed result carries, paired with the check name that attributes it. */
+function collectFixes(results: RdyResult[]): AttributedFix[] {
+  return results.flatMap((result) =>
+    result.status === 'failed' && result.fix !== null ? [{ name: result.name, fix: result.fix }] : [],
+  );
+}
+
+/** Render the end-of-report recap: the check name on the token line, its fix indented beneath. */
+function renderFixRecap(fixes: AttributedFix[]): string[] {
+  return fixes.flatMap((entry) => [`${layout.token('fix')}${entry.name}`, ...layout.formatReasonBlock([entry.fix])]);
+}
+
+/** Map a result's status, severity, and skip reason to the token that leads its line. */
+function resolveResultToken(result: RdyResult): TokenName {
+  if (result.status === 'passed') return 'passed';
+  if (result.status === 'skipped') {
+    return result.skipReason === 'precondition' ? 'blockedPrecondition' : 'skippedOptional';
+  }
+  // A failed check's severity picks its token by the same rule a tail line's worst severity does.
+  return resolveWorstToken(result.severity);
+}
+
+/** Format a progress value for display. */
+function formatProgress(progress: Progress): string {
+  if (isPercentProgress(progress)) {
+    return `${progress.percent}%`;
+  }
+  return `${progress.passedCount} of ${progress.count}`;
+}
+
 /**
  * Update a `SummaryCounts` object in place with the contribution of a single result.
  *
@@ -210,53 +199,4 @@ function tallyResult(counts: SummaryCounts, result: RdyResult): void {
   }
   if (result.skipReason === 'precondition') counts.blocked++;
   else counts.optional++;
-}
-
-/**
- * Format a readyup report as a human-readable string for terminal output.
- *
- * In `end` mode (default), errors appear inline but fix messages are collected in a "Fixes" section at the bottom.
- * In `inline` mode, error and fix messages appear directly below each failed check.
- * Results below the reporting threshold are omitted from the detail tree unless they are an ancestor of a
- * result that is shown; the summary counts always reflect the whole run.
- */
-export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string {
-  const fixLocation = options?.fixLocation ?? 'end';
-  const reportOn = options?.reportOn ?? 'recommend';
-  const lines: string[] = [];
-  const collectedFixes: string[] = [];
-
-  const visibleResults = selectVisibleResults(report.results, reportOn);
-
-  for (const result of visibleResults) {
-    const indent = ' '.repeat(3).repeat(result.depth);
-    const icon = getIcon(result);
-    let checkLine = `${indent}${icon} ${result.name} (${formatDuration(result.durationMs)})`;
-    if (result.detail !== null) {
-      checkLine += ` \u{2014} ${result.detail}`;
-    }
-    if (result.progress !== null) {
-      checkLine += ` \u{2014} ${formatProgress(result.progress)}`;
-    }
-    lines.push(checkLine);
-
-    if (result.status === 'failed') {
-      const includeFix = fixLocation === 'inline';
-      const details = collectInlineDetails(result, includeFix);
-      lines.push(...details.map((line) => `${indent}${line}`));
-
-      if (!includeFix && result.fix !== null) {
-        collectedFixes.push(result.fix);
-      }
-    }
-  }
-
-  const counts = countResults(report.results);
-  lines.push('', `${formatSummaryCounts(counts)} (${formatDuration(report.durationMs)})`);
-
-  if (fixLocation === 'end' && collectedFixes.length > 0) {
-    lines.push('', 'Fixes:', ...collectedFixes.map((fix) => `  ${ICON_FIX} ${fix}`));
-  }
-
-  return lines.join('\n');
 }

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -6,10 +6,8 @@ import type { FixLocation, Progress, RdyReport, RdyResult, Severity, SummaryCoun
 import { isPercentProgress } from './types.ts';
 import { worseSeverity } from './utils/severity.ts';
 
-/** Heading over the end-of-report fix recap. */
 const FIXES_HEADING = 'Fixes';
 
-/** A remediation message together with the check that raised it. */
 interface AttributedFix {
   fix: string;
   name: string;
@@ -23,15 +21,11 @@ export interface ReportRdyOptions {
 }
 
 /**
- * Format a readyup report as a human-readable string for terminal output.
+ * Returns a report rendered for a terminal: a tree of check lines, a count line, and any fix recap.
  *
- * A failed check's line carries only its claim; the reason renders in a block beneath, indented to
- * the name column. In `end` mode (default) fixes are recapped at the bottom, each attributed to the
- * check that raised it; in `inline` mode the fix joins that check's reason block instead.
- *
- * Results below the reporting threshold are omitted from the detail tree unless they are an ancestor
- * of a result that is shown, and `quiet` drops passed checks from what survives that. The summary
- * counts always reflect the whole run regardless of either.
+ * A failed check contributes its claim plus a reason block; every other status contributes one line.
+ * `fixLocation` places each fix either in the recap or in its check's reason block. The count line
+ * tallies every result in `report`, including those `reportOn` and `quiet` omit from the tree.
  */
 export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string {
   const fixLocation = options?.fixLocation ?? 'end';
@@ -55,7 +49,7 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
   return lines.join('\n');
 }
 
-/** Create a zeroed `SummaryCounts` object. */
+/** Returns counts with every field at zero and no worst severity. */
 export function emptyCounts(): SummaryCounts {
   return {
     passed: 0,
@@ -69,11 +63,9 @@ export function emptyCounts(): SummaryCounts {
 }
 
 /**
- * Count results by severity and skip reason.
+ * Returns the tally of `results` by severity and skip reason.
  *
- * This is the only entry point for tallying a result list, and it expects the run's
- * complete results. The reporting threshold selects what is *displayed*; passing a
- * pre-filtered list here is what once made the human, table, and JSON counts disagree.
+ * Expects a run's complete results: a pre-filtered list yields counts that describe only the subset.
  */
 export function countResults(results: RdyResult[]): SummaryCounts {
   const counts = emptyCounts();
@@ -84,18 +76,15 @@ export function countResults(results: RdyResult[]): SummaryCounts {
 }
 
 /**
- * Selects the results a reporting threshold leaves visible, retaining the ancestors of every survivor.
+ * Returns the results whose severity meets `reportOn`, plus the ancestors of each, in their original order.
  *
- * A result is visible when its own severity meets the threshold or when any of its descendants is visible, so a
- * surviving check is never rendered under a pruned parent.
- *
- * Visible results are returned in their original order.
+ * A result also survives when one of its descendants does, so no survivor is left without its parents.
  */
 export function selectVisibleResults(results: RdyResult[], reportOn: Severity): RdyResult[] {
   return retainWithAncestors(results, (result) => meetsThreshold(result.severity, reportOn));
 }
 
-/** Aggregates `source` counts into `target` in place, propagating the worse severity. */
+/** Adds `source` into `target` in place, keeping the worse of their two severities. */
 export function mergeCounts(target: SummaryCounts, source: SummaryCounts): void {
   target.passed += source.passed;
   target.errors += source.errors;
@@ -108,13 +97,7 @@ export function mergeCounts(target: SummaryCounts, source: SummaryCounts): void 
 
 // -- Helpers --
 
-/**
- * Selects what the detail tree shows: the severity threshold first, then `quiet` over what survives.
- *
- * The two are orthogonal -- one filters by severity, the other by status -- so they compose rather
- * than override. Both run through the same ancestor-retaining walk, which is what keeps a lone deep
- * failure reachable through its passed parents under either.
- */
+/** Returns the results surviving `reportOn`, then those surviving `quiet`, each pass keeping ancestors. */
 function selectReportedResults(results: RdyResult[], reportOn: Severity, quiet: boolean): RdyResult[] {
   const reported = selectVisibleResults(results, reportOn);
   if (!quiet) return reported;
@@ -122,11 +105,10 @@ function selectReportedResults(results: RdyResult[], reportOn: Severity, quiet: 
 }
 
 /**
- * Filters results to those `isVisible` accepts, retaining the ancestors of every survivor.
+ * Returns the results `isVisible` accepts, plus the ancestors of each, in their original order.
  *
- * Assumes the contiguous depth-first ordering `runRdy` produces: a result's descendants are exactly
- * the run of deeper results that follows it. Retaining whole ancestor chains preserves that property,
- * so the output of one pass is valid input to the next.
+ * Requires depth-first order, where a result's descendants are the run of deeper results following it.
+ * The returned list preserves that order, so it is valid input to a further pass.
  */
 function retainWithAncestors(results: RdyResult[], isVisible: (result: RdyResult) => boolean): RdyResult[] {
   const visible: RdyResult[] = [];
@@ -143,7 +125,7 @@ function retainWithAncestors(results: RdyResult[], isVisible: (result: RdyResult
   return visible.toReversed();
 }
 
-/** Render one result: its check line, plus the reason block a failure carries beneath it. */
+/** Returns a result's check line, followed by its reason block when the result failed. */
 function renderResult(result: RdyResult, fixLocation: FixLocation): string[] {
   const isFailed = result.status === 'failed';
   const checkLine = layout.formatCheckLine({
@@ -151,7 +133,7 @@ function renderResult(result: RdyResult, fixLocation: FixLocation): string[] {
     name: result.name,
     depth: result.depth,
     durationMs: result.durationMs,
-    // A failed check's detail is its reason, which belongs in the block beneath rather than inline.
+    // A failed check's detail is its reason, which the block beneath carries.
     ...(!isFailed && result.detail !== null && { detail: result.detail }),
     ...(result.progress !== null && { progress: formatProgress(result.progress) }),
   });
@@ -162,10 +144,9 @@ function renderResult(result: RdyResult, fixLocation: FixLocation): string[] {
 }
 
 /**
- * Collect the reason lines beneath a failed check: the authored detail, then the thrown exception.
+ * Returns a failed result's reasons in reading order: its detail, its error, then its fix.
  *
- * A failure deriving from its children has neither, and so contributes no block at all -- the subtree
- * beneath it is already the explanation, and a restatement would only push the checks further apart.
+ * Each is present only when the result carries it, so a result carrying none yields an empty list.
  */
 function collectReasons(result: RdyResult, includeFix: boolean): string[] {
   const reasons: string[] = [];
@@ -175,19 +156,19 @@ function collectReasons(result: RdyResult, includeFix: boolean): string[] {
   return reasons;
 }
 
-/** Gather every fix a failed result carries, paired with the check name that attributes it. */
+/** Returns each failed result's fix paired with the name of the check carrying it. */
 function collectFixes(results: RdyResult[]): AttributedFix[] {
   return results.flatMap((result) =>
     result.status === 'failed' && result.fix !== null ? [{ name: result.name, fix: result.fix }] : [],
   );
 }
 
-/** Render the end-of-report recap: the check name on the token line, its fix indented beneath. */
+/** Returns two lines per fix: the check's name behind a token, then the fix indented beneath. */
 function renderFixRecap(fixes: AttributedFix[]): string[] {
   return fixes.flatMap((entry) => [`${layout.token('fix')}${entry.name}`, ...layout.formatReasonBlock([entry.fix])]);
 }
 
-/** Map a result's status, severity, and skip reason to the token that leads its line. */
+/** Returns the token for a result, chosen by its status and then by its severity or skip reason. */
 function resolveResultToken(result: RdyResult): TokenName {
   if (result.status === 'passed') return 'passed';
   if (result.status === 'skipped') {
@@ -197,7 +178,7 @@ function resolveResultToken(result: RdyResult): TokenName {
   return resolveWorstToken(result.severity);
 }
 
-/** Format a progress value for display. */
+/** Returns a progress value as a percentage or a passed-of-total fraction. */
 function formatProgress(progress: Progress): string {
   if (isPercentProgress(progress)) {
     return `${progress.percent}%`;
@@ -206,11 +187,10 @@ function formatProgress(progress: Progress): string {
 }
 
 /**
- * Update a `SummaryCounts` object in place with the contribution of a single result.
+ * Adds one result to `counts` in place.
  *
- * Passed results increment `passed`. Failed results are bucketed by severity, and
- * `worstSeverity` is updated if the failure is more severe than the current worst.
- * Skipped results increment `blocked` (precondition) or `optional` (n/a).
+ * A pass increments `passed`; a failure increments its severity's field and may raise `worstSeverity`;
+ * a skip increments `blocked` or `optional` according to its reason.
  */
 function tallyResult(counts: SummaryCounts, result: RdyResult): void {
   if (result.status === 'passed') {

--- a/packages/readyup/src/terminal.ts
+++ b/packages/readyup/src/terminal.ts
@@ -2,10 +2,9 @@ import { layout } from './layout/engine.ts';
 import type { TokenName } from './layout/formatter.ts';
 import type { WriteResult } from './writeFileWithCheck.ts';
 
-/** Tokens whose lines belong on stderr, so a caller redirecting stdout still sees them. */
+/** Tokens whose lines are written to stderr. */
 const STDERR_TOKENS: ReadonlySet<TokenName> = new Set<TokenName>(['failedError']);
 
-/** A write outcome rendered into the shared vocabulary. */
 interface WriteLine {
   claim: string;
   token: TokenName;
@@ -13,16 +12,15 @@ interface WriteLine {
   reason?: string;
 }
 
-/** Print a step label as a section heading. */
+/** Writes `message` to stdout as a section heading. */
 export function printStep(message: string): void {
   console.info(layout.formatHeading(message, 'section').join('\n'));
 }
 
 /**
- * Print a write result as a check line, sending a hard failure to stderr.
+ * Writes a check line for `result`, naming the file and then its outcome.
  *
- * Naming the file first is what lets a reader scan a column of paths and see what happened to each;
- * the outcome rides as inline detail, or as a block reason where the outcome is a failure.
+ * An outcome that failed carries its cause in a block beneath and goes to stderr; the rest go to stdout.
  */
 export function reportWriteResult(result: WriteResult, dryRun: boolean): void {
   const { claim, detail, reason, token } = describeWriteResult(result, dryRun);
@@ -38,11 +36,9 @@ export function reportWriteResult(result: WriteResult, dryRun: boolean): void {
 }
 
 /**
- * Map a write outcome to its token and text.
+ * Returns the token and text for a write outcome, phrasing `dryRun` outcomes as what would happen.
  *
- * A file left alone because it already exists is a skip, not a warning -- nothing is wrong and
- * nothing needs doing. One left alone because it could not be read to compare *is* a warning: the
- * scaffold cannot say whether the file on disk is what it would have written.
+ * A skip carries a warning token only when an unreadable file left the outcome undetermined.
  */
 function describeWriteResult(result: WriteResult, dryRun: boolean): WriteLine {
   const { error, filePath, outcome } = result;

--- a/packages/readyup/src/terminal.ts
+++ b/packages/readyup/src/terminal.ts
@@ -1,58 +1,68 @@
+import { layout } from './layout/engine.ts';
+import type { TokenName } from './layout/formatter.ts';
 import type { WriteResult } from './writeFileWithCheck.ts';
 
-/** Print a step label with a right-arrow prefix. */
+/** Tokens whose lines belong on stderr, so a caller redirecting stdout still sees them. */
+const STDERR_TOKENS: ReadonlySet<TokenName> = new Set<TokenName>(['failedError']);
+
+/** A write outcome rendered into the shared vocabulary. */
+interface WriteLine {
+  claim: string;
+  token: TokenName;
+  detail?: string;
+  reason?: string;
+}
+
+/** Print a step label as a section heading. */
 export function printStep(message: string): void {
-  console.info(`\n> ${message}`);
+  console.info(layout.formatHeading(message, 'section').join('\n'));
 }
 
-/** Print a success message with a checkmark emoji prefix. */
-export function printSuccess(message: string): void {
-  console.info(`  ✅ ${message}`);
-}
-
-/** Print a skip/warning message to stdout. */
-export function printSkip(message: string): void {
-  console.info(`  ⚠️ ${message}`);
-}
-
-/** Print an error message to stderr. */
-export function printError(message: string): void {
-  console.error(`  ❌ ${message}`);
-}
-
-/** Print a terminal message for a write result based on its outcome. */
+/**
+ * Print a write result as a check line, sending a hard failure to stderr.
+ *
+ * Naming the file first is what lets a reader scan a column of paths and see what happened to each;
+ * the outcome rides as inline detail, or as a block reason where the outcome is a failure.
+ */
 export function reportWriteResult(result: WriteResult, dryRun: boolean): void {
-  switch (result.outcome) {
+  const { claim, detail, reason, token } = describeWriteResult(result, dryRun);
+
+  const lines = [
+    layout.formatCheckLine({ token, name: claim, ...(detail !== undefined && { detail }) }),
+    ...(reason === undefined ? [] : layout.formatReasonBlock([reason])),
+  ];
+  const output = lines.join('\n');
+
+  if (STDERR_TOKENS.has(token)) console.error(output);
+  else console.info(output);
+}
+
+/**
+ * Map a write outcome to its token and text.
+ *
+ * A file left alone because it already exists is a skip, not a warning -- nothing is wrong and
+ * nothing needs doing. One left alone because it could not be read to compare *is* a warning: the
+ * scaffold cannot say whether the file on disk is what it would have written.
+ */
+function describeWriteResult(result: WriteResult, dryRun: boolean): WriteLine {
+  const { error, filePath, outcome } = result;
+
+  switch (outcome) {
     case 'created':
-      if (dryRun) {
-        printSuccess(`[dry-run] Would create ${result.filePath}`);
-      } else {
-        printSuccess(`Created ${result.filePath}`);
-      }
-      break;
+      return { token: 'passed', claim: filePath, detail: dryRun ? 'would create' : 'created' };
     case 'overwritten':
-      if (dryRun) {
-        printSuccess(`[dry-run] Would overwrite ${result.filePath}`);
-      } else {
-        printSuccess(`Overwrote ${result.filePath}`);
-      }
-      break;
+      return { token: 'passed', claim: filePath, detail: dryRun ? 'would overwrite' : 'overwrote' };
     case 'up-to-date':
-      printSuccess(`${result.filePath} (up to date)`);
-      break;
+      return { token: 'passed', claim: filePath, detail: 'up to date' };
     case 'skipped':
-      if (result.error) {
-        printSkip(`${result.filePath} (could not read for comparison: ${result.error})`);
-      } else {
-        printSkip(`${result.filePath} (already exists)`);
-      }
-      break;
+      return error === undefined
+        ? { token: 'skippedOptional', claim: filePath, detail: 'already exists' }
+        : { token: 'failedWarn', claim: filePath, reason: `could not read for comparison: ${error}` };
     case 'failed':
-      if (result.error) {
-        printError(`Failed to write ${result.filePath}: ${result.error}`);
-      } else {
-        printError(`Failed to write ${result.filePath}`);
-      }
-      break;
+      return {
+        token: 'failedError',
+        claim: filePath,
+        reason: error === undefined ? 'failed to write' : `failed to write: ${error}`,
+      };
   }
 }

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -130,13 +130,10 @@ function buildVerifyEntry(name: string, status: DriftStatus, sourceStatus: Sourc
 }
 
 /**
- * Format a single per-kit line, reporting only the verdicts that have news.
+ * Returns a kit's line, carrying whichever of its two verdicts has something to report.
  *
- * A failing kit carries just its name, with each verdict on its own line beneath -- a kit whose
- * target drifted *and* whose source went stale has two things to say, and a block gives each room
- * that an inline tail joined by semicolons does not. A passing or unverified kit keeps its verdict
- * inline, and a wholly verified one says nothing beyond its token: the reader's attention belongs on
- * whatever changed.
+ * A failing kit carries each verdict on its own line beneath its name; any other kit carries them
+ * inline. A kit that passes both verdicts carries none, leaving its token to report the outcome.
  */
 function formatStatusLine(kit: RdyManifestKit, status: DriftStatus, sourceStatus: SourceStatus): string {
   const token = resolveToken(status, sourceStatus);
@@ -154,11 +151,10 @@ function formatStatusLine(kit: RdyManifestKit, status: DriftStatus, sourceStatus
 }
 
 /**
- * Pick the token for a kit's line from the worse of its two verdicts.
+ * Returns the token for the worse of a kit's two verdicts.
  *
- * A missing file and a hash mismatch both mean the tree does not match what the manifest describes,
- * so both read as failures. `unverified` shows only when it is the whole story, since a target
- * verified against its hash is not made less verified by a source the manifest never recorded.
+ * A mismatch or a missing file on either axis yields a failure. `unverified` yields the skip token only
+ * when the target itself is unverified.
  */
 function resolveToken(status: DriftStatus, sourceStatus: SourceStatus): TokenName {
   const targetFailed = status.kind === 'missing' || status.kind === 'drift';
@@ -168,7 +164,7 @@ function resolveToken(status: DriftStatus, sourceStatus: SourceStatus): TokenNam
   return 'passed';
 }
 
-/** Describe the compiled-output verdict, or nothing when the token already says it. */
+/** Returns a clause describing the compiled-output verdict, or nothing when the verdict is `ok`. */
 function describeDriftStatus(kit: RdyManifestKit, status: DriftStatus): string | undefined {
   switch (status.kind) {
     case 'ok':
@@ -182,7 +178,7 @@ function describeDriftStatus(kit: RdyManifestKit, status: DriftStatus): string |
   }
 }
 
-/** Describe the source verdict, or nothing when it has no news to add. */
+/** Returns a clause describing the source verdict, or nothing when it is `ok` or `unverified`. */
 function describeSourceStatus(kit: RdyManifestKit, status: SourceStatus): string | undefined {
   switch (status.kind) {
     case 'stale':

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -4,6 +4,8 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 
 import { configError, usageError } from '../errors.ts';
 import { EXIT_OK, EXIT_PROBLEMS_FOUND } from '../exitCodes.ts';
+import { layout } from '../layout/engine.ts';
+import type { TokenName } from '../layout/formatter.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { readManifest } from '../manifest/readManifest.ts';
@@ -21,13 +23,6 @@ const verifyOptions = {
   json: { type: 'boolean' },
   manifest: { type: 'string' },
 } as const;
-
-// A line's icon is the worse of the kit's two verdicts. The mismatch icon carries a trailing space
-// because its variation selector renders one column narrower than the others.
-const ICON_OK = '✅';
-const ICON_MISMATCH = '⚠️ ';
-const ICON_MISSING = '❓';
-const ICON_UNVERIFIED = '➖';
 
 /**
  * Handle the `verify` subcommand: read the manifest, hash each kit's source and compiled output,
@@ -68,10 +63,10 @@ export function verifyCommand(args: string[]): number {
   }
 
   const relManifestPath = path.relative(process.cwd(), manifestPath);
-  writeHuman(`Verifying kits against ${relManifestPath}:\n`, json);
+  writeHuman(layout.formatHeading(`Verifying kits against ${relManifestPath}`, 'section').join('\n') + '\n', json);
 
   if (manifest.kits.length === 0) {
-    writeHuman('  (no kits in manifest)\n', json);
+    writeHuman('(no kits in manifest)\n', json);
     return finishVerify([], true, json);
   }
 
@@ -135,37 +130,49 @@ function buildVerifyEntry(name: string, status: DriftStatus, sourceStatus: Sourc
 }
 
 /**
- * Format a single per-kit line, appending the source verdict only when it has news.
+ * Format a single per-kit line, reporting only the verdicts that have news.
  *
- * A source that is `ok`, or that no manifest entry describes, leaves the line saying exactly what it
- * said before the source verdict existed: the reader's attention belongs on whatever changed.
+ * A failing kit carries just its name, with each verdict on its own line beneath -- a kit whose
+ * target drifted *and* whose source went stale has two things to say, and a block gives each room
+ * that an inline tail joined by semicolons does not. A passing or unverified kit keeps its verdict
+ * inline, and a wholly verified one says nothing beyond its token: the reader's attention belongs on
+ * whatever changed.
  */
 function formatStatusLine(kit: RdyManifestKit, status: DriftStatus, sourceStatus: SourceStatus): string {
-  const clauses = [describeDriftStatus(kit, status)];
-  const sourceClause = describeSourceStatus(kit, sourceStatus);
-  if (sourceClause !== undefined) clauses.push(sourceClause);
-  return `  ${resolveIcon(status, sourceStatus)} ${kit.name} — ${clauses.join('; ')}\n`;
+  const token = resolveToken(status, sourceStatus);
+  const clauses = [describeDriftStatus(kit, status), describeSourceStatus(kit, sourceStatus)].filter(
+    (clause): clause is string => clause !== undefined,
+  );
+
+  if (token === 'failedError') {
+    const claim = layout.formatCheckLine({ token, name: kit.name });
+    return [claim, ...layout.formatReasonBlock(clauses)].join('\n') + '\n';
+  }
+
+  const detail = clauses.join('; ');
+  return layout.formatCheckLine({ token, name: kit.name, ...(detail !== '' && { detail }) }) + '\n';
 }
 
 /**
- * Pick the icon for a kit's line from the worse of its two verdicts.
+ * Pick the token for a kit's line from the worse of its two verdicts.
  *
- * A missing file outranks a hash mismatch: one of the artifacts the manifest describes is not there
- * at all. `unverified` shows only when it is the whole story, since a target verified against its
- * hash is not made less verified by a source the manifest never recorded.
+ * A missing file and a hash mismatch both mean the tree does not match what the manifest describes,
+ * so both read as failures. `unverified` shows only when it is the whole story, since a target
+ * verified against its hash is not made less verified by a source the manifest never recorded.
  */
-function resolveIcon(status: DriftStatus, sourceStatus: SourceStatus): string {
-  if (status.kind === 'missing' || sourceStatus.kind === 'missing') return ICON_MISSING;
-  if (status.kind === 'drift' || sourceStatus.kind === 'stale') return ICON_MISMATCH;
-  if (status.kind === 'unverified') return ICON_UNVERIFIED;
-  return ICON_OK;
+function resolveToken(status: DriftStatus, sourceStatus: SourceStatus): TokenName {
+  const targetFailed = status.kind === 'missing' || status.kind === 'drift';
+  const sourceFailed = sourceStatus.kind === 'missing' || sourceStatus.kind === 'stale';
+  if (targetFailed || sourceFailed) return 'failedError';
+  if (status.kind === 'unverified') return 'skippedOptional';
+  return 'passed';
 }
 
-/** Describe the compiled-output verdict, the clause every line carries. */
-function describeDriftStatus(kit: RdyManifestKit, status: DriftStatus): string {
+/** Describe the compiled-output verdict, or nothing when the token already says it. */
+function describeDriftStatus(kit: RdyManifestKit, status: DriftStatus): string | undefined {
   switch (status.kind) {
     case 'ok':
-      return 'ok';
+      return undefined;
     case 'drift':
       return `drift (expected ${status.expected}, got ${status.actual})`;
     case 'missing':


### PR DESCRIPTION
## What

Improves the output of `rdy` commands, giving them one shared vocabulary of statuses and headings. A run summary with failures now leads with the worst failure rather than a count of passing checks. The reason for a failing check is given on its own line, and nested checks stay aligned. A fix hint now names the check that raised it. Timings are given only for slow checks. A new `--quiet` flag filters out passing checks, keeping skipped and blocked ones, and counts still cover the whole run.

## Why

A reader had to know which command produced a line before they could read the symbol at its start, and a failing run opened with a green count that buried the news it was there to deliver. Each command had accumulated its own vocabulary, heading style, and hand-patched emoji spacing as it was added, so every new command widened the divergence instead of inheriting a format.

## Details

### 🎉 Features

- One status vocabulary spans `run`, `list`, `verify`, `init`, and `compile`. 🟢 passes, 🔴 🟠 🟡 mark the three failure severities, ⚪ marks a skip, 🚫 marks a check blocked by a precondition, and 💊 marks a remediation hint. The per-command glyphs ⏭️ ✅ ⚠️ ❌ ❓ ➖ are retired. 📄 and 📦 survive as noun glyphs naming a TypeScript source and a compiled bundle.
- A check line reads `token name · detail [progress] (duration)`. The middle dot is the only detail separator, replacing the em dash; `compile`'s transformation lines use an ASCII `->`.
- A failed line carries only its claim, with the reason rendered beneath it and indented to the name column: the authored detail first, then any thrown exception behind its `Error:` label. Passes and skips keep their detail inline.
- Checklist tail lines and the total line lead with the run's worst severity and report counts as pipe-separated fields in a fixed order (passed, errors, warnings, recommendations, blocked, skipped), omitting any field that is zero. They previously read as prose sentences led by the passed count.
- The fix recap names the check that raised each hint, with the fix indented beneath it.
- `--quiet` hides passed check lines from human output. It filters by status where `--report-on` filters by severity, so the two compose; both retain the parent checks of anything they show. Counts and the exit code always cover the whole run, and pairing it with `--json` is a usage error rather than a silently ignored flag.
- Durations appear from 100 ms up and never on a check that did not run, so a fast report is no longer littered with `(0ms)`. Tail and total lines always carry theirs.
- Headings come from one family whose rule weight encodes level: `━━` for a kit, `──` for a checklist, a step, or a summary. The `=== name ===`, `--- name ---`, and `> step` grammars are gone, and the summary table's rules are equal-width and sized to their content.
- `compile` reports a rebuilt kit as `🟢 {src} -> 📦 {out}` and an unchanged one as `⚪ {src} · no changes`, with a drift-skip carrying its hash mismatch in a block beneath the kit.
- `list` splits each section's copy-pasteable command onto its own line beneath the title, so it can be copied without the label.

### ♻️ Refactoring

- A layout engine owns all output geometry -- gutters, nesting indents, headings, line composition, and table sizing -- while a formatter supplies only its token set and rule characters. Each token declares its glyph and cell width, so widths are declared rather than measured and no Unicode-width dependency is needed. The emoji formatter's glyphs all carry `Emoji_Presentation`, which is what lets them occupy two cells without a variation selector.
- The five local icon sets and every per-call-site spacing constant are deleted, including the hardcoded continuation indent in `reportRdy.ts` and the compensating space that padded `verifyCommand.ts`'s mismatch icon.
- `selectVisibleResults` generalizes into a predicate-parameterized ancestor-retaining pass, so `--quiet` and `--report-on` share one filtering algorithm rather than each carrying its own.

### 🧪 Tests

- New suites cover the layout engine, the emoji formatter, and terminal output. Alignment is asserted at four nesting levels by counting terminal cells from each token's declared width, and every token is asserted to be a single code point carrying `Emoji_Presentation` with no variation selector.
- `--quiet` is covered for retained passing ancestors, wholly-passing subtrees, counts that include hidden passes, composition with `--report-on`, and the `--quiet --json` usage error.

### 📚 Documentation

- The README gains a "Reading the output" section carrying the symbol table, the line grammar, the duration rule, and the count ordering.
- The Authoring API documents the `detail` contract -- `detail` answers "why this status" -- with a placement table and a worked kit whose rendered output is reproduced exactly, exercising an inline pass detail, a skip reason, and a block-style failure reason at three levels of nesting.
- Output samples for the quick start, `run`, `list`, `verify`, and `compile` are regenerated from actual output, and `--quiet` is documented in the CLI reference and both help texts.

Closes #121

