### PR TITLE
#122 Add a plain output style and style selection

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -129,21 +129,33 @@ rdy <command> [options]
 
 `--quiet` hides passed check lines from the human report, keeping failures, skips, blocks, the fix recap, and every count line. It filters by status where `--report-on` filters by severity, so the two compose rather than override, and both keep the parent checks of anything they show: a failure nested under passing parents stays reachable through them. Counts and the exit code still cover the whole run. Because it changes only the human report, pairing it with `--json` is a usage error rather than a silently ignored flag.
 
+### Global options
+
+| Option                        | Description                    |
+| ----------------------------- | ------------------------------ |
+| `--style <auto\|rich\|plain>` | Output style (default: `auto`) |
+| `--help, -h`                  | Show help for the command      |
+| `--version, -V`               | Show the version number        |
+
+Every command accepts `--style`. See [choosing an output style](#choosing-an-output-style).
+
 ### Reading the output
 
-Every command renders through one layout engine, so a line means the same thing wherever it appears.
+Every command renders through one layout engine, so a line means the same thing wherever it appears. Each status has two renderings: an emoji in the `rich` style, and a fixed-width word in the `plain` style.
 
-| Token | Meaning                                                         |
-| ----- | --------------------------------------------------------------- |
-| 🟢    | passed; `verify` ok; a file created, overwritten, or up to date |
-| 🔴    | failed at `error` severity; `verify` drift or missing           |
-| 🟠    | failed at `warn` severity; a compile drift-skip                 |
-| 🟡    | failed at `recommend` severity                                  |
-| ⚪    | skipped: not applicable, already present, or no work needed     |
-| 🚫    | blocked, because a precondition failed                          |
-| 💊    | a remediation hint                                              |
+| Rich | Plain   | Meaning                                                         |
+| ---- | ------- | --------------------------------------------------------------- |
+| 🟢   | `PASS`  | passed; `verify` ok; a file created, overwritten, or up to date |
+| 🔴   | `FAIL`  | failed at `error` severity; `verify` drift or missing           |
+| 🟠   | `WARN`  | failed at `warn` severity; a compile drift-skip                 |
+| 🟡   | `RECO`  | failed at `recommend` severity                                  |
+| ⚪   | `SKIP`  | skipped: not applicable, already present, or no work needed     |
+| 🚫   | `BLOCK` | blocked, because a precondition failed                          |
+| 💊   | `FIX`   | a remediation hint                                              |
 
-📄 and 📦 are noun glyphs, not statuses: they name a TypeScript source and a compiled bundle. They lead the line in `list`, where a row names a kit instead of reporting an outcome, and sit mid-line in compile's transformation lines. Both declare the same width as every status token, which is what makes the leading position safe.
+📄 and 📦 are noun glyphs, not statuses: they name a TypeScript source and a compiled bundle. They lead the line in `list`, where a row names a kit instead of reporting an outcome, and sit mid-line in compile's transformation lines. Both declare the same width as every status token, which is what makes the leading position safe. The `plain` style omits them rather than substituting a word, since an uppercase word in the status column would read as a status; it still reserves their column, so names stay aligned.
+
+In `plain`, every character is printable ASCII: headings rule with `==` and `--`, and a middle dot giving way to `-` parts a check's name from its detail.
 
 A check line reads `token name · detail [progress] (duration)`. The middle dot is the only detail separator, so progress takes brackets rather than a second one, and compile's transformation lines take an ASCII `->`. Durations appear from 100 ms up, never on a check that did not run, and always on a tail or total line.
 
@@ -185,6 +197,55 @@ Headings come from one family whose rule weight encodes level: `━━` for a ki
 ```
 
 Under `--quiet`, that run keeps everything except `typecheck`, `bundle size`, and `database reachable`.
+
+### Choosing an output style
+
+`--style` selects how output is rendered, and `RDY_STYLE` carries a standing preference for a shell profile or a CI image. The flag outranks the environment variable, which outranks detection.
+
+| Value   | Renders                                                                       |
+| ------- | ----------------------------------------------------------------------------- |
+| `auto`  | `plain` under CI or when output is not a terminal, `rich` otherwise (default) |
+| `rich`  | Emoji tokens                                                                  |
+| `plain` | Fixed-width ASCII words                                                       |
+
+Both detection signals carry their own weight. `CI` catches a runner that attaches a pseudo-terminal, where a terminal check alone would put emoji into a log nobody can search; the terminal check catches an interactive `rdy | grep FAIL`, where `CI` is unset. An explicit `CI=false` is read as a denial.
+
+Naming a style that does not exist, from either the flag or the environment variable, fails the invocation and reports the values that are accepted.
+
+The same run renders in `plain` as:
+
+```
+-- build
+
+PASS  typecheck (343ms)
+PASS  bundle size - 42kB of a 50kB budget [84%]
+
+PASS  2 passed (343ms)
+
+-- integration
+
+PASS  database reachable
+FAIL  migrations applied (151ms)
+      2 migrations pending: add_users, add_index
+SKIP  seed data loaded - seeding is disabled outside CI
+
+FAIL  1 passed | 1 error | 1 skipped (151ms)
+
+-- Fixes
+
+FIX   migrations applied
+      Run `pnpm migrate` against the target database
+
+-- Summary
+
+--------------------------------------------------------
+PASS  build        343ms  2 passed
+FAIL  integration  151ms  1 passed | 1 error | 1 skipped
+--------------------------------------------------------
+FAIL  Total: 3 passed | 1 error | 1 skipped (494ms)
+```
+
+Once a style is named explicitly, output is byte-identical whether it goes to a terminal or a pipe, so `rdy --style rich > run.log` saves what the screen showed. `--style` is independent of `--json`: the JSON document never changes, and the style governs the prose that accompanies it on stderr.
 
 ### Advisory warnings
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -133,7 +133,7 @@ rdy <command> [options]
 
 | Option                        | Description                    |
 | ----------------------------- | ------------------------------ |
-| `--style <auto\|rich\|plain>` | Output style (default: `auto`) |
+| `--style <auto\|plain\|rich>` | Output style (default: `auto`) |
 | `--help, -h`                  | Show help for the command      |
 | `--version, -V`               | Show the version number        |
 
@@ -155,9 +155,9 @@ Every command renders through one layout engine, so a line means the same thing 
 
 📄 and 📦 are noun glyphs, not statuses: they name a TypeScript source and a compiled bundle. They lead the line in `list`, where a row names a kit instead of reporting an outcome, and sit mid-line in compile's transformation lines. Both declare the same width as every status token, which is what makes the leading position safe. The `plain` style omits them rather than substituting a word, since an uppercase word in the status column would read as a status; it still reserves their column, so names stay aligned.
 
-In `plain`, every character is printable ASCII: headings rule with `==` and `--`, and a middle dot giving way to `-` parts a check's name from its detail.
+In `plain`, every character is printable ASCII, heading rules and detail separators included.
 
-A check line reads `token name · detail [progress] (duration)`. The middle dot is the only detail separator, so progress takes brackets rather than a second one, and compile's transformation lines take an ASCII `->`. Durations appear from 100 ms up, never on a check that did not run, and always on a tail or total line.
+A check line reads `token name <separator> detail [progress] (duration)`, where the separator is the style's -- `·` in `rich`, `-` in `plain`. It is the only detail separator, so progress takes brackets rather than a second one, and compile's transformation lines take an ASCII `->`. Durations appear from 100 ms up, never on a check that did not run, and always on a tail or total line.
 
 **A failed line carries only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. A failed check that authored neither renders no reason block at all. Passes and skips keep their detail inline.
 
@@ -205,8 +205,8 @@ Under `--quiet`, that run keeps everything except `typecheck`, `bundle size`, an
 | Value   | Renders                                                                       |
 | ------- | ----------------------------------------------------------------------------- |
 | `auto`  | `plain` under CI or when output is not a terminal, `rich` otherwise (default) |
-| `rich`  | Emoji tokens                                                                  |
 | `plain` | Fixed-width ASCII words                                                       |
+| `rich`  | Emoji tokens                                                                  |
 
 Both detection signals carry their own weight. `CI` catches a runner that attaches a pseudo-terminal, where a terminal check alone would put emoji into a log nobody can search; the terminal check catches an interactive `rdy | grep FAIL`, where `CI` is unset. An explicit `CI=false` is read as a denial.
 
@@ -522,8 +522,8 @@ Where the detail lands follows from the status, so an author writes one field an
 
 | Status  | Where `detail` renders                                  |
 | ------- | ------------------------------------------------------- |
-| passed  | inline, after the middle dot                            |
-| skipped | inline, after the middle dot (return it from `skip`)    |
+| passed  | inline, after the separator                             |
+| skipped | inline, after the separator (return it from `skip`)     |
 | failed  | in a block beneath the claim, above any thrown `Error:` |
 
 Remediation is not detail. It belongs in `fix`, which is recapped at the end of the report against the check that raised it.

--- a/packages/readyup/__tests__/compileCommand.test.ts
+++ b/packages/readyup/__tests__/compileCommand.test.ts
@@ -58,15 +58,15 @@ vi.mock('../src/verify/targetHash.ts', () => ({
 
 import { compileCommand } from '../src/compile/compileCommand.ts';
 import type { KitMetadata } from '../src/compile/validateCompiledOutput.ts';
-import { emojiFormatter } from '../src/layout/emojiFormatter.ts';
+import { richFormatter } from '../src/layout/richFormatter.ts';
 import { ManifestNotFoundError } from '../src/manifest/readManifest.ts';
 import { VERSION } from '../src/version.ts';
 import { captureRdyError } from './helpers/captureRdyError.ts';
 
-const ICON_NO_CHANGES = emojiFormatter.tokens.skippedOptional.glyph;
-const ICON_COMPILED = emojiFormatter.tokens.passed.glyph;
-const ICON_DRIFT = emojiFormatter.tokens.failedWarn.glyph;
-const GLYPH_OUTPUT = emojiFormatter.tokens.docCompiled.glyph;
+const ICON_NO_CHANGES = richFormatter.tokens.skippedOptional.glyph;
+const ICON_COMPILED = richFormatter.tokens.passed.glyph;
+const ICON_DRIFT = richFormatter.tokens.failedWarn.glyph;
+const GLYPH_OUTPUT = richFormatter.tokens.docCompiled.glyph;
 
 /** Metadata as `validateCompiledOutput` returns it, defaulting to a kit with no checklists to record. */
 function kitMetadata(overrides: Partial<KitMetadata> = {}): KitMetadata {

--- a/packages/readyup/__tests__/countAgreement.test.ts
+++ b/packages/readyup/__tests__/countAgreement.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatCombinedSummary } from '../src/formatCombinedSummary.ts';
-import { layout } from '../src/layout/engine.ts';
+import { getLayout } from '../src/layout/engine.ts';
 import { countResults, reportRdy } from '../src/reportRdy.ts';
 import { runRdy } from '../src/runRdy.ts';
 import type { RdyChecklist, SummaryCounts } from '../src/types.ts';
@@ -67,7 +67,7 @@ describe('count agreement across views', () => {
 
     expect(counts).toStrictEqual(expectedCounts);
 
-    const expectedFields = layout.formatCounts(expectedCounts);
+    const expectedFields = getLayout().formatCounts(expectedCounts);
 
     // Human tail line.
     const human = reportRdy(report, { reportOn: 'error' });

--- a/packages/readyup/__tests__/formatCombinedSummary.test.ts
+++ b/packages/readyup/__tests__/formatCombinedSummary.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatCombinedSummary } from '../src/formatCombinedSummary.ts';
-import { emojiFormatter } from '../src/layout/emojiFormatter.ts';
+import { richFormatter } from '../src/layout/richFormatter.ts';
 import type { ChecklistSummary } from '../src/types.ts';
 
-const PASSED = emojiFormatter.tokens.passed.glyph;
-const FAILED_ERROR = emojiFormatter.tokens.failedError.glyph;
-const FAILED_WARN = emojiFormatter.tokens.failedWarn.glyph;
-const FAILED_RECOMMEND = emojiFormatter.tokens.failedRecommend.glyph;
+const PASSED = richFormatter.tokens.passed.glyph;
+const FAILED_ERROR = richFormatter.tokens.failedError.glyph;
+const FAILED_WARN = richFormatter.tokens.failedWarn.glyph;
+const FAILED_RECOMMEND = richFormatter.tokens.failedRecommend.glyph;
 
 function makeSummary(overrides?: Partial<ChecklistSummary>): ChecklistSummary {
   return {

--- a/packages/readyup/__tests__/layout/layoutEngine.test.ts
+++ b/packages/readyup/__tests__/layout/layoutEngine.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
+import { richFormatter } from '../../src/layout/richFormatter.ts';
 import { TOKEN_NAMES, type TokenName } from '../../src/layout/formatter.ts';
 import { createLayoutEngine, resolveWorstToken, type SummaryRow } from '../../src/layout/layoutEngine.ts';
 import type { SummaryCounts } from '../../src/types.ts';
@@ -8,12 +8,12 @@ import type { SummaryCounts } from '../../src/types.ts';
 /** Tokens naming a check that did not run. */
 const SKIPPED_TOKENS: TokenName[] = ['blockedPrecondition', 'skippedOptional'];
 
-const engine = createLayoutEngine(emojiFormatter);
+const engine = createLayoutEngine(richFormatter);
 
-const PASSED = emojiFormatter.tokens.passed.glyph;
-const FAILED_ERROR = emojiFormatter.tokens.failedError.glyph;
-const FAILED_WARN = emojiFormatter.tokens.failedWarn.glyph;
-const SKIPPED = emojiFormatter.tokens.skippedOptional.glyph;
+const PASSED = richFormatter.tokens.passed.glyph;
+const FAILED_ERROR = richFormatter.tokens.failedError.glyph;
+const FAILED_WARN = richFormatter.tokens.failedWarn.glyph;
+const SKIPPED = richFormatter.tokens.skippedOptional.glyph;
 
 function makeCounts(overrides?: Partial<SummaryCounts>): SummaryCounts {
   return {
@@ -42,7 +42,7 @@ function measureNameColumn(line: string): number {
   const groups = match?.groups;
   if (groups === undefined) throw new Error(`Not a token-led line: ${JSON.stringify(line)}`);
 
-  const token = Object.values(emojiFormatter.tokens).find((entry) => entry.glyph === groups.glyph);
+  const token = Object.values(richFormatter.tokens).find((entry) => entry.glyph === groups.glyph);
   if (token === undefined) throw new Error(`Unknown glyph: ${JSON.stringify(groups.glyph)}`);
 
   return (groups.indent?.length ?? 0) + token.width + (groups.pad?.length ?? 0);
@@ -145,7 +145,7 @@ describe('formatCheckLine', () => {
         measureNameColumn(engine.formatCheckLine({ token, name: 'check', depth: 2 })),
       );
 
-      expect(new Set(columns)).toStrictEqual(new Set([emojiFormatter.gutter * 3]));
+      expect(new Set(columns)).toStrictEqual(new Set([richFormatter.gutter * 3]));
     });
   });
 });
@@ -230,7 +230,7 @@ describe('formatCounts', () => {
   it('carries no per-field tokens', () => {
     const counts = makeCounts({ passed: 1, errors: 1, blocked: 1, optional: 1, worstSeverity: 'error' });
 
-    for (const { glyph } of Object.values(emojiFormatter.tokens)) {
+    for (const { glyph } of Object.values(richFormatter.tokens)) {
       expect(engine.formatCounts(counts)).not.toContain(glyph);
     }
   });
@@ -277,11 +277,11 @@ describe('formatSummaryTable', () => {
   /** Returns a rendered table line's width in display columns, its leading token counted as one gutter. */
   function measureWidth(line: string): number {
     const glyph = String.fromCodePoint(line.codePointAt(0) ?? 0);
-    const token = Object.values(emojiFormatter.tokens).find((entry) => entry.glyph === glyph);
+    const token = Object.values(richFormatter.tokens).find((entry) => entry.glyph === glyph);
     if (token === undefined) return line.length;
 
-    const rendered = glyph + ' '.repeat(emojiFormatter.gutter - token.width);
-    return emojiFormatter.gutter + line.slice(rendered.length).length;
+    const rendered = glyph + ' '.repeat(richFormatter.gutter - token.width);
+    return richFormatter.gutter + line.slice(rendered.length).length;
   }
 
   it('renders a heading, two rules, one row per checklist, and a total', () => {
@@ -377,9 +377,18 @@ describe('token and glyph', () => {
     expect(engine.token('passed')).toBe(`${PASSED} `);
   });
 
-  it('returns a bare glyph for mid-line placement', () => {
-    expect(engine.glyph('docCompiled')).toBe(emojiFormatter.tokens.docCompiled.glyph);
-    expect(engine.glyph('skippedOptional')).toBe(SKIPPED);
+  it('returns a glyph and one space for mid-line placement', () => {
+    expect(engine.inlineGlyph('docCompiled')).toBe(`${richFormatter.tokens.docCompiled.glyph} `);
+    expect(engine.inlineGlyph('skippedOptional')).toBe(`${SKIPPED} `);
+  });
+
+  it('returns nothing for a token the formatter gives no glyph, so no orphan space is left behind', () => {
+    const glyphless = createLayoutEngine({
+      ...richFormatter,
+      tokens: { ...richFormatter.tokens, docCompiled: { glyph: '', width: 0 } },
+    });
+
+    expect(glyphless.inlineGlyph('docCompiled')).toBe('');
   });
 
   it('indents by one gutter per level', () => {

--- a/packages/readyup/__tests__/layout/layoutEngine.test.ts
+++ b/packages/readyup/__tests__/layout/layoutEngine.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { richFormatter } from '../../src/layout/richFormatter.ts';
 import { TOKEN_NAMES, type TokenName } from '../../src/layout/formatter.ts';
 import { createLayoutEngine, resolveWorstToken, type SummaryRow } from '../../src/layout/layoutEngine.ts';
+import { richFormatter } from '../../src/layout/richFormatter.ts';
 import type { SummaryCounts } from '../../src/types.ts';
 
 /** Tokens naming a check that did not run. */

--- a/packages/readyup/__tests__/layout/plainFormatter.test.ts
+++ b/packages/readyup/__tests__/layout/plainFormatter.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { TOKEN_NAMES } from '../../src/layout/formatter.ts';
+import { createLayoutEngine } from '../../src/layout/layoutEngine.ts';
+import { plainFormatter } from '../../src/layout/plainFormatter.ts';
+import type { SummaryCounts } from '../../src/types.ts';
+
+/** Every printable ASCII character, plus the newline that separates rendered lines. */
+const PRINTABLE_ASCII = /^[\x20-\x7E\n]*$/;
+
+/** Tokens that name a kind of file rather than reporting an outcome. */
+const NOUN_TOKENS = ['docCompiled', 'docInternal'] as const;
+
+const engine = createLayoutEngine(plainFormatter);
+
+const entries = TOKEN_NAMES.map((name) => ({ name, ...plainFormatter.tokens[name] }));
+
+function makeCounts(overrides?: Partial<SummaryCounts>): SummaryCounts {
+  return {
+    passed: 0,
+    errors: 0,
+    warnings: 0,
+    recommendations: 0,
+    blocked: 0,
+    optional: 0,
+    worstSeverity: null,
+    ...overrides,
+  };
+}
+
+/** Returns the display column at which a rendered line's name begins. */
+function measureNameColumn(line: string): number {
+  const match = /^(?<indent> *)(?<word>[A-Z]*)(?<pad> +)/u.exec(line);
+  const groups = match?.groups;
+  if (groups === undefined) throw new Error(`Not a token-led line: ${JSON.stringify(line)}`);
+
+  return (groups.indent?.length ?? 0) + (groups.word?.length ?? 0) + (groups.pad?.length ?? 0);
+}
+
+/** Returns a line's count of leading spaces, one per column. */
+function measureIndent(line: string): number {
+  return line.length - line.trimStart().length;
+}
+
+/** Returns every line the engine can produce, so a whole-vocabulary assertion has something to run against. */
+function renderEverything(): string {
+  const counts = makeCounts({ passed: 2, errors: 1, warnings: 1, recommendations: 1, blocked: 1, optional: 1 });
+
+  return [
+    ...TOKEN_NAMES.map((token) =>
+      engine.formatCheckLine({ token, name: 'check', detail: 'detail', progress: '50%', durationMs: 250, depth: 1 }),
+    ),
+    ...engine.formatHeading('deploy', 'kit'),
+    ...engine.formatHeading('build', 'section'),
+    ...engine.formatReasonBlock(['a reason'], 2),
+    engine.formatCountLine(counts, 800),
+    ...engine.formatSummaryTable({
+      rows: [
+        { name: 'build', counts: makeCounts({ passed: 2 }), durationMs: 410 },
+        { name: 'integration', counts, durationMs: 1400 },
+      ],
+      totals: counts,
+      totalDurationMs: 1810,
+    }),
+    ...TOKEN_NAMES.map((token) => engine.inlineGlyph(token)),
+  ].join('\n');
+}
+
+describe('plainFormatter', () => {
+  it('supplies a token for every semantic state and no others', () => {
+    expect(new Set(Object.keys(plainFormatter.tokens))).toStrictEqual(new Set<string>(TOKEN_NAMES));
+  });
+
+  it('distinguishes the heading levels by rule character', () => {
+    expect(plainFormatter.rules.kit).not.toBe(plainFormatter.rules.section);
+  });
+
+  it('leaves room for a separating space after the widest token', () => {
+    const widest = Math.max(...entries.map((entry) => entry.width));
+
+    expect(plainFormatter.gutter).toBeGreaterThan(widest);
+  });
+
+  describe.each(entries)('$name', ({ glyph, width }) => {
+    it('declares the width it occupies', () => {
+      expect(width).toBe(glyph.length);
+    });
+  });
+
+  it.each(NOUN_TOKENS)('gives %s no glyph, so it is omitted rather than substituted', (token) => {
+    expect(plainFormatter.tokens[token].glyph).toBe('');
+  });
+});
+
+describe('rendered output', () => {
+  it('is printable ASCII throughout', () => {
+    expect(renderEverything()).toMatch(PRINTABLE_ASCII);
+  });
+
+  it('spells each status as a word a log search can find', () => {
+    expect(engine.formatCheckLine({ token: 'failedError', name: 'migrations' })).toBe('FAIL  migrations');
+  });
+
+  it('reserves the gutter for a token carrying no glyph, so names stay in one column', () => {
+    const noun = engine.formatCheckLine({ token: 'docCompiled', name: 'deploy' });
+    const status = engine.formatCheckLine({ token: 'passed', name: 'deploy' });
+
+    expect(measureNameColumn(noun)).toBe(measureNameColumn(status));
+    expect(noun).toBe('      deploy');
+  });
+
+  it('parts a detail from the name with an ASCII separator', () => {
+    expect(engine.formatCheckLine({ token: 'failedWarn', name: 'lint', detail: 'not installed' })).toBe(
+      'WARN  lint - not installed',
+    );
+  });
+
+  it('heads a section with an ASCII rule', () => {
+    expect(engine.formatHeadingLine('code-quality', 'section')).toBe('-- code-quality');
+    expect(engine.formatHeadingLine('deploy', 'kit')).toBe('== deploy');
+  });
+});
+
+describe('alignment', () => {
+  it('starts each nesting level one gutter right of the level above', () => {
+    const columns = [0, 1, 2, 3].map((depth) =>
+      measureNameColumn(engine.formatCheckLine({ token: 'passed', name: 'check', depth })),
+    );
+
+    expect(columns).toStrictEqual([6, 12, 18, 24]);
+  });
+
+  it('puts a child token under its parent name at every level', () => {
+    for (const depth of [0, 1, 2, 3]) {
+      const parent = engine.formatCheckLine({ token: 'passed', name: 'parent', depth });
+      const child = engine.formatCheckLine({ token: 'blockedPrecondition', name: 'child', depth: depth + 1 });
+
+      expect(measureIndent(child)).toBe(measureNameColumn(parent));
+    }
+  });
+
+  it('lands the name at one column whichever token leads the line', () => {
+    const columns = TOKEN_NAMES.map((token) =>
+      measureNameColumn(engine.formatCheckLine({ token, name: 'check', depth: 2 })),
+    );
+
+    expect(new Set(columns)).toStrictEqual(new Set([plainFormatter.gutter * 3]));
+  });
+
+  it('holds the column through three levels of nesting, widest token included', () => {
+    const rendered = [
+      engine.formatCheckLine({ token: 'failedError', name: 'bitbucket-pipelines.yml exists' }),
+      engine.formatCheckLine({ token: 'blockedPrecondition', name: 'pipeline runs checks', depth: 1 }),
+      engine.formatCheckLine({ token: 'skippedOptional', name: 'branch-protection query', depth: 2 }),
+    ].join('\n');
+
+    expect(rendered).toBe(
+      [
+        'FAIL  bitbucket-pipelines.yml exists',
+        '      BLOCK pipeline runs checks',
+        '            SKIP  branch-protection query',
+      ].join('\n'),
+    );
+  });
+});

--- a/packages/readyup/__tests__/layout/plainFormatter.test.ts
+++ b/packages/readyup/__tests__/layout/plainFormatter.test.ts
@@ -6,7 +6,7 @@ import { plainFormatter } from '../../src/layout/plainFormatter.ts';
 import type { SummaryCounts } from '../../src/types.ts';
 
 /** Every printable ASCII character, plus the newline that separates rendered lines. */
-const PRINTABLE_ASCII = /^[\x20-\x7E\n]*$/;
+const PRINTABLE_ASCII = /^[\u{20}-\u{7E}\n]*$/u;
 
 /** Tokens that name a kind of file rather than reporting an outcome. */
 const NOUN_TOKENS = ['docCompiled', 'docInternal'] as const;

--- a/packages/readyup/__tests__/layout/resolveStyle.test.ts
+++ b/packages/readyup/__tests__/layout/resolveStyle.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeInvalidStyle, resolveStyle, STYLE_ENV_VAR, STYLE_FLAG } from '../../src/layout/resolveStyle.ts';
+
+/** An environment naming no style and no CI, so detection rests on the terminal alone. */
+const BARE_ENV = {};
+
+const TTY = true;
+const PIPE = false;
+
+describe('the --style flag', () => {
+  it.each(['plain', 'rich'] as const)('takes %s as a spaced value', (style) => {
+    expect(resolveStyle([STYLE_FLAG, style], BARE_ENV, TTY).style).toBe(style);
+  });
+
+  it.each(['plain', 'rich'] as const)('takes %s as an assigned value', (style) => {
+    expect(resolveStyle([`${STYLE_FLAG}=${style}`], BARE_ENV, TTY).style).toBe(style);
+  });
+
+  it('outranks the environment variable', () => {
+    expect(resolveStyle([STYLE_FLAG, 'rich'], { [STYLE_ENV_VAR]: 'plain' }, PIPE).style).toBe('rich');
+  });
+
+  it('keeps the last occurrence, as the argument parser would', () => {
+    expect(resolveStyle([STYLE_FLAG, 'rich', STYLE_FLAG, 'plain'], BARE_ENV, TTY).style).toBe('plain');
+  });
+
+  it('ignores a value after the positional terminator', () => {
+    expect(resolveStyle(['--', STYLE_FLAG, 'plain'], BARE_ENV, TTY).style).toBe('rich');
+  });
+
+  it('defers to detection when it names auto', () => {
+    expect(resolveStyle([STYLE_FLAG, 'auto'], BARE_ENV, PIPE).style).toBe('plain');
+    expect(resolveStyle([STYLE_FLAG, 'auto'], BARE_ENV, TTY).style).toBe('rich');
+  });
+
+  it('defers to detection even when the environment names a style', () => {
+    expect(resolveStyle([STYLE_FLAG, 'auto'], { [STYLE_ENV_VAR]: 'plain' }, TTY).style).toBe('rich');
+  });
+});
+
+describe('the environment variable', () => {
+  it.each(['plain', 'rich'] as const)('is honored when it names %s', (style) => {
+    expect(resolveStyle([], { [STYLE_ENV_VAR]: style }, PIPE).style).toBe(style);
+  });
+
+  it('outranks detection', () => {
+    expect(resolveStyle([], { [STYLE_ENV_VAR]: 'rich' }, PIPE).style).toBe('rich');
+  });
+
+  it('is ignored when empty, so an unset-looking export does not shadow detection', () => {
+    expect(resolveStyle([], { [STYLE_ENV_VAR]: '' }, TTY).style).toBe('rich');
+  });
+
+  it('defers to detection when it names auto', () => {
+    expect(resolveStyle([], { [STYLE_ENV_VAR]: 'auto' }, PIPE).style).toBe('plain');
+  });
+});
+
+describe('detection', () => {
+  it('chooses rich for a terminal outside CI', () => {
+    expect(resolveStyle([], BARE_ENV, TTY).style).toBe('rich');
+  });
+
+  it('chooses plain when the output is not a terminal', () => {
+    expect(resolveStyle([], BARE_ENV, PIPE).style).toBe('plain');
+  });
+
+  it('chooses plain under CI even when a terminal is attached', () => {
+    expect(resolveStyle([], { CI: 'true' }, TTY).style).toBe('plain');
+  });
+
+  it.each(['1', 'yes', 'anything'])('reads CI=%s as CI', (value) => {
+    expect(resolveStyle([], { CI: value }, TTY).style).toBe('plain');
+  });
+
+  it.each(['false', ''])('reads CI=%s as a denial', (value) => {
+    expect(resolveStyle([], { CI: value }, TTY).style).toBe('rich');
+  });
+});
+
+describe('a value naming no style', () => {
+  it('is reported rather than thrown, so the complaint still has a style to render in', () => {
+    const resolution = resolveStyle([STYLE_FLAG, 'emoji'], BARE_ENV, TTY);
+
+    expect(resolution.invalid).toStrictEqual({ source: STYLE_FLAG, value: 'emoji' });
+    expect(resolution.style).toBe('rich');
+  });
+
+  it('is reported for the environment variable too', () => {
+    const resolution = resolveStyle([], { [STYLE_ENV_VAR]: 'text' }, PIPE);
+
+    expect(resolution.invalid).toStrictEqual({ source: STYLE_ENV_VAR, value: 'text' });
+    expect(resolution.style).toBe('plain');
+  });
+
+  it('falls through to the next source for the rendering itself', () => {
+    const resolution = resolveStyle([STYLE_FLAG, 'nonsense'], { [STYLE_ENV_VAR]: 'plain' }, TTY);
+
+    expect(resolution.style).toBe('plain');
+    expect(resolution.invalid?.source).toBe(STYLE_FLAG);
+  });
+
+  it('blames the flag over the environment when both are wrong', () => {
+    const resolution = resolveStyle([STYLE_FLAG, 'a'], { [STYLE_ENV_VAR]: 'b' }, TTY);
+
+    expect(resolution.invalid).toStrictEqual({ source: STYLE_FLAG, value: 'a' });
+  });
+
+  it('is absent from a resolution nothing is wrong with', () => {
+    expect(resolveStyle([STYLE_FLAG, 'plain'], BARE_ENV, TTY).invalid).toBeUndefined();
+  });
+
+  it('names the valid set in its message', () => {
+    const message = describeInvalidStyle({ source: STYLE_FLAG, value: 'emoji' });
+
+    expect(message).toBe('--style must be one of: auto, plain, rich (got "emoji")');
+  });
+});

--- a/packages/readyup/__tests__/layout/richFormatter.test.ts
+++ b/packages/readyup/__tests__/layout/richFormatter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
+import { richFormatter } from '../../src/layout/richFormatter.ts';
 import { TOKEN_NAMES } from '../../src/layout/formatter.ts';
 
 const VARIATION_SELECTOR_16 = '\u{FE0F}';
@@ -8,11 +8,11 @@ const VARIATION_SELECTOR_16 = '\u{FE0F}';
 /** Glyphs no token may use, each stripped of any variation selector. */
 const RETIRED_GLYPHS = ['\u{23ED}', '\u{2705}', '\u{26A0}', '\u{274C}', '\u{2753}', '\u{2796}'];
 
-const entries = TOKEN_NAMES.map((name) => ({ name, ...emojiFormatter.tokens[name] }));
+const entries = TOKEN_NAMES.map((name) => ({ name, ...richFormatter.tokens[name] }));
 
-describe('emojiFormatter', () => {
+describe('richFormatter', () => {
   it('supplies a token for every semantic state and no others', () => {
-    expect(new Set(Object.keys(emojiFormatter.tokens))).toStrictEqual(new Set<string>(TOKEN_NAMES));
+    expect(new Set(Object.keys(richFormatter.tokens))).toStrictEqual(new Set<string>(TOKEN_NAMES));
   });
 
   it('retires the glyphs the unified vocabulary replaced', () => {
@@ -24,13 +24,13 @@ describe('emojiFormatter', () => {
   });
 
   it('distinguishes the heading levels by rule weight', () => {
-    expect(emojiFormatter.rules.kit).not.toBe(emojiFormatter.rules.section);
+    expect(richFormatter.rules.kit).not.toBe(richFormatter.rules.section);
   });
 
   it('leaves room for a separating space after the widest token', () => {
     const widest = Math.max(...entries.map((entry) => entry.width));
 
-    expect(emojiFormatter.gutter).toBeGreaterThan(widest);
+    expect(richFormatter.gutter).toBeGreaterThan(widest);
   });
 
   describe.each(entries)('$name', ({ glyph, width }) => {

--- a/packages/readyup/__tests__/layout/richFormatter.test.ts
+++ b/packages/readyup/__tests__/layout/richFormatter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { richFormatter } from '../../src/layout/richFormatter.ts';
 import { TOKEN_NAMES } from '../../src/layout/formatter.ts';
+import { richFormatter } from '../../src/layout/richFormatter.ts';
 
 const VARIATION_SELECTOR_16 = '\u{FE0F}';
 

--- a/packages/readyup/__tests__/list/formatList.test.ts
+++ b/packages/readyup/__tests__/list/formatList.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
+import { richFormatter } from '../../src/layout/richFormatter.ts';
 import { formatConsumerView, formatEmpty, formatManifestView, formatOwnerView } from '../../src/list/formatList.ts';
 
-const COMPILED = emojiFormatter.tokens.docCompiled.glyph;
-const INTERNAL = emojiFormatter.tokens.docInternal.glyph;
+const COMPILED = richFormatter.tokens.docCompiled.glyph;
+const INTERNAL = richFormatter.tokens.docInternal.glyph;
 
 /**
  * Returns the line beneath a section's title, which is where its command sits.

--- a/packages/readyup/__tests__/reportRdy.test.ts
+++ b/packages/readyup/__tests__/reportRdy.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { emojiFormatter } from '../src/layout/emojiFormatter.ts';
+import { richFormatter } from '../src/layout/richFormatter.ts';
 import { countResults, reportRdy, selectVisibleResults } from '../src/reportRdy.ts';
 import type { FailedResult, PassedResult, RdyReport, RdyResult, SkippedResult, SummaryCounts } from '../src/types.ts';
 
-const PASSED = emojiFormatter.tokens.passed.glyph;
-const FAILED_ERROR = emojiFormatter.tokens.failedError.glyph;
-const FAILED_WARN = emojiFormatter.tokens.failedWarn.glyph;
-const FAILED_RECOMMEND = emojiFormatter.tokens.failedRecommend.glyph;
-const SKIPPED_OPTIONAL = emojiFormatter.tokens.skippedOptional.glyph;
-const BLOCKED = emojiFormatter.tokens.blockedPrecondition.glyph;
-const FIX = emojiFormatter.tokens.fix.glyph;
+const PASSED = richFormatter.tokens.passed.glyph;
+const FAILED_ERROR = richFormatter.tokens.failedError.glyph;
+const FAILED_WARN = richFormatter.tokens.failedWarn.glyph;
+const FAILED_RECOMMEND = richFormatter.tokens.failedRecommend.glyph;
+const SKIPPED_OPTIONAL = richFormatter.tokens.skippedOptional.glyph;
+const BLOCKED = richFormatter.tokens.blockedPrecondition.glyph;
+const FIX = richFormatter.tokens.fix.glyph;
 
 /** A duration above the engine's floor, so lines eligible for one show it. */
 const SLOW_MS = 250;

--- a/packages/readyup/__tests__/styleSelection.test.ts
+++ b/packages/readyup/__tests__/styleSelection.test.ts
@@ -7,8 +7,8 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 
 import { routeCommand } from '../src/bin/route.ts';
 import { plainFormatter } from '../src/layout/plainFormatter.ts';
-import { richFormatter } from '../src/layout/richFormatter.ts';
 import { STYLE_ENV_VAR } from '../src/layout/resolveStyle.ts';
+import { richFormatter } from '../src/layout/richFormatter.ts';
 import { hashBytes } from '../src/verify/targetHash.ts';
 
 /** A kit whose single check passes. */
@@ -90,7 +90,7 @@ describe('--style plain', () => {
 
     const rendered = [...stdout, ...stderr].join('');
     expect(rendered).not.toBe('');
-    expect(rendered).toMatch(/^[\x20-\x7E\n]*$/);
+    expect(rendered).toMatch(/^[\u{20}-\u{7E}\n]*$/u);
   });
 
   it.each(RENDERING_COMMANDS)('spells $name status as a word rather than a glyph', async ({ args }) => {

--- a/packages/readyup/__tests__/styleSelection.test.ts
+++ b/packages/readyup/__tests__/styleSelection.test.ts
@@ -1,0 +1,215 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { routeCommand } from '../src/bin/route.ts';
+import { plainFormatter } from '../src/layout/plainFormatter.ts';
+import { richFormatter } from '../src/layout/richFormatter.ts';
+import { STYLE_ENV_VAR } from '../src/layout/resolveStyle.ts';
+import { hashBytes } from '../src/verify/targetHash.ts';
+
+/** A kit whose single check passes. */
+const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
+
+const COMPILED_BYTES = Buffer.from(PASSING_KIT);
+
+const PLAIN_PASS = plainFormatter.tokens.passed.glyph;
+const RICH_PASS = richFormatter.tokens.passed.glyph;
+
+/** Every command that renders output, with arguments that make it produce some against the fixture. */
+const RENDERING_COMMANDS = [
+  { name: 'run', args: ['run', 'passing'] },
+  { name: 'list', args: ['list'] },
+  { name: 'verify', args: ['verify', '--manifest', 'manifest.json'] },
+  { name: 'compile', args: ['compile', '--skip-manifest', 'src/passing.ts'] },
+  { name: 'init', args: ['init', '--dry-run'] },
+] as const;
+
+let cwd: string;
+let originalCwd: string;
+let originalIsTty: boolean;
+let stdout: string[];
+let stderr: string[];
+
+beforeAll(() => {
+  originalCwd = process.cwd();
+  cwd = mkdtempSync(path.join(tmpdir(), 'readyup-style-'));
+  mkdirSync(path.join(cwd, '.readyup/kits'), { recursive: true });
+  mkdirSync(path.join(cwd, 'src'), { recursive: true });
+  writeFileSync(path.join(cwd, '.readyup/kits/passing.js'), PASSING_KIT);
+  writeFileSync(path.join(cwd, 'src/passing.ts'), PASSING_KIT);
+  writeFileSync(path.join(cwd, 'passing.js'), COMPILED_BYTES);
+  writeFileSync(
+    path.join(cwd, 'manifest.json'),
+    JSON.stringify({
+      version: 1,
+      kits: [{ name: 'passing', path: 'passing.js', source: 'src/passing.ts', targetHash: hashBytes(COMPILED_BYTES) }],
+    }),
+  );
+  process.chdir(cwd);
+});
+
+afterAll(() => {
+  process.chdir(originalCwd);
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  stdout = [];
+  stderr = [];
+  originalIsTty = process.stdout.isTTY;
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    stderr.push(String(chunk));
+    return true;
+  });
+  // `init` reports through the console rather than the streams directly, so both channels are captured.
+  vi.spyOn(console, 'info').mockImplementation((chunk: unknown) => {
+    stdout.push(`${String(chunk)}\n`);
+  });
+  vi.spyOn(console, 'error').mockImplementation((chunk: unknown) => {
+    stderr.push(`${String(chunk)}\n`);
+  });
+});
+
+afterEach(() => {
+  process.stdout.isTTY = originalIsTty;
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('--style plain', () => {
+  it.each(RENDERING_COMMANDS)('renders $name without leaving the ASCII range', async ({ args }) => {
+    await routeCommand([...args, '--style', 'plain']);
+
+    const rendered = [...stdout, ...stderr].join('');
+    expect(rendered).not.toBe('');
+    expect(rendered).toMatch(/^[\x20-\x7E\n]*$/);
+  });
+
+  it.each(RENDERING_COMMANDS)('spells $name status as a word rather than a glyph', async ({ args }) => {
+    await routeCommand([...args, '--style', 'plain']);
+
+    const rendered = [...stdout, ...stderr].join('');
+    expect(rendered).not.toContain(RICH_PASS);
+  });
+
+  it('is accepted as an assigned value too', async () => {
+    await routeCommand(['verify', '--manifest', 'manifest.json', '--style=plain']);
+
+    expect(stdout.join('')).toContain(`${PLAIN_PASS}  passing`);
+  });
+});
+
+describe('--style rich', () => {
+  it('renders glyphs even when the environment would detect otherwise', async () => {
+    vi.stubEnv('CI', 'true');
+    process.stdout.isTTY = false;
+
+    await routeCommand(['verify', '--manifest', 'manifest.json', '--style', 'rich']);
+
+    expect(stdout.join('')).toContain(`${RICH_PASS} passing`);
+  });
+});
+
+describe('an unrecognized style', () => {
+  it('fails the invocation and names the valid set', async () => {
+    const exitCode = await routeCommand(['verify', '--style', 'emoji']);
+
+    expect(exitCode).toBe(2);
+    expect(stderr.join('')).toContain('--style must be one of: auto, plain, rich (got "emoji")');
+  });
+
+  it('is rejected from the environment variable as well', async () => {
+    vi.stubEnv(STYLE_ENV_VAR, 'text');
+
+    const exitCode = await routeCommand(['verify', '--manifest', 'manifest.json']);
+
+    expect(exitCode).toBe(2);
+    expect(stderr.join('')).toContain(`${STYLE_ENV_VAR} must be one of: auto, plain, rich (got "text")`);
+  });
+});
+
+describe('detection', () => {
+  // The suite pins RDY_STYLE so rendering never depends on the environment it runs in. These tests
+  // deliberately unpin it: they are the only coverage of the wiring that reads CI and the terminal.
+  it('chooses plain under CI', async () => {
+    vi.stubEnv(STYLE_ENV_VAR, undefined);
+    vi.stubEnv('CI', 'true');
+    process.stdout.isTTY = true;
+
+    await routeCommand(['verify', '--manifest', 'manifest.json']);
+
+    expect(stdout.join('')).toContain(`${PLAIN_PASS}  passing`);
+  });
+
+  it('chooses plain when the output is not a terminal', async () => {
+    vi.stubEnv(STYLE_ENV_VAR, undefined);
+    vi.stubEnv('CI', undefined);
+    process.stdout.isTTY = false;
+
+    await routeCommand(['verify', '--manifest', 'manifest.json']);
+
+    expect(stdout.join('')).toContain(`${PLAIN_PASS}  passing`);
+  });
+
+  it('chooses rich for a terminal outside CI', async () => {
+    vi.stubEnv(STYLE_ENV_VAR, undefined);
+    vi.stubEnv('CI', undefined);
+    process.stdout.isTTY = true;
+
+    await routeCommand(['verify', '--manifest', 'manifest.json']);
+
+    expect(stdout.join('')).toContain(`${RICH_PASS} passing`);
+  });
+
+  it('is outranked by the environment variable', async () => {
+    vi.stubEnv(STYLE_ENV_VAR, 'rich');
+    vi.stubEnv('CI', 'true');
+
+    await routeCommand(['verify', '--manifest', 'manifest.json']);
+
+    expect(stdout.join('')).toContain(`${RICH_PASS} passing`);
+  });
+});
+
+describe('an explicitly chosen style', () => {
+  it.each(['plain', 'rich'] as const)('renders %s identically with and without a terminal', async (style) => {
+    process.stdout.isTTY = true;
+    await routeCommand(['verify', '--manifest', 'manifest.json', '--style', style]);
+    const attached = stdout.join('');
+
+    stdout = [];
+    process.stdout.isTTY = false;
+    await routeCommand(['verify', '--manifest', 'manifest.json', '--style', style]);
+
+    expect(stdout.join('')).toBe(attached);
+  });
+});
+
+describe('alongside --json', () => {
+  it('leaves the JSON document on stdout and styles the prose on stderr', async () => {
+    await routeCommand(['verify', '--manifest', 'manifest.json', '--json', '--style', 'plain']);
+
+    const document: unknown = JSON.parse(stdout.join(''));
+    expect(document).toMatchObject({ passed: true });
+    expect(stderr.join('')).toContain(PLAIN_PASS);
+    expect(stderr.join('')).not.toContain(RICH_PASS);
+  });
+
+  it('emits the same JSON whichever style is selected', async () => {
+    await routeCommand(['verify', '--manifest', 'manifest.json', '--json', '--style', 'plain']);
+    const plain = stdout.join('');
+
+    stdout = [];
+    await routeCommand(['verify', '--manifest', 'manifest.json', '--json', '--style', 'rich']);
+
+    expect(stdout.join('')).toBe(plain);
+  });
+});

--- a/packages/readyup/__tests__/styleSelection.test.ts
+++ b/packages/readyup/__tests__/styleSelection.test.ts
@@ -19,13 +19,20 @@ const COMPILED_BYTES = Buffer.from(PASSING_KIT);
 const PLAIN_PASS = plainFormatter.tokens.passed.glyph;
 const RICH_PASS = richFormatter.tokens.passed.glyph;
 
-/** Every command that renders output, with arguments that make it produce some against the fixture. */
+/**
+ * Every command that renders output, with arguments that make it produce some against the fixture.
+ *
+ * `expected` matches a line the command emits in plain style. `list` matches a bare column, since every
+ * row it renders leads with a noun token, whose plain rendering is the reserved space alone. `compile`
+ * accepts either status: the first invocation against the fixture builds the bundle and the rest find it
+ * unchanged, and both outcomes render through the vocabulary under test.
+ */
 const RENDERING_COMMANDS = [
-  { name: 'run', args: ['run', 'passing'] },
-  { name: 'list', args: ['list'] },
-  { name: 'verify', args: ['verify', '--manifest', 'manifest.json'] },
-  { name: 'compile', args: ['compile', '--skip-manifest', 'src/passing.ts'] },
-  { name: 'init', args: ['init', '--dry-run'] },
+  { name: 'run', args: ['run', 'passing'], expected: /^PASS {2}ok$/mu },
+  { name: 'list', args: ['list', '--manifest', 'manifest.json'], expected: /^ {6}passing$/mu },
+  { name: 'verify', args: ['verify', '--manifest', 'manifest.json'], expected: /^PASS {2}passing$/mu },
+  { name: 'compile', args: ['compile', '--skip-manifest', 'src/passing.ts'], expected: /^(?:PASS|SKIP) {2}src/mu },
+  { name: 'init', args: ['init', '--dry-run'], expected: /^PASS {2}\.config\/readyup\.config\.ts/mu },
 ] as const;
 
 let cwd: string;
@@ -93,17 +100,50 @@ describe('--style plain', () => {
     expect(rendered).toMatch(/^[\u{20}-\u{7E}\n]*$/u);
   });
 
-  it.each(RENDERING_COMMANDS)('spells $name status as a word rather than a glyph', async ({ args }) => {
+  it.each(RENDERING_COMMANDS)('renders $name through the plain vocabulary', async ({ args, expected }) => {
     await routeCommand([...args, '--style', 'plain']);
 
-    const rendered = [...stdout, ...stderr].join('');
-    expect(rendered).not.toContain(RICH_PASS);
+    expect([...stdout, ...stderr].join('')).toMatch(expected);
   });
 
   it('is accepted as an assigned value too', async () => {
     await routeCommand(['verify', '--manifest', 'manifest.json', '--style=plain']);
 
     expect(stdout.join('')).toContain(`${PLAIN_PASS}  passing`);
+  });
+});
+
+describe('a style named ahead of the command', () => {
+  it.each(RENDERING_COMMANDS)('reaches $name without being taken for a kit name', async ({ args }) => {
+    const exitCode = await routeCommand(['--style', 'plain', ...args]);
+
+    expect(stderr.join('')).not.toContain('not found');
+    expect(exitCode).not.toBe(2);
+  });
+
+  it('is accepted as an assigned value too', async () => {
+    const exitCode = await routeCommand(['--style=plain', 'verify', '--manifest', 'manifest.json']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout.join('')).toContain(`${PLAIN_PASS}  passing`);
+  });
+
+  it('leaves --help showing the top-level help rather than the run subcommand\u{2019}s', async () => {
+    await routeCommand(['--style', 'plain', '--help']);
+
+    expect(stdout.join('')).toContain('rdy <command> [options]');
+  });
+
+  it('leaves --version reporting the version', async () => {
+    await routeCommand(['--style', 'plain', '--version']);
+
+    expect(stdout.join('')).toMatch(/^\d+\.\d+\.\d+/u);
+  });
+
+  it('still rejects a trailing --style that carries no value', async () => {
+    const exitCode = await routeCommand(['--style']);
+
+    expect(exitCode).toBe(2);
   });
 });
 

--- a/packages/readyup/__tests__/terminal.test.ts
+++ b/packages/readyup/__tests__/terminal.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import { emojiFormatter } from '../src/layout/emojiFormatter.ts';
+import { richFormatter } from '../src/layout/richFormatter.ts';
 import { printStep, reportWriteResult } from '../src/terminal.ts';
 import type { WriteResult } from '../src/writeFileWithCheck.ts';
 
-const PASSED = emojiFormatter.tokens.passed.glyph;
-const SKIPPED = emojiFormatter.tokens.skippedOptional.glyph;
-const WARNED = emojiFormatter.tokens.failedWarn.glyph;
-const FAILED = emojiFormatter.tokens.failedError.glyph;
+const PASSED = richFormatter.tokens.passed.glyph;
+const SKIPPED = richFormatter.tokens.skippedOptional.glyph;
+const WARNED = richFormatter.tokens.failedWarn.glyph;
+const FAILED = richFormatter.tokens.failedError.glyph;
 
 const PATH = '.config/readyup.config.ts';
 

--- a/packages/readyup/__tests__/verify/verifyCommand.integration.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.integration.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
-import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
+import { richFormatter } from '../../src/layout/richFormatter.ts';
 import { hashBytes } from '../../src/verify/targetHash.ts';
 import { verifyCommand } from '../../src/verify/verifyCommand.ts';
 
@@ -13,8 +13,8 @@ import { verifyCommand } from '../../src/verify/verifyCommand.ts';
  * against real files in a tempdir, without mocking the drift helper. Unit tests cover the branches;
  * this locks in the wiring (e.g., that `manifestDir` is threaded through correctly).
  */
-const OK = emojiFormatter.tokens.passed.glyph;
-const FAILED = emojiFormatter.tokens.failedError.glyph;
+const OK = richFormatter.tokens.passed.glyph;
+const FAILED = richFormatter.tokens.failedError.glyph;
 
 describe('verifyCommand (integration)', () => {
   let tempDir: string;

--- a/packages/readyup/__tests__/verify/verifyCommand.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.test.ts
@@ -20,13 +20,13 @@ vi.mock('../../src/verify/checkSourceDrift.ts', () => ({
   checkSourceDrift: mockCheckSourceDrift,
 }));
 
-import { emojiFormatter } from '../../src/layout/emojiFormatter.ts';
+import { richFormatter } from '../../src/layout/richFormatter.ts';
 import { verifyCommand } from '../../src/verify/verifyCommand.ts';
 import { captureRdyError } from '../helpers/captureRdyError.ts';
 
-const OK = emojiFormatter.tokens.passed.glyph;
-const FAILED = emojiFormatter.tokens.failedError.glyph;
-const UNVERIFIED = emojiFormatter.tokens.skippedOptional.glyph;
+const OK = richFormatter.tokens.passed.glyph;
+const FAILED = richFormatter.tokens.failedError.glyph;
+const UNVERIFIED = richFormatter.tokens.skippedOptional.glyph;
 
 describe(verifyCommand, () => {
   let stdoutSpy: MockInstance;

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -12,7 +12,7 @@ import { hasJsonFlag } from '../hasJsonFlag.ts';
 import { initCommand } from '../init/initCommand.ts';
 import { KITS_DIR } from '../kitsDir.ts';
 import { setStyle } from '../layout/engine.ts';
-import { describeInvalidStyle, resolveStyle } from '../layout/resolveStyle.ts';
+import { describeInvalidStyle, resolveStyle, STYLE_FLAG } from '../layout/resolveStyle.ts';
 import { listCommand } from '../list/listCommand.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { extractMessage } from '../utils/error-handling.ts';
@@ -60,7 +60,7 @@ Run options:
                                      cover the whole run
 
 Global options:
-  --style <auto|rich|plain>  Output style: emoji, ASCII words, or detected (default: auto)
+  --style <auto|plain|rich>  Output style: emoji, ASCII words, or detected (default: auto)
   --help, -h                 Show this help message
   --version, -V              Show version number
 
@@ -136,7 +136,7 @@ Options:
   --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
                                      plus the parent checks of anything shown; summary counts always
                                      cover the whole run
-  --style <auto|rich|plain>          Output style (default: auto)
+  --style <auto|plain|rich>          Output style (default: auto)
   --help, -h                         Show this help message
 
 Positional args accept relative paths (e.g., shared/deploy).
@@ -172,7 +172,7 @@ Options:
   --force                    Overwrite compiled kits even if they have drifted from the manifest
   --json                     Report each kit's status as JSON
   --skip-manifest            Do not read or write the manifest
-  --style <auto|rich|plain>  Output style (default: auto)
+  --style <auto|plain|rich>  Output style (default: auto)
   --help, -h                 Show this help message
 
 Drift detection:
@@ -210,7 +210,7 @@ manifest exits 2.
 Options:
   --manifest <path>          Manifest file path (default: .readyup/manifest.json)
   --json                     Report each kit's verification status as JSON
-  --style <auto|rich|plain>  Output style (default: auto)
+  --style <auto|plain|rich>  Output style (default: auto)
   --help, -h                 Show this help message
 `;
 
@@ -231,7 +231,7 @@ Options:
   --from <source>            Kit source (github:org/repo[@ref], bitbucket:ws/repo[@ref], global, dir:path, or local path)
   --manifest <path>          List the kits a manifest file declares
   --json                     Output the kit list as JSON
-  --style <auto|rich|plain>  Output style (default: auto)
+  --style <auto|plain|rich>  Output style (default: auto)
   --help, -h                 Show this help message
 
 A local --from source with no manifest beside its kits falls back to listing the compiled
@@ -255,7 +255,7 @@ Scaffold a starter config and kit file.
 Options:
   --dry-run, -n              Preview changes without writing files
   --force                    Overwrite existing files
-  --style <auto|rich|plain>  Output style (default: auto)
+  --style <auto|plain|rich>  Output style (default: auto)
   --help, -h                 Show this help message
 `;
 
@@ -300,7 +300,8 @@ export function reportFailure(error: unknown, json: boolean): number {
 }
 
 /** Selects and runs the subcommand named by the first argument. */
-async function dispatchCommand(args: string[], json: boolean): Promise<number> {
+async function dispatchCommand(argv: string[], json: boolean): Promise<number> {
+  const args = dropLeadingStyleFlag(argv);
   const command = args[0];
 
   if (command === undefined || command === '--help' || command === '-h') {
@@ -410,6 +411,29 @@ function handleInit(flags: string[]): number {
   }
 
   return initCommand({ dryRun: parsed.values['dry-run'] === true, force: parsed.values.force === true });
+}
+
+/**
+ * Returns `argv` without a leading `--style` and the value it carries.
+ *
+ * Command selection reads the first argument, so a style named ahead of the command would otherwise be
+ * taken for a kit name. `routeCommand` has already read the value, so nothing downstream needs the
+ * tokens. Scanning stops at the first argument that is not part of a style flag, which leaves a later
+ * occurrence for the subcommand's own parser, and leaves a valueless trailing `--style` for it to
+ * reject.
+ */
+function dropLeadingStyleFlag(argv: string[]): string[] {
+  const assignment = `${STYLE_FLAG}=`;
+  let index = 0;
+
+  while (index < argv.length) {
+    const arg = argv[index];
+    if (arg?.startsWith(assignment) === true) index += 1;
+    else if (arg === STYLE_FLAG && index + 1 < argv.length) index += 2;
+    else break;
+  }
+
+  return argv.slice(index);
 }
 
 /** Returns true when the flags request help for the current subcommand. */

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -272,7 +272,7 @@ export async function routeCommand(args: string[]): Promise<number> {
   // Binding the style precedes the try because the catch renders through it: a style named in argv has
   // to govern the usage error that argv itself provokes. A value naming no style still yields one to
   // render with, and becomes the error raised inside.
-  const { style, invalid } = resolveStyle(args, process.env, process.stdout.isTTY === true);
+  const { style, invalid } = resolveStyle(args, process.env, process.stdout.isTTY);
   setStyle(style);
 
   try {

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -11,6 +11,8 @@ import { formatJsonError } from '../formatJsonError.ts';
 import { hasJsonFlag } from '../hasJsonFlag.ts';
 import { initCommand } from '../init/initCommand.ts';
 import { KITS_DIR } from '../kitsDir.ts';
+import { setStyle } from '../layout/engine.ts';
+import { describeInvalidStyle, resolveStyle } from '../layout/resolveStyle.ts';
 import { listCommand } from '../list/listCommand.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { extractMessage } from '../utils/error-handling.ts';
@@ -260,7 +262,15 @@ Options:
  */
 export async function routeCommand(args: string[]): Promise<number> {
   const json = hasJsonFlag(args);
+
+  // Binding the style precedes the try because the catch renders through it: a style named in argv has
+  // to govern the usage error that argv itself provokes. A value naming no style still yields one to
+  // render with, and becomes the error raised inside.
+  const { style, invalid } = resolveStyle(args, process.env, process.stdout.isTTY === true);
+  setStyle(style);
+
   try {
+    if (invalid !== undefined) throw usageError(describeInvalidStyle(invalid));
     return await dispatchCommand(args, json);
   } catch (error: unknown) {
     return reportFailure(error, json);
@@ -382,6 +392,8 @@ function handleInit(flags: string[]): number {
   const initOptions = {
     'dry-run': { type: 'boolean', short: 'n' },
     force: { type: 'boolean' },
+    // Declared so strict parsing accepts it; `routeCommand` consumed its value before dispatch.
+    style: { type: 'string' },
   } as const;
 
   let parsed;

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -60,8 +60,9 @@ Run options:
                                      cover the whole run
 
 Global options:
-  --help, -h           Show this help message
-  --version, -V        Show version number
+  --style <auto|rich|plain>  Output style: emoji, ASCII words, or detected (default: auto)
+  --help, -h                 Show this help message
+  --version, -V              Show version number
 
 Run 'rdy <command> --help' for command-specific options.
 
@@ -135,6 +136,7 @@ Options:
   --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
                                      plus the parent checks of anything shown; summary counts always
                                      cover the whole run
+  --style <auto|rich|plain>          Output style (default: auto)
   --help, -h                         Show this help message
 
 Positional args accept relative paths (e.g., shared/deploy).
@@ -165,12 +167,13 @@ Modes:
   rdy compile <file>           Compile a single file
 
 Options:
-  --output, -o <path>  Output file path (single-file mode only)
-  --manifest <path>    Manifest file path (default: .readyup/manifest.json)
-  --force              Overwrite compiled kits even if they have drifted from the manifest
-  --json               Report each kit's status as JSON
-  --skip-manifest      Do not read or write the manifest
-  --help, -h           Show this help message
+  --output, -o <path>        Output file path (single-file mode only)
+  --manifest <path>          Manifest file path (default: .readyup/manifest.json)
+  --force                    Overwrite compiled kits even if they have drifted from the manifest
+  --json                     Report each kit's status as JSON
+  --skip-manifest            Do not read or write the manifest
+  --style <auto|rich|plain>  Output style (default: auto)
+  --help, -h                 Show this help message
 
 Drift detection:
   rdy compile refuses to overwrite a compiled kit whose on-disk hash differs from the
@@ -205,9 +208,10 @@ Exits 1 when any kit is in drift or missing; unverified kits do not fail. An unr
 manifest exits 2.
 
 Options:
-  --manifest <path>  Manifest file path (default: .readyup/manifest.json)
-  --json             Report each kit's verification status as JSON
-  --help, -h         Show this help message
+  --manifest <path>          Manifest file path (default: .readyup/manifest.json)
+  --json                     Report each kit's verification status as JSON
+  --style <auto|rich|plain>  Output style (default: auto)
+  --help, -h                 Show this help message
 `;
 
 const LIST_HELP = `
@@ -224,10 +228,11 @@ Modes:
   rdy list --from bitbucket:ws/repo[@ref]   List kits in a remote Bitbucket repository
 
 Options:
-  --from <source>    Kit source (github:org/repo[@ref], bitbucket:ws/repo[@ref], global, dir:path, or local path)
-  --manifest <path>  List the kits a manifest file declares
-  --json             Output the kit list as JSON
-  --help, -h         Show this help message
+  --from <source>            Kit source (github:org/repo[@ref], bitbucket:ws/repo[@ref], global, dir:path, or local path)
+  --manifest <path>          List the kits a manifest file declares
+  --json                     Output the kit list as JSON
+  --style <auto|rich|plain>  Output style (default: auto)
+  --help, -h                 Show this help message
 
 A local --from source with no manifest beside its kits falls back to listing the compiled
 kits on disk, which are the same kits rdy run --from would resolve. Those rows carry only
@@ -248,9 +253,10 @@ Usage: rdy init [options]
 Scaffold a starter config and kit file.
 
 Options:
-  --dry-run, -n   Preview changes without writing files
-  --force         Overwrite existing files
-  --help, -h      Show this help message
+  --dry-run, -n              Preview changes without writing files
+  --force                    Overwrite existing files
+  --style <auto|rich|plain>  Output style (default: auto)
+  --help, -h                 Show this help message
 `;
 
 /**

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -9,7 +9,7 @@ import { EXIT_OK, EXIT_PROBLEMS_FOUND, EXIT_TOOL_FAILURE } from './exitCodes.ts'
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonReport, type KitInput } from './formatJsonReport.ts';
 import { KITS_DIR, resolveHomeDir } from './kitsDir.ts';
-import { layout } from './layout/engine.ts';
+import { getLayout } from './layout/engine.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './loadRemoteKit.ts';
 import { DEFAULT_MANIFEST_PATH } from './manifest/manifestPath.ts';
 import type { RdyManifest } from './manifest/manifestSchema.ts';
@@ -687,7 +687,7 @@ async function runMultiKitHumanMode(
   for (const entry of kitEntries) {
     // Precedes the load so stdout lists every requested kit, including one that never ran.
     if (showKitHeader) {
-      process.stdout.write(layout.formatHeading(entry.name, 'kit').join('\n') + '\n');
+      process.stdout.write(getLayout().formatHeading(entry.name, 'kit').join('\n') + '\n');
     }
 
     try {
@@ -724,7 +724,7 @@ async function runSingleKitHumanMode(
 
   for (const checklist of checklists) {
     if (showChecklistHeader) {
-      process.stdout.write(layout.formatHeading(checklist.name, 'section').join('\n') + '\n');
+      process.stdout.write(getLayout().formatHeading(checklist.name, 'section').join('\n') + '\n');
     }
 
     const report = await runRdy(checklist, {

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -85,6 +85,8 @@ const runOptions = {
   json: { type: 'boolean' },
   quiet: { type: 'boolean' },
   'report-on': { type: 'string' },
+  // Declared so strict parsing accepts it; `routeCommand` consumed its value before dispatch.
+  style: { type: 'string' },
   url: { type: 'string' },
 } as const;
 

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -7,7 +7,7 @@ import picomatch from 'picomatch';
 
 import { configError, usageError } from '../errors.ts';
 import { EXIT_OK, EXIT_PROBLEMS_FOUND } from '../exitCodes.ts';
-import { layout } from '../layout/engine.ts';
+import { getLayout } from '../layout/engine.ts';
 import { loadConfig } from '../loadConfig.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
@@ -429,23 +429,23 @@ function detectDrift(args: DetectDriftArgs): DriftSkip | undefined {
 /** Returns a line naming the output a rebuilt kit produced, or reporting an unchanged one as skipped. */
 function formatResultLine(srcName: string, outName: string, changed: boolean): string {
   if (!changed) {
-    return layout.formatCheckLine({ token: 'skippedOptional', name: srcName, detail: 'no changes' }) + '\n';
+    return getLayout().formatCheckLine({ token: 'skippedOptional', name: srcName, detail: 'no changes' }) + '\n';
   }
 
-  const claim = layout.formatCheckLine({ token: 'passed', name: srcName });
-  return `${claim} ${TRANSFORM_ARROW} ${layout.inlineGlyph('docCompiled')}${outName}\n`;
+  const claim = getLayout().formatCheckLine({ token: 'passed', name: srcName });
+  return `${claim} ${TRANSFORM_ARROW} ${getLayout().inlineGlyph('docCompiled')}${outName}\n`;
 }
 
 /** Returns a warning line for a source, with the hash mismatch from `status` in a block beneath. */
 function formatDriftLine(srcName: string, status: Extract<DriftStatus, { kind: 'drift' }>): string {
   const target = path.basename(status.resolvedPath);
-  const claim = layout.formatCheckLine({ token: 'failedWarn', name: srcName });
+  const claim = getLayout().formatCheckLine({ token: 'failedWarn', name: srcName });
   const reason = `drift in ${target}: expected ${status.expected}, got ${status.actual}`;
 
-  return [claim, ...layout.formatReasonBlock([reason])].join('\n') + '\n';
+  return [claim, ...getLayout().formatReasonBlock([reason])].join('\n') + '\n';
 }
 
 /** Returns a section heading as a single writable string, newline-terminated. */
 function formatSectionHeading(label: string): string {
-  return layout.formatHeading(label, 'section').join('\n') + '\n';
+  return getLayout().formatHeading(label, 'section').join('\n') + '\n';
 }

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -433,7 +433,7 @@ function formatResultLine(srcName: string, outName: string, changed: boolean): s
   }
 
   const claim = layout.formatCheckLine({ token: 'passed', name: srcName });
