### PR TITLE
#116 Retire three lint rules that are not worth enforcing

### DIFF
--- a/.config/eslint/deferred-lint-rules.ts
+++ b/.config/eslint/deferred-lint-rules.ts
@@ -1,7 +1,6 @@
-// `@williamthorsen/eslint-config-typescript` v6 added new unicorn rules, surfacing new violations in existing code.
-// Errors are downgraded to warnings here until a decision is made whether to remove the rule or fix the violations.
+// `@williamthorsen/eslint-config-typescript` added unicorn rules that surface violations in existing code.
+// Errors are downgraded to warnings here until the violations are fixed; #152 and #153 clear the remainder.
 export const deferredLintRules = {
-  'unicorn/max-nested-calls': 'warn',
   'unicorn/no-computed-property-existence-check': 'warn',
   'unicorn/no-declarations-before-early-exit': 'warn',
   'unicorn/no-duplicate-if-branches': 'warn',
@@ -11,7 +10,5 @@ export const deferredLintRules = {
   'unicorn/prefer-await': 'warn',
   'unicorn/prefer-else-if': 'warn',
   'unicorn/prefer-includes-over-repeated-comparisons': 'warn',
-  'unicorn/prefer-simple-condition-first': 'warn',
-  'unicorn/require-array-sort-compare': 'warn', // 🔴⚫ Disallows cases when the default sort is desired
   'preserve-caught-error': 'warn',
 } as const;

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -14,6 +14,14 @@ const config = defineConfig([
     rules: deferredLintRules,
   },
   {
+    // `prefer-simple-condition-first` reorders conditions to save a property read, at the cost of the reading
+    // order the surrounding error messages use. Its own diagnostic concedes it cannot verify the reorder is safe.
+    files: ['**/*.ts', '**/*.mts', '**/*.tsx', '**/*.md/*.ts'],
+    rules: {
+      'unicorn/prefer-simple-condition-first': 'off',
+    },
+  },
+  {
     files: ['**/*.js', '**/*.cjs', '**/*.mjs', '**/*.ts', '**/*.tsx'],
     rules: {
       'n/no-extraneous-import': 'off',


### PR DESCRIPTION
## What

Removes three overly opinionated `unicorn` lint rules from the lint configuration.

## Why

A blanket deferral of newly surfaced lint rules left no way to distinguish a rule worth enforcing from one that is not, and quietly kept alive two rules the shared configuration had already retired. Deciding each rule on its own terms is the first step toward removing the deferral entirely, which #152 and #153 complete.

## Details

### ⚙️ Tooling

- Removed `unicorn/max-nested-calls` and `unicorn/require-array-sort-compare` from `.config/eslint/deferred-lint-rules.ts`. Both are `off` in `@williamthorsen/eslint-config-typescript`; because the deferral block is spread after the base config, the entries were overriding that back to `warn`.
- Disabled `unicorn/prefer-simple-condition-first` in `eslint.config.ts`, in its own config object scoped to the TypeScript globs, with the rationale recorded inline. `williamthorsen/eslint-config#124` proposes the same change upstream, which would let the local override go.
- Corrected the allowlist's header comment, which cited a superseded major version of the shared config, and pointed it at the tickets that empty it.

Closes #116
