### PR TITLE
#152 Fix computed-property-access lint violations

### DIFF
--- a/.config/eslint/deferred-lint-rules.ts
+++ b/.config/eslint/deferred-lint-rules.ts
@@ -1,7 +1,6 @@
 // `@williamthorsen/eslint-config-typescript` added unicorn rules that surface violations in existing code.
-// Errors are downgraded to warnings here until the violations are fixed; #152 and #153 clear the remainder.
+// Errors are downgraded to warnings here until the violations are fixed; #153 clears the remainder.
 export const deferredLintRules = {
-  'unicorn/no-computed-property-existence-check': 'warn',
   'unicorn/no-declarations-before-early-exit': 'warn',
   'unicorn/no-duplicate-if-branches': 'warn',
   'unicorn/no-return-array-push': 'warn',

--- a/packages/readyup/__tests__/resolveRequestedNames.test.ts
+++ b/packages/readyup/__tests__/resolveRequestedNames.test.ts
@@ -85,6 +85,13 @@ describe(resolveRequestedNames, () => {
 
     expect(error.message).not.toContain('Suites');
   });
+
+  it('treats a name matching an Object.prototype member as unknown', () => {
+    const kit = makeKit({ suites: { ci: ['deploy'] } });
+
+    expect(() => resolveRequestedNames(['valueOf'], kit)).toThrow('Unknown name(s): valueOf');
+    expect(() => resolveRequestedNames(['toString'], kit)).toThrow('Unknown name(s): toString');
+  });
 });
 
 /** Extract the thrown error from a function call. */

--- a/packages/readyup/src/check-utils/json-value.ts
+++ b/packages/readyup/src/check-utils/json-value.ts
@@ -4,7 +4,7 @@ import { isRecord } from '../isRecord.ts';
 export function getJsonValue(obj: Record<string, unknown>, ...keys: string[]): unknown {
   let current: unknown = obj;
   for (const key of keys) {
-    if (!isRecord(current)) return undefined;
+    if (!isRecord(current) || !Object.hasOwn(current, key)) return undefined;
     current = current[key];
   }
   return current;

--- a/packages/readyup/src/check-utils/json.ts
+++ b/packages/readyup/src/check-utils/json.ts
@@ -17,9 +17,8 @@ export function readJsonFile(relativePath: string): Record<string, unknown> | un
 /** Check whether a JSON file has a field, optionally with a specific value. */
 export function hasJsonField(relativePath: string, field: string, expectedValue?: string): boolean {
   const data = readJsonFile(relativePath);
-  if (data === undefined) return false;
-  if (expectedValue !== undefined) return data[field] === expectedValue;
-  return field in data;
+  if (data === undefined || !Object.hasOwn(data, field)) return false;
+  return expectedValue === undefined || data[field] === expectedValue;
 }
 
 /** Read a JSON file and extract a nested value by traversing the key path. */
@@ -32,6 +31,6 @@ export function readJsonValue(relativeFilePath: string, ...keys: string[]): unkn
 /** Check whether a JSON file has all of the specified fields. */
 export function hasJsonFields(relativePath: string, fields: string[]): CheckOutcome {
   const data = readJsonFile(relativePath) ?? {};
-  const presentFields = fields.filter((field) => field in data);
+  const presentFields = fields.filter((field) => Object.hasOwn(data, field));
   return missingFrom('fields', fields, presentFields);
 }

--- a/packages/readyup/src/check-utils/package-json.ts
+++ b/packages/readyup/src/check-utils/package-json.ts
@@ -17,7 +17,7 @@ export function hasDevDependency(name: string): boolean {
   const pkg = readJsonFile('package.json');
   if (pkg === undefined) return false;
   const devDeps = pkg.devDependencies;
-  return isRecord(devDeps) && name in devDeps;
+  return isRecord(devDeps) && Object.hasOwn(devDeps, name);
 }
 
 /** Check whether a dev dependency meets a minimum version, with optional exemption predicate. */
@@ -29,7 +29,7 @@ export function hasMinDevDependencyVersion(
   const pkg = readJsonFile('package.json');
   if (pkg === undefined) return false;
   const devDeps = pkg.devDependencies;
-  if (!isRecord(devDeps) || !(name in devDeps)) return false;
+  if (!isRecord(devDeps) || !Object.hasOwn(devDeps, name)) return false;
   const range = devDeps[name];
   if (typeof range !== 'string') return false;
   if (options?.exempt?.(range)) return true;

--- a/packages/readyup/src/compile/extractJsonPaths.ts
+++ b/packages/readyup/src/compile/extractJsonPaths.ts
@@ -21,7 +21,7 @@ export function extractJsonPaths(
     // Traverse the source object to verify the path exists.
     let current: unknown = obj;
     for (const key of keys) {
-      if (!isRecord(current) || !(key in current)) {
+      if (!isRecord(current) || !Object.hasOwn(current, key)) {
         throw new Error(`Path not found in JSON: ${keys.join('.')}`);
       }
       current = current[key];

--- a/packages/readyup/src/resolveRequestedNames.ts
+++ b/packages/readyup/src/resolveRequestedNames.ts
@@ -22,7 +22,7 @@ export function resolveRequestedNames(requestedNames: string[], kit: RdyKit): st
   const seen = new Set<string>();
 
   for (const name of requestedNames) {
-    const suiteEntries = suites[name];
+    const suiteEntries = Object.hasOwn(suites, name) ? suites[name] : undefined;
     if (suiteEntries !== undefined) {
       for (const entry of suiteEntries) {
         if (seen.has(entry)) {


### PR DESCRIPTION
## What

Improves the safety of JSON lookups using computed properties in ReadyUp kit operations.

## Why

Seven lookups resolved names the source never declared, because they reached inherited properties rather than reading only what the object carries. A lint rule catches five of the seven, and it stayed downgraded to a warning while those sites went unfixed.

## Details

### ♻️ Refactoring

- Seven lookup sites gate on `Object.hasOwn`: `hasJsonField` and `hasJsonFields` (`check-utils/json.ts`), `getJsonValue` (`check-utils/json-value.ts`), `hasDevDependency` and `hasMinDevDependencyVersion` (`check-utils/package-json.ts`), the traversal guard in `compile/extractJsonPaths.ts`, and the suite lookup in `resolveRequestedNames.ts`.
- `hasJsonField` collapses its two branches into a single guard plus one value comparison. The value branch's behavior is unchanged: `expectedValue` is a `string`, so the old comparison could never match an inherited function.
- The two lookups in `getJsonValue` and `resolveRequestedNames` are dynamic reads that no lint rule can distinguish from legitimate indexing, so neither was flagged.

### 🧪 Tests

- `resolveRequestedNames` covers a requested name matching a built-in property, asserting the `Unknown name(s)` error in place of the previous crash.

### ⚙️ Tooling

- `unicorn/no-computed-property-existence-check` is removed from `.config/eslint/deferred-lint-rules.ts` and enforces at `error` again, leaving nine deferred rules for #153.


Closes #152