-  return `${claim} ${TRANSFORM_ARROW} ${layout.glyph('docCompiled')} ${outName}\n`;
+  return `${claim} ${TRANSFORM_ARROW} ${layout.inlineGlyph('docCompiled')}${outName}\n`;
 }
 
 /** Returns a warning line for a source, with the hash mismatch from `status` in a block beneath. */

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -33,6 +33,8 @@ const compileOptions = {
   manifest: { type: 'string' },
   output: { type: 'string', short: 'o' },
   'skip-manifest': { type: 'boolean' },
+  // Declared so strict parsing accepts it; `routeCommand` consumed its value before dispatch.
+  style: { type: 'string' },
 } as const;
 
 /** Separator between a compiled kit's source and its output. ASCII, so its width is two cells everywhere. */

--- a/packages/readyup/src/formatCombinedSummary.ts
+++ b/packages/readyup/src/formatCombinedSummary.ts
@@ -1,4 +1,4 @@
-import { layout } from './layout/engine.ts';
+import { getLayout } from './layout/engine.ts';
 import { emptyCounts, mergeCounts } from './reportRdy.ts';
 import type { ChecklistSummary, SummaryCounts } from './types.ts';
 
@@ -10,7 +10,7 @@ export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
     durationMs: summary.durationMs,
   }));
 
