### PR TITLE
#123 Rewrite the README as a complete reference and trim --help

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -151,6 +151,20 @@ All helpers are type-safe identity functions that provide editor autocomplete wi
 | `defineRdyStagedChecklist` | Staged checklist    |
 | `defineChecklists`         | Array of checklists |
 
+### Config
+
+Repo-level settings live in `.config/readyup.config.ts`.
+
+| Key               | Default         | Meaning                                                       |
+| ----------------- | --------------- | ------------------------------------------------------------- |
+| `compile.srcDir`  | `.readyup/kits` | Directory `rdy compile` reads sources from                    |
+| `compile.outDir`  | `.readyup/kits` | Directory it writes bundles to                                |
+| `compile.include` | all `.ts` files | Glob limiting which sources a sweep compiles                  |
+| `internal.dir`    | `.`             | Directory holding internal sources, relative to the kits root |
+| `internal.infix`  | none            | Filename segment marking a file as internal                   |
+
+See [internal kits](#internal-kits) for what the `internal` keys select.
+
 ### Kit
 
 | Field             | Type                         | Default     | Meaning                                    |
@@ -680,12 +694,7 @@ Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `fa
 
 ### Internal kits
 
-Internal kits are TypeScript sources a repo runs on itself rather than publishing. Two config keys locate them:
-
-| Key              | Default | Meaning                                                       |
-| ---------------- | ------- | ------------------------------------------------------------- |
-| `internal.dir`   | `.`     | Directory holding internal sources, relative to the kits root |
-| `internal.infix` | none    | Filename segment marking a file as internal                   |
+Internal kits are TypeScript sources a repo runs on itself rather than publishing. The `internal.dir` and `internal.infix` [config keys](#config) locate them.
 
 An **infix** is a segment between the kit name and the extension. With `infix: 'internal'`, the kit `deploy` lives at `deploy.internal.ts`; with no infix configured -- the default -- it is simply `deploy.ts`.
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1,4 +1,4 @@
-# readyup
+# ReadyUp
 
 Run pre-deployment verification checks against your environment and configuration. Define checklists in TypeScript kits, run them locally or from a remote source, and get clear pass/fail reporting with remediation hints.
 
@@ -343,7 +343,7 @@ rdy deploy:fast
 
 Neither `rdy compile` nor `rdy run --jit` type-checks the kit it loads, so both validate structure at load time, identically -- `rdy compile` refuses to publish a kit that `rdy run` would reject.
 
-Every check is validated wherever it appears: in `checks`, in `groups`, in `preconditions`, and nested. A check needs a non-empty `name` and a `check` function; `severity` must be a valid value; `skip` must be a function and `fix` a string when present. Unknown keys are allowed, so a kit written for a later readyup still loads.
+Every check is validated wherever it appears: in `checks`, in `groups`, in `preconditions`, and nested. A check needs a non-empty `name` and a `check` function; `severity` must be a valid value; `skip` must be a function and `fix` a string when present. Unknown keys are allowed, so a kit written for a later ReadyUp still loads.
 
 ```
 Invalid kit at .readyup/kits/default.js:
@@ -505,7 +505,7 @@ Once a style is named explicitly, output is byte-identical to a terminal or a pi
 | -------------- | -------------------------------------------------------------------------- |
 | `source-stale` | The kit's TypeScript changed since the compiled bundle was built from it   |
 | `target-drift` | The compiled bundle no longer matches the manifest's recorded hash         |
-| `version-skew` | The kit was compiled against a readyup version differing from the runner's |
+| `version-skew` | The kit was compiled against a ReadyUp version differing from the runner's |
 
 They are silent when the manifest is absent, when no entry describes the kit, when an entry records no hashes, or when a file cannot be read. Only the local manifest is consulted, so a kit reached through `--from` is out of scope -- run `rdy verify` in that root instead. They also do not apply to `--url` or `--jit`.
 
@@ -543,7 +543,7 @@ Each section names the command that runs the kits beneath it:
 📦 smoke
 ```
 
-`--manifest` reports each kit's compile-time readyup version and description:
+`--manifest` reports each kit's compile-time ReadyUp version and description:
 
 ```
 ── Manifest: .readyup/manifest.json
@@ -589,7 +589,7 @@ Each `$id` is the same path under `https://unpkg.com/readyup/`. The schemas are 
 
 The five payloads version independently.
 
-- **Adding an optional field does not bump `schemaVersion`.** A validator pinned to `v1` keeps accepting payloads from a later readyup.
+- **Adding an optional field does not bump `schemaVersion`.** A validator pinned to `v1` keeps accepting payloads from a later ReadyUp.
 - **Removing, renaming, or re-typing a field does bump it**, publishing a new `vN` beside the old. Widening a closed set counts as re-typing.
 - **A field is `required` only when every payload carries it.** Omission is reserved for absent or empty data.
 - **`warnings[].code` is an open set**, exempt from the widening rule. Consumers must tolerate an unknown code, displaying its `message` and `remedy`. `error.code` stays closed.
@@ -848,7 +848,7 @@ const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
 
 `readyup/check-utils` is the stable, versioned surface for kit-author imports. It follows semver: no breaking changes within a major version.
 
-Compiled kits embed nothing of readyup itself -- the runner satisfies `readyup` and `readyup/*` imports at runtime via its module-resolution hook. Kits are therefore version-coupled to the runner across breaking boundaries: when upgrading across a major, recompile with `rdy compile`.
+Compiled kits embed nothing of ReadyUp itself -- the runner satisfies `readyup` and `readyup/*` imports at runtime via its module-resolution hook. Kits are therefore version-coupled to the runner across breaking boundaries: when upgrading across a major, recompile with `rdy compile`.
 
 ## License
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -366,6 +366,12 @@ rdy deploy release         # two kits
 
 `--checklists` filters within a single kit, and pairs with one positional kit, with `--file` or `--url`, or with no kit at all. Naming two kits, or one that already carries a `:checklist` filter, is an error rather than a merge.
 
+Kit names may contain `/`, as in `shared/deploy`. To name one that starts with `-`, place it last, after `--`:
+
+```bash
+rdy run -- "--odd-kit-name"
+```
+
 ### Run options
 
 | Option                        | Description                                           |

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -4,6 +4,18 @@ Run pre-deployment verification checks against your environment and configuratio
 
 <!-- section:release-notes --><!-- /section:release-notes -->
 
+## Contents
+
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [Concepts](#concepts)
+- [Authoring kits](#authoring-kits)
+- [Running checks](#running-checks)
+- [JSON output](#json-output)
+- [Publishing kits](#publishing-kits)
+- [Check utilities](#check-utilities)
+- [Compatibility](#compatibility)
+
 ## Installation
 
 ```bash
@@ -13,8 +25,6 @@ pnpm add --save-dev readyup
 Node 24 or later is required, for the runner and for the kits it compiles.
 
 ## Quick start
-
-Install readyup as shown above, then scaffold a starter config and kit:
 
 ```bash
 rdy init
@@ -46,7 +56,7 @@ export default defineRdyKit({
       name: 'deploy',
       checks: [
         {
-          name: 'environment variables set',
+          name: 'NODE_ENV is set',
           check: () => Boolean(process.env['NODE_ENV']),
           fix: 'Set NODE_ENV before deploying',
         },
@@ -56,44 +66,280 @@ export default defineRdyKit({
 });
 ```
 
-Compile the kit, then run the checks:
+Compile the kit, then run it:
 
 ```bash
 rdy compile
 rdy run
 ```
 
-Compiling reports what it rebuilt:
+With `NODE_ENV` unset:
 
 ```
-── Compiling kits in .readyup/kits
-
-🟢 default.ts -> 📦 default.js
-```
-
-Running reports what it found. With `NODE_ENV` unset, the starter check fails and its remediation is recapped at the end, attributed to the check that raised it:
-
-```
-🔴 environment variables set
+🔴 NODE_ENV is set
 
 🔴 1 error (0ms)
 
 ── Fixes
 
-💊 environment variables set
+💊 NODE_ENV is set
    Set NODE_ENV before deploying
 ```
 
-The failed line carries only its claim, because this check reports no reason of its own -- it returns a bare `false`. Returning a `detail` instead is what puts an explanation beneath the claim; see [the `detail` contract](#the-detail-contract).
+`rdy run --jit` skips compilation and runs the TypeScript source directly, which is the faster loop while writing checks. Compiled kits stay the vetted artifact: they are what `rdy verify` hashes and what a consumer running `rdy run --from` gets.
 
-`rdy compile` bundles `.readyup/kits/default.ts` into `.readyup/kits/default.js`, and `rdy run` loads that compiled kit. Recompile whenever the source changes.
+## Concepts
 
-To skip compiling and run straight from the TypeScript source, use `rdy run --jit`. It reads the same `.readyup/kits/default.ts` and needs no compiled bundle, which makes it the faster loop while you are still writing checks. Compiled kits stay the vetted artifact: they are what `rdy verify` hashes and what a consumer running `rdy run --from` gets.
+### Kits, checklists, and checks
 
-## CLI reference
+A **kit** is a file exporting one or more **checklists**. A checklist holds **checks**, and a check may nest further checks beneath it. A check that fails blocks its descendants.
 
 ```
-rdy [names...] [options]
+kit
+└── checklist
+    └── check
+        └── check
+```
+
+### Severities
+
+Every check carries a severity. It decides whether a failure fails the run and whether the result is reported -- not whether the check runs.
+
+| Severity    | Meaning           |
+| ----------- | ----------------- |
+| `error`     | Must be fixed     |
+| `warn`      | Should be fixed   |
+| `recommend` | Worth considering |
+
+### Statuses
+
+A check result has one of three statuses -- `passed`, `failed`, or `skipped`. The token shown in output is derived by crossing status with severity (for failures) or with the skip reason (for skips), which is why an author returns a boolean and declares severity separately rather than choosing a token.
+
+| Rich | Plain   | Status    | Derived from                                 |
+| ---- | ------- | --------- | -------------------------------------------- |
+| 🟢   | `PASS`  | `passed`  | --                                           |
+| 🔴   | `FAIL`  | `failed`  | severity `error`                             |
+| 🟠   | `WARN`  | `failed`  | severity `warn`                              |
+| 🟡   | `RECO`  | `failed`  | severity `recommend`                         |
+| ⚪   | `SKIP`  | `skipped` | `skip` returned a reason; counts as optional |
+| 🚫   | `BLOCK` | `skipped` | a precondition failed; counts as blocked     |
+
+💊 `FIX` marks a remediation hint rather than a result. 📄 and 📦 are nouns, not statuses: a TypeScript source and a compiled bundle.
+
+### Thresholds
+
+Two thresholds govern a run, each resolved as **CLI flag, then the kit's own field, then the default**.
+
+| Threshold | Field / flag               | Default     | Governs                                |
+| --------- | -------------------------- | ----------- | -------------------------------------- |
+| Failure   | `failOn` / `--fail-on`     | `error`     | Whether a failure fails the run        |
+| Reporting | `reportOn` / `--report-on` | `recommend` | Whether a result appears in the output |
+
+A check with no `severity` takes the kit's `defaultSeverity`, which itself defaults to `error`.
+
+Reporting prunes the detail tree only. Summary counts, worst severity, and the exit code always reflect the whole run.
+
+## Authoring kits
+
+All helpers are type-safe identity functions that provide editor autocomplete without runtime overhead. Import them from `readyup`.
+
+| Helper                     | Defines             |
+| -------------------------- | ------------------- |
+| `defineRdyConfig`          | Repo-level config   |
+| `defineRdyKit`             | Kit                 |
+| `defineRdyChecklist`       | Flat checklist      |
+| `defineRdyStagedChecklist` | Staged checklist    |
+| `defineChecklists`         | Array of checklists |
+
+### Kit
+
+| Field             | Type                         | Default     | Meaning                                    |
+| ----------------- | ---------------------------- | ----------- | ------------------------------------------ |
+| `checklists`      | `Array<Checklist \| Staged>` | required    | The checklists this kit runs               |
+| `description`     | `string`                     | --          | Summary, reported by `rdy list --manifest` |
+| `suites`          | `Record<string, string[]>`   | --          | Named subsets of checklists                |
+| `defaultSeverity` | `Severity`                   | `error`     | Severity for checks that declare none      |
+| `failOn`          | `Severity`                   | `error`     | Failure threshold                          |
+| `reportOn`        | `Severity`                   | `recommend` | Reporting threshold                        |
+| `fixLocation`     | `'inline' \| 'end'`          | `end`       | Where fixes render                         |
+
+### Checklists
+
+| Field           | Type                | Meaning                                     |
+| --------------- | ------------------- | ------------------------------------------- |
+| `name`          | `string`            | Display name                                |
+| `checks`        | `RdyCheck[]`        | Checks, run concurrently (flat checklist)   |
+| `groups`        | `RdyCheck[][]`      | Groups, run sequentially (staged checklist) |
+| `preconditions` | `RdyCheck[]`        | Gating checks                               |
+| `fixLocation`   | `'inline' \| 'end'` | Overrides the kit's setting                 |
+
+A checklist carries either `checks` or `groups`, never both.
+
+### Checks
+
+| Field      | Type                            | Meaning                                    |
+| ---------- | ------------------------------- | ------------------------------------------ |
+| `name`     | `string`                        | The claim being asserted                   |
+| `check`    | `() => boolean \| CheckOutcome` | The assertion; may be async                |
+| `severity` | `Severity`                      | Overrides the kit's `defaultSeverity`      |
+| `skip`     | `() => false \| string`         | Reason string to skip; `false` to run      |
+| `fix`      | `string`                        | Remediation, shown when the check fails    |
+| `checks`   | `RdyCheck[]`                    | Nested checks, run only if this one passes |
+
+A check returns a boolean or a `CheckOutcome`:
+
+| Field      | Type       | Meaning                                                                      |
+| ---------- | ---------- | ---------------------------------------------------------------------------- |
+| `ok`       | `boolean`  | Whether the assertion holds                                                  |
+| `detail`   | `string`   | Why this status                                                              |
+| `progress` | `Progress` | `{ type: 'fraction', passedCount, count }` or `{ type: 'percent', percent }` |
+
+### Naming checks
+
+Three fields, three questions:
+
+> **`name` states what must be true. `detail` answers why this status. `fix` says what to do about it.**
+
+A name is a claim that reads true on a pass and false on a fail. `🔴 Node >= 24` fails that test: the operator leaves the reader to infer which direction is the violation.
+
+| Poor                    | Better                     | Why                                                 |
+| ----------------------- | -------------------------- | --------------------------------------------------- |
+| `Node >= 24`            | `Node 24 or later`         | words fix the direction without moving the boundary |
+| `outdated dependencies` | `dependencies are current` | a name true on _failure_ inverts the status token   |
+| `check git status`      | `working tree is clean`    | names the action, not the condition                 |
+| `env vars`              | `NODE_ENV is set`          | names the subject, not the claim                    |
+
+Rewriting a name often exposes an ambiguous predicate: an author writing "newer than 24" frequently discovers they meant a floor of 24.
+
+### The detail contract
+
+`detail` answers "why this status" -- not "what this check asserts", which the name already says. On a pass it reports the evidence; on a skip, why the check did not apply; on a failure, what went wrong.
+
+| Status  | Where `detail` renders                                  |
+| ------- | ------------------------------------------------------- |
+| passed  | inline, after the separator                             |
+| skipped | inline, after the separator                             |
+| failed  | in a block beneath the claim, above any thrown `Error:` |
+
+Remediation is not detail. It belongs in `fix`.
+
+This kit exercises all three placements at three levels of nesting:
+
+```ts
+import { defineRdyKit } from 'readyup';
+
+export default defineRdyKit({
+  checklists: [
+    {
+      name: 'release',
+      checks: [
+        {
+          name: 'working tree is clean',
+          check: () => ({ ok: true, detail: 'no uncommitted changes' }),
+        },
+        {
+          name: 'dependencies are installed',
+          check: () => true,
+          checks: [
+            {
+              name: 'lockfile is current',
+              check: () => ({ ok: true, progress: { type: 'fraction', passedCount: 4, count: 4 } }),
+              checks: [
+                {
+                  name: 'no duplicated majors',
+                  check: () => ({ ok: false, detail: 'react resolves to both 18.3.1 and 19.0.0' }),
+                  fix: 'Run `pnpm dedupe`, then commit the lockfile',
+                },
+              ],
+            },
+            {
+              name: 'native modules are rebuilt',
+              check: () => true,
+              skip: () => 'no native dependencies in this workspace',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+```
+
+It produces:
+
+```
+🟢 working tree is clean · no uncommitted changes
+🟢 dependencies are installed
+   🟢 lockfile is current [4 of 4]
+      🔴 no duplicated majors
+         react resolves to both 18.3.1 and 19.0.0
+   ⚪ native modules are rebuilt · no native dependencies in this workspace
+
+🔴 3 passed | 1 error | 1 skipped (0ms)
+
+── Fixes
+
+💊 no duplicated majors
+   Run `pnpm dedupe`, then commit the lockfile
+```
+
+A failing descendant turns the tail line red while every ancestor stays green. `progress` needs no `detail`: `[4 of 4]` is already the evidence.
+
+### Staged checklists
+
+A staged checklist replaces `checks` with `groups`. Groups run in order; checks within a group run concurrently.
+
+```ts
+import { defineRdyStagedChecklist } from 'readyup';
+
+export default defineRdyStagedChecklist({
+  name: 'release',
+  groups: [[{ name: 'working tree is clean', check: () => true }], [{ name: 'tests pass', check: () => true }]],
+});
+```
+
+A failure in a group stops the groups after it. Only top-level results gate: a failing _nested_ check does not halt the next group.
+
+### Preconditions
+
+A checklist's `preconditions` gate the checks that follow. If any precondition fails, every check is skipped and each records `precondition` as its reason.
+
+- **A failed precondition gates regardless of severity.** Severity decides whether the run fails; the gate decides whether the checks are worth running.
+- **A precondition skipped `n/a` does not gate.** To make a whole checklist inapplicable, nest its checks under one parent check whose `skip` returns a reason.
+
+### Suites
+
+`suites` names reusable subsets of checklists. A suite name is accepted anywhere a checklist name is, and expands in the order the suite declares.
+
+```ts
+export default defineRdyKit({
+  suites: { fast: ['lint', 'types'] },
+  checklists: [/* lint, types, integration */],
+});
+```
+
+```bash
+rdy deploy:fast
+```
+
+### Validation
+
+Neither `rdy compile` nor `rdy run --jit` type-checks the kit it loads, so both validate structure at load time, identically -- `rdy compile` refuses to publish a kit that `rdy run` would reject.
+
+Every check is validated wherever it appears: in `checks`, in `groups`, in `preconditions`, and nested. A check needs a non-empty `name` and a `check` function; `severity` must be a valid value; `skip` must be a function and `fix` a string when present. Unknown keys are allowed, so a kit written for a later readyup still loads.
+
+```
+Invalid kit at .readyup/kits/default.js:
+  checklists[0].checks[1].severity: expected one of "error", "warn", "recommend", got "info"
+  checklists[0].checks[2].check: expected a function, got string
+```
+
+A typo'd `severity` is the mistake this matters most for: an unrecognized value would otherwise exclude the check from both thresholds, and the run would pass.
+
+## Running checks
+
+```
+rdy [kit[:checklist,...] ...] [options]
 rdy <command> [options]
 ```
 
@@ -107,27 +353,36 @@ rdy <command> [options]
 | `list`           | List available kits                              |
 | `verify`         | Check compiled kits against manifest hashes      |
 
+### Selecting what runs
+
+A positional argument names a kit, optionally with checklists or suites after a colon:
+
+```bash
+rdy deploy                 # every checklist in the deploy kit
+rdy deploy:build,test      # two checklists from it
+rdy deploy:fast            # a suite
+rdy deploy release         # two kits
+```
+
+`--checklists` filters within a single kit, and pairs with one positional kit, with `--file` or `--url`, or with no kit at all. Naming two kits, or one that already carries a `:checklist` filter, is an error rather than a merge.
+
 ### Run options
 
-| Option                        | Description                                                    |
-| ----------------------------- | -------------------------------------------------------------- |
-| `--from <source>`             | Kit source (see [kit sources](#kit-sources) below)             |
-| `--file, -f <path>`           | Path to a local kit file                                       |
-| `--url <url>`                 | Fetch kit from a URL                                           |
-| `--jit`                       | Run from TypeScript source instead of compiled JS              |
-| `--internal`                  | Use internal kit directory and infix from config               |
-| `--checklists, -c <name,...>` | Filter checklists within the selected kit                      |
-| `--json`                      | Output results as JSON                                         |
-| `--detail <summary\|full>`    | How much of the JSON report to emit (default: `full`)          |
-| `--fail-on <severity>`        | Fail on this severity or above (`error`, `warn`, `recommend`)  |
-| `--quiet`                     | Hide passed checks from the report; incompatible with `--json` |
-| `--report-on <severity>`      | Show this severity or above (`error`, `warn`, `recommend`)     |
+| Option                        | Description                                           |
+| ----------------------------- | ----------------------------------------------------- |
+| `--from <source>`             | Kit source (see [kit sources](#kit-sources))          |
+| `--file, -f <path>`           | Path to a local kit file                              |
+| `--url <url>`                 | Fetch kit from a URL                                  |
+| `--jit`                       | Run from TypeScript source instead of compiled JS     |
+| `--internal`                  | Use the internal kit directory and infix from config  |
+| `--checklists, -c <name,...>` | Filter checklists within the selected kit             |
+| `--json`                      | Output results as JSON                                |
+| `--detail <summary\|full>`    | How much of the JSON report to emit (default: `full`) |
+| `--fail-on <severity>`        | Fail on this severity or above                        |
+| `--report-on <severity>`      | Show this severity or above                           |
+| `--quiet`                     | Hide passed checks; incompatible with `--json`        |
 
-`--checklists` selects checklists within one kit. Pair it with a single positional kit, with `--file` or `--url`, or with no kit at all to filter the default kit. Naming two or more kits, or naming one that already carries a `:checklist` filter, is an error rather than a merge.
-
-`--report-on` prunes only the reported detail tree, and keeps the parent checks of anything it shows so nesting stays intact. Summary counts, worst severity, and the exit code always reflect the whole run.
-
-`--quiet` hides passed check lines from the human report, keeping failures, skips, blocks, the fix recap, and every count line. It filters by status where `--report-on` filters by severity, so the two compose rather than override, and both keep the parent checks of anything they show: a failure nested under passing parents stays reachable through them. Counts and the exit code still cover the whole run. Because it changes only the human report, pairing it with `--json` is a usage error rather than a silently ignored flag.
+`--quiet` filters by status where `--report-on` filters by severity, so the two compose rather than override. Both keep the parent checks of anything they show, so a failure nested under passing parents stays reachable.
 
 ### Global options
 
@@ -137,54 +392,50 @@ rdy <command> [options]
 | `--help, -h`                  | Show help for the command      |
 | `--version, -V`               | Show the version number        |
 
-Every command accepts `--style`. See [choosing an output style](#choosing-an-output-style).
+### Kit sources
+
+| Source     | Format                    | Example                     |
+| ---------- | ------------------------- | --------------------------- |
+| GitHub     | `github:org/repo[@ref]`   | `--from github:acme/ops@v2` |
+| Bitbucket  | `bitbucket:ws/repo[@ref]` | `--from bitbucket:team/ops` |
+| Local repo | `<path>`                  | `--from ../other-repo`      |
+| Directory  | `dir:<path>`              | `--from dir:/shared/kits`   |
+| Global     | `global`                  | `--from global`             |
+
+`@ref` defaults to `main`. Local repo paths look for kits in `<path>/.readyup/kits/`; `dir:` paths are used directly.
+
+Private repositories use ambient tokens: `GITHUB_TOKEN` (falling back to `gh auth token`) and `BITBUCKET_TOKEN`. Without a token, requests go anonymous and only public repositories succeed.
 
 ### Reading the output
 
-Every command renders through one layout engine, so a line means the same thing wherever it appears. Each status has two renderings: an emoji in the `rich` style, and a fixed-width word in the `plain` style.
+A check line reads `token name <separator> detail [progress] (duration)`. The separator is `·` in `rich` and `-` in `plain`; progress takes brackets. Durations appear from 100 ms up, never on a check that did not run, and always on a tail or total line.
 
-| Rich | Plain   | Meaning                                                         |
-| ---- | ------- | --------------------------------------------------------------- |
-| 🟢   | `PASS`  | passed; `verify` ok; a file created, overwritten, or up to date |
-| 🔴   | `FAIL`  | failed at `error` severity; `verify` drift or missing           |
-| 🟠   | `WARN`  | failed at `warn` severity; a compile drift-skip                 |
-| 🟡   | `RECO`  | failed at `recommend` severity                                  |
-| ⚪   | `SKIP`  | skipped: not applicable, already present, or no work needed     |
-| 🚫   | `BLOCK` | blocked, because a precondition failed                          |
-| 💊   | `FIX`   | a remediation hint                                              |
+**A failed line carries only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. Passes and skips keep their detail inline.
 
-📄 and 📦 are noun glyphs, not statuses: they name a TypeScript source and a compiled bundle. They lead the line in `list`, where a row names a kit instead of reporting an outcome, and sit mid-line in compile's transformation lines. Both declare the same width as every status token, which is what makes the leading position safe. The `plain` style omits them rather than substituting a word, since an uppercase word in the status column would read as a status; it still reserves their column, so names stay aligned.
+Tail and total lines lead with the run's worst severity, then report counts in a fixed order -- passed, errors, warnings, recommendations, blocked, skipped -- omitting any that is zero.
 
-In `plain`, every character is printable ASCII, heading rules and detail separators included.
-
-A check line reads `token name <separator> detail [progress] (duration)`, where the separator is the style's -- `·` in `rich`, `-` in `plain`. It is the only detail separator, so progress takes brackets rather than a second one, and compile's transformation lines take an ASCII `->`. Durations appear from 100 ms up, never on a check that did not run, and always on a tail or total line.
-
-**A failed line carries only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. A failed check that authored neither renders no reason block at all. Passes and skips keep their detail inline.
-
-Tail and total lines lead with the run's worst severity rather than its passed count, then report the counts in a fixed order -- passed, errors, warnings, recommendations, blocked, skipped -- omitting any field that is zero.
-
-Headings come from one family whose rule weight encodes level: `━━` for a kit, `──` for a checklist, a step, or a summary. When more than one checklist runs, a table follows, its rules sized to the widest row:
+Headings encode level by rule weight: `━━` for a kit, `──` for a checklist, step, or summary. More than one checklist adds a summary table:
 
 ```
 ── build
 
-🟢 typecheck (343ms)
-🟢 bundle size · 42kB of a 50kB budget [84%]
+🟢 types check cleanly (343ms)
+🟢 bundle is within budget · 42kB of a 50kB budget [84%]
 
 🟢 2 passed (343ms)
 
 ── integration
 
-🟢 database reachable
-🔴 migrations applied (151ms)
+🟢 database is reachable
+🔴 migrations are applied (151ms)
    2 migrations pending: add_users, add_index
-⚪ seed data loaded · seeding is disabled outside CI
+⚪ seed data is loaded · seeding is disabled outside CI
 
 🔴 1 passed | 1 error | 1 skipped (151ms)
 
 ── Fixes
 
-💊 migrations applied
+💊 migrations are applied
    Run `pnpm migrate` against the target database
 
 ── Summary
@@ -196,11 +447,9 @@ Headings come from one family whose rule weight encodes level: `━━` for a ki
 🔴 Total: 3 passed | 1 error | 1 skipped (494ms)
 ```
 
-Under `--quiet`, that run keeps everything except `typecheck`, `bundle size`, and `database reachable`.
+### Output styles
 
-### Choosing an output style
-
-`--style` selects how output is rendered, and `RDY_STYLE` carries a standing preference for a shell profile or a CI image. The flag outranks the environment variable, which outranks detection.
+`--style` selects rendering; `RDY_STYLE` carries a standing preference. The flag outranks the environment variable, which outranks detection.
 
 | Value   | Renders                                                                       |
 | ------- | ----------------------------------------------------------------------------- |
@@ -208,122 +457,142 @@ Under `--quiet`, that run keeps everything except `typecheck`, `bundle size`, an
 | `plain` | Fixed-width ASCII words                                                       |
 | `rich`  | Emoji tokens                                                                  |
 
-Both detection signals carry their own weight. `CI` catches a runner that attaches a pseudo-terminal, where a terminal check alone would put emoji into a log nobody can search; the terminal check catches an interactive `rdy | grep FAIL`, where `CI` is unset. An explicit `CI=false` is read as a denial.
+`CI` catches a runner that attaches a pseudo-terminal; the terminal check catches an interactive `rdy | grep FAIL`. An explicit `CI=false` is read as a denial. Naming a style that does not exist fails the invocation.
 
-Naming a style that does not exist, from either the flag or the environment variable, fails the invocation and reports the values that are accepted.
-
-The same run renders in `plain` as:
+In `plain`, every character is printable ASCII, heading rules and separators included, and the noun glyphs are omitted while keeping their column so names stay aligned:
 
 ```
--- build
-
-PASS  typecheck (343ms)
-PASS  bundle size - 42kB of a 50kB budget [84%]
-
-PASS  2 passed (343ms)
-
 -- integration
 
-PASS  database reachable
-FAIL  migrations applied (151ms)
+PASS  database is reachable
+FAIL  migrations are applied (151ms)
       2 migrations pending: add_users, add_index
-SKIP  seed data loaded - seeding is disabled outside CI
+SKIP  seed data is loaded - seeding is disabled outside CI
 
 FAIL  1 passed | 1 error | 1 skipped (151ms)
-
--- Fixes
-
-FIX   migrations applied
-      Run `pnpm migrate` against the target database
-
--- Summary
-
---------------------------------------------------------
-PASS  build        343ms  2 passed
-FAIL  integration  151ms  1 passed | 1 error | 1 skipped
---------------------------------------------------------
-FAIL  Total: 3 passed | 1 error | 1 skipped (494ms)
 ```
 
-Once a style is named explicitly, output is byte-identical whether it goes to a terminal or a pipe, so `rdy --style rich > run.log` saves what the screen showed. `--style` is independent of `--json`: the JSON document never changes, and the style governs the prose that accompanies it on stderr.
+Once a style is named explicitly, output is byte-identical to a terminal or a pipe. `--style` is independent of `--json`: the JSON document never changes.
 
 ### Advisory warnings
 
-`rdy run` compares the kits it is about to run against `.readyup/manifest.json` in the current working directory, and says so when the two disagree. Warnings go to stderr in both output modes and appear under `warnings` in the JSON report; none of them affects the exit code.
+`rdy run` compares the kits it is about to run against `.readyup/manifest.json` and says so when they disagree. Warnings go to stderr in both modes and appear under `warnings` in JSON; none affects the exit code.
 
-| Code           | Raised when                                                                   |
-| -------------- | ----------------------------------------------------------------------------- |
-| `source-stale` | The kit's TypeScript has changed since the compiled bundle was built from it  |
-| `target-drift` | The compiled bundle no longer matches the hash the manifest recorded for it   |
-| `version-skew` | The kit was compiled against a readyup version that differs from the runner's |
+| Code           | Raised when                                                                |
+| -------------- | -------------------------------------------------------------------------- |
+| `source-stale` | The kit's TypeScript changed since the compiled bundle was built from it   |
+| `target-drift` | The compiled bundle no longer matches the manifest's recorded hash         |
+| `version-skew` | The kit was compiled against a readyup version differing from the runner's |
 
-The staleness warnings are silent when that manifest is absent, when no entry in it describes the kit being run, when the entry records no hashes, or when a file they would hash cannot be read. That one manifest is the only one consulted, so a kit reached through `--from` is outside their scope: it resolves under another root, whose own manifest `rdy run` never reads. Run `rdy verify` in that root to check those kits. The warnings also do not apply to `--url` sources, which no local manifest describes, or to `--jit`, which runs the source directly. `rdy verify` is the enforcing gate; see [the staleness model](#the-staleness-model).
+They are silent when the manifest is absent, when no entry describes the kit, when an entry records no hashes, or when a file cannot be read. Only the local manifest is consulted, so a kit reached through `--from` is out of scope -- run `rdy verify` in that root instead. They also do not apply to `--url` or `--jit`.
 
 ### Exit codes
 
-| Code | Meaning                                                                                                                       |
-| ---- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `0`  | Ran and found no problems                                                                                                     |
-| `1`  | Ran and found problems with the repo or its kits: failed checks, a `verify` drift or missing kit, a kit that fails to compile |
-| `2`  | Could not complete the invocation: a usage, config, kit-load, or internal error                                               |
+| Code | Meaning                                                                                             |
+| ---- | --------------------------------------------------------------------------------------------------- |
+| `0`  | Ran and found no problems                                                                           |
+| `1`  | Ran and found problems: failed checks, a `verify` drift or missing kit, a kit that fails to compile |
+| `2`  | Could not complete the invocation: a usage, config, kit-load, or internal error                     |
 
-The distinction is between "fix the repo" (`1`) and "fix the invocation" (`2`), so a pipeline can branch on which is which. `rdy list` and `rdy init` produce only `0` and `2` -- neither can find problems to report.
+The distinction is "fix the repo" (`1`) versus "fix the invocation" (`2`). `rdy list` and `rdy init` produce only `0` and `2`. A run that loses a kit part-way exits `2` even when the kits that ran found problems, and still reports what it collected.
 
-A run that loses a kit part-way exits `2` even when the kits that ran also found problems, since part of the invocation did not complete. It still reports what it collected.
+### Listing kits
 
-### JSON output
+```
+rdy list                       List internal and compiled kits (owner view)
+rdy list --from <source>       List compiled kits at a local path or remote source
+rdy list --manifest <path>     List the kits a manifest file declares
+```
 
-`run`, `compile`, `list`, and `verify` all accept `--json`. `init` does not: scaffolding is interactive and stays human-only.
+Each section names the command that runs the kits beneath it:
 
-With `--json`, stdout carries exactly one JSON document and every human-readable line -- headers, progress, warnings, errors -- goes to stderr. The exceptions are `--help` and `--version`, which have no JSON form: their text goes to stderr and stdout stays empty.
+```
+── Internal
+   rdy run --jit <name>
 
-#### Published schemas
+📄 deploy
+📄 smoke
 
-Each payload is specified by a JSON Schema shipped with the package, and carries an integer `schemaVersion` matching the `vN` in its schema's filename.
+── Compiled
+   rdy run <name>
 
-| Payload        | Import path                              | `$id`                                                      |
-| -------------- | ---------------------------------------- | ---------------------------------------------------------- |
-| `compile`      | `readyup/schemas/compile.v1.json`        | `https://unpkg.com/readyup/schemas/compile.v1.json`        |
-| error envelope | `readyup/schemas/error-envelope.v1.json` | `https://unpkg.com/readyup/schemas/error-envelope.v1.json` |
-| `list`         | `readyup/schemas/list.v1.json`           | `https://unpkg.com/readyup/schemas/list.v1.json`           |
-| `run` report   | `readyup/schemas/report.v1.json`         | `https://unpkg.com/readyup/schemas/report.v1.json`         |
-| `verify`       | `readyup/schemas/verify.v1.json`         | `https://unpkg.com/readyup/schemas/verify.v1.json`         |
+📦 deploy
+📦 smoke
+```
 
-The schemas are generated from the same definitions the exported `Json*` TypeScript types are derived from, so the published contract and the types cannot drift apart.
+`--manifest` reports each kit's compile-time readyup version and description:
 
-#### Evolution policy
+```
+── Manifest: .readyup/manifest.json
 
-The five payloads version independently: reshaping the report leaves a consumer pinned to `list.v1.json` untouched.
+📦 deploy (readyup v0.22.0) · Pre-deployment checks
+📦 smoke (readyup v0.22.0)
+```
 
-- **Adding an optional field does not bump `schemaVersion`.** The schemas do not constrain properties they have not heard of, so a validator pinned to `v1` keeps accepting payloads from a later readyup that added one.
-- **Removing, renaming, or re-typing a field does bump it**, and publishes a new `vN` file beside the old one. Widening a closed set of values -- an error `code`, a check `status` -- counts as re-typing.
-- **A field is `required` only when every payload carries it.** Omission is reserved for genuinely absent or empty data, so a present field never means "nothing here".
-- **`warnings[].code` is an open set**, exempt from the widening rule above: the schema accepts a known code or any other string, so a newly raised advisory never bumps the version. Consumers must tolerate a code they have not heard of, displaying its `message` and `remedy` as they would any other. `error.code` stays closed, because an unknown error code leaves a consumer with no branch to select, and that is a break worth announcing.
+A local `--from` source with no manifest falls back to listing the compiled kits on disk; those rows carry a name and path only. A remote source still requires a manifest.
 
-#### Error envelope
+Rows are keyed by `name` **and** `kind` together. Under the default configuration a compiled source appears twice -- once as `internal` and once as `compiled` -- so a consumer indexing on `name` alone silently drops one.
 
-An invocation that fails before it can produce anything else emits the envelope:
+### Scaffolding
+
+```
+rdy init                       Scaffold a starter config and kit
+```
+
+| Option          | Description                           |
+| --------------- | ------------------------------------- |
+| `--dry-run, -n` | Preview changes without writing files |
+| `--force`       | Overwrite existing files              |
+
+## JSON output
+
+`run`, `compile`, `list`, and `verify` accept `--json`; `init` does not. With `--json`, stdout carries exactly one JSON document and every human-readable line goes to stderr. `--help` and `--version` have no JSON form.
+
+### Published schemas
+
+Each payload is specified by a JSON Schema shipped with the package and carries an integer `schemaVersion` matching the `vN` in its filename.
+
+| Payload        | Import path                              |
+| -------------- | ---------------------------------------- |
+| `compile`      | `readyup/schemas/compile.v1.json`        |
+| error envelope | `readyup/schemas/error-envelope.v1.json` |
+| `list`         | `readyup/schemas/list.v1.json`           |
+| `run` report   | `readyup/schemas/report.v1.json`         |
+| `verify`       | `readyup/schemas/verify.v1.json`         |
+
+Each `$id` is the same path under `https://unpkg.com/readyup/`. The schemas are generated from the definitions the exported `Json*` types derive from, so the published contract and the types cannot drift apart.
+
+### Evolution policy
+
+The five payloads version independently.
+
+- **Adding an optional field does not bump `schemaVersion`.** A validator pinned to `v1` keeps accepting payloads from a later readyup.
+- **Removing, renaming, or re-typing a field does bump it**, publishing a new `vN` beside the old. Widening a closed set counts as re-typing.
+- **A field is `required` only when every payload carries it.** Omission is reserved for absent or empty data.
+- **`warnings[].code` is an open set**, exempt from the widening rule. Consumers must tolerate an unknown code, displaying its `message` and `remedy`. `error.code` stays closed.
+
+### Error envelope
+
+An invocation that fails before producing anything else emits:
 
 ```json
 { "schemaVersion": 1, "error": { "code": "usage", "message": "Unknown option '--bogus'" } }
 ```
 
-`code` is one of `usage`, `config`, `kit-load`, or `internal`. The exit code does not determine which document appears.
-
-The envelope covers only failures that precede dispatch. Once the run reaches its kits, a kit that fails is reported inside the report instead of replacing it, so each entry in `kits` takes one of two shapes, told apart by whether `error` is present:
+`code` is one of `usage`, `config`, `kit-load`, or `internal`. The envelope covers only failures preceding dispatch; once the run reaches its kits, a failing kit is reported inside the report:
 
 ```json
 { "name": "release", "error": { "code": "kit-load", "message": "Cannot find .readyup/kits/release.js" } }
 ```
 
-An error entry carries no counts and no verdict, because a kit that never ran has neither to report; the top-level totals cover only the kits that ran. In human mode the same failure goes to stderr, which keeps it distinct from a failed check. A run of more than one kit prefixes the kit's name, as `Error [release]: ...`.
+An error entry carries no counts and no verdict, and the top-level totals cover only the kits that ran.
 
-#### The run report
+### The run report
 
 ```json
 {
   "schemaVersion": 1,
-  "readyupVersion": "0.21.2",
+  "readyupVersion": "0.22.0",
   "passed": false,
   "counts": { "passed": 4, "errors": 1, "warnings": 0, "recommendations": 0, "blocked": 2, "optional": 1 },
   "worstSeverity": "error",
@@ -344,99 +613,44 @@ An error entry carries no counts and no verdict, because a kit that never ran ha
 }
 ```
 
-- **`passed`** is the run verdict: true when every requested kit produced results and every kit passed under its own `failOn`, so it agrees with exit code 0 in every case. Kit and checklist entries carry their own `passed`, which means the narrower "nothing at or above this kit's `failOn` failed here".
-- **`counts`** holds the six result tallies at the report, kit, and checklist levels. They nest rather than sitting flat so the count names and the verdict names share no namespace, which is what makes the additive-evolution rule above sound rather than merely conventional.
-- **`worstSeverity`** sits beside `counts` -- it is derived verdict data, not a count -- and is omitted when nothing failed.
-- **`failOn`** and **`reportOn`** appear in two places, answering two different questions. At the top level they report what the invocation _requested_, so each is present only when you passed the flag: absence means "not requested", never "defaulted". On each kit that ran they report the threshold that _governed_ it, resolved as CLI flag, then the kit's own declaration, then the default, and both are always present there. The two differ whenever a kit declares its own, which is also why a kit's verdict cannot be recomputed from a run-level value and why a multi-kit run needs one threshold per kit rather than one for the report.
-- **`detail`** has no per-kit form, so requested and effective are the same value and it is always present at the top level.
-- **`warnings`** carries any advisory the run raised, as `{ code, message, remedy? }`. Warnings keep their stderr line in both modes; under `--json` they are captured here as well, because a consumer that owns only stdout would otherwise never see them. The field is absent when the run raised none.
+- **`passed`** is the run verdict, agreeing with exit code 0 in every case. Kit and checklist entries carry their own.
+- **`counts`** holds the six tallies at report, kit, and checklist level, nested so count names and verdict names share no namespace.
+- **`worstSeverity`** is derived verdict data, omitted when nothing failed.
+- **`failOn`** and **`reportOn`** appear at the top level only when the corresponding flag was passed, and on every kit that ran as the value that governed it. See [thresholds](#thresholds) for how each resolves.
+- **`warnings`** carries any advisory as `{ code, message, remedy? }`, absent when none was raised.
 
-Payloads are slim by construction: a field carrying nothing is omitted rather than emitted as `null`, empty `checks` arrays are dropped, durations are whole milliseconds, and `fix` appears only on checks that failed.
+Payloads are slim by construction: a field carrying nothing is omitted rather than emitted as `null`, empty `checks` arrays are dropped, and `fix` appears only on failed checks.
 
-#### Choosing how much detail to receive
+### Detail level
 
-`--detail summary` keeps the counts, verdicts, and worst severity but reduces the detail tree to the checks that failed and the fixes they carry -- the shape an agent needs to decide what to do next, at a fraction of the tokens. `--detail full` is the default and keeps every reported check.
+`--detail summary` keeps counts, verdicts, and worst severity but reduces the detail tree to failed checks and their fixes -- the shape an agent needs, at a fraction of the tokens. `--detail full` is the default.
 
-```bash
-rdy run --json --detail summary
-```
+Both projections are described by `report.v1.json`, and the report's own `detail` field names which one was received. Passing `--detail` without `--json`, or to any command other than `run`, is a usage error.
 
-Both projections are described by `report.v1.json`, so a consumer validates one document either way and reads the report's own `detail` field to learn which projection it received. Passing `--detail` without `--json`, or to any command other than `run`, is a usage error rather than a silently ignored flag.
+## Publishing kits
 
-### Kit sources
+The path from source to a consumer:
 
-The `--from` flag accepts these source types:
+1. Author `.readyup/kits/<name>.ts`.
+2. Run `rdy compile` to bundle it to `<name>.js` and record its hashes in `.readyup/manifest.json`.
+3. Commit both the compiled `.js` and the manifest.
+4. Consumers run `rdy run --from github:org/repo`, which fetches the bundle the manifest describes.
+5. Run `rdy verify` in CI to catch a bundle edited by hand or a source left uncompiled.
 
-| Source     | Format                    | Example                                                 |
-| ---------- | ------------------------- | ------------------------------------------------------- |
-| Bitbucket  | `bitbucket:ws/repo[@ref]` | `--from bitbucket:team/ops`                             |
-| GitHub     | `github:org/repo[@ref]`   | `--from github:acme/ops` or `--from github:acme/ops@v2` |
-| Local repo | `<path>`                  | `--from .` or `--from ../other-repo`                    |
-| Global     | `global`                  | `--from global`                                         |
-| Directory  | `dir:<path>`              | `--from dir:/shared/kits`                               |
-
-`@ref` defaults to `main` when omitted. Local repo paths look for kits in `<path>/.readyup/kits/`, while `dir:` paths are used directly.
-
-### Authentication for remote sources
-
-Private repositories are accessed via tokens resolved from ambient sources:
-
-- **GitHub** (`--from github:`): reads `GITHUB_TOKEN`; falls back to `gh auth token` when the env var is unset.
-- **Bitbucket** (`--from bitbucket:`): reads `BITBUCKET_TOKEN`.
-
-When no token is available, requests go anonymous and only public repositories will succeed.
-
-### List
-
-```
-rdy list                       List internal and compiled kits (owner view)
-rdy list --from <path>         List compiled kits at a local path
-rdy list --from global         List compiled kits in the global directory
-rdy list --from dir:<path>     List kits in an arbitrary directory
-rdy list --from github:org/repo[@ref]      List kits from a GitHub manifest
-rdy list --from bitbucket:ws/repo[@ref]    List kits from a Bitbucket manifest
-rdy list --manifest <path>     List the kits a manifest file declares
-```
-
-Each section names the command that runs the kits beneath it, on its own line so it can be copied without the label:
-
-```
-── Internal
-   rdy run --jit <name>
-
-📄 deploy
-📄 smoke
-
-── Compiled
-   rdy run <name>
-
-📦 deploy
-📦 smoke
-```
-
-`--manifest` reads a manifest instead, reporting each kit's compile-time readyup version and its description:
-
-```
-── Manifest: .readyup/manifest.json
-
-📦 deploy (readyup v0.22.0) · Pre-deployment checks
-📦 smoke (readyup v0.22.0)
-```
-
-A local `--from` source with no manifest beside its kits falls back to listing the compiled kits on disk, which are the same kits `rdy run --from` would resolve. Those rows carry a name and a path only; descriptions, checklist names, and versions live in the manifest that is absent. A remote source still requires one.
-
-Under `--json`, each row reports `name`, `kind` (`internal` for a TypeScript source, `compiled` for a bundle), `path`, and -- for kits a manifest describes -- `checklists`, `description`, and `readyupVersion`. Checklist names are read from the manifest, so listing kits never imports a compiled bundle and never runs kit code.
-
-Rows are keyed by `name` and `kind` together, not by `name` alone. Under the default configuration both the internal source directory and the compile output directory resolve to `.readyup/kits`, so a compiled source appears twice: once as `internal`, which `rdy run --jit <name>` runs, and once as `compiled`, which `rdy run <name>` runs. Both rows are meaningful, so a consumer indexing on `name` alone silently drops one of them.
-
-### Compile
+### Compiling
 
 ```
 rdy compile                    Compile every source in the config's srcDir
 rdy compile <file>             Compile a single file
 ```
 
-A rebuilt kit names its output; one whose bundle is already current says so instead:
+| Option                | Description                                                 |
+| --------------------- | ----------------------------------------------------------- |
+| `--output, -o <path>` | Output file path (single-file mode only)                    |
+| `--manifest <path>`   | Manifest file path (default: `.readyup/manifest.json`)      |
+| `--skip-manifest`     | Do not read or write the manifest                           |
+| `--force`             | Overwrite compiled kits that have drifted from the manifest |
+| `--json`              | Report each kit's status as JSON                            |
 
 ```
 ── Compiling kits in .readyup/kits
@@ -445,33 +659,44 @@ A rebuilt kit names its output; one whose bundle is already current says so inst
 ⚪ smoke.ts · no changes
 ```
 
-A sweep runs to completion: a kit that fails to compile is reported and the next kit is tried, so one broken kit cannot hide the state of the kits that sort after it. A kit that failed is never recorded as though it had compiled, and the run exits 1. A kit that had been compiled before keeps the entry it already had, because that entry still describes the tree: a bundling failure leaves the previous output and its recorded hash untouched, and a validation failure deletes the output, which `rdy verify` then reports as missing. Dropping the entry would hide both, and would leave the next successful compile with no record to check drift against.
+A sweep runs to completion: a kit that fails is reported, the next is tried, and the run exits 1. A failed kit is never recorded as though it had compiled, and one compiled previously keeps its existing manifest entry.
 
-`rdy compile` refuses to overwrite a compiled kit whose on-disk hash differs from the manifest's recorded `targetHash`; someone edited the compiled file directly. Drifted kits are reported and skipped, with the mismatch beneath the kit that carries it:
+`rdy compile` refuses to overwrite a compiled kit whose on-disk hash differs from the manifest's recorded `targetHash` -- someone edited the bundle directly:
 
 ```
-── Compiling kits in .readyup/kits
-
 🟠 deploy.ts
    drift in deploy.js: expected 6f58905a, got eb104f57
-⚪ smoke.ts · no changes
 
 1 of 2 kits skipped due to drift. Re-run with --force to overwrite, or move edits into the source.
 ```
 
-`--force` overwrites them anyway.
-
-Each kit's checklist names are recorded in the manifest so `rdy list` can report them without running the kit. The field is optional and absent from manifests written by earlier versions, so the manifest format stays at version 1.
-
 Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `failed`), and the reason it was skipped or failed.
 
-### Verify
+### Internal kits
+
+Internal kits are TypeScript sources a repo runs on itself rather than publishing. Two config keys locate them:
+
+| Key              | Default | Meaning                                                       |
+| ---------------- | ------- | ------------------------------------------------------------- |
+| `internal.dir`   | `.`     | Directory holding internal sources, relative to the kits root |
+| `internal.infix` | none    | Filename segment marking a file as internal                   |
+
+An **infix** is a segment between the kit name and the extension. With `infix: 'internal'`, the kit `deploy` lives at `deploy.internal.ts`; with no infix configured -- the default -- it is simply `deploy.ts`.
+
+```ts
+export default defineRdyConfig({
+  internal: { dir: 'internal', infix: 'internal' },
+});
+```
+
+`rdy run --internal <name>` resolves through these settings, and `rdy list` buckets sources under **Internal** and bundles under **Compiled**.
+
+### Verifying
 
 ```
 rdy verify                     Check compiled kits against the manifest's hashes
+rdy verify --manifest <path>   Use a manifest other than .readyup/manifest.json
 ```
-
-A verified kit carries nothing beyond its token; a failing one carries each verdict on the line beneath it:
 
 ```
 ── Verifying kits against .readyup/manifest.json
@@ -483,202 +708,72 @@ A verified kit carries nothing beyond its token; a failing one carries each verd
 1 of 2 kits failed verification.
 ```
 
-Each kit carries two independent verdicts, because a kit is two artifacts: the TypeScript source and the bundle compiled from it.
+Each kit carries two independent verdicts, because a kit is two artifacts. The compiled output is `ok`, `drift`, `missing`, or `unverified`; the source is `ok`, `stale`, `missing`, or `unverified`. `drift` means someone edited the bundle by hand; `stale` means the source moved on and nobody recompiled. A kit can be both at once.
 
-The compiled output is reported as `ok`, `drift`, `missing`, or `unverified`. The source is reported as `ok`, `stale`, `missing`, or `unverified`. Both axes are checked for every kit, and a kit can be stale at the source and drifted at the target at once: `drift` means someone edited the bundle by hand, while `stale` means the source moved on and nobody recompiled.
+Anything other than `ok` or `unverified` on either axis fails the run. `unverified` does not, since an entry with no recorded hash says nothing about whether the kit changed.
 
-Anything other than `ok` or `unverified` on either axis fails the run. `unverified` does not, since a manifest entry with no recorded hash says nothing about whether the kit has changed; a manifest written before source hashes existed reports `unverified` for the source and still passes.
+Under `--json`, each kit reports `status` and `sourceStatus`. A `drift` verdict carries `expected` and `actual`; a `stale` verdict carries `sourceExpected` and `sourceActual`.
 
-Under `--json`, each kit reports `status` for the compiled output and `sourceStatus` for the source. A `drift` verdict carries `expected` and `actual`; a `stale` verdict carries `sourceExpected` and `sourceActual`. `sourceStatus` is optional in the published schema, so a consumer pinned to `verify.v1.json` still validates payloads from an earlier readyup.
+In CI:
 
-### The staleness model
-
-Editing a kit's `.ts` without recompiling leaves `rdy run` executing the bundle it was compiled from, which is no longer what the source says. The two commands treat that differently on purpose:
-
-- **`rdy verify` enforces.** A stale source fails the run and exits 1. This is the gate to put in CI.
-- **`rdy run` advises.** It emits a warning and runs anyway, leaving the exit code alone. A verification tool that refused to run because its own bookkeeping was out of date would be worse than one that ran and said so.
-
-## Authoring API
-
-All helpers are type-safe identity functions that provide editor autocomplete without runtime overhead. Import them from `readyup`.
-
-| Helper                     | Description                          |
-| -------------------------- | ------------------------------------ |
-| `defineRdyConfig`          | Repo-level config                    |
-| `defineRdyKit`             | Kit (collection of checklists)       |
-| `defineRdyChecklist`       | Flat checklist                       |
-| `defineRdyStagedChecklist` | Staged checklist (sequential groups) |
-| `defineChecklists`         | Array of checklists                  |
-
-### The `detail` contract
-
-A check may return a `CheckOutcome` rather than a bare boolean, carrying a `detail` string and optional `progress`. One rule governs what belongs in `detail`:
-
-> **`detail` answers "why this status".**
-
-Not "what this check asserts" -- the check's `name` already says that, and repeating it in `detail` doubles the line's width without adding a fact. On a pass, `detail` reports the evidence. On a skip, it reports why the check did not apply. On a failure, it reports what went wrong, and it is the text that renders beneath the claim.
-
-Where the detail lands follows from the status, so an author writes one field and the report places it:
-
-| Status  | Where `detail` renders                                  |
-| ------- | ------------------------------------------------------- |
-| passed  | inline, after the separator                             |
-| skipped | inline, after the separator (return it from `skip`)     |
-| failed  | in a block beneath the claim, above any thrown `Error:` |
-
-Remediation is not detail. It belongs in `fix`, which is recapped at the end of the report against the check that raised it.
-
-This kit exercises all three placements at three levels of nesting:
-
-```ts
-import { defineRdyKit } from 'readyup';
-
-export default defineRdyKit({
-  checklists: [
-    {
-      name: 'release',
-      checks: [
-        {
-          name: 'working tree is clean',
-          check: () => ({ ok: true, detail: 'no uncommitted changes' }),
-        },
-        {
-          name: 'dependencies',
-          check: () => true,
-          checks: [
-            {
-              name: 'lockfile is current',
-              check: () => ({ ok: true, progress: { type: 'fraction', passedCount: 4, count: 4 } }),
-              checks: [
-                {
-                  name: 'no duplicated majors',
-                  check: () => ({ ok: false, detail: 'react resolves to both 18.3.1 and 19.0.0' }),
-                  fix: 'Run `pnpm dedupe`, then commit the lockfile',
-                },
-              ],
-            },
-            {
-              name: 'native modules rebuilt',
-              check: () => true,
-              skip: () => 'no native dependencies in this workspace',
-            },
-          ],
-        },
-      ],
-    },
-  ],
-});
+```yaml
+- run: npx rdy verify
 ```
 
-It produces:
-
-```
-🟢 working tree is clean · no uncommitted changes
-🟢 dependencies
-   🟢 lockfile is current [4 of 4]
-      🔴 no duplicated majors
-         react resolves to both 18.3.1 and 19.0.0
-   ⚪ native modules rebuilt · no native dependencies in this workspace
-
-🔴 3 passed | 1 error | 1 skipped (0ms)
-
-── Fixes
-
-💊 no duplicated majors
-   Run `pnpm dedupe`, then commit the lockfile
-```
-
-Four things to read off that output:
-
-- **`dependencies` passed, which is why anything beneath it ran at all.** A check that fails blocks its descendants, so they report 🚫 without running. The 🔴 on `no duplicated majors` is reachable only because both checks above it passed, and a failing descendant is what turns the tail line red while every ancestor stays green.
-- **`no duplicated majors` sits at the third level, and its reason lines up under its own name** -- one indent step per level, so a reason is never mistaken for a check.
-- **No check line carries a duration.** Every check here returns immediately, and durations appear only from 100 ms up, so a fast report is not littered with `(0ms)`. The tail line shows the run's total regardless.
-- **`progress` needs no `detail`.** `[4 of 4]` is the evidence; a detail restating it would spend the line's one separator to say the same thing twice.
-
-### Preconditions
-
-A checklist's `preconditions` gate the checks that follow it. If any precondition fails, every check in the checklist is skipped, and each skipped result records `precondition` as its reason.
-
-Two rules govern the gate:
-
-- **A failed precondition gates regardless of its severity.** A precondition declared `recommend` gates exactly as one declared `error` does. Severity decides whether the run _fails_; the gate decides whether the checks are worth _running_, and those are separate questions. A `recommend` precondition that fails under the default `--fail-on error` therefore skips the whole checklist and still exits 0.
-- **A precondition skipped `n/a` does not gate.** "The gate does not apply" is not "the gate failed", so the checklist runs in full. To make a whole checklist inapplicable instead, nest its checks under a single parent check whose `skip` returns a reason: an `n/a` skip terminates its own subtree, and nothing beneath it produces a result.
-
-Precondition results and the checks they skip follow the same reporting threshold as everything else: a result appears in the output only when its own severity is at or above `--report-on`.
-
-### Kit validation
-
-The authoring helpers are type-level only, and neither `rdy compile` nor `rdy run --jit` type-checks the kit it loads, so both commands validate the kit's structure at load time. Validation is the same in both, which means `rdy compile` refuses to publish a kit that `rdy run` would reject.
-
-Every check is validated wherever it appears: in a checklist's `checks`, in a staged checklist's `groups`, in its `preconditions`, and in the `checks` nested under another check. A check must carry a non-empty `name` and a `check` function; `severity` must be one of `error`, `warn`, or `recommend`; `skip` must be a function and `fix` a string when present. Unknown extra keys are allowed, so a kit written for a later readyup still loads.
-
-A typo'd `severity` is the mistake this catches that matters most: before validation reached individual checks, an unrecognized value silently excluded the check from both the failure and the reporting thresholds, and the run passed.
-
-Failures name the kit and the location of each offending value:
-
-```
-Invalid kit at .readyup/kits/default.js:
-  checklists[0].checks[1].severity: expected one of "error", "warn", "recommend", got "info"
-  checklists[0].checks[2].check: expected a function, got string
-```
+`rdy verify` enforces where `rdy run` advises: a stale source fails verification and exits 1, while a run emits a warning and proceeds. A verification tool that refused to run because its own bookkeeping was out of date would be worse than one that ran and said so.
 
 ## Check utilities
 
 Reusable check functions for common assertions:
 
 ```ts
-import { fileExists, fileContains, hasPackageJsonField } from 'readyup/check-utils';
+import { fileExists, hasPackageJsonField } from 'readyup/check-utils';
 ```
 
-| Function                                    | Description                                                             |
-| ------------------------------------------- | ----------------------------------------------------------------------- |
-| `fileExists(path)`                          | File exists at path                                                     |
-| `fileContains(path, pattern)`               | File matches a string or regex                                          |
-| `fileDoesNotContain(path, pattern)`         | File does not match                                                     |
-| `readFile(path)`                            | Read file contents (returns `undefined` if missing)                     |
-| `hasPackageJsonField(field, value?)`        | package.json has a field (optionally matching a value)                  |
-| `hasDevDependency(name)`                    | package.json has a dev dependency                                       |
-| `hasMinDevDependencyVersion(name, version)` | Dev dependency meets minimum version                                    |
-| `readPackageJson()`                         | Parse package.json                                                      |
-| `discoverWorkspaces(options?)`              | Enumerate monorepo workspaces (single-workspace repos return one entry) |
-| `compareVersions(a, b)`                     | Compare semver strings                                                  |
-| `readTsconfigLanguageLevel(path)`           | Effective `lib` and `target` of a tsconfig, resolved through `extends`  |
-| `readEnginesNodeFloor(manifest)`            | Minimum Node version a parsed manifest declares in `engines.node`       |
-| `satisfiesNodeFloor(version, floor)`        | Runtime is at or above a floor (`undefined` if either is uncomparable)  |
-| `readToolVersionsNode(path?)`               | Node version declared in `.tool-versions`                               |
-| `esYearForNodeMajor(major)`                 | ECMAScript year a Node major supports (`24` → `es2025`)                 |
-| `runGit(path, ...args)`                     | Run a git command and return trimmed stdout                             |
-| `expandHome(path)`                          | Expand leading `~` or `~/` to the home directory                        |
-| `isAtRepoRoot(path)`                        | Path is the top of a git working tree                                   |
-| `isGitRepo(path)`                           | Path is inside a git working tree                                       |
-| `compareLocalRefs(path, refA, refB)`        | Compare two local refs (discriminated-union result)                     |
-| `compareRefToRemote(path, ref, remote?)`    | Compare a local ref to its remote counterpart                           |
-| `makeLocalRefSyncCheck(options)`            | Check factory: verify two local refs match                              |
-| `makeRemoteRefSyncCheck(options)`           | Check factory: verify a ref matches its remote counterpart              |
+### Filesystem
 
-### Discovering workspaces
+| Function                            | Returns                             |
+| ----------------------------------- | ----------------------------------- |
+| `fileExists(path)`                  | File exists                         |
+| `filesExist(paths, options?)`       | `CheckOutcome` over several paths   |
+| `readFile(path)`                    | Contents, or `undefined` if missing |
+| `fileContains(path, pattern)`       | File matches a `RegExp`             |
+| `fileDoesNotContain(path, pattern)` | File does not match a `RegExp`      |
+| `commandExists(name)`               | Command is on `PATH`                |
 
-`discoverWorkspaces()` returns a uniform `Workspace[]` that collapses pnpm, npm, and yarn monorepo conventions -- and single-workspace repos -- into one iteration shape. Every entry includes `dir` (relative to `cwd`; `'.'` for a single-workspace repo), `absolutePath`, `name`, `isPackage` (true when `package.json.private !== true`), and the parsed `packageJson`.
+### JSON
 
-Common filter pattern -- get all publishable workspaces:
+| Function                            | Returns                                   |
+| ----------------------------------- | ----------------------------------------- |
+| `readJsonFile(path)`                | Parsed object, or `undefined`             |
+| `readJsonValue(path, ...keys)`      | Value at a key path within a file         |
+| `hasJsonField(path, field, value?)` | Field exists, optionally matching a value |
+| `hasJsonFields(path, fields)`       | `CheckOutcome` over several fields        |
+| `getJsonValue(obj, ...keys)`        | Value at a key path within an object      |
+| `hasJsonValue(obj, ...keys)`        | Key path is present                       |
+| `isRecord(value)`                   | Type guard for `Record<string, unknown>`  |
 
-```ts
-import { discoverWorkspaces } from 'readyup/check-utils';
+### Package manifests
 
-const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
-```
+| Function                                    | Returns                                   |
+| ------------------------------------------- | ----------------------------------------- |
+| `readPackageJson()`                         | Parsed `package.json`                     |
+| `hasPackageJsonField(field, value?)`        | Field exists, optionally matching a value |
+| `hasDevDependency(name)`                    | Dev dependency is declared                |
+| `hasMinDevDependencyVersion(name, version)` | Dev dependency meets a minimum            |
 
-Note: `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs using YAML anchors, flow sequences, negation patterns, or other non-trivial features will raise a clear error with a pointer to file an issue.
+### Versions and runtime alignment
 
-### Reading runtime alignment
+| Function                             | Returns                                                                                  |
+| ------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `compareVersions(a, b)`              | Comparison of two semver strings                                                         |
+| `readEnginesNodeFloor(manifest)`     | `{ kind: 'found', floor, raw }`, `{ kind: 'absent' }`, or `{ kind: 'unparseable', raw }` |
+| `satisfiesNodeFloor(version, floor)` | Whether a runtime meets a floor; `undefined` if either is uncomparable                   |
+| `readToolVersionsNode(path?)`        | Node version declared in `.tool-versions`                                                |
+| `esYearForNodeMajor(major)`          | ECMAScript year a Node major supports (`24` → `es2025`)                                  |
+| `readTsconfigLanguageLevel(path)`    | Effective `lib` and `target`, resolved through `extends`                                 |
 
-`readTsconfigLanguageLevel(path)` reports what language level a tsconfig actually declares, which may be several `extends` hops away. Alongside `lib` and `target` -- lowercased, so comparisons are string equality -- it returns `chain`, the configs it read with the entry file first, and `unresolvedExtends`, the references it could not follow. Bare package specifiers such as `@tsconfig/node24/tsconfig.json` are never followed, and a missing or unparseable parent ends that branch of the walk; both land in `unresolvedExtends`, so a check can tell an incomplete answer from a genuinely undeclared setting. A missing or unparseable entry file returns `undefined`. Configs are read as JSONC, so comments and trailing commas are fine.
-
-`readEnginesNodeFloor(manifest)` recognizes only the range forms from which a single floor follows: `>=24`, `^22.1`, and a bare `24.1.0`. Anything else -- a union such as `^20 || ^22`, a hyphen range, a wildcard -- comes back as `{ kind: 'unparseable' }` rather than an invented floor. It takes an already-parsed manifest, so it composes with `discoverWorkspaces` without re-reading files.
-
-`satisfiesNodeFloor(version, floor)` compares two dotted numeric versions and returns `undefined` for anything else. That matters because `readToolVersionsNode` reports whatever the file names, and `lts`, `latest`, `system`, and `ref:<git ref>` are all valid pins: without the `undefined`, an unreadable pin would be indistinguishable from a runtime that genuinely sits below the floor.
-
-Each reader answers only what it can see, so a check composing them decides for itself what each unknown means. Collapsing them into a single boolean is what lets real drift pass unreported:
+Each reader answers only what it can see, so a check composing them decides for itself what each unknown means. `readEnginesNodeFloor` recognizes only forms from which a single floor follows (`>=24`, `^22.1`, `24.1.0`); a union or wildcard comes back `unparseable` rather than an invented floor. `readTsconfigLanguageLevel` also returns `chain` (the configs it read) and `unresolvedExtends` (references it could not follow), so a check can tell an incomplete answer from an undeclared setting.
 
 ```ts
 import {
@@ -701,11 +796,41 @@ const findings = discoverWorkspaces().flatMap(({ dir, packageJson }) => {
 });
 ```
 
+### Git
+
+| Function                                 | Returns                                           |
+| ---------------------------------------- | ------------------------------------------------- |
+| `runGit(path, ...args)`                  | Trimmed stdout of a git command                   |
+| `isGitRepo(path)`                        | Path is inside a git working tree                 |
+| `isAtRepoRoot(path)`                     | Path is the top of a working tree                 |
+| `expandHome(path)`                       | Leading `~` expanded to the home directory        |
+| `compareLocalRefs(path, refA, refB)`     | Discriminated union comparing two local refs      |
+| `compareRefToRemote(path, ref, remote?)` | Discriminated union comparing a ref to its remote |
+| `makeLocalRefSyncCheck(options)`         | An `RdyCheck` verifying two local refs match      |
+| `makeRemoteRefSyncCheck(options)`        | An `RdyCheck` verifying a ref matches its remote  |
+
+### Hashing
+
+| Function                          | Returns                          |
+| --------------------------------- | -------------------------------- |
+| `computeHash(content)`            | Hash of a string                 |
+| `fileMatchesHash(path, expected)` | File's hash matches the expected |
+
+### Workspaces
+
+`discoverWorkspaces()` returns a uniform `Workspace[]` collapsing pnpm, npm, and yarn monorepo conventions -- and single-workspace repos -- into one iteration shape. Each entry carries `dir` (relative to `cwd`; `'.'` for a single-workspace repo), `absolutePath`, `name`, `isPackage` (`package.json.private !== true`), and the parsed `packageJson`.
+
+```ts
+const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
+```
+
+`pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs using YAML anchors, flow sequences, or negation patterns raise a clear error.
+
 ## Compatibility
 
-`readyup/check-utils` is the stable, versioned surface for kit-author imports of check utilities. It follows semver: no breaking changes within a major version.
+`readyup/check-utils` is the stable, versioned surface for kit-author imports. It follows semver: no breaking changes within a major version.
 
-Compiled kits embed nothing of readyup itself -- the runner satisfies `readyup` and `readyup/*` imports at runtime via its module-resolution hook. Kits are therefore version-coupled to the runner across breaking boundaries: when you upgrade readyup across a major, recompile your kits with `rdy compile` so any newly-shipped or changed check utilities are picked up.
+Compiled kits embed nothing of readyup itself -- the runner satisfies `readyup` and `readyup/*` imports at runtime via its module-resolution hook. Kits are therefore version-coupled to the runner across breaking boundaries: when upgrading across a major, recompile with `rdy compile`.
 
 ## License
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -15,6 +15,7 @@ Run pre-deployment verification checks against your environment and configuratio
 - [Publishing kits](#publishing-kits)
 - [Check utilities](#check-utilities)
 - [Compatibility](#compatibility)
+- [License](#license)
 
 ## Installation
 
@@ -103,7 +104,7 @@ kit
 
 ### Severities
 
-Every check carries a severity. It decides whether a failure fails the run and whether the result is reported -- not whether the check runs.
+Every check carries a severity. It decides whether a failure fails the run and whether the result is reported, and it never decides whether that check itself runs. It reaches later work in one place only: a failed check at or above the failure threshold stops the remaining groups of a [staged checklist](#staged-checklists).
 
 | Severity    | Meaning           |
 | ----------- | ----------------- |
@@ -179,26 +180,26 @@ See [internal kits](#internal-kits) for what the `internal` keys select.
 
 ### Checklists
 
-| Field           | Type                | Meaning                                     |
-| --------------- | ------------------- | ------------------------------------------- |
-| `name`          | `string`            | Display name                                |
-| `checks`        | `RdyCheck[]`        | Checks, run concurrently (flat checklist)   |
-| `groups`        | `RdyCheck[][]`      | Groups, run sequentially (staged checklist) |
-| `preconditions` | `RdyCheck[]`        | Gating checks                               |
-| `fixLocation`   | `'inline' \| 'end'` | Overrides the kit's setting                 |
+| Field           | Type                | Default            | Meaning                                     |
+| --------------- | ------------------- | ------------------ | ------------------------------------------- |
+| `name`          | `string`            | required           | Display name                                |
+| `checks`        | `RdyCheck[]`        | required if flat   | Checks, run concurrently (flat checklist)   |
+| `groups`        | `RdyCheck[][]`      | required if staged | Groups, run sequentially (staged checklist) |
+| `preconditions` | `RdyCheck[]`        | --                 | Gating checks                               |
+| `fixLocation`   | `'inline' \| 'end'` | the kit's setting  | Overrides the kit's setting                 |
 
 A checklist carries either `checks` or `groups`, never both.
 
 ### Checks
 
-| Field      | Type                            | Meaning                                    |
-| ---------- | ------------------------------- | ------------------------------------------ |
-| `name`     | `string`                        | The claim being asserted                   |
-| `check`    | `() => boolean \| CheckOutcome` | The assertion; may be async                |
-| `severity` | `Severity`                      | Overrides the kit's `defaultSeverity`      |
-| `skip`     | `() => false \| string`         | Reason string to skip; `false` to run      |
-| `fix`      | `string`                        | Remediation, shown when the check fails    |
-| `checks`   | `RdyCheck[]`                    | Nested checks, run only if this one passes |
+| Field      | Type                            | Default                     | Meaning                                    |
+| ---------- | ------------------------------- | --------------------------- | ------------------------------------------ |
+| `name`     | `string`                        | required                    | The claim being asserted                   |
+| `check`    | `() => boolean \| CheckOutcome` | required                    | The assertion; may be async                |
+| `severity` | `Severity`                      | the kit's `defaultSeverity` | Overrides the kit's `defaultSeverity`      |
+| `skip`     | `() => false \| string`         | --                          | Reason string to skip; `false` to run      |
+| `fix`      | `string`                        | --                          | Remediation, shown when the check fails    |
+| `checks`   | `RdyCheck[]`                    | --                          | Nested checks, run only if this one passes |
 
 A check returns a boolean or a `CheckOutcome`:
 
@@ -312,13 +313,15 @@ export default defineRdyStagedChecklist({
 });
 ```
 
-A failure in a group stops the groups after it. Only top-level results gate: a failing _nested_ check does not halt the next group.
+A failure at or above the [failure threshold](#thresholds) stops the groups after it; a below-threshold failure is reported and the next group still runs. Only top-level results gate: a failing _nested_ check does not halt the next group.
+
+This is the one gate that consults the threshold. A failed check blocks its own descendants, and a failed precondition gates its checklist, whatever the severity.
 
 ### Preconditions
 
 A checklist's `preconditions` gate the checks that follow. If any precondition fails, every check is skipped and each records `precondition` as its reason.
 
-- **A failed precondition gates regardless of severity.** Severity decides whether the run fails; the gate decides whether the checks are worth running.
+- **A failed precondition gates regardless of severity.** Severity decides whether the run fails; the gate decides whether the checks are worth running. Unlike a staged checklist's groups, the gate does not consult the [failure threshold](#thresholds).
 - **A precondition skipped `n/a` does not gate.** To make a whole checklist inapplicable, nest its checks under one parent check whose `skip` returns a reason.
 
 ### Suites

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -37,7 +37,8 @@ vi.mock('../src/version.ts', () => ({
   VERSION: '1.2.3',
 }));
 
-import { routeCommand } from '../src/bin/route.ts';
+import packageJson from '../package.json' with { type: 'json' };
+import { DOCS_POINTER, routeCommand } from '../src/bin/route.ts';
 import { usageError } from '../src/errors.ts';
 
 /** Scratch project root for the tests that need a kit file on disk. */
@@ -159,7 +160,21 @@ describe(routeCommand, () => {
     await routeCommand(args);
 
     const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(output).toContain('Full documentation: https://github.com/williamthorsen/workshop');
+    expect(output).toContain(DOCS_POINTER);
+  });
+
+  it('points at the documented package homepage', () => {
+    expect(DOCS_POINTER.endsWith(packageJson.homepage)).toBe(true);
+  });
+
+  it.each([
+    { label: 'exit codes', text: 'Exit codes:' },
+    { label: 'schema evolution', text: 'schemaVersion' },
+  ])('leaves $label to the documentation rather than top-level help', async ({ text }) => {
+    await routeCommand(['--help']);
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).not.toContain(text);
   });
 
   it.each([

--- a/packages/readyup/__tests__/route.test.ts
+++ b/packages/readyup/__tests__/route.test.ts
@@ -151,6 +151,20 @@ describe(routeCommand, () => {
   it.each([
     { label: 'top-level', args: ['--help'] },
     { label: 'run', args: ['run', '--help'] },
+    { label: 'compile', args: ['compile', '--help'] },
+    { label: 'init', args: ['init', '--help'] },
+    { label: 'list', args: ['list', '--help'] },
+    { label: 'verify', args: ['verify', '--help'] },
+  ])('points at the documentation from $label help', async ({ args }) => {
+    await routeCommand(args);
+
+    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('Full documentation: https://github.com/williamthorsen/workshop');
+  });
+
+  it.each([
+    { label: 'top-level', args: ['--help'] },
+    { label: 'run', args: ['run', '--help'] },
     { label: 'list', args: ['list', '--help'] },
   ])('shows examples in $label help', async ({ args }) => {
     await routeCommand(args);

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -33,6 +33,14 @@ const KIT_EXTENSIONS = ['.js', '.ts'];
 /** Flags naming where a kit comes from, each of which resolves it somewhere the local probe cannot see. */
 const SOURCE_FLAGS = new Set(['--file', '-f', '--from', '--internal', '--url']);
 
+/**
+ * Where help output sends a reader for anything it does not cover.
+ *
+ * Help lists the surface; the README explains it. A repository URL rather than a relative path, so the pointer
+ * resolves from a global install as readily as from a local one.
+ */
+const DOCS_POINTER = 'Full documentation: https://github.com/williamthorsen/workshop/tree/main/packages/readyup#readme';
+
 const HELP = `
 Usage: rdy [kit[:checklist,...] ...] [options]
        rdy <command> [options]
@@ -75,33 +83,7 @@ Examples:
   rdy compile                                      Compile every kit source into a bundle
   rdy list --from github:williamthorsen/workshop   List kits published by a repository
 
-Exit codes:
-  0  Ran and found no problems
-  1  Ran and found problems with the repo or its kits
-  2  Could not complete the invocation (usage, config, kit-load, or internal error)
-
-  list and init use only 0 and 2; neither can find problems to report.
-
-run, compile, list, and verify accept --json; init does not, since scaffolding is
-interactive. With --json, stdout carries exactly one JSON document and all prose goes to
-stderr. For run that document is the report when a run produced one, otherwise the error
-envelope {"schemaVersion", "error": {"code", "message"}}. --help and --version have no
-JSON form: their text goes to stderr and stdout stays empty.
-
-Every payload carries an integer schemaVersion and is specified by a JSON Schema shipped
-with the package, importable as readyup/schemas/<name>.v1.json. Adding an optional field
-does not bump a payload's schemaVersion; removing, renaming, or re-typing one does.
-Warning codes are an open set, so a new advisory never bumps the version and a consumer
-must tolerate a code it does not recognize.
-
-In the report, failOn and reportOn appear at the top level only when the matching flag was
-given, naming what the invocation requested. Each kit that ran carries the thresholds that
-governed it, so a kit declaring its own is readable from its entry rather than inferred.
-
-A kit that fails once the run has reached its kits does not discard the kits that ran.
-Under --json it becomes a kits entry carrying "error" in place of results; otherwise it
-is reported on stderr, prefixed with the kit's name when more than one kit was
-requested. Either way the run continues and exits 2.
+${DOCS_POINTER}
 `;
 
 const RUN_HELP = `
@@ -125,17 +107,10 @@ Options:
   --checklists, -c <name,...>        Filter checklists within the selected kit; requires a
                                      single kit and no ":" filter on it
   --json                             Output results as JSON
-  --detail <summary|full>            How much of the JSON report to emit (default: full); requires --json.
-                                     "summary" drops the detail tree to the failed checks and their fixes,
-                                     keeping counts, verdicts, and worst severity intact
+  --detail <summary|full>            How much of the JSON report to emit (default: full); requires --json
   --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
-  --quiet                            Hide passed checks from the report, keeping failures, skips, the
-                                     fix recap, and every count line. Human output only, so it cannot
-                                     be combined with --json; counts and the exit code still cover the
-                                     whole run
-  --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
-                                     plus the parent checks of anything shown; summary counts always
-                                     cover the whole run
+  --quiet                            Hide passed checks from the report; incompatible with --json
+  --report-on <severity>             Show this severity or above (error, warn, recommend)
   --style <auto|plain|rich>          Output style (default: auto)
   --help, -h                         Show this help message
 
@@ -154,6 +129,8 @@ Examples:
   rdy run --fail-on warn                 Fail the run on warnings as well as errors
   rdy run --quiet                        Report only what is not passing
   rdy run --json --detail summary        Emit a JSON report carrying only failed checks
+
+${DOCS_POINTER}
 `;
 
 const COMPILE_HELP = `
@@ -175,20 +152,7 @@ Options:
   --style <auto|plain|rich>  Output style (default: auto)
   --help, -h                 Show this help message
 
-Drift detection:
-  rdy compile refuses to overwrite a compiled kit whose on-disk hash differs from the
-  manifest's recorded targetHash (e.g. someone edited the compiled file directly).
-  Drifted kits are reported and skipped; use --force to overwrite anyway.
-
-A sweep runs to completion: a kit that fails to compile is reported and the next kit is
-tried, so every kit's status is known after one run. A kit that failed is never recorded as
-though it had compiled, and one that had compiled before keeps the entry it already had.
-
-Each kit's checklist names are recorded in the manifest so rdy list can report them
-without running the kit. The field is optional, so the manifest format stays at version 1.
-
-Exits 1 when a kit fails to compile or is skipped as drifted, and 2 when the config or
-manifest cannot be read or written.
+${DOCS_POINTER}
 `;
 
 const VERIFY_HELP = `
@@ -196,22 +160,13 @@ Usage: rdy verify [options]
 
 Check compiled kits against the hashes recorded in the manifest.
 
-Each kit is reported as one of:
-  ok          on-disk hash matches the manifest's targetHash
-  drift       on-disk hash differs from the manifest's targetHash
-  missing     compiled file is absent
-  unverified  manifest entry has no targetHash (predates the feature)
-
-A failing kit carries its name alone, with each verdict on the line beneath it.
-
-Exits 1 when any kit is in drift or missing; unverified kits do not fail. An unreadable
-manifest exits 2.
-
 Options:
   --manifest <path>          Manifest file path (default: .readyup/manifest.json)
   --json                     Report each kit's verification status as JSON
   --style <auto|plain|rich>  Output style (default: auto)
   --help, -h                 Show this help message
+
+${DOCS_POINTER}
 `;
 
 const LIST_HELP = `
@@ -234,17 +189,14 @@ Options:
   --style <auto|plain|rich>  Output style (default: auto)
   --help, -h                 Show this help message
 
-A local --from source with no manifest beside its kits falls back to listing the compiled
-kits on disk, which are the same kits rdy run --from would resolve. Those rows carry only
-a name and a path; descriptions, checklist names, and versions live in the absent manifest.
-A remote source still requires a manifest.
-
 Examples:
   rdy list                                         Show kits in the current project
   rdy list --from .                                Show compiled kits in the current directory
   rdy list --from global                           Show kits in the global directory
   rdy list --from github:williamthorsen/workshop   Show kits in a remote GitHub repository
   rdy list --from bitbucket:tutorials/markdowndemo@master Show kits in a remote Bitbucket repository
+
+${DOCS_POINTER}
 `;
 
 const INIT_HELP = `
@@ -257,6 +209,8 @@ Options:
   --force                    Overwrite existing files
   --style <auto|plain|rich>  Output style (default: auto)
   --help, -h                 Show this help message
+
+${DOCS_POINTER}
 `;
 
 /**

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -39,7 +39,8 @@ const SOURCE_FLAGS = new Set(['--file', '-f', '--from', '--internal', '--url']);
  * Help lists the surface; the README explains it. A repository URL rather than a relative path, so the pointer
  * resolves from a global install as readily as from a local one.
  */
-const DOCS_POINTER = 'Full documentation: https://github.com/williamthorsen/workshop/tree/main/packages/readyup#readme';
+export const DOCS_POINTER =
+  'Full documentation: https://github.com/williamthorsen/workshop/tree/main/packages/readyup#readme';
 
 const HELP = `
 Usage: rdy [kit[:checklist,...] ...] [options]
@@ -63,9 +64,7 @@ Run options:
   --detail <summary|full>            How much of the JSON report to emit (default: full); requires --json
   --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
   --quiet                            Hide passed checks from the report; incompatible with --json
-  --report-on <severity>             Show this severity or above in the detail tree (error, warn, recommend),
-                                     plus the parent checks of anything shown; summary counts always
-                                     cover the whole run
+  --report-on <severity>             Show this severity or above (error, warn, recommend)
 
 Global options:
   --style <auto|plain|rich>  Output style: emoji, ASCII words, or detected (default: auto)


### PR DESCRIPTION
## What

Adds comprehensive documentation to ReadyUp's README, covering every command, flag, and authoring field. The `--help` output has been trimmed to concise help on command options and points the reader to the README for details.

## Why

The README documented a fraction of ReadyUp's surface, over-explained the fraction it covered, and `--help` restated it at length -- so an author reaching for `suites`, staged checklists, internal kits, or half the flag set found nothing, while a reader who wanted one fact read several paragraphs of design rationale to reach it. Nothing told an author how to name a check either, which is why `🔴 Node >= 24` could not say whether the run wanted Node 24 and lacked it or had it and was in violation. Agents are the expected kit authors, and both problems cost them disproportionately: absent reference sends them guessing, and verbose reference costs tokens on every read.

## Details

### 🧪 Tests

- Each of the five help screens is asserted to carry the documentation pointer, and the pointer is asserted to match the package's declared homepage, so renaming the repository or moving the package cannot leave help pointing at a dead link while tests stay green.
- Negative assertions hold the trim in place: top-level help is asserted not to mention exit codes or `schemaVersion`, which is what keeps the removed prose from creeping back.

### 📚 Documentation

- The README is rewritten in lifecycle order -- concepts, authoring, running, JSON output, publishing, utilities, compatibility -- with a table of contents. Reference lives in tables, each fact is stated once and cross-linked, and design rationale moved to code comments.
- A concepts section owns the shared vocabulary every later section defers to: the kit/checklist/check hierarchy, the three severities, the six status tokens with both their emoji and ASCII renderings, and how the failure and reporting thresholds resolve.
- Field references cover `RdyConfig`, `RdyKit`, both checklist forms, `RdyCheck`, and `CheckOutcome`, each with its default and whether it is required.
- The staged-checklist halt rule is stated with its condition: only a top-level failure at or above the failure threshold stops later groups, so under the default `failOn: error` a `warn` failure is reported and the next group still runs. This is the one gate that consults the threshold -- a failed check blocks its own descendants and a failed precondition gates its checklist whatever the severity.
- Newly documented: staged checklists, suites, preconditions, internal kits with "infix" defined, the publishing path from kit source to a consumer's `--from`, exit codes, the positional `kit:checklist,...` syntax, and the flags `compile --output`, `compile --manifest`, `compile --skip-manifest`, `verify --manifest`, `init --dry-run`, and `init --force`.
- The naming contract joins the existing detail contract as one three-part rule: `name` states what must be true, `detail` answers why this status, `fix` says what to do. Every example check name in the document conforms to it.
- Help output loses the exit-code table, the JSON schema-evolution paragraphs, compile's drift and sweep prose, list's manifest-fallback paragraph, and verify's status legend, keeping usage, options, examples, and one pointer to the README. Every option row survives.

Closes #123