-  return layout
+  return getLayout()
     .formatSummaryTable({
       rows,
       totals: aggregateCounts(summaries),

--- a/packages/readyup/src/layout/engine.ts
+++ b/packages/readyup/src/layout/engine.ts
@@ -1,5 +1,29 @@
 import { createLayoutEngine, type LayoutEngine } from './layoutEngine.ts';
+import { plainFormatter } from './plainFormatter.ts';
+import type { Style } from './resolveStyle.ts';
 import { richFormatter } from './richFormatter.ts';
 
-/** The layout engine bound to the rich formatter. */
-export const layout: LayoutEngine = createLayoutEngine(richFormatter);
+/** One engine per style, each bound to that style's vocabulary. */
+const engines: Record<Style, LayoutEngine> = {
+  plain: createLayoutEngine(plainFormatter),
+  rich: createLayoutEngine(richFormatter),
+};
+
+/**
+ * The engine every command renders through, rich until an invocation selects otherwise.
+ *
+ * The default is a fixed style rather than a detected one. Detection belongs to the invocation, so
+ * anything rendering without one -- a test formatting a report directly, say -- gets one answer rather
+ * than one that changes with the terminal it happens to run under.
+ */
+let active: LayoutEngine = engines.rich;
+
+/** Returns the engine bound to the selected style. */
+export function getLayout(): LayoutEngine {
+  return active;
+}
+
+/** Binds every later render to `style`. */
+export function setStyle(style: Style): void {
+  active = engines[style];
+}

--- a/packages/readyup/src/layout/engine.ts
+++ b/packages/readyup/src/layout/engine.ts
@@ -1,5 +1,5 @@
-import { emojiFormatter } from './emojiFormatter.ts';
 import { createLayoutEngine, type LayoutEngine } from './layoutEngine.ts';
+import { richFormatter } from './richFormatter.ts';
 
-/** The layout engine bound to the emoji formatter. */
-export const layout: LayoutEngine = createLayoutEngine(emojiFormatter);
+/** The layout engine bound to the rich formatter. */
+export const layout: LayoutEngine = createLayoutEngine(richFormatter);

--- a/packages/readyup/src/layout/formatter.ts
+++ b/packages/readyup/src/layout/formatter.ts
@@ -23,6 +23,9 @@ export type HeadingLevel = 'kit' | 'section';
 
 /** A vocabulary of status tokens and heading rule characters, from which the layout engine derives geometry. */
 export interface Formatter {
+  /** Character parting a check's name from its inline detail. The engine supplies the spaces around it. */
+  detailSeparator: string;
+
   /** Columns from the start of a status token to the start of the name beside it. Exceeds every token's width. */
   gutter: number;
 

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -5,9 +5,6 @@ import type { Formatter, HeadingLevel, TokenName } from './formatter.ts';
 /** Milliseconds below which a line omits its duration, leaving only timings worth reading. */
 const DURATION_FLOOR_MS = 100;
 
-/** Middle dot, U+00B7. */
-const DETAIL_SEPARATOR = '\u{00B7}';
-
 /** Rule characters in a heading's leading sigil. */
 const HEADING_SIGIL_WIDTH = 2;
 
@@ -81,17 +78,21 @@ export interface LayoutEngine {
   formatHeadingLine(name: string, level: HeadingLevel): string;
   formatReasonBlock(reasons: string[], depth?: number): string[];
   formatSummaryTable(input: SummaryTableInput): string[];
-  glyph(token: TokenName): string;
   indent(depth: number): string;
+  inlineGlyph(token: TokenName): string;
   token(token: TokenName): string;
 }
 
 /** Returns string builders bound to `formatter`, each deriving its spacing from the formatter's gutter. */
 export function createLayoutEngine(formatter: Formatter): LayoutEngine {
-  /** Returns one line, `token name · detail [progress] (duration)`, dropping the segments it lacks. */
+  /**
+   * Returns one line, `token name <separator> detail [progress] (duration)`, dropping the segments it lacks.
+   *
+   * The separator is the formatter's, so the shape holds across styles while the punctuation varies.
+   */
   function formatCheckLine(input: CheckLineInput): string {
     const segments = [`${indent(input.depth ?? 0)}${token(input.token)}${input.name}`];
-    if (input.detail !== undefined) segments.push(`${DETAIL_SEPARATOR} ${input.detail}`);
+    if (input.detail !== undefined) segments.push(`${formatter.detailSeparator} ${input.detail}`);
     if (input.progress !== undefined) segments.push(`[${input.progress}]`);
 
     const duration = resolveDuration(input.token, input.durationMs);
@@ -156,14 +157,20 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
     ];
   }
 
-  /** Returns a token's glyph unpadded. */
-  function glyph(name: TokenName): string {
-    return formatter.tokens[name].glyph;
-  }
-
   /** Returns `depth` gutters' worth of spaces. */
   function indent(depth: number): string {
     return ' '.repeat(formatter.gutter * depth);
+  }
+
+  /**
+   * Returns a token's glyph and one trailing space, for placement mid-sentence rather than at a line's head.
+   *
+   * A formatter that gives the token no glyph returns nothing, so the sentence closes up instead of
+   * carrying the space that would have followed one.
+   */
+  function inlineGlyph(name: TokenName): string {
+    const { glyph } = formatter.tokens[name];
+    return glyph === '' ? '' : `${glyph} `;
   }
 
   /** Returns a token's glyph padded to the gutter, so what follows starts at a fixed column. */
@@ -188,8 +195,8 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
     formatHeadingLine,
     formatReasonBlock,
     formatSummaryTable,
-    glyph,
     indent,
+    inlineGlyph,
     token,
   };
 }

--- a/packages/readyup/src/layout/plainFormatter.ts
+++ b/packages/readyup/src/layout/plainFormatter.ts
@@ -1,0 +1,33 @@
+import type { Formatter } from './formatter.ts';
+
+/**
+ * A formatter whose tokens are fixed-width ASCII words.
+ *
+ * Every character is printable ASCII, so the output survives a CI log, a `grep`, a screen reader, and a
+ * terminal with no emoji font. Each status token is a word rather than a symbol, which is what makes
+ * `grep FAIL` find a failure.
+ *
+ * The two noun tokens carry no glyph. They name a kind of file rather than reporting an outcome, and an
+ * uppercase word in the status column would read as a status; the section heading already says which kind
+ * a row is. Declaring zero width still reserves the gutter, so names hold the same column as every status
+ * line.
+ */
+export const plainFormatter: Formatter = {
+  detailSeparator: '-',
+  gutter: 6,
+  rules: {
+    kit: '=',
+    section: '-',
+  },
+  tokens: {
+    blockedPrecondition: { glyph: 'BLOCK', width: 5 },
+    docCompiled: { glyph: '', width: 0 },
+    docInternal: { glyph: '', width: 0 },
+    failedError: { glyph: 'FAIL', width: 4 },
+    failedRecommend: { glyph: 'RECO', width: 4 },
+    failedWarn: { glyph: 'WARN', width: 4 },
+    fix: { glyph: 'FIX', width: 3 },
+    passed: { glyph: 'PASS', width: 4 },
+    skippedOptional: { glyph: 'SKIP', width: 4 },
+  },
+};

--- a/packages/readyup/src/layout/resolveStyle.ts
+++ b/packages/readyup/src/layout/resolveStyle.ts
@@ -1,0 +1,111 @@
+/** Styles output can actually be rendered in. */
+export const STYLES = ['plain', 'rich'] as const;
+
+export type Style = (typeof STYLES)[number];
+
+/** Everything `--style` accepts, including the value that defers to detection. */
+export const STYLE_SETTINGS = ['auto', ...STYLES] as const;
+
+export type StyleSetting = (typeof STYLE_SETTINGS)[number];
+
+/** Flag naming the style for one invocation. */
+export const STYLE_FLAG = '--style';
+
+/** Environment variable carrying a standing style preference. */
+export const STYLE_ENV_VAR = 'RDY_STYLE';
+
+/** The source that named a style, and the value it named. */
+export interface InvalidStyle {
+  source: string;
+  value: string;
+}
+
+/** A style to render with, alongside the complaint the inputs earned. */
+export interface StyleResolution {
+  style: Style;
+  invalid?: InvalidStyle;
+}
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Resolves the style to render in: the flag, else the environment variable, else detection.
+ *
+ * Pure by design. The environment and the terminal arrive as arguments rather than being read from
+ * `process`, so every branch below is reachable from a plain assertion instead of a stubbed global.
+ *
+ * Never throws. A value naming no style is reported back rather than raised, because the caller has to
+ * render its complaint about that value in some style, and a resolver that threw would leave it none.
+ * Resolution continues past a bad value, so the rendering falls to whatever the next source says.
+ */
+export function resolveStyle(argv: string[], env: Environment, isTty: boolean): StyleResolution {
+  const candidates = [
+    { source: STYLE_FLAG, value: readStyleFlag(argv) },
+    { source: STYLE_ENV_VAR, value: env[STYLE_ENV_VAR] },
+  ];
+
+  let invalid: InvalidStyle | undefined;
+  let setting: StyleSetting | undefined;
+
+  for (const candidate of candidates) {
+    const { source, value } = candidate;
+    if (value === undefined || value === '') continue;
+
+    if (!isStyleSetting(value)) {
+      invalid ??= { source, value };
+      continue;
+    }
+
+    setting = value;
+    break;
+  }
+
+  const style = setting === undefined || setting === 'auto' ? detectStyle(env, isTty) : setting;
+  return invalid === undefined ? { style } : { style, invalid };
+}
+
+/** Returns the usage message for a source that named a style that does not exist. */
+export function describeInvalidStyle({ source, value }: InvalidStyle): string {
+  return `${source} must be one of: ${STYLE_SETTINGS.join(', ')} (got "${value}")`;
+}
+
+// -- Helpers --
+
+/**
+ * Reads the style an invocation asks for by scanning raw argv, before any flag parsing happens.
+ *
+ * Answering this without `parseArgs` is what lets a flag-parse failure be rendered in the style the caller
+ * asked for. The scan accepts both `--style plain` and `--style=plain`, stops at the `--` terminator after
+ * which arguments are positional, and keeps the last occurrence, matching what `parseArgs` would resolve.
+ */
+function readStyleFlag(argv: string[]): string | undefined {
+  const assignment = `${STYLE_FLAG}=`;
+  let value: string | undefined;
+
+  for (const [index, arg] of argv.entries()) {
+    if (arg === '--') break;
+    if (arg === STYLE_FLAG) value = argv[index + 1];
+    else if (arg.startsWith(assignment)) value = arg.slice(assignment.length);
+  }
+
+  return value;
+}
+
+/**
+ * Returns the style the environment implies: plain wherever the output is not a person's terminal.
+ *
+ * Both signals carry their own weight. `CI` catches a runner that allocates a pseudo-terminal, where the
+ * terminal check alone would emit emoji into a log nobody can grep; the terminal check catches an
+ * interactive pipe into `grep`, where `CI` is unset. `CI` is also not universal -- Jenkins does not set
+ * it. An explicit `CI=false` is honored as a denial, which is how the wider ecosystem reads it.
+ */
+function detectStyle(env: Environment, isTty: boolean): Style {
+  const ci = env.CI;
+  if (ci !== undefined && ci !== '' && ci !== 'false') return 'plain';
+  return isTty ? 'rich' : 'plain';
+}
+
+/** Reports whether a string names a style the flag accepts. */
+function isStyleSetting(value: string): value is StyleSetting {
+  return (STYLE_SETTINGS as readonly string[]).includes(value);
+}

--- a/packages/readyup/src/layout/resolveStyle.ts
+++ b/packages/readyup/src/layout/resolveStyle.ts
@@ -14,6 +14,9 @@ export const STYLE_FLAG = '--style';
 /** Environment variable carrying a standing style preference. */
 export const STYLE_ENV_VAR = 'RDY_STYLE';
 
+/** The accepted settings widened to strings, so an arbitrary input can be tested for membership. */
+const ACCEPTED_SETTINGS: ReadonlySet<string> = new Set<string>(STYLE_SETTINGS);
+
 /** The source that named a style, and the value it named. */
 export interface InvalidStyle {
   source: string;
@@ -107,5 +110,5 @@ function detectStyle(env: Environment, isTty: boolean): Style {
 
 /** Reports whether a string names a style the flag accepts. */
 function isStyleSetting(value: string): value is StyleSetting {
-  return (STYLE_SETTINGS as readonly string[]).includes(value);
+  return ACCEPTED_SETTINGS.has(value);
 }

--- a/packages/readyup/src/layout/richFormatter.ts
+++ b/packages/readyup/src/layout/richFormatter.ts
@@ -7,7 +7,8 @@ import type { Formatter } from './formatter.ts';
  * variation selector. A glyph lacking that property renders one cell wide in some terminals and two in
  * others, so its declared width would be wrong somewhere.
  */
-export const emojiFormatter: Formatter = {
+export const richFormatter: Formatter = {
+  detailSeparator: '\u{00B7}',
   gutter: 3,
   rules: {
     kit: '\u{2501}',

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -1,4 +1,4 @@
-import { layout } from '../layout/engine.ts';
+import { getLayout } from '../layout/engine.ts';
 import type { TokenName } from '../layout/formatter.ts';
 
 /** Returns the positional-name placeholder, bracketed when `kits` contains a default. */
@@ -122,14 +122,14 @@ export function formatManifestView({ kits, manifestPath }: ManifestViewOptions):
 
   const items = kits.map((kit) => {
     const versionSegment = kit.readyupVersion !== undefined ? ` (readyup v${kit.readyupVersion})` : '';
-    return layout.formatCheckLine({
+    return getLayout().formatCheckLine({
       token: 'docCompiled',
       name: `${kit.name}${versionSegment}`,
       ...(kit.description !== undefined && { detail: kit.description }),
     });
   });
 
-  return [...layout.formatHeading(`Manifest: ${manifestPath}`, 'section'), ...items].join('\n');
+  return [...getLayout().formatHeading(`Manifest: ${manifestPath}`, 'section'), ...items].join('\n');
 }
 
 // -- Helpers --
@@ -140,6 +140,8 @@ export function formatManifestView({ kits, manifestPath }: ManifestViewOptions):
  * `hint` sits against the title with no blank between them, so the command reads as part of the heading.
  */
 function formatSection(title: string, hint: string, kits: string[], token: TokenName): string {
-  const items = kits.map((name) => layout.formatCheckLine({ token, name }));
-  return ['', layout.formatHeadingLine(title, 'section'), `${layout.indent(1)}${hint}`, '', ...items].join('\n');
+  const items = kits.map((name) => getLayout().formatCheckLine({ token, name }));
+  return ['', getLayout().formatHeadingLine(title, 'section'), `${getLayout().indent(1)}${hint}`, '', ...items].join(
+    '\n',
+  );
 }

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -31,6 +31,8 @@ const listOptions = {
   from: { type: 'string' },
   json: { type: 'boolean' },
   manifest: { type: 'string' },
+  // Declared so strict parsing accepts it; `routeCommand` consumed its value before dispatch.
+  style: { type: 'string' },
 } as const;
 
 /**

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -1,4 +1,4 @@
-import { layout } from './layout/engine.ts';
+import { getLayout } from './layout/engine.ts';
 import type { TokenName } from './layout/formatter.ts';
 import { resolveWorstToken } from './layout/layoutEngine.ts';
 import { meetsThreshold } from './runRdy.ts';
@@ -37,12 +37,12 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
   // The blank line separates the count line from the tree, so an empty tree needs none: the heading
   // above already supplies one, and a second would open a gap under every fully-hidden checklist.
   if (lines.length > 0) lines.push('');
-  lines.push(layout.formatCountLine(countResults(report.results), report.durationMs));
+  lines.push(getLayout().formatCountLine(countResults(report.results), report.durationMs));
 
   if (fixLocation === 'end') {
     const fixes = collectFixes(visibleResults);
     if (fixes.length > 0) {
-      lines.push(...layout.formatHeading(FIXES_HEADING, 'section'), ...renderFixRecap(fixes));
+      lines.push(...getLayout().formatHeading(FIXES_HEADING, 'section'), ...renderFixRecap(fixes));
     }
   }
 
@@ -128,7 +128,7 @@ function retainWithAncestors(results: RdyResult[], isVisible: (result: RdyResult
 /** Returns a result's check line, followed by its reason block when the result failed. */
 function renderResult(result: RdyResult, fixLocation: FixLocation): string[] {
   const isFailed = result.status === 'failed';
-  const checkLine = layout.formatCheckLine({
+  const checkLine = getLayout().formatCheckLine({
     token: resolveResultToken(result),
     name: result.name,
     depth: result.depth,
@@ -140,7 +140,7 @@ function renderResult(result: RdyResult, fixLocation: FixLocation): string[] {
 
   if (!isFailed) return [checkLine];
 
-  return [checkLine, ...layout.formatReasonBlock(collectReasons(result, fixLocation === 'inline'), result.depth)];
+  return [checkLine, ...getLayout().formatReasonBlock(collectReasons(result, fixLocation === 'inline'), result.depth)];
 }
 
 /**
@@ -152,7 +152,7 @@ function collectReasons(result: RdyResult, includeFix: boolean): string[] {
   const reasons: string[] = [];
   if (result.detail !== null) reasons.push(result.detail);
   if (result.error !== null) reasons.push(`Error: ${result.error.message}`);
-  if (includeFix && result.fix !== null) reasons.push(`${layout.token('fix')}${result.fix}`);
+  if (includeFix && result.fix !== null) reasons.push(`${getLayout().token('fix')}${result.fix}`);
   return reasons;
 }
 
@@ -165,7 +165,10 @@ function collectFixes(results: RdyResult[]): AttributedFix[] {
 
 /** Returns two lines per fix: the check's name behind a token, then the fix indented beneath. */
 function renderFixRecap(fixes: AttributedFix[]): string[] {
-  return fixes.flatMap((entry) => [`${layout.token('fix')}${entry.name}`, ...layout.formatReasonBlock([entry.fix])]);
+  return fixes.flatMap((entry) => [
+    `${getLayout().token('fix')}${entry.name}`,
+    ...getLayout().formatReasonBlock([entry.fix]),
+  ]);
 }
 
 /** Returns the token for a result, chosen by its status and then by its severity or skip reason. */

--- a/packages/readyup/src/terminal.ts
+++ b/packages/readyup/src/terminal.ts
@@ -1,4 +1,4 @@
-import { layout } from './layout/engine.ts';
+import { getLayout } from './layout/engine.ts';
 import type { TokenName } from './layout/formatter.ts';
 import type { WriteResult } from './writeFileWithCheck.ts';
 
@@ -14,7 +14,7 @@ interface WriteLine {
 
 /** Writes `message` to stdout as a section heading. */
 export function printStep(message: string): void {
-  console.info(layout.formatHeading(message, 'section').join('\n'));
+  console.info(getLayout().formatHeading(message, 'section').join('\n'));
 }
 
 /**
@@ -26,8 +26,8 @@ export function reportWriteResult(result: WriteResult, dryRun: boolean): void {
   const { claim, detail, reason, token } = describeWriteResult(result, dryRun);
 
   const lines = [
-    layout.formatCheckLine({ token, name: claim, ...(detail !== undefined && { detail }) }),
-    ...(reason === undefined ? [] : layout.formatReasonBlock([reason])),
+    getLayout().formatCheckLine({ token, name: claim, ...(detail !== undefined && { detail }) }),
+    ...(reason === undefined ? [] : getLayout().formatReasonBlock([reason])),
   ];
   const output = lines.join('\n');
 

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -4,7 +4,7 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 
 import { configError, usageError } from '../errors.ts';
 import { EXIT_OK, EXIT_PROBLEMS_FOUND } from '../exitCodes.ts';
-import { layout } from '../layout/engine.ts';
+import { getLayout } from '../layout/engine.ts';
 import type { TokenName } from '../layout/formatter.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
@@ -63,7 +63,7 @@ export function verifyCommand(args: string[]): number {
   }
 
   const relManifestPath = path.relative(process.cwd(), manifestPath);
-  writeHuman(layout.formatHeading(`Verifying kits against ${relManifestPath}`, 'section').join('\n') + '\n', json);
+  writeHuman(getLayout().formatHeading(`Verifying kits against ${relManifestPath}`, 'section').join('\n') + '\n', json);
 
   if (manifest.kits.length === 0) {
     writeHuman('(no kits in manifest)\n', json);
@@ -142,12 +142,12 @@ function formatStatusLine(kit: RdyManifestKit, status: DriftStatus, sourceStatus
   );
 
   if (token === 'failedError') {
-    const claim = layout.formatCheckLine({ token, name: kit.name });
-    return [claim, ...layout.formatReasonBlock(clauses)].join('\n') + '\n';
+    const claim = getLayout().formatCheckLine({ token, name: kit.name });
+    return [claim, ...getLayout().formatReasonBlock(clauses)].join('\n') + '\n';
   }
 
   const detail = clauses.join('; ');
-  return layout.formatCheckLine({ token, name: kit.name, ...(detail !== '' && { detail }) }) + '\n';
+  return getLayout().formatCheckLine({ token, name: kit.name, ...(detail !== '' && { detail }) }) + '\n';
 }
 
 /**

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -22,6 +22,8 @@ import { checkSourceDrift } from './checkSourceDrift.ts';
 const verifyOptions = {
   json: { type: 'boolean' },
   manifest: { type: 'string' },
+  // Declared so strict parsing accepts it; `routeCommand` consumed its value before dispatch.
+  style: { type: 'string' },
 } as const;
 
 /**

--- a/packages/readyup/vitest.config.ts
+++ b/packages/readyup/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import { baseConfig } from '../../.config/vitest/vitest.config.ts';
+
+const config = defineConfig({
+  test: {
+    // Pinning the style keeps rendering deterministic: left to detection, output would follow whether the
+    // runner attached a terminal and whether CI was set, so the same assertion would pass locally and fail
+    // on the runner. A test wanting plain output passes `--style plain`, which outranks this.
+    env: {
+      RDY_STYLE: 'rich',
+    },
+    include: ['**/__tests__/**/*.test.{ts,tsx}'],
+  },
+});
+
+export default mergeConfig(baseConfig, config);


### PR DESCRIPTION
## What

Status in `rdy` output can now be words instead of emoji, readable on a terminal with no emoji font or through a screen reader. Every command now takes `--style auto|plain|rich`, and `RDY_STYLE` carries a standing preference the flag outranks. If `CI` is set or output is not directed to a terminal (a pipe or a redirect), output defaults to plain style.

## Why

Status was encoded only as emoji, with no words anywhere. A CI log, a `grep FAIL`, a screen reader, and a terminal with a poor emoji font each turned status into something invisible or garbled, and there was no plain-output mode of any kind to fall back to.

## Details

### 🎉 Features

- `--style <auto|plain|rich>` on every output-producing command, accepted both before and after the command name, and as either `--style plain` or `--style=plain`. `RDY_STYLE` carries a standing preference; precedence is flag, then environment variable, then `auto`.
- `auto` resolves to `plain` when `CI` is set or stdout is not a terminal, and to `rich` otherwise. Both signals are load-bearing: `CI` catches runners that attach a pseudo-terminal, and the terminal check catches an interactive `rdy | grep FAIL`. An explicit `CI=false` is read as a denial.
- The `plain` style renders `PASS`, `FAIL`, `WARN`, `RECO`, `SKIP`, `BLOCK`, and `FIX` as fixed-width ASCII words, rules headings with `==` and `--`, and parts a check's detail with `-`. Every character it emits is printable ASCII, and columns stay aligned at any nesting depth. The two noun glyphs are omitted rather than substituted, since an uppercase word in the status column would read as a status.
- Naming a style that does not exist, from either the flag or the environment variable, fails the invocation and reports the accepted values.
- `--style` is independent of `--json`: the JSON document is unchanged, and the style governs the prose that accompanies it on stderr. With a style named explicitly, output is byte-identical whether it goes to a terminal or a pipe.
- Emoji output is unchanged, byte for byte, for anyone who does nothing.

### 🏗️ Internal features

- A second formatter supplies the ASCII vocabulary at a gutter of six, which the shared engine renders through unchanged.
- The engine is chosen when an invocation starts rather than fixed when the module loads. Consumers read it through an accessor, so a module-scope capture cannot silently freeze one style.
- A pure resolver decides the style from argv, the environment, and terminal-ness, all passed as arguments. It reports an unusable value rather than throwing, so the usage error complaining about a bad style is itself rendered in a valid one.

### ♻️ Refactoring

- The characters that punctuate a check line and separate its detail moved from the layout engine onto the formatter, leaving no glyph decision in engine-level constants.
- The inline-glyph accessor now returns the glyph with its trailing space, so a formatter that gives a token no glyph closes the sentence up instead of leaving an orphan space.
- The emoji formatter is renamed to match the user-facing `rich`, so one vocabulary spans the flag, the docs, and the code.

### 🧪 Tests

- New suites cover the plain vocabulary, the resolver's full flag/environment/detection matrix, and end-to-end style selection through all five commands.
- The ASCII property is asserted against a rendering of the whole token vocabulary rather than a sampled line, and column positions are re-derived from rendered text rather than restated as constants.
- A per-package Vitest config pins `RDY_STYLE` for the suite, so rendering assertions no longer depend on whether the runner attached a terminal. Four tests deliberately unpin it to cover the detection wiring.

### 📚 Documentation

- The README's token table gains a plain column rather than a parallel section, so the two styles cannot drift apart in the docs.
- A new section documents the flag, the environment variable, the precedence cascade, and the detection rule, with a worked example showing the same run in each style.
- `--style` appears in the top-level help and in every command's help.

Closes #122
