### PR TITLE
#156 Share temp-directory and stdio scaffolding across test suites

### DIFF
--- a/.config/eslint/deferred-lint-rules.ts
+++ b/.config/eslint/deferred-lint-rules.ts
@@ -4,7 +4,6 @@ export const deferredLintRules = {
   'unicorn/no-declarations-before-early-exit': 'warn',
   'unicorn/no-duplicate-if-branches': 'warn',
   'unicorn/no-return-array-push': 'warn',
-  'unicorn/no-top-level-assignment-in-function': 'warn',
   'unicorn/no-unreadable-for-of-expression': 'warn',
   'unicorn/prefer-await': 'warn',
   'unicorn/prefer-else-if': 'warn',

--- a/packages/readyup/__tests__/check-utils/filesystem.test.ts
+++ b/packages/readyup/__tests__/check-utils/filesystem.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   commandExists,
@@ -8,9 +8,9 @@ import {
   filesExist,
   readFile,
 } from '../../src/check-utils/filesystem.ts';
-import { createTempDirTest } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({ prefix: 'rdy-fs-', cwd: 'mock' });
+const temp = useTempDir({ prefix: 'rdy-fs-', cwd: 'mock' });
 
 describe(commandExists, () => {
   it('returns true for a command that exists', () => {
@@ -29,7 +29,7 @@ describe(commandExists, () => {
 });
 
 describe(fileExists, () => {
-  it('returns true when the file exists', ({ temp }) => {
+  it('returns true when the file exists', () => {
     temp.write('found.txt', 'content');
 
     expect(fileExists('found.txt')).toBe(true);
@@ -41,13 +41,13 @@ describe(fileExists, () => {
 });
 
 describe(fileContains, () => {
-  it('returns true when the file matches the pattern', ({ temp }) => {
+  it('returns true when the file matches the pattern', () => {
     temp.write('data.txt', 'version: 3.2.1');
 
     expect(fileContains('data.txt', /version:\s*\d+/)).toBe(true);
   });
 
-  it('returns false when the file does not match the pattern', ({ temp }) => {
+  it('returns false when the file does not match the pattern', () => {
     temp.write('data.txt', 'no match here');
 
     expect(fileContains('data.txt', /version:/)).toBe(false);
@@ -59,13 +59,13 @@ describe(fileContains, () => {
 });
 
 describe(fileDoesNotContain, () => {
-  it('returns true when the file does not match the pattern', ({ temp }) => {
+  it('returns true when the file does not match the pattern', () => {
     temp.write('clean.txt', 'all good');
 
     expect(fileDoesNotContain('clean.txt', /bad/)).toBe(true);
   });
 
-  it('returns false when the file matches the pattern', ({ temp }) => {
+  it('returns false when the file matches the pattern', () => {
     temp.write('dirty.txt', 'contains bad stuff');
 
     expect(fileDoesNotContain('dirty.txt', /bad/)).toBe(false);
@@ -86,7 +86,7 @@ describe(filesExist, () => {
     });
   });
 
-  it('returns ok when all files exist', ({ temp }) => {
+  it('returns ok when all files exist', () => {
     temp.write('a.txt', '');
     temp.write('b.txt', '');
 
@@ -98,7 +98,7 @@ describe(filesExist, () => {
     });
   });
 
-  it('returns not ok with missing files listed', ({ temp }) => {
+  it('returns not ok with missing files listed', () => {
     temp.write('a.txt', '');
 
     const result = filesExist(['a.txt', 'b.txt', 'c.txt']);
@@ -110,7 +110,7 @@ describe(filesExist, () => {
     });
   });
 
-  it('resolves paths relative to baseDir when provided', ({ temp }) => {
+  it('resolves paths relative to baseDir when provided', () => {
     temp.write('sub/found.txt', '');
 
     const result = filesExist(['found.txt', 'missing.txt'], { baseDir: 'sub' });
@@ -124,7 +124,7 @@ describe(filesExist, () => {
 });
 
 describe(readFile, () => {
-  it('returns the file content as a string', ({ temp }) => {
+  it('returns the file content as a string', () => {
     temp.write('hello.txt', 'hello world');
 
     expect(readFile('hello.txt')).toBe('hello world');

--- a/packages/readyup/__tests__/check-utils/filesystem.test.ts
+++ b/packages/readyup/__tests__/check-utils/filesystem.test.ts
@@ -1,8 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import {
   commandExists,
@@ -12,18 +8,9 @@ import {
   filesExist,
   readFile,
 } from '../../src/check-utils/filesystem.ts';
+import { createTempDirTest } from '../helpers/tempDir.ts';
 
-let tempDir: string;
-let cwdSpy: MockInstance;
-
-beforeEach(() => {
-  tempDir = mkdtempSync(join(tmpdir(), 'rdy-fs-'));
-  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
-});
-
-afterEach(() => {
-  cwdSpy.mockRestore();
-});
+const it = createTempDirTest({ prefix: 'rdy-fs-', cwd: 'mock' });
 
 describe(commandExists, () => {
   it('returns true for a command that exists', () => {
@@ -42,8 +29,8 @@ describe(commandExists, () => {
 });
 
 describe(fileExists, () => {
-  it('returns true when the file exists', () => {
-    writeFileSync(join(tempDir, 'found.txt'), 'content');
+  it('returns true when the file exists', ({ temp }) => {
+    temp.write('found.txt', 'content');
 
     expect(fileExists('found.txt')).toBe(true);
   });
@@ -54,14 +41,14 @@ describe(fileExists, () => {
 });
 
 describe(fileContains, () => {
-  it('returns true when the file matches the pattern', () => {
-    writeFileSync(join(tempDir, 'data.txt'), 'version: 3.2.1');
+  it('returns true when the file matches the pattern', ({ temp }) => {
+    temp.write('data.txt', 'version: 3.2.1');
 
     expect(fileContains('data.txt', /version:\s*\d+/)).toBe(true);
   });
 
-  it('returns false when the file does not match the pattern', () => {
-    writeFileSync(join(tempDir, 'data.txt'), 'no match here');
+  it('returns false when the file does not match the pattern', ({ temp }) => {
+    temp.write('data.txt', 'no match here');
 
     expect(fileContains('data.txt', /version:/)).toBe(false);
   });
@@ -72,14 +59,14 @@ describe(fileContains, () => {
 });
 
 describe(fileDoesNotContain, () => {
-  it('returns true when the file does not match the pattern', () => {
-    writeFileSync(join(tempDir, 'clean.txt'), 'all good');
+  it('returns true when the file does not match the pattern', ({ temp }) => {
+    temp.write('clean.txt', 'all good');
 
     expect(fileDoesNotContain('clean.txt', /bad/)).toBe(true);
   });
 
-  it('returns false when the file matches the pattern', () => {
-    writeFileSync(join(tempDir, 'dirty.txt'), 'contains bad stuff');
+  it('returns false when the file matches the pattern', ({ temp }) => {
+    temp.write('dirty.txt', 'contains bad stuff');
 
     expect(fileDoesNotContain('dirty.txt', /bad/)).toBe(false);
   });
@@ -99,9 +86,9 @@ describe(filesExist, () => {
     });
   });
 
-  it('returns ok when all files exist', () => {
-    writeFileSync(join(tempDir, 'a.txt'), '');
-    writeFileSync(join(tempDir, 'b.txt'), '');
+  it('returns ok when all files exist', ({ temp }) => {
+    temp.write('a.txt', '');
+    temp.write('b.txt', '');
 
     const result = filesExist(['a.txt', 'b.txt']);
 
@@ -111,8 +98,8 @@ describe(filesExist, () => {
     });
   });
 
-  it('returns not ok with missing files listed', () => {
-    writeFileSync(join(tempDir, 'a.txt'), '');
+  it('returns not ok with missing files listed', ({ temp }) => {
+    temp.write('a.txt', '');
 
     const result = filesExist(['a.txt', 'b.txt', 'c.txt']);
 
@@ -123,9 +110,8 @@ describe(filesExist, () => {
     });
   });
 
-  it('resolves paths relative to baseDir when provided', () => {
-    mkdirSync(join(tempDir, 'sub'), { recursive: true });
-    writeFileSync(join(tempDir, 'sub', 'found.txt'), '');
+  it('resolves paths relative to baseDir when provided', ({ temp }) => {
+    temp.write('sub/found.txt', '');
 
     const result = filesExist(['found.txt', 'missing.txt'], { baseDir: 'sub' });
 
@@ -138,8 +124,8 @@ describe(filesExist, () => {
 });
 
 describe(readFile, () => {
-  it('returns the file content as a string', () => {
-    writeFileSync(join(tempDir, 'hello.txt'), 'hello world');
+  it('returns the file content as a string', ({ temp }) => {
+    temp.write('hello.txt', 'hello world');
 
     expect(readFile('hello.txt')).toBe('hello world');
   });

--- a/packages/readyup/__tests__/check-utils/hashing.test.ts
+++ b/packages/readyup/__tests__/check-utils/hashing.test.ts
@@ -1,23 +1,11 @@
 import { createHash } from 'node:crypto';
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { computeHash, fileMatchesHash } from '../../src/check-utils/hashing.ts';
+import { createTempDirTest } from '../helpers/tempDir.ts';
 
-let tempDir: string;
-let cwdSpy: MockInstance;
-
-beforeEach(() => {
-  tempDir = mkdtempSync(join(tmpdir(), 'rdy-hash-'));
-  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
-});
-
-afterEach(() => {
-  cwdSpy.mockRestore();
-});
+const it = createTempDirTest({ prefix: 'rdy-hash-', cwd: 'mock' });
 
 describe(computeHash, () => {
   it('returns a SHA-256 hex digest of the given string', () => {
@@ -37,16 +25,16 @@ describe(computeHash, () => {
 });
 
 describe(fileMatchesHash, () => {
-  it('returns true when the file content matches the expected hash', () => {
+  it('returns true when the file content matches the expected hash', ({ temp }) => {
     const content = 'exact content';
-    writeFileSync(join(tempDir, 'config.js'), content);
+    temp.write('config.js', content);
     const hash = createHash('sha256').update(content).digest('hex');
 
     expect(fileMatchesHash('config.js', hash)).toBe(true);
   });
 
-  it('returns false when the file content does not match the expected hash', () => {
-    writeFileSync(join(tempDir, 'config.js'), 'actual content');
+  it('returns false when the file content does not match the expected hash', ({ temp }) => {
+    temp.write('config.js', 'actual content');
 
     expect(fileMatchesHash('config.js', 'wrong-hash')).toBe(false);
   });

--- a/packages/readyup/__tests__/check-utils/hashing.test.ts
+++ b/packages/readyup/__tests__/check-utils/hashing.test.ts
@@ -1,11 +1,11 @@
 import { createHash } from 'node:crypto';
 
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { computeHash, fileMatchesHash } from '../../src/check-utils/hashing.ts';
-import { createTempDirTest } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({ prefix: 'rdy-hash-', cwd: 'mock' });
+const temp = useTempDir({ prefix: 'rdy-hash-', cwd: 'mock' });
 
 describe(computeHash, () => {
   it('returns a SHA-256 hex digest of the given string', () => {
@@ -25,7 +25,7 @@ describe(computeHash, () => {
 });
 
 describe(fileMatchesHash, () => {
-  it('returns true when the file content matches the expected hash', ({ temp }) => {
+  it('returns true when the file content matches the expected hash', () => {
     const content = 'exact content';
     temp.write('config.js', content);
     const hash = createHash('sha256').update(content).digest('hex');
@@ -33,7 +33,7 @@ describe(fileMatchesHash, () => {
     expect(fileMatchesHash('config.js', hash)).toBe(true);
   });
 
-  it('returns false when the file content does not match the expected hash', ({ temp }) => {
+  it('returns false when the file content does not match the expected hash', () => {
     temp.write('config.js', 'actual content');
 
     expect(fileMatchesHash('config.js', 'wrong-hash')).toBe(false);

--- a/packages/readyup/__tests__/check-utils/json.test.ts
+++ b/packages/readyup/__tests__/check-utils/json.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from '../../src/check-utils/json.ts';
-import { createTempDirTest } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({ prefix: 'rdy-json-', cwd: 'mock' });
+const temp = useTempDir({ prefix: 'rdy-json-', cwd: 'mock' });
 
 describe(readJsonFile, () => {
-  it('returns the parsed object from a JSON file', ({ temp }) => {
+  it('returns the parsed object from a JSON file', () => {
     temp.writeJson('config.json', { key: 'value' });
 
     expect(readJsonFile('config.json')).toStrictEqual({ key: 'value' });
@@ -16,13 +16,13 @@ describe(readJsonFile, () => {
     expect(readJsonFile('missing.json')).toBeUndefined();
   });
 
-  it('returns undefined when the file content is not an object', ({ temp }) => {
+  it('returns undefined when the file content is not an object', () => {
     temp.writeJson('array.json', [1, 2, 3]);
 
     expect(readJsonFile('array.json')).toBeUndefined();
   });
 
-  it('returns undefined when the file contains malformed JSON', ({ temp }) => {
+  it('returns undefined when the file contains malformed JSON', () => {
     temp.write('bad.json', '{ not valid json }}}');
 
     expect(readJsonFile('bad.json')).toBeUndefined();
@@ -30,7 +30,7 @@ describe(readJsonFile, () => {
 });
 
 describe(readJsonValue, () => {
-  it('returns a nested value from a JSON file', ({ temp }) => {
+  it('returns a nested value from a JSON file', () => {
     temp.writeJson('config.json', { publishConfig: { access: 'public' } });
 
     expect(readJsonValue('config.json', 'publishConfig', 'access')).toBe('public');
@@ -40,19 +40,19 @@ describe(readJsonValue, () => {
     expect(readJsonValue('missing.json', 'key')).toBeUndefined();
   });
 
-  it('returns undefined when the JSON is invalid', ({ temp }) => {
+  it('returns undefined when the JSON is invalid', () => {
     temp.write('bad.json', '{ not valid }}}');
 
     expect(readJsonValue('bad.json', 'key')).toBeUndefined();
   });
 
-  it('returns undefined when a key in the path is missing', ({ temp }) => {
+  it('returns undefined when a key in the path is missing', () => {
     temp.writeJson('config.json', { a: { b: 'value' } });
 
     expect(readJsonValue('config.json', 'a', 'missing', 'deep')).toBeUndefined();
   });
 
-  it('returns the full object when no keys are provided', ({ temp }) => {
+  it('returns the full object when no keys are provided', () => {
     temp.writeJson('config.json', { name: 'test' });
 
     expect(readJsonValue('config.json')).toStrictEqual({ name: 'test' });
@@ -60,25 +60,25 @@ describe(readJsonValue, () => {
 });
 
 describe(hasJsonField, () => {
-  it('returns true when the field exists', ({ temp }) => {
+  it('returns true when the field exists', () => {
     temp.writeJson('data.json', { type: 'module' });
 
     expect(hasJsonField('data.json', 'type')).toBe(true);
   });
 
-  it('returns false when the field does not exist', ({ temp }) => {
+  it('returns false when the field does not exist', () => {
     temp.writeJson('data.json', {});
 
     expect(hasJsonField('data.json', 'type')).toBe(false);
   });
 
-  it('returns true when the field matches the expected value', ({ temp }) => {
+  it('returns true when the field matches the expected value', () => {
     temp.writeJson('data.json', { type: 'module' });
 
     expect(hasJsonField('data.json', 'type', 'module')).toBe(true);
   });
 
-  it('returns false when the field does not match the expected value', ({ temp }) => {
+  it('returns false when the field does not match the expected value', () => {
     temp.writeJson('data.json', { type: 'commonjs' });
 
     expect(hasJsonField('data.json', 'type', 'module')).toBe(false);
@@ -90,7 +90,7 @@ describe(hasJsonField, () => {
 });
 
 describe(hasJsonFields, () => {
-  it('returns ok when all fields are present', ({ temp }) => {
+  it('returns ok when all fields are present', () => {
     temp.writeJson('data.json', { name: 'test', version: '1.0.0' });
 
     const result = hasJsonFields('data.json', ['name', 'version']);
@@ -101,7 +101,7 @@ describe(hasJsonFields, () => {
     });
   });
 
-  it('returns not ok with missing fields listed', ({ temp }) => {
+  it('returns not ok with missing fields listed', () => {
     temp.writeJson('data.json', { name: 'test' });
 
     const result = hasJsonFields('data.json', ['name', 'version', 'type']);
@@ -113,7 +113,7 @@ describe(hasJsonFields, () => {
     });
   });
 
-  it('returns ok with zero counts when fields array is empty', ({ temp }) => {
+  it('returns ok with zero counts when fields array is empty', () => {
     temp.writeJson('data.json', { name: 'test' });
 
     const result = hasJsonFields('data.json', []);

--- a/packages/readyup/__tests__/check-utils/json.test.ts
+++ b/packages/readyup/__tests__/check-utils/json.test.ts
@@ -1,26 +1,13 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from '../../src/check-utils/json.ts';
+import { createTempDirTest } from '../helpers/tempDir.ts';
 
-let tempDir: string;
-let cwdSpy: MockInstance;
-
-beforeEach(() => {
-  tempDir = mkdtempSync(join(tmpdir(), 'rdy-json-'));
-  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
-});
-
-afterEach(() => {
-  cwdSpy.mockRestore();
-});
+const it = createTempDirTest({ prefix: 'rdy-json-', cwd: 'mock' });
 
 describe(readJsonFile, () => {
-  it('returns the parsed object from a JSON file', () => {
-    writeJson('config.json', { key: 'value' });
+  it('returns the parsed object from a JSON file', ({ temp }) => {
+    temp.writeJson('config.json', { key: 'value' });
 
     expect(readJsonFile('config.json')).toStrictEqual({ key: 'value' });
   });
@@ -29,22 +16,22 @@ describe(readJsonFile, () => {
     expect(readJsonFile('missing.json')).toBeUndefined();
   });
 
-  it('returns undefined when the file content is not an object', () => {
-    writeJson('array.json', [1, 2, 3]);
+  it('returns undefined when the file content is not an object', ({ temp }) => {
+    temp.writeJson('array.json', [1, 2, 3]);
 
     expect(readJsonFile('array.json')).toBeUndefined();
   });
 
-  it('returns undefined when the file contains malformed JSON', () => {
-    writeRaw('bad.json', '{ not valid json }}}');
+  it('returns undefined when the file contains malformed JSON', ({ temp }) => {
+    temp.write('bad.json', '{ not valid json }}}');
 
     expect(readJsonFile('bad.json')).toBeUndefined();
   });
 });
 
 describe(readJsonValue, () => {
-  it('returns a nested value from a JSON file', () => {
-    writeJson('config.json', { publishConfig: { access: 'public' } });
+  it('returns a nested value from a JSON file', ({ temp }) => {
+    temp.writeJson('config.json', { publishConfig: { access: 'public' } });
 
     expect(readJsonValue('config.json', 'publishConfig', 'access')).toBe('public');
   });
@@ -53,46 +40,46 @@ describe(readJsonValue, () => {
     expect(readJsonValue('missing.json', 'key')).toBeUndefined();
   });
 
-  it('returns undefined when the JSON is invalid', () => {
-    writeRaw('bad.json', '{ not valid }}}');
+  it('returns undefined when the JSON is invalid', ({ temp }) => {
+    temp.write('bad.json', '{ not valid }}}');
 
     expect(readJsonValue('bad.json', 'key')).toBeUndefined();
   });
 
-  it('returns undefined when a key in the path is missing', () => {
-    writeJson('config.json', { a: { b: 'value' } });
+  it('returns undefined when a key in the path is missing', ({ temp }) => {
+    temp.writeJson('config.json', { a: { b: 'value' } });
 
     expect(readJsonValue('config.json', 'a', 'missing', 'deep')).toBeUndefined();
   });
 
-  it('returns the full object when no keys are provided', () => {
-    writeJson('config.json', { name: 'test' });
+  it('returns the full object when no keys are provided', ({ temp }) => {
+    temp.writeJson('config.json', { name: 'test' });
 
     expect(readJsonValue('config.json')).toStrictEqual({ name: 'test' });
   });
 });
 
 describe(hasJsonField, () => {
-  it('returns true when the field exists', () => {
-    writeJson('data.json', { type: 'module' });
+  it('returns true when the field exists', ({ temp }) => {
+    temp.writeJson('data.json', { type: 'module' });
 
     expect(hasJsonField('data.json', 'type')).toBe(true);
   });
 
-  it('returns false when the field does not exist', () => {
-    writeJson('data.json', {});
+  it('returns false when the field does not exist', ({ temp }) => {
+    temp.writeJson('data.json', {});
 
     expect(hasJsonField('data.json', 'type')).toBe(false);
   });
 
-  it('returns true when the field matches the expected value', () => {
-    writeJson('data.json', { type: 'module' });
+  it('returns true when the field matches the expected value', ({ temp }) => {
+    temp.writeJson('data.json', { type: 'module' });
 
     expect(hasJsonField('data.json', 'type', 'module')).toBe(true);
   });
 
-  it('returns false when the field does not match the expected value', () => {
-    writeJson('data.json', { type: 'commonjs' });
+  it('returns false when the field does not match the expected value', ({ temp }) => {
+    temp.writeJson('data.json', { type: 'commonjs' });
 
     expect(hasJsonField('data.json', 'type', 'module')).toBe(false);
   });
@@ -103,8 +90,8 @@ describe(hasJsonField, () => {
 });
 
 describe(hasJsonFields, () => {
-  it('returns ok when all fields are present', () => {
-    writeJson('data.json', { name: 'test', version: '1.0.0' });
+  it('returns ok when all fields are present', ({ temp }) => {
+    temp.writeJson('data.json', { name: 'test', version: '1.0.0' });
 
     const result = hasJsonFields('data.json', ['name', 'version']);
 
@@ -114,8 +101,8 @@ describe(hasJsonFields, () => {
     });
   });
 
-  it('returns not ok with missing fields listed', () => {
-    writeJson('data.json', { name: 'test' });
+  it('returns not ok with missing fields listed', ({ temp }) => {
+    temp.writeJson('data.json', { name: 'test' });
 
     const result = hasJsonFields('data.json', ['name', 'version', 'type']);
 
@@ -126,8 +113,8 @@ describe(hasJsonFields, () => {
     });
   });
 
-  it('returns ok with zero counts when fields array is empty', () => {
-    writeJson('data.json', { name: 'test' });
+  it('returns ok with zero counts when fields array is empty', ({ temp }) => {
+    temp.writeJson('data.json', { name: 'test' });
 
     const result = hasJsonFields('data.json', []);
 
@@ -147,15 +134,3 @@ describe(hasJsonFields, () => {
     });
   });
 });
-
-// region | Helpers
-
-function writeJson(filename: string, content: unknown): void {
-  writeFileSync(join(tempDir, filename), JSON.stringify(content));
-}
-
-function writeRaw(filename: string, content: string): void {
-  writeFileSync(join(tempDir, filename), content);
-}
-
-// endregion | Helpers

--- a/packages/readyup/__tests__/check-utils/package-json.test.ts
+++ b/packages/readyup/__tests__/check-utils/package-json.test.ts
@@ -1,8 +1,4 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import {
   hasDevDependency,
@@ -10,22 +6,13 @@ import {
   hasPackageJsonField,
   readPackageJson,
 } from '../../src/check-utils/package-json.ts';
+import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
 
-let tempDir: string;
-let cwdSpy: MockInstance;
-
-beforeEach(() => {
-  tempDir = mkdtempSync(join(tmpdir(), 'rdy-pkg-'));
-  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
-});
-
-afterEach(() => {
-  cwdSpy.mockRestore();
-});
+const it = createTempDirTest({ prefix: 'rdy-pkg-', cwd: 'mock' });
 
 describe(readPackageJson, () => {
-  it('returns the parsed package.json', () => {
-    writePackageJson({ name: 'test-pkg', version: '1.0.0' });
+  it('returns the parsed package.json', ({ temp }) => {
+    writePackageJson(temp, { name: 'test-pkg', version: '1.0.0' });
 
     const result = readPackageJson();
 
@@ -36,34 +23,34 @@ describe(readPackageJson, () => {
     expect(readPackageJson()).toBeUndefined();
   });
 
-  it('returns undefined when package.json is not an object', () => {
-    writeFileSync(join(tempDir, 'package.json'), '"not an object"');
+  it('returns undefined when package.json is not an object', ({ temp }) => {
+    temp.write('package.json', '"not an object"');
 
     expect(readPackageJson()).toBeUndefined();
   });
 });
 
 describe(hasPackageJsonField, () => {
-  it('returns true when the field exists', () => {
-    writePackageJson({ type: 'module' });
+  it('returns true when the field exists', ({ temp }) => {
+    writePackageJson(temp, { type: 'module' });
 
     expect(hasPackageJsonField('type')).toBe(true);
   });
 
-  it('returns false when the field does not exist', () => {
-    writePackageJson({});
+  it('returns false when the field does not exist', ({ temp }) => {
+    writePackageJson(temp, {});
 
     expect(hasPackageJsonField('type')).toBe(false);
   });
 
-  it('returns true when the field matches the expected value', () => {
-    writePackageJson({ type: 'module' });
+  it('returns true when the field matches the expected value', ({ temp }) => {
+    writePackageJson(temp, { type: 'module' });
 
     expect(hasPackageJsonField('type', 'module')).toBe(true);
   });
 
-  it('returns false when the field does not match the expected value', () => {
-    writePackageJson({ type: 'commonjs' });
+  it('returns false when the field does not match the expected value', ({ temp }) => {
+    writePackageJson(temp, { type: 'commonjs' });
 
     expect(hasPackageJsonField('type', 'module')).toBe(false);
   });
@@ -74,46 +61,46 @@ describe(hasPackageJsonField, () => {
 });
 
 describe(hasDevDependency, () => {
-  it('returns true when the dependency is present', () => {
-    writePackageJson({ devDependencies: { vitest: '^1.0.0' } });
+  it('returns true when the dependency is present', ({ temp }) => {
+    writePackageJson(temp, { devDependencies: { vitest: '^1.0.0' } });
 
     expect(hasDevDependency('vitest')).toBe(true);
   });
 
-  it('returns false when the dependency is absent', () => {
-    writePackageJson({ devDependencies: {} });
+  it('returns false when the dependency is absent', ({ temp }) => {
+    writePackageJson(temp, { devDependencies: {} });
 
     expect(hasDevDependency('vitest')).toBe(false);
   });
 
-  it('returns false when devDependencies is missing', () => {
-    writePackageJson({});
+  it('returns false when devDependencies is missing', ({ temp }) => {
+    writePackageJson(temp, {});
 
     expect(hasDevDependency('vitest')).toBe(false);
   });
 });
 
 describe(hasMinDevDependencyVersion, () => {
-  it('returns true when the version meets the minimum', () => {
-    writePackageJson({ devDependencies: { vitest: '^2.0.0' } });
+  it('returns true when the version meets the minimum', ({ temp }) => {
+    writePackageJson(temp, { devDependencies: { vitest: '^2.0.0' } });
 
     expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(true);
   });
 
-  it('returns false when the version is below the minimum', () => {
-    writePackageJson({ devDependencies: { vitest: '^0.34.0' } });
+  it('returns false when the version is below the minimum', ({ temp }) => {
+    writePackageJson(temp, { devDependencies: { vitest: '^0.34.0' } });
 
     expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
   });
 
-  it('returns false when the dependency is not present', () => {
-    writePackageJson({ devDependencies: {} });
+  it('returns false when the dependency is not present', ({ temp }) => {
+    writePackageJson(temp, { devDependencies: {} });
 
     expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
   });
 
-  it('returns true when the exempt predicate matches', () => {
-    writePackageJson({ devDependencies: { core: 'workspace:*' } });
+  it('returns true when the exempt predicate matches', ({ temp }) => {
+    writePackageJson(temp, { devDependencies: { core: 'workspace:*' } });
 
     expect(
       hasMinDevDependencyVersion('core', '1.0.0', {
@@ -122,13 +109,18 @@ describe(hasMinDevDependencyVersion, () => {
     ).toBe(true);
   });
 
-  it('returns false when the version range has no extractable version', () => {
-    writePackageJson({ devDependencies: { vitest: 'latest' } });
+  it('returns false when the version range has no extractable version', ({ temp }) => {
+    writePackageJson(temp, { devDependencies: { vitest: 'latest' } });
 
     expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
   });
 });
 
-function writePackageJson(content: Record<string, unknown>): void {
-  writeFileSync(join(tempDir, 'package.json'), JSON.stringify(content));
+// region | Helpers
+
+/** Writes the project manifest the check-utils under test read from the working directory. */
+function writePackageJson(temp: TempDir, content: Record<string, unknown>): void {
+  temp.writeJson('package.json', content);
 }
+
+// endregion | Helpers

--- a/packages/readyup/__tests__/check-utils/package-json.test.ts
+++ b/packages/readyup/__tests__/check-utils/package-json.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   hasDevDependency,
@@ -6,13 +6,13 @@ import {
   hasPackageJsonField,
   readPackageJson,
 } from '../../src/check-utils/package-json.ts';
-import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({ prefix: 'rdy-pkg-', cwd: 'mock' });
+const temp = useTempDir({ prefix: 'rdy-pkg-', cwd: 'mock' });
 
 describe(readPackageJson, () => {
-  it('returns the parsed package.json', ({ temp }) => {
-    writePackageJson(temp, { name: 'test-pkg', version: '1.0.0' });
+  it('returns the parsed package.json', () => {
+    writePackageJson({ name: 'test-pkg', version: '1.0.0' });
 
     const result = readPackageJson();
 
@@ -23,7 +23,7 @@ describe(readPackageJson, () => {
     expect(readPackageJson()).toBeUndefined();
   });
 
-  it('returns undefined when package.json is not an object', ({ temp }) => {
+  it('returns undefined when package.json is not an object', () => {
     temp.write('package.json', '"not an object"');
 
     expect(readPackageJson()).toBeUndefined();
@@ -31,26 +31,26 @@ describe(readPackageJson, () => {
 });
 
 describe(hasPackageJsonField, () => {
-  it('returns true when the field exists', ({ temp }) => {
-    writePackageJson(temp, { type: 'module' });
+  it('returns true when the field exists', () => {
+    writePackageJson({ type: 'module' });
 
     expect(hasPackageJsonField('type')).toBe(true);
   });
 
-  it('returns false when the field does not exist', ({ temp }) => {
-    writePackageJson(temp, {});
+  it('returns false when the field does not exist', () => {
+    writePackageJson({});
 
     expect(hasPackageJsonField('type')).toBe(false);
   });
 
-  it('returns true when the field matches the expected value', ({ temp }) => {
-    writePackageJson(temp, { type: 'module' });
+  it('returns true when the field matches the expected value', () => {
+    writePackageJson({ type: 'module' });
 
     expect(hasPackageJsonField('type', 'module')).toBe(true);
   });
 
-  it('returns false when the field does not match the expected value', ({ temp }) => {
-    writePackageJson(temp, { type: 'commonjs' });
+  it('returns false when the field does not match the expected value', () => {
+    writePackageJson({ type: 'commonjs' });
 
     expect(hasPackageJsonField('type', 'module')).toBe(false);
   });
@@ -61,46 +61,46 @@ describe(hasPackageJsonField, () => {
 });
 
 describe(hasDevDependency, () => {
-  it('returns true when the dependency is present', ({ temp }) => {
-    writePackageJson(temp, { devDependencies: { vitest: '^1.0.0' } });
+  it('returns true when the dependency is present', () => {
+    writePackageJson({ devDependencies: { vitest: '^1.0.0' } });
 
     expect(hasDevDependency('vitest')).toBe(true);
   });
 
-  it('returns false when the dependency is absent', ({ temp }) => {
-    writePackageJson(temp, { devDependencies: {} });
+  it('returns false when the dependency is absent', () => {
+    writePackageJson({ devDependencies: {} });
 
     expect(hasDevDependency('vitest')).toBe(false);
   });
 
-  it('returns false when devDependencies is missing', ({ temp }) => {
-    writePackageJson(temp, {});
+  it('returns false when devDependencies is missing', () => {
+    writePackageJson({});
 
     expect(hasDevDependency('vitest')).toBe(false);
   });
 });
 
 describe(hasMinDevDependencyVersion, () => {
-  it('returns true when the version meets the minimum', ({ temp }) => {
-    writePackageJson(temp, { devDependencies: { vitest: '^2.0.0' } });
+  it('returns true when the version meets the minimum', () => {
+    writePackageJson({ devDependencies: { vitest: '^2.0.0' } });
 
     expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(true);
   });
 
-  it('returns false when the version is below the minimum', ({ temp }) => {
-    writePackageJson(temp, { devDependencies: { vitest: '^0.34.0' } });
+  it('returns false when the version is below the minimum', () => {
+    writePackageJson({ devDependencies: { vitest: '^0.34.0' } });
 
     expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
   });
 
-  it('returns false when the dependency is not present', ({ temp }) => {
-    writePackageJson(temp, { devDependencies: {} });
+  it('returns false when the dependency is not present', () => {
+    writePackageJson({ devDependencies: {} });
 
     expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
   });
 
-  it('returns true when the exempt predicate matches', ({ temp }) => {
-    writePackageJson(temp, { devDependencies: { core: 'workspace:*' } });
+  it('returns true when the exempt predicate matches', () => {
+    writePackageJson({ devDependencies: { core: 'workspace:*' } });
 
     expect(
       hasMinDevDependencyVersion('core', '1.0.0', {
@@ -109,8 +109,8 @@ describe(hasMinDevDependencyVersion, () => {
     ).toBe(true);
   });
 
-  it('returns false when the version range has no extractable version', ({ temp }) => {
-    writePackageJson(temp, { devDependencies: { vitest: 'latest' } });
+  it('returns false when the version range has no extractable version', () => {
+    writePackageJson({ devDependencies: { vitest: 'latest' } });
 
     expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
   });
@@ -119,7 +119,7 @@ describe(hasMinDevDependencyVersion, () => {
 // region | Helpers
 
 /** Writes the project manifest the check-utils under test read from the working directory. */
-function writePackageJson(temp: TempDir, content: Record<string, unknown>): void {
+function writePackageJson(content: Record<string, unknown>): void {
   temp.writeJson('package.json', content);
 }
 

--- a/packages/readyup/__tests__/check-utils/pnpmWorkspaceYaml.test.ts
+++ b/packages/readyup/__tests__/check-utils/pnpmWorkspaceYaml.test.ts
@@ -1,56 +1,44 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { readPnpmWorkspacePackages } from '../../src/check-utils/pnpmWorkspaceYaml.ts';
+import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
 
-let tempDir: string;
-let yamlPath: string;
+const it = createTempDirTest({ prefix: 'rdy-yaml-' });
 
 describe(readPnpmWorkspacePackages, () => {
-  beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), 'rdy-yaml-'));
-    yamlPath = join(tempDir, 'pnpm-workspace.yaml');
-  });
-
-  afterEach(() => {
-    // Temp directory is cleaned up by the OS; leaving it in place keeps the test fast.
-  });
-
-  it('returns a single unquoted item', () => {
-    writeYaml(['packages:', '  - packages/*', ''].join('\n'));
+  it('returns a single unquoted item', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*']);
   });
 
-  it('returns multiple unquoted items in order', () => {
-    writeYaml(['packages:', '  - packages/*', '  - apps/*', '  - tools/*', ''].join('\n'));
+  it('returns multiple unquoted items in order', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', '  - apps/*', '  - tools/*', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*', 'tools/*']);
   });
 
-  it('strips single quotes from items', () => {
-    writeYaml(['packages:', "  - 'apps/*'", ''].join('\n'));
+  it('strips single quotes from items', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', "  - 'apps/*'", ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['apps/*']);
   });
 
-  it('strips double quotes from items', () => {
-    writeYaml(['packages:', '  - "tools/*"', ''].join('\n'));
+  it('strips double quotes from items', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - "tools/*"', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['tools/*']);
   });
 
-  it('handles mixed quoting in one file', () => {
-    writeYaml(['packages:', '  - packages/*', "  - 'apps/*'", '  - "tools/*"', ''].join('\n'));
+  it('handles mixed quoting in one file', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', "  - 'apps/*'", '  - "tools/*"', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*', 'tools/*']);
   });
 
-  it('ignores full-line comments', () => {
-    writeYaml(
+  it('ignores full-line comments', ({ temp }) => {
+    const yamlPath = writeYaml(
+      temp,
       [
         '# a leading comment',
         'packages:',
@@ -65,32 +53,36 @@ describe(readPnpmWorkspacePackages, () => {
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*']);
   });
 
-  it('strips inline trailing comments on items', () => {
-    writeYaml(['packages:', '  - packages/* # primary packages', '  - apps/*    # apps', ''].join('\n'));
+  it('strips inline trailing comments on items', ({ temp }) => {
+    const yamlPath = writeYaml(
+      temp,
+      ['packages:', '  - packages/* # primary packages', '  - apps/*    # apps', ''].join('\n'),
+    );
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*']);
   });
 
-  it('preserves `#` inside single-quoted items (not treated as an inline comment)', () => {
-    writeYaml(['packages:', "  - 'packages/foo#bar'", ''].join('\n'));
+  it('preserves `#` inside single-quoted items (not treated as an inline comment)', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', "  - 'packages/foo#bar'", ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/foo#bar']);
   });
 
-  it('preserves `#` inside double-quoted items (not treated as an inline comment)', () => {
-    writeYaml(['packages:', '  - "packages/foo#bar"', ''].join('\n'));
+  it('preserves `#` inside double-quoted items (not treated as an inline comment)', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - "packages/foo#bar"', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/foo#bar']);
   });
 
-  it('ignores blank lines between items', () => {
-    writeYaml(['packages:', '  - packages/*', '', '  - apps/*', '', ''].join('\n'));
+  it('ignores blank lines between items', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', '', '  - apps/*', '', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*']);
   });
 
-  it('ignores other top-level keys', () => {
-    writeYaml(
+  it('ignores other top-level keys', ({ temp }) => {
+    const yamlPath = writeYaml(
+      temp,
       [
         'onlyBuiltDependencies:',
         '  - esbuild',
@@ -105,101 +97,101 @@ describe(readPnpmWorkspacePackages, () => {
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*']);
   });
 
-  it('returns null when the `packages` key is absent', () => {
-    writeYaml(['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
+  it('returns null when the `packages` key is absent', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toBeNull();
   });
 
-  it('returns an empty array when `packages` key has no sequence items', () => {
-    writeYaml(['packages:', 'onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
+  it('returns an empty array when `packages` key has no sequence items', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', 'onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual([]);
   });
 
-  it('returns an empty array when `packages` is the only key and has no items', () => {
-    writeYaml(['packages:', ''].join('\n'));
+  it('returns an empty array when `packages` is the only key and has no items', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual([]);
   });
 
-  it('throws on a negation pattern with a message naming the pattern and file path', () => {
-    writeYaml(['packages:', '  - packages/*', '  - "!packages/deprecated/*"', ''].join('\n'));
+  it('throws on a negation pattern with a message naming the pattern and file path', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', '  - "!packages/deprecated/*"', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(yamlPath);
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/please open an issue/);
   });
 
-  it('throws on an unquoted negation pattern', () => {
-    writeYaml(['packages:', '  - !packages/deprecated/*', ''].join('\n'));
+  it('throws on an unquoted negation pattern', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - !packages/deprecated/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
   });
 
-  it('throws on a flow sequence for `packages`', () => {
-    writeYaml(['packages: [packages/*, apps/*]', ''].join('\n'));
+  it('throws on a flow sequence for `packages`', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages: [packages/*, apps/*]', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/non-list value/);
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(yamlPath);
   });
 
-  it('throws on a flow sequence as an item value', () => {
-    writeYaml(['packages:', '  - [a, b]', ''].join('\n'));
+  it('throws on a flow sequence as an item value', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - [a, b]', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/flow sequence or mapping/);
   });
 
-  it('throws on an anchor (&name) on an item', () => {
-    writeYaml(['packages:', '  - &anchor packages/*', ''].join('\n'));
+  it('throws on an anchor (&name) on an item', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - &anchor packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/anchor/);
   });
 
-  it('throws on an alias (*name) on an item', () => {
-    writeYaml(['packages:', '  - *alias', ''].join('\n'));
+  it('throws on an alias (*name) on an item', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - *alias', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/alias/);
   });
 
-  it('throws on a multi-document marker', () => {
-    writeYaml(['---', 'packages:', '  - packages/*', ''].join('\n'));
+  it('throws on a multi-document marker', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['---', 'packages:', '  - packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/multi-document/);
   });
 
-  it('throws on a YAML tag (!!str)', () => {
-    writeYaml(['packages:', '  - !!str packages/*', ''].join('\n'));
+  it('throws on a YAML tag (!!str)', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - !!str packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/YAML tag/);
   });
 
-  it('throws on a folded block scalar (>)', () => {
-    writeYaml(['packages:', '  - >', '    packages/*', ''].join('\n'));
+  it('throws on a folded block scalar (>)', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - >', '    packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/block scalar/);
   });
 
-  it('throws on a literal block scalar (|)', () => {
-    writeYaml(['packages:', '  - |', '    packages/*', ''].join('\n'));
+  it('throws on a literal block scalar (|)', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - |', '    packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/block scalar/);
   });
 
-  it('throws when `packages` is a string instead of a list', () => {
-    writeYaml(['packages: just-a-string', ''].join('\n'));
+  it('throws when `packages` is a string instead of a list', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages: just-a-string', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/non-list value/);
   });
 
-  it('throws when `packages` value is a mapping', () => {
-    writeYaml(['packages:', '  key: value', ''].join('\n'));
+  it('throws when `packages` value is a mapping', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  key: value', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/non-list value/);
   });
 
-  it('includes the offending line number and line text in the error message', () => {
-    writeYaml(['packages:', '  - packages/*', '  - [flow, sequence]', ''].join('\n'));
+  it('includes the offending line number and line text in the error message', ({ temp }) => {
+    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', '  - [flow, sequence]', ''].join('\n'));
 
     const attempt = (): string[] | null => readPnpmWorkspacePackages(yamlPath);
     expect(attempt).toThrow(/pnpm-workspace\.yaml:3/);
@@ -207,6 +199,11 @@ describe(readPnpmWorkspacePackages, () => {
   });
 });
 
-function writeYaml(content: string): void {
-  writeFileSync(yamlPath, content);
+// region | Helpers
+
+/** Writes the workspace manifest and returns its path, which the parser under test is given directly. */
+function writeYaml(temp: TempDir, content: string): string {
+  return temp.write('pnpm-workspace.yaml', content);
 }
+
+// endregion | Helpers

--- a/packages/readyup/__tests__/check-utils/pnpmWorkspaceYaml.test.ts
+++ b/packages/readyup/__tests__/check-utils/pnpmWorkspaceYaml.test.ts
@@ -1,44 +1,43 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { readPnpmWorkspacePackages } from '../../src/check-utils/pnpmWorkspaceYaml.ts';
-import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({ prefix: 'rdy-yaml-' });
+const temp = useTempDir({ prefix: 'rdy-yaml-' });
 
 describe(readPnpmWorkspacePackages, () => {
-  it('returns a single unquoted item', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
+  it('returns a single unquoted item', () => {
+    const yamlPath = writeYaml(['packages:', '  - packages/*', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*']);
   });
 
-  it('returns multiple unquoted items in order', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', '  - apps/*', '  - tools/*', ''].join('\n'));
+  it('returns multiple unquoted items in order', () => {
+    const yamlPath = writeYaml(['packages:', '  - packages/*', '  - apps/*', '  - tools/*', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*', 'tools/*']);
   });
 
-  it('strips single quotes from items', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', "  - 'apps/*'", ''].join('\n'));
+  it('strips single quotes from items', () => {
+    const yamlPath = writeYaml(['packages:', "  - 'apps/*'", ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['apps/*']);
   });
 
-  it('strips double quotes from items', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - "tools/*"', ''].join('\n'));
+  it('strips double quotes from items', () => {
+    const yamlPath = writeYaml(['packages:', '  - "tools/*"', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['tools/*']);
   });
 
-  it('handles mixed quoting in one file', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', "  - 'apps/*'", '  - "tools/*"', ''].join('\n'));
+  it('handles mixed quoting in one file', () => {
+    const yamlPath = writeYaml(['packages:', '  - packages/*', "  - 'apps/*'", '  - "tools/*"', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*', 'tools/*']);
   });
 
-  it('ignores full-line comments', ({ temp }) => {
+  it('ignores full-line comments', () => {
     const yamlPath = writeYaml(
-      temp,
       [
         '# a leading comment',
         'packages:',
@@ -53,36 +52,34 @@ describe(readPnpmWorkspacePackages, () => {
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*']);
   });
 
-  it('strips inline trailing comments on items', ({ temp }) => {
+  it('strips inline trailing comments on items', () => {
     const yamlPath = writeYaml(
-      temp,
       ['packages:', '  - packages/* # primary packages', '  - apps/*    # apps', ''].join('\n'),
     );
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*']);
   });
 
-  it('preserves `#` inside single-quoted items (not treated as an inline comment)', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', "  - 'packages/foo#bar'", ''].join('\n'));
+  it('preserves `#` inside single-quoted items (not treated as an inline comment)', () => {
+    const yamlPath = writeYaml(['packages:', "  - 'packages/foo#bar'", ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/foo#bar']);
   });
 
-  it('preserves `#` inside double-quoted items (not treated as an inline comment)', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - "packages/foo#bar"', ''].join('\n'));
+  it('preserves `#` inside double-quoted items (not treated as an inline comment)', () => {
+    const yamlPath = writeYaml(['packages:', '  - "packages/foo#bar"', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/foo#bar']);
   });
 
-  it('ignores blank lines between items', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', '', '  - apps/*', '', ''].join('\n'));
+  it('ignores blank lines between items', () => {
+    const yamlPath = writeYaml(['packages:', '  - packages/*', '', '  - apps/*', '', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*', 'apps/*']);
   });
 
-  it('ignores other top-level keys', ({ temp }) => {
+  it('ignores other top-level keys', () => {
     const yamlPath = writeYaml(
-      temp,
       [
         'onlyBuiltDependencies:',
         '  - esbuild',
@@ -97,101 +94,101 @@ describe(readPnpmWorkspacePackages, () => {
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual(['packages/*']);
   });
 
-  it('returns null when the `packages` key is absent', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
+  it('returns null when the `packages` key is absent', () => {
+    const yamlPath = writeYaml(['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toBeNull();
   });
 
-  it('returns an empty array when `packages` key has no sequence items', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', 'onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
+  it('returns an empty array when `packages` key has no sequence items', () => {
+    const yamlPath = writeYaml(['packages:', 'onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual([]);
   });
 
-  it('returns an empty array when `packages` is the only key and has no items', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', ''].join('\n'));
+  it('returns an empty array when `packages` is the only key and has no items', () => {
+    const yamlPath = writeYaml(['packages:', ''].join('\n'));
 
     expect(readPnpmWorkspacePackages(yamlPath)).toStrictEqual([]);
   });
 
-  it('throws on a negation pattern with a message naming the pattern and file path', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', '  - "!packages/deprecated/*"', ''].join('\n'));
+  it('throws on a negation pattern with a message naming the pattern and file path', () => {
+    const yamlPath = writeYaml(['packages:', '  - packages/*', '  - "!packages/deprecated/*"', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(yamlPath);
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/please open an issue/);
   });
 
-  it('throws on an unquoted negation pattern', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - !packages/deprecated/*', ''].join('\n'));
+  it('throws on an unquoted negation pattern', () => {
+    const yamlPath = writeYaml(['packages:', '  - !packages/deprecated/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
   });
 
-  it('throws on a flow sequence for `packages`', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages: [packages/*, apps/*]', ''].join('\n'));
+  it('throws on a flow sequence for `packages`', () => {
+    const yamlPath = writeYaml(['packages: [packages/*, apps/*]', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/non-list value/);
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(yamlPath);
   });
 
-  it('throws on a flow sequence as an item value', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - [a, b]', ''].join('\n'));
+  it('throws on a flow sequence as an item value', () => {
+    const yamlPath = writeYaml(['packages:', '  - [a, b]', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/flow sequence or mapping/);
   });
 
-  it('throws on an anchor (&name) on an item', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - &anchor packages/*', ''].join('\n'));
+  it('throws on an anchor (&name) on an item', () => {
+    const yamlPath = writeYaml(['packages:', '  - &anchor packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/anchor/);
   });
 
-  it('throws on an alias (*name) on an item', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - *alias', ''].join('\n'));
+  it('throws on an alias (*name) on an item', () => {
+    const yamlPath = writeYaml(['packages:', '  - *alias', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/alias/);
   });
 
-  it('throws on a multi-document marker', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['---', 'packages:', '  - packages/*', ''].join('\n'));
+  it('throws on a multi-document marker', () => {
+    const yamlPath = writeYaml(['---', 'packages:', '  - packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/multi-document/);
   });
 
-  it('throws on a YAML tag (!!str)', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - !!str packages/*', ''].join('\n'));
+  it('throws on a YAML tag (!!str)', () => {
+    const yamlPath = writeYaml(['packages:', '  - !!str packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/YAML tag/);
   });
 
-  it('throws on a folded block scalar (>)', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - >', '    packages/*', ''].join('\n'));
+  it('throws on a folded block scalar (>)', () => {
+    const yamlPath = writeYaml(['packages:', '  - >', '    packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/block scalar/);
   });
 
-  it('throws on a literal block scalar (|)', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - |', '    packages/*', ''].join('\n'));
+  it('throws on a literal block scalar (|)', () => {
+    const yamlPath = writeYaml(['packages:', '  - |', '    packages/*', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/block scalar/);
   });
 
-  it('throws when `packages` is a string instead of a list', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages: just-a-string', ''].join('\n'));
+  it('throws when `packages` is a string instead of a list', () => {
+    const yamlPath = writeYaml(['packages: just-a-string', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/non-list value/);
   });
 
-  it('throws when `packages` value is a mapping', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  key: value', ''].join('\n'));
+  it('throws when `packages` value is a mapping', () => {
+    const yamlPath = writeYaml(['packages:', '  key: value', ''].join('\n'));
 
     expect(() => readPnpmWorkspacePackages(yamlPath)).toThrow(/non-list value/);
   });
 
-  it('includes the offending line number and line text in the error message', ({ temp }) => {
-    const yamlPath = writeYaml(temp, ['packages:', '  - packages/*', '  - [flow, sequence]', ''].join('\n'));
+  it('includes the offending line number and line text in the error message', () => {
+    const yamlPath = writeYaml(['packages:', '  - packages/*', '  - [flow, sequence]', ''].join('\n'));
 
     const attempt = (): string[] | null => readPnpmWorkspacePackages(yamlPath);
     expect(attempt).toThrow(/pnpm-workspace\.yaml:3/);
@@ -202,7 +199,7 @@ describe(readPnpmWorkspacePackages, () => {
 // region | Helpers
 
 /** Writes the workspace manifest and returns its path, which the parser under test is given directly. */
-function writeYaml(temp: TempDir, content: string): string {
+function writeYaml(content: string): string {
   return temp.write('pnpm-workspace.yaml', content);
 }
 

--- a/packages/readyup/__tests__/check-utils/tool-versions.test.ts
+++ b/packages/readyup/__tests__/check-utils/tool-versions.test.ts
@@ -1,55 +1,55 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { readToolVersionsNode } from '../../src/check-utils/tool-versions.ts';
-import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({ prefix: 'rdy-tool-versions-', cwd: 'mock' });
+const temp = useTempDir({ prefix: 'rdy-tool-versions-', cwd: 'mock' });
 
 describe(readToolVersionsNode, () => {
-  it('reads a plain nodejs entry', ({ temp }) => {
-    writeToolVersions(temp, ['nodejs 24.18.0', '']);
+  it('reads a plain nodejs entry', () => {
+    writeToolVersions(['nodejs 24.18.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('reads an entry written with the `node` tool name', ({ temp }) => {
-    writeToolVersions(temp, ['node 22.11.0', '']);
+  it('reads an entry written with the `node` tool name', () => {
+    writeToolVersions(['node 22.11.0', '']);
 
     expect(readToolVersionsNode()).toBe('22.11.0');
   });
 
-  it('ignores a trailing comment', ({ temp }) => {
-    writeToolVersions(temp, ['nodejs 24.18.0 # pinned to the engines floor', '']);
+  it('ignores a trailing comment', () => {
+    writeToolVersions(['nodejs 24.18.0 # pinned to the engines floor', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('takes the first of several fallback versions', ({ temp }) => {
-    writeToolVersions(temp, ['nodejs 24.18.0 22.11.0 20.19.0', '']);
+  it('takes the first of several fallback versions', () => {
+    writeToolVersions(['nodejs 24.18.0 22.11.0 20.19.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('skips other tools, comment lines, and blank lines', ({ temp }) => {
-    writeToolVersions(temp, ['# Managed by mise', '', 'pnpm 11.15.0', '\tnodejs\t24.18.0', 'python 3.13.0', '']);
+  it('skips other tools, comment lines, and blank lines', () => {
+    writeToolVersions(['# Managed by mise', '', 'pnpm 11.15.0', '\tnodejs\t24.18.0', 'python 3.13.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('takes the first Node declaration when several are present', ({ temp }) => {
-    writeToolVersions(temp, ['nodejs 24.18.0', 'nodejs 22.11.0', '']);
+  it('takes the first Node declaration when several are present', () => {
+    writeToolVersions(['nodejs 24.18.0', 'nodejs 22.11.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('skips a Node line that names no version', ({ temp }) => {
-    writeToolVersions(temp, ['nodejs', 'nodejs 24.18.0', '']);
+  it('skips a Node line that names no version', () => {
+    writeToolVersions(['nodejs', 'nodejs 24.18.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('returns undefined when no Node entry is present', ({ temp }) => {
-    writeToolVersions(temp, ['pnpm 11.15.0', '']);
+  it('returns undefined when no Node entry is present', () => {
+    writeToolVersions(['pnpm 11.15.0', '']);
 
     expect(readToolVersionsNode()).toBeUndefined();
   });
@@ -58,7 +58,7 @@ describe(readToolVersionsNode, () => {
     expect(readToolVersionsNode()).toBeUndefined();
   });
 
-  it('reads a file at a caller-supplied path', ({ temp }) => {
+  it('reads a file at a caller-supplied path', () => {
     temp.write('.tool-versions.local', 'nodejs 20.19.0\n');
 
     expect(readToolVersionsNode('.tool-versions.local')).toBe('20.19.0');
@@ -68,7 +68,7 @@ describe(readToolVersionsNode, () => {
 // region | Helpers
 
 /** Writes the given lines to `.tool-versions`, the default path the check reads. */
-function writeToolVersions(temp: TempDir, lines: string[]): void {
+function writeToolVersions(lines: string[]): void {
   temp.write('.tool-versions', lines.join('\n'));
 }
 

--- a/packages/readyup/__tests__/check-utils/tool-versions.test.ts
+++ b/packages/readyup/__tests__/check-utils/tool-versions.test.ts
@@ -1,68 +1,55 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { readToolVersionsNode } from '../../src/check-utils/tool-versions.ts';
+import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
 
-let tempDir: string;
-let cwdSpy: MockInstance;
-
-beforeEach(() => {
-  tempDir = mkdtempSync(join(tmpdir(), 'rdy-tool-versions-'));
-  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
-});
-
-afterEach(() => {
-  cwdSpy.mockRestore();
-});
+const it = createTempDirTest({ prefix: 'rdy-tool-versions-', cwd: 'mock' });
 
 describe(readToolVersionsNode, () => {
-  it('reads a plain nodejs entry', () => {
-    writeToolVersions(['nodejs 24.18.0', '']);
+  it('reads a plain nodejs entry', ({ temp }) => {
+    writeToolVersions(temp, ['nodejs 24.18.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('reads an entry written with the `node` tool name', () => {
-    writeToolVersions(['node 22.11.0', '']);
+  it('reads an entry written with the `node` tool name', ({ temp }) => {
+    writeToolVersions(temp, ['node 22.11.0', '']);
 
     expect(readToolVersionsNode()).toBe('22.11.0');
   });
 
-  it('ignores a trailing comment', () => {
-    writeToolVersions(['nodejs 24.18.0 # pinned to the engines floor', '']);
+  it('ignores a trailing comment', ({ temp }) => {
+    writeToolVersions(temp, ['nodejs 24.18.0 # pinned to the engines floor', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('takes the first of several fallback versions', () => {
-    writeToolVersions(['nodejs 24.18.0 22.11.0 20.19.0', '']);
+  it('takes the first of several fallback versions', ({ temp }) => {
+    writeToolVersions(temp, ['nodejs 24.18.0 22.11.0 20.19.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('skips other tools, comment lines, and blank lines', () => {
-    writeToolVersions(['# Managed by mise', '', 'pnpm 11.15.0', '\tnodejs\t24.18.0', 'python 3.13.0', '']);
+  it('skips other tools, comment lines, and blank lines', ({ temp }) => {
+    writeToolVersions(temp, ['# Managed by mise', '', 'pnpm 11.15.0', '\tnodejs\t24.18.0', 'python 3.13.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('takes the first Node declaration when several are present', () => {
-    writeToolVersions(['nodejs 24.18.0', 'nodejs 22.11.0', '']);
+  it('takes the first Node declaration when several are present', ({ temp }) => {
+    writeToolVersions(temp, ['nodejs 24.18.0', 'nodejs 22.11.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('skips a Node line that names no version', () => {
-    writeToolVersions(['nodejs', 'nodejs 24.18.0', '']);
+  it('skips a Node line that names no version', ({ temp }) => {
+    writeToolVersions(temp, ['nodejs', 'nodejs 24.18.0', '']);
 
     expect(readToolVersionsNode()).toBe('24.18.0');
   });
 
-  it('returns undefined when no Node entry is present', () => {
-    writeToolVersions(['pnpm 11.15.0', '']);
+  it('returns undefined when no Node entry is present', ({ temp }) => {
+    writeToolVersions(temp, ['pnpm 11.15.0', '']);
 
     expect(readToolVersionsNode()).toBeUndefined();
   });
@@ -71,8 +58,8 @@ describe(readToolVersionsNode, () => {
     expect(readToolVersionsNode()).toBeUndefined();
   });
 
-  it('reads a file at a caller-supplied path', () => {
-    writeFileSync(join(tempDir, '.tool-versions.local'), 'nodejs 20.19.0\n');
+  it('reads a file at a caller-supplied path', ({ temp }) => {
+    temp.write('.tool-versions.local', 'nodejs 20.19.0\n');
 
     expect(readToolVersionsNode('.tool-versions.local')).toBe('20.19.0');
   });
@@ -80,9 +67,9 @@ describe(readToolVersionsNode, () => {
 
 // region | Helpers
 
-/** Writes the given lines to `.tool-versions` in the temp directory. */
-function writeToolVersions(lines: string[]): void {
-  writeFileSync(join(tempDir, '.tool-versions'), lines.join('\n'));
+/** Writes the given lines to `.tool-versions`, the default path the check reads. */
+function writeToolVersions(temp: TempDir, lines: string[]): void {
+  temp.write('.tool-versions', lines.join('\n'));
 }
 
 // endregion | Helpers

--- a/packages/readyup/__tests__/check-utils/tsconfig.test.ts
+++ b/packages/readyup/__tests__/check-utils/tsconfig.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { readTsconfigLanguageLevel } from '../../src/check-utils/tsconfig.ts';
-import { createTempDirTest } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({ prefix: 'rdy-tsconfig-', cwd: 'mock' });
+const temp = useTempDir({ prefix: 'rdy-tsconfig-', cwd: 'mock' });
 
 describe(readTsconfigLanguageLevel, () => {
-  it('reads lib and target from a single config', ({ temp }) => {
+  it('reads lib and target from a single config', () => {
     temp.writeJson('tsconfig.json', { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } });
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
@@ -17,7 +17,7 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('reports lib and target as undefined when no config declares them', ({ temp }) => {
+  it('reports lib and target as undefined when no config declares them', () => {
     temp.writeJson('tsconfig.json', { compilerOptions: { strict: true } });
 
     const result = readTsconfigLanguageLevel('tsconfig.json');
@@ -26,7 +26,7 @@ describe(readTsconfigLanguageLevel, () => {
     expect(result?.target).toBeUndefined();
   });
 
-  it('resolves lib and target through a relative extends chain', ({ temp }) => {
+  it('resolves lib and target through a relative extends chain', () => {
     temp.writeJson('base.json', { compilerOptions: { lib: ['ES2023'], target: 'ES2023' } });
     temp.writeJson('middle.json', { extends: './base.json' });
     temp.writeJson('tsconfig.json', { extends: './middle.json' });
@@ -39,7 +39,7 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('lets a package config override the root config it extends', ({ temp }) => {
+  it('lets a package config override the root config it extends', () => {
     temp.writeJson('tsconfig.json', { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } });
     temp.writeJson('packages/alpha/tsconfig.json', {
       extends: '../../tsconfig.json',
@@ -55,7 +55,7 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('appends .json to an extends specifier written without an extension', ({ temp }) => {
+  it('appends .json to an extends specifier written without an extension', () => {
     temp.writeJson('base.json', { compilerOptions: { target: 'ES2022' } });
     temp.writeJson('tsconfig.json', { extends: './base' });
 
@@ -65,7 +65,7 @@ describe(readTsconfigLanguageLevel, () => {
     expect(result?.chain).toStrictEqual(['tsconfig.json', 'base.json']);
   });
 
-  it('gives a later array-extends entry precedence over an earlier one', ({ temp }) => {
+  it('gives a later array-extends entry precedence over an earlier one', () => {
     temp.writeJson('first.json', { compilerOptions: { lib: ['ES2021'], target: 'ES2021' } });
     temp.writeJson('second.json', { compilerOptions: { lib: ['ES2024'] } });
     temp.writeJson('tsconfig.json', { extends: ['./first.json', './second.json'] });
@@ -78,7 +78,7 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('reads a shared parent once, along the higher-priority branch', ({ temp }) => {
+  it('reads a shared parent once, along the higher-priority branch', () => {
     temp.writeJson('base.json', { compilerOptions: { lib: ['ES2021'], target: 'ES2021' } });
     temp.writeJson('low.json', { extends: './base.json', compilerOptions: { target: 'ES2022' } });
     temp.writeJson('high.json', { extends: './base.json', compilerOptions: { target: 'ES2024' } });
@@ -93,7 +93,7 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('parses JSONC comments and trailing commas', ({ temp }) => {
+  it('parses JSONC comments and trailing commas', () => {
     temp.write(
       'tsconfig.json',
       [
@@ -117,7 +117,7 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('reports a bare package specifier as unresolved without following it', ({ temp }) => {
+  it('reports a bare package specifier as unresolved without following it', () => {
     temp.writeJson('tsconfig.json', {
       extends: '@tsconfig/node24/tsconfig.json',
       compilerOptions: { target: 'ES2025' },
@@ -131,7 +131,7 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('reports a missing parent as unresolved', ({ temp }) => {
+  it('reports a missing parent as unresolved', () => {
     temp.writeJson('tsconfig.json', { extends: './absent.json', compilerOptions: { lib: ['ES2025'] } });
 
     const result = readTsconfigLanguageLevel('tsconfig.json');
@@ -140,7 +140,7 @@ describe(readTsconfigLanguageLevel, () => {
     expect(result?.unresolvedExtends).toStrictEqual(['./absent.json']);
   });
 
-  it('reports a malformed parent as unresolved and keeps reading the rest of the chain', ({ temp }) => {
+  it('reports a malformed parent as unresolved and keeps reading the rest of the chain', () => {
     temp.write('broken.json', 'this is not a config at all');
     temp.writeJson('good.json', { compilerOptions: { target: 'ES2024' } });
     temp.writeJson('tsconfig.json', { extends: ['./broken.json', './good.json'] });
@@ -153,7 +153,7 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('stops at a cycle in the extends chain', ({ temp }) => {
+  it('stops at a cycle in the extends chain', () => {
     temp.writeJson('a.json', { extends: './b.json', compilerOptions: { target: 'ES2022' } });
     temp.writeJson('b.json', { extends: './a.json', compilerOptions: { lib: ['ES2022'] } });
 
@@ -169,13 +169,13 @@ describe(readTsconfigLanguageLevel, () => {
     expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();
   });
 
-  it('returns undefined when the entry file is malformed', ({ temp }) => {
+  it('returns undefined when the entry file is malformed', () => {
     temp.write('tsconfig.json', '@@@ not json @@@');
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();
   });
 
-  it('returns undefined when the entry file holds a non-object', ({ temp }) => {
+  it('returns undefined when the entry file holds a non-object', () => {
     temp.write('tsconfig.json', '["ES2025"]');
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();

--- a/packages/readyup/__tests__/check-utils/tsconfig.test.ts
+++ b/packages/readyup/__tests__/check-utils/tsconfig.test.ts
@@ -1,26 +1,13 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { readTsconfigLanguageLevel } from '../../src/check-utils/tsconfig.ts';
+import { createTempDirTest } from '../helpers/tempDir.ts';
 
-let tempDir: string;
-let cwdSpy: MockInstance;
+const it = createTempDirTest({ prefix: 'rdy-tsconfig-', cwd: 'mock' });
 
 describe(readTsconfigLanguageLevel, () => {
-  beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), 'rdy-tsconfig-'));
-    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
-  });
-
-  afterEach(() => {
-    cwdSpy.mockRestore();
-  });
-
-  it('reads lib and target from a single config', () => {
-    writeConfig('tsconfig.json', { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } });
+  it('reads lib and target from a single config', ({ temp }) => {
+    temp.writeJson('tsconfig.json', { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } });
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
       lib: ['es2025'],
@@ -30,8 +17,8 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('reports lib and target as undefined when no config declares them', () => {
-    writeConfig('tsconfig.json', { compilerOptions: { strict: true } });
+  it('reports lib and target as undefined when no config declares them', ({ temp }) => {
+    temp.writeJson('tsconfig.json', { compilerOptions: { strict: true } });
 
     const result = readTsconfigLanguageLevel('tsconfig.json');
 
@@ -39,10 +26,10 @@ describe(readTsconfigLanguageLevel, () => {
     expect(result?.target).toBeUndefined();
   });
 
-  it('resolves lib and target through a relative extends chain', () => {
-    writeConfig('base.json', { compilerOptions: { lib: ['ES2023'], target: 'ES2023' } });
-    writeConfig('middle.json', { extends: './base.json' });
-    writeConfig('tsconfig.json', { extends: './middle.json' });
+  it('resolves lib and target through a relative extends chain', ({ temp }) => {
+    temp.writeJson('base.json', { compilerOptions: { lib: ['ES2023'], target: 'ES2023' } });
+    temp.writeJson('middle.json', { extends: './base.json' });
+    temp.writeJson('tsconfig.json', { extends: './middle.json' });
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
       lib: ['es2023'],
@@ -52,9 +39,9 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('lets a package config override the root config it extends', () => {
-    writeConfig('tsconfig.json', { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } });
-    writeConfig('packages/alpha/tsconfig.json', {
+  it('lets a package config override the root config it extends', ({ temp }) => {
+    temp.writeJson('tsconfig.json', { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } });
+    temp.writeJson('packages/alpha/tsconfig.json', {
       extends: '../../tsconfig.json',
       compilerOptions: { lib: ['ES2022'] },
     });
@@ -68,9 +55,9 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('appends .json to an extends specifier written without an extension', () => {
-    writeConfig('base.json', { compilerOptions: { target: 'ES2022' } });
-    writeConfig('tsconfig.json', { extends: './base' });
+  it('appends .json to an extends specifier written without an extension', ({ temp }) => {
+    temp.writeJson('base.json', { compilerOptions: { target: 'ES2022' } });
+    temp.writeJson('tsconfig.json', { extends: './base' });
 
     const result = readTsconfigLanguageLevel('tsconfig.json');
 
@@ -78,10 +65,10 @@ describe(readTsconfigLanguageLevel, () => {
     expect(result?.chain).toStrictEqual(['tsconfig.json', 'base.json']);
   });
 
-  it('gives a later array-extends entry precedence over an earlier one', () => {
-    writeConfig('first.json', { compilerOptions: { lib: ['ES2021'], target: 'ES2021' } });
-    writeConfig('second.json', { compilerOptions: { lib: ['ES2024'] } });
-    writeConfig('tsconfig.json', { extends: ['./first.json', './second.json'] });
+  it('gives a later array-extends entry precedence over an earlier one', ({ temp }) => {
+    temp.writeJson('first.json', { compilerOptions: { lib: ['ES2021'], target: 'ES2021' } });
+    temp.writeJson('second.json', { compilerOptions: { lib: ['ES2024'] } });
+    temp.writeJson('tsconfig.json', { extends: ['./first.json', './second.json'] });
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
       lib: ['es2024'],
@@ -91,11 +78,11 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('reads a shared parent once, along the higher-priority branch', () => {
-    writeConfig('base.json', { compilerOptions: { lib: ['ES2021'], target: 'ES2021' } });
-    writeConfig('low.json', { extends: './base.json', compilerOptions: { target: 'ES2022' } });
-    writeConfig('high.json', { extends: './base.json', compilerOptions: { target: 'ES2024' } });
-    writeConfig('tsconfig.json', { extends: ['./low.json', './high.json'] });
+  it('reads a shared parent once, along the higher-priority branch', ({ temp }) => {
+    temp.writeJson('base.json', { compilerOptions: { lib: ['ES2021'], target: 'ES2021' } });
+    temp.writeJson('low.json', { extends: './base.json', compilerOptions: { target: 'ES2022' } });
+    temp.writeJson('high.json', { extends: './base.json', compilerOptions: { target: 'ES2024' } });
+    temp.writeJson('tsconfig.json', { extends: ['./low.json', './high.json'] });
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
       // `high` outranks `low`, so `base` is reached through it; `low` is visited with both fields already resolved.
@@ -106,8 +93,8 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('parses JSONC comments and trailing commas', () => {
-    writeRawConfig(
+  it('parses JSONC comments and trailing commas', ({ temp }) => {
+    temp.write(
       'tsconfig.json',
       [
         '// TSConfig for monorepo root',
@@ -130,8 +117,8 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('reports a bare package specifier as unresolved without following it', () => {
-    writeConfig('tsconfig.json', {
+  it('reports a bare package specifier as unresolved without following it', ({ temp }) => {
+    temp.writeJson('tsconfig.json', {
       extends: '@tsconfig/node24/tsconfig.json',
       compilerOptions: { target: 'ES2025' },
     });
@@ -144,8 +131,8 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('reports a missing parent as unresolved', () => {
-    writeConfig('tsconfig.json', { extends: './absent.json', compilerOptions: { lib: ['ES2025'] } });
+  it('reports a missing parent as unresolved', ({ temp }) => {
+    temp.writeJson('tsconfig.json', { extends: './absent.json', compilerOptions: { lib: ['ES2025'] } });
 
     const result = readTsconfigLanguageLevel('tsconfig.json');
 
@@ -153,10 +140,10 @@ describe(readTsconfigLanguageLevel, () => {
     expect(result?.unresolvedExtends).toStrictEqual(['./absent.json']);
   });
 
-  it('reports a malformed parent as unresolved and keeps reading the rest of the chain', () => {
-    writeRawConfig('broken.json', 'this is not a config at all');
-    writeConfig('good.json', { compilerOptions: { target: 'ES2024' } });
-    writeConfig('tsconfig.json', { extends: ['./broken.json', './good.json'] });
+  it('reports a malformed parent as unresolved and keeps reading the rest of the chain', ({ temp }) => {
+    temp.write('broken.json', 'this is not a config at all');
+    temp.writeJson('good.json', { compilerOptions: { target: 'ES2024' } });
+    temp.writeJson('tsconfig.json', { extends: ['./broken.json', './good.json'] });
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
       lib: undefined,
@@ -166,9 +153,9 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('stops at a cycle in the extends chain', () => {
-    writeConfig('a.json', { extends: './b.json', compilerOptions: { target: 'ES2022' } });
-    writeConfig('b.json', { extends: './a.json', compilerOptions: { lib: ['ES2022'] } });
+  it('stops at a cycle in the extends chain', ({ temp }) => {
+    temp.writeJson('a.json', { extends: './b.json', compilerOptions: { target: 'ES2022' } });
+    temp.writeJson('b.json', { extends: './a.json', compilerOptions: { lib: ['ES2022'] } });
 
     expect(readTsconfigLanguageLevel('a.json')).toStrictEqual({
       lib: ['es2022'],
@@ -182,31 +169,15 @@ describe(readTsconfigLanguageLevel, () => {
     expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();
   });
 
-  it('returns undefined when the entry file is malformed', () => {
-    writeRawConfig('tsconfig.json', '@@@ not json @@@');
+  it('returns undefined when the entry file is malformed', ({ temp }) => {
+    temp.write('tsconfig.json', '@@@ not json @@@');
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();
   });
 
-  it('returns undefined when the entry file holds a non-object', () => {
-    writeRawConfig('tsconfig.json', '["ES2025"]');
+  it('returns undefined when the entry file holds a non-object', ({ temp }) => {
+    temp.write('tsconfig.json', '["ES2025"]');
 
     expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();
   });
 });
-
-// region | Helpers
-
-/** Writes a config as JSON at a temp-dir-relative path, creating parent directories as needed. */
-function writeConfig(relativePath: string, content: Record<string, unknown>): void {
-  writeRawConfig(relativePath, JSON.stringify(content));
-}
-
-/** Writes verbatim config text at a temp-dir-relative path, creating parent directories as needed. */
-function writeRawConfig(relativePath: string, content: string): void {
-  const fullPath = join(tempDir, relativePath);
-  mkdirSync(dirname(fullPath), { recursive: true });
-  writeFileSync(fullPath, content);
-}
-
-// endregion | Helpers

--- a/packages/readyup/__tests__/check-utils/workspaces.test.ts
+++ b/packages/readyup/__tests__/check-utils/workspaces.test.ts
@@ -1,31 +1,20 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { discoverWorkspaces } from '../../src/check-utils/workspaces.ts';
+import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
 
-let tempDir: string;
-let cwdSpy: MockInstance;
+const it = createTempDirTest({ prefix: 'rdy-ws-', cwd: 'mock' });
 
 describe(discoverWorkspaces, () => {
-  beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), 'rdy-ws-'));
-    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tempDir);
-  });
-
-  afterEach(() => {
-    cwdSpy.mockRestore();
-  });
-
   describe('pnpm workspaces', () => {
-    it('discovers workspaces listed via `packages` block sequence', () => {
-      writeRootPackageJson({ name: 'root', private: true });
-      writePnpmWorkspaceYaml(['packages:', '  - packages/*', '  - apps/**', ''].join('\n'));
-      writeWorkspacePackage('packages/alpha', { name: 'alpha', version: '1.0.0' });
-      writeWorkspacePackage('packages/beta', { name: 'beta', version: '1.0.0' });
-      writeWorkspacePackage('apps/web', { name: 'web', version: '1.0.0' });
+    it('discovers workspaces listed via `packages` block sequence', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true });
+      writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', '  - apps/**', ''].join('\n'));
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha', version: '1.0.0' });
+      writeWorkspacePackage(temp, 'packages/beta', { name: 'beta', version: '1.0.0' });
+      writeWorkspacePackage(temp, 'apps/web', { name: 'web', version: '1.0.0' });
 
       const workspaces = discoverWorkspaces();
 
@@ -33,23 +22,23 @@ describe(discoverWorkspaces, () => {
       expect(workspaces.map((w) => w.name)).toStrictEqual(['web', 'alpha', 'beta']);
     });
 
-    it('returns an empty array when a pattern expands to zero directories', () => {
-      writeRootPackageJson({ name: 'root', private: true });
-      writePnpmWorkspaceYaml(['packages:', '  - packages/*', ''].join('\n'));
+    it('returns an empty array when a pattern expands to zero directories', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true });
+      writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
 
       expect(discoverWorkspaces()).toStrictEqual([]);
     });
 
-    it('falls through to npm/single detection when `packages` key is absent', () => {
-      writeRootPackageJson({ name: 'root', version: '1.0.0' });
-      writePnpmWorkspaceYaml(['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
+    it('falls through to npm/single detection when `packages` key is absent', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', version: '1.0.0' });
+      writePnpmWorkspaceYaml(temp, ['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces).toStrictEqual([
         {
           dir: '.',
-          absolutePath: tempDir,
+          absolutePath: temp.dir,
           name: 'root',
           isPackage: true,
           packageJson: { name: 'root', version: '1.0.0' },
@@ -57,43 +46,43 @@ describe(discoverWorkspaces, () => {
       ]);
     });
 
-    it('propagates errors from the YAML reader for unsupported features', () => {
-      writeRootPackageJson({ name: 'root', private: true });
-      writePnpmWorkspaceYaml(['packages:', '  - &anchor packages/*', ''].join('\n'));
+    it('propagates errors from the YAML reader for unsupported features', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true });
+      writePnpmWorkspaceYaml(temp, ['packages:', '  - &anchor packages/*', ''].join('\n'));
 
       expect(() => discoverWorkspaces()).toThrow(/anchor/);
     });
   });
 
   describe('npm/yarn workspaces', () => {
-    it('discovers workspaces when `workspaces` is a string array', () => {
-      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage('packages/beta', { name: 'beta' });
+    it('discovers workspaces when `workspaces` is a string array', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage(temp, 'packages/beta', { name: 'beta' });
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha', 'packages/beta']);
     });
 
-    it('discovers workspaces when `workspaces.packages` is a string array', () => {
-      writeRootPackageJson({
+    it('discovers workspaces when `workspaces.packages` is a string array', ({ temp }) => {
+      writeRootPackageJson(temp, {
         name: 'root',
         private: true,
         workspaces: { packages: ['packages/*', 'apps/*'] },
       });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage('apps/web', { name: 'web' });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage(temp, 'apps/web', { name: 'web' });
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces.map((w) => w.dir)).toStrictEqual(['apps/web', 'packages/alpha']);
     });
 
-    it('returns isPackage: false for a discovered workspace with `private: true`', () => {
-      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage('packages/internal', { name: 'internal', private: true });
+    it('returns isPackage: false for a discovered workspace with `private: true`', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage(temp, 'packages/internal', { name: 'internal', private: true });
 
       const workspaces = discoverWorkspaces();
       const byDir = Object.fromEntries(workspaces.map((w) => [w.dir, w.isPackage]));
@@ -103,15 +92,15 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('single-workspace repo', () => {
-    it('returns a single entry with dir: "." when no workspace config is present', () => {
-      writeRootPackageJson({ name: 'solo', version: '1.0.0' });
+    it('returns a single entry with dir: "." when no workspace config is present', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'solo', version: '1.0.0' });
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces).toStrictEqual([
         {
           dir: '.',
-          absolutePath: tempDir,
+          absolutePath: temp.dir,
           name: 'solo',
           isPackage: true,
           packageJson: { name: 'solo', version: '1.0.0' },
@@ -119,42 +108,42 @@ describe(discoverWorkspaces, () => {
       ]);
     });
 
-    it('returns isPackage: false when `private: true`', () => {
-      writeRootPackageJson({ name: 'solo', private: true });
+    it('returns isPackage: false when `private: true`', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'solo', private: true });
 
       expect(discoverWorkspaces()[0]?.isPackage).toBe(false);
     });
 
-    it('returns isPackage: true when `private` is absent', () => {
-      writeRootPackageJson({ name: 'solo' });
+    it('returns isPackage: true when `private` is absent', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'solo' });
 
       expect(discoverWorkspaces()[0]?.isPackage).toBe(true);
     });
 
-    it('returns isPackage: true when `private: false`', () => {
-      writeRootPackageJson({ name: 'solo', private: false });
+    it('returns isPackage: true when `private: false`', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'solo', private: false });
 
       expect(discoverWorkspaces()[0]?.isPackage).toBe(true);
     });
 
-    it('returns isPackage: true when `private` is a non-true value like the string "false"', () => {
-      writeRootPackageJson({ name: 'solo', private: 'false' });
+    it('returns isPackage: true when `private` is a non-true value like the string "false"', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'solo', private: 'false' });
 
       expect(discoverWorkspaces()[0]?.isPackage).toBe(true);
     });
 
-    it('returns `name: undefined` when root package.json has no `name` field', () => {
-      writeRootPackageJson({ version: '1.0.0' });
+    it('returns `name: undefined` when root package.json has no `name` field', ({ temp }) => {
+      writeRootPackageJson(temp, { version: '1.0.0' });
 
       expect(discoverWorkspaces()[0]?.name).toBeUndefined();
     });
   });
 
   describe('filter option', () => {
-    it('excludes workspaces for which the filter returns false', () => {
-      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage('packages/beta', { name: 'beta', private: true });
+    it('excludes workspaces for which the filter returns false', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage(temp, 'packages/beta', { name: 'beta', private: true });
 
       const workspaces = discoverWorkspaces({ filter: (w) => w.isPackage });
 
@@ -163,42 +152,41 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('skipping non-workspace matched directories', () => {
-    it('skips a matched directory without a package.json', () => {
-      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
-      mkdirSync(join(tempDir, 'packages/empty'), { recursive: true });
+    it('skips a matched directory without a package.json', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      temp.mkdir('packages/empty');
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha']);
     });
 
-    it('skips a matched directory with an unparseable package.json', () => {
-      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
-      mkdirSync(join(tempDir, 'packages/broken'), { recursive: true });
-      writeFileSync(join(tempDir, 'packages/broken/package.json'), '{ not valid json');
+    it('skips a matched directory with an unparseable package.json', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      temp.write('packages/broken/package.json', '{ not valid json');
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha']);
     });
 
-    it('does not traverse into node_modules', () => {
-      writeRootPackageJson({ name: 'root', private: true, workspaces: ['**/*'] });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+    it('does not traverse into node_modules', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['**/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
       // A fake workspace hiding inside node_modules — must not appear in results.
-      writeWorkspacePackage('node_modules/sneaky', { name: 'sneaky' });
+      writeWorkspacePackage(temp, 'node_modules/sneaky', { name: 'sneaky' });
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces.map((w) => w.name)).not.toContain('sneaky');
     });
 
-    it('does not traverse into .git', () => {
-      writeRootPackageJson({ name: 'root', private: true, workspaces: ['**/*'] });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage('.git/fake', { name: 'fake' });
+    it('does not traverse into .git', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['**/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage(temp, '.git/fake', { name: 'fake' });
 
       const workspaces = discoverWorkspaces();
 
@@ -207,24 +195,24 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('error: missing root package.json', () => {
-    it('throws with a message that includes the resolved path', () => {
+    it('throws with a message that includes the resolved path', ({ temp }) => {
       expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
-      expect(() => discoverWorkspaces()).toThrow(tempDir);
+      expect(() => discoverWorkspaces()).toThrow(temp.dir);
     });
 
-    it('throws even when pnpm-workspace.yaml is present', () => {
-      writePnpmWorkspaceYaml(['packages:', '  - packages/*', ''].join('\n'));
+    it('throws even when pnpm-workspace.yaml is present', ({ temp }) => {
+      writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
 
       expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
     });
   });
 
   describe('sorting', () => {
-    it('sorts results by dir ascending', () => {
-      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage('packages/zeta', { name: 'zeta' });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage('packages/mu', { name: 'mu' });
+    it('sorts results by dir ascending', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/zeta', { name: 'zeta' });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage(temp, 'packages/mu', { name: 'mu' });
 
       const workspaces = discoverWorkspaces();
 
@@ -233,15 +221,15 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('Workspace shape', () => {
-    it('includes absolutePath, name, isPackage, and packageJson for a monorepo workspace', () => {
-      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage('packages/alpha', { name: 'alpha', version: '1.2.3' });
+    it('includes absolutePath, name, isPackage, and packageJson for a monorepo workspace', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha', version: '1.2.3' });
 
       const [workspace] = discoverWorkspaces();
 
       expect(workspace).toStrictEqual({
         dir: 'packages/alpha',
-        absolutePath: join(tempDir, 'packages/alpha'),
+        absolutePath: join(temp.dir, 'packages/alpha'),
         name: 'alpha',
         isPackage: true,
         packageJson: { name: 'alpha', version: '1.2.3' },
@@ -250,8 +238,8 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('negation patterns in npm workspaces', () => {
-    it('throws when `workspaces` contains a negation pattern', () => {
-      writeRootPackageJson({
+    it('throws when `workspaces` contains a negation pattern', ({ temp }) => {
+      writeRootPackageJson(temp, {
         name: 'root',
         private: true,
         workspaces: ['packages/*', '!packages/deprecated/*'],
@@ -260,8 +248,8 @@ describe(discoverWorkspaces, () => {
       expect(() => discoverWorkspaces()).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
     });
 
-    it('throws when `workspaces.packages` contains a negation pattern', () => {
-      writeRootPackageJson({
+    it('throws when `workspaces.packages` contains a negation pattern', ({ temp }) => {
+      writeRootPackageJson(temp, {
         name: 'root',
         private: true,
         workspaces: { packages: ['packages/*', '!packages/deprecated/*'] },
@@ -274,17 +262,19 @@ describe(discoverWorkspaces, () => {
 
 // region | Helpers
 
-function writeRootPackageJson(content: Record<string, unknown>): void {
-  writeFileSync(join(tempDir, 'package.json'), JSON.stringify(content));
+/** Writes the root manifest that declares the workspace globs. */
+function writeRootPackageJson(temp: TempDir, content: Record<string, unknown>): void {
+  temp.writeJson('package.json', content);
 }
 
-function writeWorkspacePackage(relDir: string, content: Record<string, unknown>): void {
-  mkdirSync(join(tempDir, relDir), { recursive: true });
-  writeFileSync(join(tempDir, relDir, 'package.json'), JSON.stringify(content));
+/** Writes a workspace member's manifest at a root-relative directory. */
+function writeWorkspacePackage(temp: TempDir, relDir: string, content: Record<string, unknown>): void {
+  temp.writeJson(join(relDir, 'package.json'), content);
 }
 
-function writePnpmWorkspaceYaml(content: string): void {
-  writeFileSync(join(tempDir, 'pnpm-workspace.yaml'), content);
+/** Writes the pnpm workspace manifest, which takes precedence over the `workspaces` field. */
+function writePnpmWorkspaceYaml(temp: TempDir, content: string): void {
+  temp.write('pnpm-workspace.yaml', content);
 }
 
 // endregion | Helpers

--- a/packages/readyup/__tests__/check-utils/workspaces.test.ts
+++ b/packages/readyup/__tests__/check-utils/workspaces.test.ts
@@ -1,20 +1,20 @@
 import { join } from 'node:path';
 
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { discoverWorkspaces } from '../../src/check-utils/workspaces.ts';
-import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({ prefix: 'rdy-ws-', cwd: 'mock' });
+const temp = useTempDir({ prefix: 'rdy-ws-', cwd: 'mock' });
 
 describe(discoverWorkspaces, () => {
   describe('pnpm workspaces', () => {
-    it('discovers workspaces listed via `packages` block sequence', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true });
-      writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', '  - apps/**', ''].join('\n'));
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha', version: '1.0.0' });
-      writeWorkspacePackage(temp, 'packages/beta', { name: 'beta', version: '1.0.0' });
-      writeWorkspacePackage(temp, 'apps/web', { name: 'web', version: '1.0.0' });
+    it('discovers workspaces listed via `packages` block sequence', () => {
+      writeRootPackageJson({ name: 'root', private: true });
+      writePnpmWorkspaceYaml(['packages:', '  - packages/*', '  - apps/**', ''].join('\n'));
+      writeWorkspacePackage('packages/alpha', { name: 'alpha', version: '1.0.0' });
+      writeWorkspacePackage('packages/beta', { name: 'beta', version: '1.0.0' });
+      writeWorkspacePackage('apps/web', { name: 'web', version: '1.0.0' });
 
       const workspaces = discoverWorkspaces();
 
@@ -22,16 +22,16 @@ describe(discoverWorkspaces, () => {
       expect(workspaces.map((w) => w.name)).toStrictEqual(['web', 'alpha', 'beta']);
     });
 
-    it('returns an empty array when a pattern expands to zero directories', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true });
-      writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
+    it('returns an empty array when a pattern expands to zero directories', () => {
+      writeRootPackageJson({ name: 'root', private: true });
+      writePnpmWorkspaceYaml(['packages:', '  - packages/*', ''].join('\n'));
 
       expect(discoverWorkspaces()).toStrictEqual([]);
     });
 
-    it('falls through to npm/single detection when `packages` key is absent', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', version: '1.0.0' });
-      writePnpmWorkspaceYaml(temp, ['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
+    it('falls through to npm/single detection when `packages` key is absent', () => {
+      writeRootPackageJson({ name: 'root', version: '1.0.0' });
+      writePnpmWorkspaceYaml(['onlyBuiltDependencies:', '  - esbuild', ''].join('\n'));
 
       const workspaces = discoverWorkspaces();
 
@@ -46,43 +46,43 @@ describe(discoverWorkspaces, () => {
       ]);
     });
 
-    it('propagates errors from the YAML reader for unsupported features', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true });
-      writePnpmWorkspaceYaml(temp, ['packages:', '  - &anchor packages/*', ''].join('\n'));
+    it('propagates errors from the YAML reader for unsupported features', () => {
+      writeRootPackageJson({ name: 'root', private: true });
+      writePnpmWorkspaceYaml(['packages:', '  - &anchor packages/*', ''].join('\n'));
 
       expect(() => discoverWorkspaces()).toThrow(/anchor/);
     });
   });
 
   describe('npm/yarn workspaces', () => {
-    it('discovers workspaces when `workspaces` is a string array', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage(temp, 'packages/beta', { name: 'beta' });
+    it('discovers workspaces when `workspaces` is a string array', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('packages/beta', { name: 'beta' });
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha', 'packages/beta']);
     });
 
-    it('discovers workspaces when `workspaces.packages` is a string array', ({ temp }) => {
-      writeRootPackageJson(temp, {
+    it('discovers workspaces when `workspaces.packages` is a string array', () => {
+      writeRootPackageJson({
         name: 'root',
         private: true,
         workspaces: { packages: ['packages/*', 'apps/*'] },
       });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage(temp, 'apps/web', { name: 'web' });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('apps/web', { name: 'web' });
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces.map((w) => w.dir)).toStrictEqual(['apps/web', 'packages/alpha']);
     });
 
-    it('returns isPackage: false for a discovered workspace with `private: true`', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage(temp, 'packages/internal', { name: 'internal', private: true });
+    it('returns isPackage: false for a discovered workspace with `private: true`', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('packages/internal', { name: 'internal', private: true });
 
       const workspaces = discoverWorkspaces();
       const byDir = Object.fromEntries(workspaces.map((w) => [w.dir, w.isPackage]));
@@ -92,8 +92,8 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('single-workspace repo', () => {
-    it('returns a single entry with dir: "." when no workspace config is present', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'solo', version: '1.0.0' });
+    it('returns a single entry with dir: "." when no workspace config is present', () => {
+      writeRootPackageJson({ name: 'solo', version: '1.0.0' });
 
       const workspaces = discoverWorkspaces();
 
@@ -108,42 +108,42 @@ describe(discoverWorkspaces, () => {
       ]);
     });
 
-    it('returns isPackage: false when `private: true`', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'solo', private: true });
+    it('returns isPackage: false when `private: true`', () => {
+      writeRootPackageJson({ name: 'solo', private: true });
 
       expect(discoverWorkspaces()[0]?.isPackage).toBe(false);
     });
 
-    it('returns isPackage: true when `private` is absent', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'solo' });
+    it('returns isPackage: true when `private` is absent', () => {
+      writeRootPackageJson({ name: 'solo' });
 
       expect(discoverWorkspaces()[0]?.isPackage).toBe(true);
     });
 
-    it('returns isPackage: true when `private: false`', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'solo', private: false });
+    it('returns isPackage: true when `private: false`', () => {
+      writeRootPackageJson({ name: 'solo', private: false });
 
       expect(discoverWorkspaces()[0]?.isPackage).toBe(true);
     });
 
-    it('returns isPackage: true when `private` is a non-true value like the string "false"', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'solo', private: 'false' });
+    it('returns isPackage: true when `private` is a non-true value like the string "false"', () => {
+      writeRootPackageJson({ name: 'solo', private: 'false' });
 
       expect(discoverWorkspaces()[0]?.isPackage).toBe(true);
     });
 
-    it('returns `name: undefined` when root package.json has no `name` field', ({ temp }) => {
-      writeRootPackageJson(temp, { version: '1.0.0' });
+    it('returns `name: undefined` when root package.json has no `name` field', () => {
+      writeRootPackageJson({ version: '1.0.0' });
 
       expect(discoverWorkspaces()[0]?.name).toBeUndefined();
     });
   });
 
   describe('filter option', () => {
-    it('excludes workspaces for which the filter returns false', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage(temp, 'packages/beta', { name: 'beta', private: true });
+    it('excludes workspaces for which the filter returns false', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('packages/beta', { name: 'beta', private: true });
 
       const workspaces = discoverWorkspaces({ filter: (w) => w.isPackage });
 
@@ -152,9 +152,9 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('skipping non-workspace matched directories', () => {
-    it('skips a matched directory without a package.json', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+    it('skips a matched directory without a package.json', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
       temp.mkdir('packages/empty');
 
       const workspaces = discoverWorkspaces();
@@ -162,9 +162,9 @@ describe(discoverWorkspaces, () => {
       expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha']);
     });
 
-    it('skips a matched directory with an unparseable package.json', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+    it('skips a matched directory with an unparseable package.json', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
       temp.write('packages/broken/package.json', '{ not valid json');
 
       const workspaces = discoverWorkspaces();
@@ -172,21 +172,21 @@ describe(discoverWorkspaces, () => {
       expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha']);
     });
 
-    it('does not traverse into node_modules', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['**/*'] });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+    it('does not traverse into node_modules', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['**/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
       // A fake workspace hiding inside node_modules — must not appear in results.
-      writeWorkspacePackage(temp, 'node_modules/sneaky', { name: 'sneaky' });
+      writeWorkspacePackage('node_modules/sneaky', { name: 'sneaky' });
 
       const workspaces = discoverWorkspaces();
 
       expect(workspaces.map((w) => w.name)).not.toContain('sneaky');
     });
 
-    it('does not traverse into .git', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['**/*'] });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage(temp, '.git/fake', { name: 'fake' });
+    it('does not traverse into .git', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['**/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('.git/fake', { name: 'fake' });
 
       const workspaces = discoverWorkspaces();
 
@@ -195,24 +195,24 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('error: missing root package.json', () => {
-    it('throws with a message that includes the resolved path', ({ temp }) => {
+    it('throws with a message that includes the resolved path', () => {
       expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
       expect(() => discoverWorkspaces()).toThrow(temp.dir);
     });
 
-    it('throws even when pnpm-workspace.yaml is present', ({ temp }) => {
-      writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
+    it('throws even when pnpm-workspace.yaml is present', () => {
+      writePnpmWorkspaceYaml(['packages:', '  - packages/*', ''].join('\n'));
 
       expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
     });
   });
 
   describe('sorting', () => {
-    it('sorts results by dir ascending', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage(temp, 'packages/zeta', { name: 'zeta' });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
-      writeWorkspacePackage(temp, 'packages/mu', { name: 'mu' });
+    it('sorts results by dir ascending', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/zeta', { name: 'zeta' });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage('packages/mu', { name: 'mu' });
 
       const workspaces = discoverWorkspaces();
 
@@ -221,9 +221,9 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('Workspace shape', () => {
-    it('includes absolutePath, name, isPackage, and packageJson for a monorepo workspace', ({ temp }) => {
-      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
-      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha', version: '1.2.3' });
+    it('includes absolutePath, name, isPackage, and packageJson for a monorepo workspace', () => {
+      writeRootPackageJson({ name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage('packages/alpha', { name: 'alpha', version: '1.2.3' });
 
       const [workspace] = discoverWorkspaces();
 
@@ -238,8 +238,8 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('negation patterns in npm workspaces', () => {
-    it('throws when `workspaces` contains a negation pattern', ({ temp }) => {
-      writeRootPackageJson(temp, {
+    it('throws when `workspaces` contains a negation pattern', () => {
+      writeRootPackageJson({
         name: 'root',
         private: true,
         workspaces: ['packages/*', '!packages/deprecated/*'],
@@ -248,8 +248,8 @@ describe(discoverWorkspaces, () => {
       expect(() => discoverWorkspaces()).toThrow(/negation pattern "!packages\/deprecated\/\*"/);
     });
 
-    it('throws when `workspaces.packages` contains a negation pattern', ({ temp }) => {
-      writeRootPackageJson(temp, {
+    it('throws when `workspaces.packages` contains a negation pattern', () => {
+      writeRootPackageJson({
         name: 'root',
         private: true,
         workspaces: { packages: ['packages/*', '!packages/deprecated/*'] },
@@ -263,17 +263,17 @@ describe(discoverWorkspaces, () => {
 // region | Helpers
 
 /** Writes the root manifest that declares the workspace globs. */
-function writeRootPackageJson(temp: TempDir, content: Record<string, unknown>): void {
+function writeRootPackageJson(content: Record<string, unknown>): void {
   temp.writeJson('package.json', content);
 }
 
 /** Writes a workspace member's manifest at a root-relative directory. */
-function writeWorkspacePackage(temp: TempDir, relDir: string, content: Record<string, unknown>): void {
+function writeWorkspacePackage(relDir: string, content: Record<string, unknown>): void {
   temp.writeJson(join(relDir, 'package.json'), content);
 }
 
 /** Writes the pnpm workspace manifest, which takes precedence over the `workspaces` field. */
-function writePnpmWorkspaceYaml(temp: TempDir, content: string): void {
+function writePnpmWorkspaceYaml(content: string): void {
   temp.write('pnpm-workspace.yaml', content);
 }
 

--- a/packages/readyup/__tests__/detailProjection.test.ts
+++ b/packages/readyup/__tests__/detailProjection.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
-import { type CapturedStdio, createStdioFixture } from './helpers/capturedStdio.ts';
-import { createTempDirTest } from './helpers/tempDir.ts';
+import { useCapturedStdio } from './helpers/capturedStdio.ts';
+import { useTempDir } from './helpers/tempDir.ts';
 
 /** A kit with one passing check and one failing check that carries a fix. */
 const MIXED_KIT =
@@ -11,15 +11,17 @@ const MIXED_KIT =
   `  { name: 'nope', check: () => false, fix: 'do the thing' },\n` +
   `] }] };\n`;
 
-const it = createTempDirTest({
+const temp = useTempDir({
   prefix: 'readyup-detail-',
   cwd: 'chdir',
   scope: 'file',
-  setup: (temp) => temp.write('.readyup/kits/default.js', MIXED_KIT),
-}).extend<{ io: CapturedStdio }>({ io: createStdioFixture() });
+  setup: () => temp.write('.readyup/kits/default.js', MIXED_KIT),
+});
+
+const io = useCapturedStdio();
 
 describe('--detail projection', () => {
-  it('defaults to the full tree, echoing the projection it used', async ({ io }) => {
+  it('defaults to the full tree, echoing the projection it used', async () => {
     await routeCommand(['--json']);
 
     expect(JSON.parse(io.stdout)).toMatchObject({
@@ -28,7 +30,7 @@ describe('--detail projection', () => {
     });
   });
 
-  it('reduces the tree to failed checks and their fixes under summary', async ({ io }) => {
+  it('reduces the tree to failed checks and their fixes under summary', async () => {
     await routeCommand(['--json', '--detail', 'summary']);
 
     expect(JSON.parse(io.stdout)).toMatchObject({
@@ -40,7 +42,7 @@ describe('--detail projection', () => {
     expect(io.stdout).not.toContain('clean');
   });
 
-  it('reports --detail without --json as a usage error rather than ignoring it', async ({ io }) => {
+  it('reports --detail without --json as a usage error rather than ignoring it', async () => {
     const exitCode = await routeCommand(['--detail', 'summary']);
 
     expect(exitCode).toBe(2);
@@ -48,7 +50,7 @@ describe('--detail projection', () => {
     expect(io.stderr).toContain('--detail requires --json');
   });
 
-  it.for(['compile', 'init', 'list', 'verify'])('reports --detail on %s as a usage error', async (command, { io }) => {
+  it.for(['compile', 'init', 'list', 'verify'])('reports --detail on %s as a usage error', async (command) => {
     const exitCode = await routeCommand([command, '--detail', 'summary', '--json']);
 
     expect(exitCode).toBe(2);

--- a/packages/readyup/__tests__/detailProjection.test.ts
+++ b/packages/readyup/__tests__/detailProjection.test.ts
@@ -1,11 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
-import process from 'node:process';
-
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
+import { type CapturedStdio, createStdioFixture } from './helpers/capturedStdio.ts';
+import { createTempDirTest } from './helpers/tempDir.ts';
 
 /** A kit with one passing check and one failing check that carries a fix. */
 const MIXED_KIT =
@@ -14,77 +11,47 @@ const MIXED_KIT =
   `  { name: 'nope', check: () => false, fix: 'do the thing' },\n` +
   `] }] };\n`;
 
-let cwd: string;
-let originalCwd: string;
-let stdout: string[];
-let stdoutSpy: MockInstance;
-let stderrSpy: MockInstance;
-
-beforeAll(() => {
-  originalCwd = process.cwd();
-  cwd = mkdtempSync(path.join(tmpdir(), 'readyup-detail-'));
-  mkdirSync(path.join(cwd, '.readyup/kits'), { recursive: true });
-  writeFileSync(path.join(cwd, '.readyup/kits/default.js'), MIXED_KIT);
-  process.chdir(cwd);
-});
-
-beforeEach(() => {
-  stdout = [];
-  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
-    stdout.push(String(chunk));
-    return true;
-  });
-  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-});
-
-afterEach(() => {
-  stdoutSpy.mockRestore();
-  stderrSpy.mockRestore();
-});
-
-afterAll(() => {
-  process.chdir(originalCwd);
-  rmSync(cwd, { recursive: true, force: true });
-});
+const it = createTempDirTest({
+  prefix: 'readyup-detail-',
+  cwd: 'chdir',
+  scope: 'file',
+  setup: (temp) => temp.write('.readyup/kits/default.js', MIXED_KIT),
+}).extend<{ io: CapturedStdio }>({ io: createStdioFixture() });
 
 describe('--detail projection', () => {
-  it('defaults to the full tree, echoing the projection it used', async () => {
+  it('defaults to the full tree, echoing the projection it used', async ({ io }) => {
     await routeCommand(['--json']);
 
-    expect(JSON.parse(readStdout())).toMatchObject({
+    expect(JSON.parse(io.stdout)).toMatchObject({
       detail: 'full',
       kits: [{ checklists: [{ checks: [{ name: 'clean' }, { name: 'nope' }] }] }],
     });
   });
 
-  it('reduces the tree to failed checks and their fixes under summary', async () => {
+  it('reduces the tree to failed checks and their fixes under summary', async ({ io }) => {
     await routeCommand(['--json', '--detail', 'summary']);
 
-    expect(JSON.parse(readStdout())).toMatchObject({
+    expect(JSON.parse(io.stdout)).toMatchObject({
       detail: 'summary',
       counts: { passed: 1, errors: 1 },
       worstSeverity: 'error',
       kits: [{ checklists: [{ checks: [{ name: 'nope', fix: 'do the thing' }] }] }],
     });
-    expect(readStdout()).not.toContain('clean');
+    expect(io.stdout).not.toContain('clean');
   });
 
-  it('reports --detail without --json as a usage error rather than ignoring it', async () => {
+  it('reports --detail without --json as a usage error rather than ignoring it', async ({ io }) => {
     const exitCode = await routeCommand(['--detail', 'summary']);
 
     expect(exitCode).toBe(2);
-    expect(readStdout()).toBe('');
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('--detail requires --json'));
+    expect(io.stdout).toBe('');
+    expect(io.stderr).toContain('--detail requires --json');
   });
 
-  it.each(['compile', 'init', 'list', 'verify'])('reports --detail on %s as a usage error', async (command) => {
+  it.for(['compile', 'init', 'list', 'verify'])('reports --detail on %s as a usage error', async (command, { io }) => {
     const exitCode = await routeCommand([command, '--detail', 'summary', '--json']);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'usage' } });
+    expect(JSON.parse(io.stdout)).toMatchObject({ error: { code: 'usage' } });
   });
 });
-
-function readStdout(): string {
-  return stdout.join('');
-}

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -3,11 +3,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
-import { type CapturedStdio, createStdioFixture } from './helpers/capturedStdio.ts';
-import { createTempDirTest } from './helpers/tempDir.ts';
+import { useCapturedStdio } from './helpers/capturedStdio.ts';
+import { useTempDir } from './helpers/tempDir.ts';
 
 /** A kit whose single check passes. */
 const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
@@ -26,11 +26,11 @@ const MULTI_KIT =
   `  { name: 'lint', checks: [{ name: 'lint-ok', check: () => true }] },\n` +
   `] };\n`;
 
-const it = createTempDirTest({
+const temp = useTempDir({
   prefix: 'readyup-exit-codes-',
   cwd: 'chdir',
   scope: 'file',
-  setup: (temp) => {
+  setup: () => {
     temp.write('.readyup/kits/passing.js', PASSING_KIT);
     temp.write('.readyup/kits/failing.js', FAILING_KIT);
     temp.write('.readyup/kits/invalid.js', INVALID_KIT);
@@ -44,7 +44,9 @@ const it = createTempDirTest({
     // error banner that appears in an otherwise-passing test run belongs to this fixture.
     temp.write('broken.ts', 'export default { this is not valid TypeScript\n');
   },
-}).extend<{ io: CapturedStdio }>({ io: createStdioFixture() });
+});
+
+const io = useCapturedStdio();
 
 describe('exit codes', () => {
   it.for([
@@ -62,7 +64,7 @@ describe('exit codes', () => {
     await expect(routeCommand(args)).resolves.toBe(expected);
   });
 
-  it('reports a pre-dispatch failure through the error envelope', async ({ io }) => {
+  it('reports a pre-dispatch failure through the error envelope', async () => {
     const exitCode = await routeCommand(['--bogus', '--json']);
 
     expect(exitCode).toBe(2);
@@ -76,7 +78,7 @@ describe('exit codes', () => {
     { label: 'an unknown checklist', args: ['passing:absent'], kit: 'passing', code: 'usage' },
     { label: 'a missing kit', args: ['absent'], kit: 'absent', code: 'kit-load' },
     { label: 'an unloadable kit', args: ['invalid'], kit: 'invalid', code: 'kit-load' },
-  ])('reports code "$code" as a per-kit error entry for $label', async ({ args, kit, code }, { io }) => {
+  ])('reports code "$code" as a per-kit error entry for $label', async ({ args, kit, code }) => {
     const exitCode = await routeCommand([...args, '--json']);
 
     expect(exitCode).toBe(2);
@@ -85,7 +87,7 @@ describe('exit codes', () => {
     });
   });
 
-  it('reports code "config" for an unreadable config file', async ({ io, temp }) => {
+  it('reports code "config" for an unreadable config file', async () => {
     // A separate tree, so the broken config does not reach the other cases in this file.
     const brokenCwd = mkdtempSync(path.join(tmpdir(), 'readyup-bad-config-'));
     mkdirSync(path.join(brokenCwd, '.config'), { recursive: true });
@@ -117,7 +119,7 @@ describe('stdout purity under --json', () => {
     { label: 'a list failure', args: ['list', '--from', 'dir:/definitely/absent', '--json'] },
     { label: 'a verify failure', args: ['verify', '--manifest', 'absent.json', '--json'] },
     { label: 'an init usage error', args: ['init', '--json'] },
-  ])('writes exactly one JSON document to stdout for $label', async ({ args }, { io }) => {
+  ])('writes exactly one JSON document to stdout for $label', async ({ args }) => {
     await routeCommand(args);
 
     const written = io.stdout;
@@ -127,13 +129,13 @@ describe('stdout purity under --json', () => {
     expect(written.trimEnd()).not.toContain('\n');
   });
 
-  it('keeps stderr empty when an error is reported through the envelope', async ({ io }) => {
+  it('keeps stderr empty when an error is reported through the envelope', async () => {
     await routeCommand(['--bogus', '--json']);
 
     expect(io.stderr).toBe('');
   });
 
-  it('reports errors as prose on stderr when --json is absent', async ({ io }) => {
+  it('reports errors as prose on stderr when --json is absent', async () => {
     const exitCode = await routeCommand(['--bogus']);
 
     expect(exitCode).toBe(2);
@@ -144,7 +146,7 @@ describe('stdout purity under --json', () => {
   it.for([
     { label: 'the retired short flag', flag: '-j' },
     { label: 'a short cluster containing j', flag: '-jJ' },
-  ])('takes the prose path for a flag-parse failure spelled with $label', async ({ flag }, { io }) => {
+  ])('takes the prose path for a flag-parse failure spelled with $label', async ({ flag }) => {
     const exitCode = await routeCommand([flag]);
 
     expect(exitCode).toBe(2);
@@ -154,15 +156,12 @@ describe('stdout purity under --json', () => {
 });
 
 describe('flag surface', () => {
-  it.for(['-J', '-F', '-R', '-i', '-u', '-j'])(
-    'exits 2 with a usage error for the retired short %s',
-    async (short, { io }) => {
-      const exitCode = await routeCommand(['--json', short]);
+  it.for(['-J', '-F', '-R', '-i', '-u', '-j'])('exits 2 with a usage error for the retired short %s', async (short) => {
+    const exitCode = await routeCommand(['--json', short]);
 
-      expect(exitCode).toBe(2);
-      expect(JSON.parse(io.stdout)).toMatchObject({ error: { code: 'usage' } });
-    },
-  );
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(io.stdout)).toMatchObject({ error: { code: 'usage' } });
+  });
 
   it.for([
     { long: '--jit', args: ['--jit'] },
@@ -170,7 +169,7 @@ describe('flag surface', () => {
     { long: '--url', args: ['--url', 'file://absent'] },
     { long: '--fail-on', args: ['passing', '--fail-on', 'warn'] },
     { long: '--report-on', args: ['passing', '--report-on', 'error'] },
-  ])('leaves $long accepted after its short is retired', async ({ args }, { io }) => {
+  ])('leaves $long accepted after its short is retired', async ({ args }) => {
     // The flag may still fail for want of a kit; what matters is that it is not a usage error.
     const exitCode = await routeCommand([...args, '--json']);
 
@@ -179,7 +178,7 @@ describe('flag surface', () => {
     }
   });
 
-  it('runs the named checklists from a single positional kit', async ({ io }) => {
+  it('runs the named checklists from a single positional kit', async () => {
     const exitCode = await routeCommand(['deploy', '--checklists', 'build,test', '--json']);
 
     expect(exitCode).toBe(0);
@@ -192,7 +191,7 @@ describe('flag surface', () => {
   it.for([
     { label: 'a ":" filter competing with --checklists', args: ['deploy:build', '--checklists', 'test'] },
     { label: 'more than one positional kit', args: ['deploy', 'passing', '--checklists', 'build'] },
-  ])('exits 2 with a usage error for $label', async ({ args }, { io }) => {
+  ])('exits 2 with a usage error for $label', async ({ args }) => {
     const exitCode = await routeCommand([...args, '--json']);
 
     expect(exitCode).toBe(2);
@@ -201,7 +200,7 @@ describe('flag surface', () => {
 
   // Asserted without `--json`, which `init` does not accept either; adding it would let this pass
   // on the wrong flag.
-  it('exits 2 for the retired init -f short', async ({ io }) => {
+  it('exits 2 for the retired init -f short', async () => {
     const exitCode = await routeCommand(['init', '-f']);
 
     expect(exitCode).toBe(2);
@@ -216,7 +215,7 @@ describe('subcommand error classification', () => {
     { command: 'verify', args: ['verify', '--bogus'] },
     { command: 'compile', args: ['compile', '--bogus'] },
     { command: 'init', args: ['init', '--bogus'] },
-  ])('exits 2 with a usage error for $command', async ({ args }, { io }) => {
+  ])('exits 2 with a usage error for $command', async ({ args }) => {
     const exitCode = await routeCommand([...args, '--json']);
 
     expect(exitCode).toBe(2);

--- a/packages/readyup/__tests__/exitCodes.test.ts
+++ b/packages/readyup/__tests__/exitCodes.test.ts
@@ -3,9 +3,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
+import { type CapturedStdio, createStdioFixture } from './helpers/capturedStdio.ts';
+import { createTempDirTest } from './helpers/tempDir.ts';
 
 /** A kit whose single check passes. */
 const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
@@ -24,60 +26,28 @@ const MULTI_KIT =
   `  { name: 'lint', checks: [{ name: 'lint-ok', check: () => true }] },\n` +
   `] };\n`;
 
-let cwd: string;
-let originalCwd: string;
-let stdout: string[];
-let stderr: string[];
-let stdoutSpy: MockInstance;
-let stderrSpy: MockInstance;
-
-beforeAll(() => {
-  originalCwd = process.cwd();
-  cwd = mkdtempSync(path.join(tmpdir(), 'readyup-exit-codes-'));
-  mkdirSync(path.join(cwd, '.readyup/kits'), { recursive: true });
-  writeFileSync(path.join(cwd, '.readyup/kits/passing.js'), PASSING_KIT);
-  writeFileSync(path.join(cwd, '.readyup/kits/failing.js'), FAILING_KIT);
-  writeFileSync(path.join(cwd, '.readyup/kits/invalid.js'), INVALID_KIT);
-  writeFileSync(path.join(cwd, '.readyup/kits/deploy.js'), MULTI_KIT);
-  // A manifest whose recorded hash cannot match the file on disk, so `verify` reports drift.
-  writeFileSync(
-    path.join(cwd, '.readyup/manifest.json'),
-    JSON.stringify({
+const it = createTempDirTest({
+  prefix: 'readyup-exit-codes-',
+  cwd: 'chdir',
+  scope: 'file',
+  setup: (temp) => {
+    temp.write('.readyup/kits/passing.js', PASSING_KIT);
+    temp.write('.readyup/kits/failing.js', FAILING_KIT);
+    temp.write('.readyup/kits/invalid.js', INVALID_KIT);
+    temp.write('.readyup/kits/deploy.js', MULTI_KIT);
+    // A manifest whose recorded hash cannot match the file on disk, so `verify` reports drift.
+    temp.writeJson('.readyup/manifest.json', {
       version: 1,
       kits: [{ name: 'passing', path: 'kits/passing.js', targetHash: '0'.repeat(8) }],
-    }),
-  );
-  // Compiling this drives real esbuild, which writes its own diagnostic straight to stderr; the
-  // error banner that appears in an otherwise-passing test run belongs to this fixture.
-  writeFileSync(path.join(cwd, 'broken.ts'), 'export default { this is not valid TypeScript\n');
-  process.chdir(cwd);
-});
-
-beforeEach(() => {
-  stdout = [];
-  stderr = [];
-  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
-    stdout.push(String(chunk));
-    return true;
-  });
-  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
-    stderr.push(String(chunk));
-    return true;
-  });
-});
-
-afterEach(() => {
-  stdoutSpy.mockRestore();
-  stderrSpy.mockRestore();
-});
-
-afterAll(() => {
-  process.chdir(originalCwd);
-  rmSync(cwd, { recursive: true, force: true });
-});
+    });
+    // Compiling this drives real esbuild, which writes its own diagnostic straight to stderr; the
+    // error banner that appears in an otherwise-passing test run belongs to this fixture.
+    temp.write('broken.ts', 'export default { this is not valid TypeScript\n');
+  },
+}).extend<{ io: CapturedStdio }>({ io: createStdioFixture() });
 
 describe('exit codes', () => {
-  it.each([
+  it.for([
     { label: 'a passing run', args: ['passing'], expected: 0 },
     { label: 'a failing run', args: ['failing'], expected: 1 },
     { label: 'verify drift', args: ['verify'], expected: 1 },
@@ -92,30 +62,30 @@ describe('exit codes', () => {
     await expect(routeCommand(args)).resolves.toBe(expected);
   });
 
-  it('reports a pre-dispatch failure through the error envelope', async () => {
+  it('reports a pre-dispatch failure through the error envelope', async ({ io }) => {
     const exitCode = await routeCommand(['--bogus', '--json']);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(readStdout())).toStrictEqual({
+    expect(JSON.parse(io.stdout)).toStrictEqual({
       schemaVersion: 1,
       error: { code: 'usage', message: expect.any(String) },
     });
   });
 
-  it.each([
+  it.for([
     { label: 'an unknown checklist', args: ['passing:absent'], kit: 'passing', code: 'usage' },
     { label: 'a missing kit', args: ['absent'], kit: 'absent', code: 'kit-load' },
     { label: 'an unloadable kit', args: ['invalid'], kit: 'invalid', code: 'kit-load' },
-  ])('reports code "$code" as a per-kit error entry for $label', async ({ args, kit, code }) => {
+  ])('reports code "$code" as a per-kit error entry for $label', async ({ args, kit, code }, { io }) => {
     const exitCode = await routeCommand([...args, '--json']);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(readStdout())).toMatchObject({
+    expect(JSON.parse(io.stdout)).toMatchObject({
       kits: [{ name: kit, error: { code, message: expect.any(String) } }],
     });
   });
 
-  it('reports code "config" for an unreadable config file', async () => {
+  it('reports code "config" for an unreadable config file', async ({ io, temp }) => {
     // A separate tree, so the broken config does not reach the other cases in this file.
     const brokenCwd = mkdtempSync(path.join(tmpdir(), 'readyup-bad-config-'));
     mkdirSync(path.join(brokenCwd, '.config'), { recursive: true });
@@ -126,19 +96,19 @@ describe('exit codes', () => {
       const exitCode = await routeCommand(['--json']);
 
       expect(exitCode).toBe(2);
-      expect(JSON.parse(readStdout())).toStrictEqual({
+      expect(JSON.parse(io.stdout)).toStrictEqual({
         schemaVersion: 1,
         error: { code: 'config', message: expect.any(String) },
       });
     } finally {
-      process.chdir(cwd);
+      process.chdir(temp.dir);
       rmSync(brokenCwd, { recursive: true, force: true });
     }
   });
 });
 
 describe('stdout purity under --json', () => {
-  it.each([
+  it.for([
     { label: 'a passing run', args: ['passing', '--json'] },
     { label: 'a failing run', args: ['failing', '--json'] },
     { label: 'a bad flag', args: ['--bogus', '--json'] },
@@ -147,119 +117,109 @@ describe('stdout purity under --json', () => {
     { label: 'a list failure', args: ['list', '--from', 'dir:/definitely/absent', '--json'] },
     { label: 'a verify failure', args: ['verify', '--manifest', 'absent.json', '--json'] },
     { label: 'an init usage error', args: ['init', '--json'] },
-  ])('writes exactly one JSON document to stdout for $label', async ({ args }) => {
+  ])('writes exactly one JSON document to stdout for $label', async ({ args }, { io }) => {
     await routeCommand(args);
 
-    const written = readStdout();
+    const written = io.stdout;
     expect(() => {
       JSON.parse(written);
     }).not.toThrow();
     expect(written.trimEnd()).not.toContain('\n');
   });
 
-  it('keeps stderr empty when an error is reported through the envelope', async () => {
+  it('keeps stderr empty when an error is reported through the envelope', async ({ io }) => {
     await routeCommand(['--bogus', '--json']);
 
-    expect(readStderr()).toBe('');
+    expect(io.stderr).toBe('');
   });
 
-  it('reports errors as prose on stderr when --json is absent', async () => {
+  it('reports errors as prose on stderr when --json is absent', async ({ io }) => {
     const exitCode = await routeCommand(['--bogus']);
 
     expect(exitCode).toBe(2);
-    expect(readStderr()).toContain('Error:');
-    expect(readStdout()).toBe('');
+    expect(io.stderr).toContain('Error:');
+    expect(io.stdout).toBe('');
   });
 
-  it.each([
+  it.for([
     { label: 'the retired short flag', flag: '-j' },
     { label: 'a short cluster containing j', flag: '-jJ' },
-  ])('takes the prose path for a flag-parse failure spelled with $label', async ({ flag }) => {
+  ])('takes the prose path for a flag-parse failure spelled with $label', async ({ flag }, { io }) => {
     const exitCode = await routeCommand([flag]);
 
     expect(exitCode).toBe(2);
-    expect(readStdout()).toBe('');
-    expect(readStderr()).toContain('Error:');
+    expect(io.stdout).toBe('');
+    expect(io.stderr).toContain('Error:');
   });
 });
 
 describe('flag surface', () => {
-  it.each(['-J', '-F', '-R', '-i', '-u', '-j'])(
+  it.for(['-J', '-F', '-R', '-i', '-u', '-j'])(
     'exits 2 with a usage error for the retired short %s',
-    async (short) => {
+    async (short, { io }) => {
       const exitCode = await routeCommand(['--json', short]);
 
       expect(exitCode).toBe(2);
-      expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'usage' } });
+      expect(JSON.parse(io.stdout)).toMatchObject({ error: { code: 'usage' } });
     },
   );
 
-  it.each([
+  it.for([
     { long: '--jit', args: ['--jit'] },
     { long: '--internal', args: ['--internal'] },
     { long: '--url', args: ['--url', 'file://absent'] },
     { long: '--fail-on', args: ['passing', '--fail-on', 'warn'] },
     { long: '--report-on', args: ['passing', '--report-on', 'error'] },
-  ])('leaves $long accepted after its short is retired', async ({ args }) => {
+  ])('leaves $long accepted after its short is retired', async ({ args }, { io }) => {
     // The flag may still fail for want of a kit; what matters is that it is not a usage error.
     const exitCode = await routeCommand([...args, '--json']);
 
     if (exitCode === 2) {
-      expect(JSON.parse(readStdout())).not.toMatchObject({ error: { code: 'usage' } });
+      expect(JSON.parse(io.stdout)).not.toMatchObject({ error: { code: 'usage' } });
     }
   });
 
-  it('runs the named checklists from a single positional kit', async () => {
+  it('runs the named checklists from a single positional kit', async ({ io }) => {
     const exitCode = await routeCommand(['deploy', '--checklists', 'build,test', '--json']);
 
     expect(exitCode).toBe(0);
-    const written = readStdout();
+    const written = io.stdout;
     expect(written).toContain('build');
     expect(written).toContain('test');
     expect(written).not.toContain('lint');
   });
 
-  it.each([
+  it.for([
     { label: 'a ":" filter competing with --checklists', args: ['deploy:build', '--checklists', 'test'] },
     { label: 'more than one positional kit', args: ['deploy', 'passing', '--checklists', 'build'] },
-  ])('exits 2 with a usage error for $label', async ({ args }) => {
+  ])('exits 2 with a usage error for $label', async ({ args }, { io }) => {
     const exitCode = await routeCommand([...args, '--json']);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'usage' } });
+    expect(JSON.parse(io.stdout)).toMatchObject({ error: { code: 'usage' } });
   });
 
   // Asserted without `--json`, which `init` does not accept either; adding it would let this pass
   // on the wrong flag.
-  it('exits 2 for the retired init -f short', async () => {
+  it('exits 2 for the retired init -f short', async ({ io }) => {
     const exitCode = await routeCommand(['init', '-f']);
 
     expect(exitCode).toBe(2);
-    expect(readStderr()).toContain("Unknown option '-f'");
+    expect(io.stderr).toContain("Unknown option '-f'");
   });
 });
 
 describe('subcommand error classification', () => {
-  it.each([
+  it.for([
     { command: 'run', args: ['run', '--bogus'] },
     { command: 'list', args: ['list', '--bogus'] },
     { command: 'verify', args: ['verify', '--bogus'] },
     { command: 'compile', args: ['compile', '--bogus'] },
     { command: 'init', args: ['init', '--bogus'] },
-  ])('exits 2 with a usage error for $command', async ({ args }) => {
+  ])('exits 2 with a usage error for $command', async ({ args }, { io }) => {
     const exitCode = await routeCommand([...args, '--json']);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(readStdout())).toMatchObject({ error: { code: 'usage' } });
+    expect(JSON.parse(io.stdout)).toMatchObject({ error: { code: 'usage' } });
   });
 });
-
-/** Everything written to stdout during the current test. */
-function readStdout(): string {
-  return stdout.join('');
-}
-
-/** Everything written to stderr during the current test. */
-function readStderr(): string {
-  return stderr.join('');
-}

--- a/packages/readyup/__tests__/helpers/capturedStdio.ts
+++ b/packages/readyup/__tests__/helpers/capturedStdio.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-import { type MockInstance, vi } from 'vitest';
+import { afterEach, beforeEach, type MockInstance, vi } from 'vitest';
 
 /** The output a command wrote while a test ran. */
 export interface CapturedStdio {
@@ -10,31 +10,31 @@ export interface CapturedStdio {
   reset(): void;
 }
 
-/** Options for a captured-stdio fixture. */
+/** Options for captured stdio. */
 export interface CapturedStdioOptions {
   /** Captures `console.info` into stdout and `console.error` into stderr, for commands that report through them. */
   console?: boolean;
 }
 
-/** The fixture shape `test.extend` accepts: a setup that hands the value to `use` and resumes for teardown. */
-type StdioFixture = (context: object, use: (value: CapturedStdio) => Promise<void>) => Promise<void>;
-
 /**
- * Returns a fixture that buffers both output streams and exposes them as text.
+ * Registers stream capture for the enclosing suite and returns a handle exposing both streams as text.
  *
  * `process.stdout.isTTY` is saved and restored around every test, so a test may assign it directly to exercise
  * style detection without leaking the value into the tests that follow.
  */
-export function createStdioFixture(options: CapturedStdioOptions = {}): StdioFixture {
+export function useCapturedStdio(options: CapturedStdioOptions = {}): CapturedStdio {
   const { console: captureConsole = false } = options;
 
-  // eslint-disable-next-line no-empty-pattern -- Vitest parses this pattern to detect fixture dependencies.
-  return async ({}, use) => {
-    const outChunks: string[] = [];
-    const errChunks: string[] = [];
-    const originalIsTty = process.stdout.isTTY;
+  const outChunks: string[] = [];
+  const errChunks: string[] = [];
+  const spies: MockInstance[] = [];
+  const originalIsTty = process.stdout.isTTY;
 
-    const spies: MockInstance[] = [
+  beforeEach(() => {
+    outChunks.length = 0;
+    errChunks.length = 0;
+
+    spies.push(
       vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
         outChunks.push(String(chunk));
         return true;
@@ -43,7 +43,7 @@ export function createStdioFixture(options: CapturedStdioOptions = {}): StdioFix
         errChunks.push(String(chunk));
         return true;
       }),
-    ];
+    );
 
     if (captureConsole) {
       spies.push(
@@ -55,23 +55,26 @@ export function createStdioFixture(options: CapturedStdioOptions = {}): StdioFix
         }),
       );
     }
+  });
 
-    await use({
-      get stdout() {
-        return outChunks.join('');
-      },
-      get stderr() {
-        return errChunks.join('');
-      },
-      reset() {
-        outChunks.length = 0;
-        errChunks.length = 0;
-      },
-    });
-
+  afterEach(() => {
     process.stdout.isTTY = originalIsTty;
     for (const spy of spies) {
       spy.mockRestore();
     }
+    spies.length = 0;
+  });
+
+  return {
+    get stdout() {
+      return outChunks.join('');
+    },
+    get stderr() {
+      return errChunks.join('');
+    },
+    reset() {
+      outChunks.length = 0;
+      errChunks.length = 0;
+    },
   };
 }

--- a/packages/readyup/__tests__/helpers/capturedStdio.ts
+++ b/packages/readyup/__tests__/helpers/capturedStdio.ts
@@ -1,0 +1,77 @@
+import process from 'node:process';
+
+import { type MockInstance, vi } from 'vitest';
+
+/** The output a command wrote while a test ran. */
+export interface CapturedStdio {
+  readonly stdout: string;
+  readonly stderr: string;
+  /** Empties both buffers, which a test comparing two invocations of the same command needs between them. */
+  reset(): void;
+}
+
+/** Options for a captured-stdio fixture. */
+export interface CapturedStdioOptions {
+  /** Captures `console.info` into stdout and `console.error` into stderr, for commands that report through them. */
+  console?: boolean;
+}
+
+/** The fixture shape `test.extend` accepts: a setup that hands the value to `use` and resumes for teardown. */
+type StdioFixture = (context: object, use: (value: CapturedStdio) => Promise<void>) => Promise<void>;
+
+/**
+ * Returns a fixture that buffers both output streams and exposes them as text.
+ *
+ * `process.stdout.isTTY` is saved and restored around every test, so a test may assign it directly to exercise
+ * style detection without leaking the value into the tests that follow.
+ */
+export function createStdioFixture(options: CapturedStdioOptions = {}): StdioFixture {
+  const { console: captureConsole = false } = options;
+
+  // eslint-disable-next-line no-empty-pattern -- Vitest parses this pattern to detect fixture dependencies.
+  return async ({}, use) => {
+    const outChunks: string[] = [];
+    const errChunks: string[] = [];
+    const originalIsTty = process.stdout.isTTY;
+
+    const spies: MockInstance[] = [
+      vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+        outChunks.push(String(chunk));
+        return true;
+      }),
+      vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+        errChunks.push(String(chunk));
+        return true;
+      }),
+    ];
+
+    if (captureConsole) {
+      spies.push(
+        vi.spyOn(console, 'info').mockImplementation((chunk: unknown) => {
+          outChunks.push(`${String(chunk)}\n`);
+        }),
+        vi.spyOn(console, 'error').mockImplementation((chunk: unknown) => {
+          errChunks.push(`${String(chunk)}\n`);
+        }),
+      );
+    }
+
+    await use({
+      get stdout() {
+        return outChunks.join('');
+      },
+      get stderr() {
+        return errChunks.join('');
+      },
+      reset() {
+        outChunks.length = 0;
+        errChunks.length = 0;
+      },
+    });
+
+    process.stdout.isTTY = originalIsTty;
+    for (const spy of spies) {
+      spy.mockRestore();
+    }
+  };
+}

--- a/packages/readyup/__tests__/helpers/tempDir.ts
+++ b/packages/readyup/__tests__/helpers/tempDir.ts
@@ -31,31 +31,40 @@ export interface TempDirOptions {
   setup?: (temp: TempDir) => void;
 }
 
+/** A fixture definition in the tuple form `test.extend` accepts, carrying its own scope. */
+type TempDirFixture = [
+  (context: object, use: (value: TempDir) => Promise<void>) => Promise<void>,
+  { scope: 'file' | 'test'; auto: boolean },
+];
+
+/** Returns a test API whose `temp` fixture is a scaffolded temporary directory, removed on teardown. */
+export function createTempDirTest(options: TempDirOptions): TestAPI<{ temp: TempDir }> {
+  return baseIt.extend<{ temp: TempDir }>({ temp: createTempDirFixture(options) });
+}
+
 /**
- * Returns a test API whose `temp` fixture is a scaffolded temporary directory, removed on teardown.
+ * Returns a temporary-directory fixture, for a suite that needs a second one alongside its `temp`.
  *
  * Any `cwd` redirection makes the fixture automatic. A test asserting that a file is absent never names
- * `temp`, and a lazily created fixture would leave it reading the real working directory.
+ * the fixture, and a lazily created one would leave it reading the real working directory.
  */
-export function createTempDirTest(options: TempDirOptions): TestAPI<{ temp: TempDir }> {
+export function createTempDirFixture(options: TempDirOptions): TempDirFixture {
   const { prefix, cwd = 'none', scope = 'test', setup } = options;
 
-  return baseIt.extend<{ temp: TempDir }>({
-    temp: [
-      // eslint-disable-next-line no-empty-pattern -- Vitest parses this pattern to detect fixture dependencies.
-      async ({}, use) => {
-        const temp = createTempDir(prefix);
-        const restoreCwd = pointCwdAt(temp.dir, cwd);
-        setup?.(temp);
+  return [
+    // eslint-disable-next-line no-empty-pattern -- Vitest parses this pattern to detect fixture dependencies.
+    async ({}, use) => {
+      const temp = createTempDir(prefix);
+      const restoreCwd = pointCwdAt(temp.dir, cwd);
+      setup?.(temp);
 
-        await use(temp);
+      await use(temp);
 
-        restoreCwd();
-        rmSync(temp.dir, { recursive: true, force: true });
-      },
-      { scope, auto: cwd !== 'none' },
-    ],
-  });
+      restoreCwd();
+      rmSync(temp.dir, { recursive: true, force: true });
+    },
+    { scope, auto: cwd !== 'none' },
+  ];
 }
 
 // region | Helpers

--- a/packages/readyup/__tests__/helpers/tempDir.ts
+++ b/packages/readyup/__tests__/helpers/tempDir.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 
-import { it as baseIt, type TestAPI, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 
 /** A temporary directory and the writes a suite makes against it. */
 export interface TempDir {
@@ -19,7 +19,7 @@ export interface TempDir {
 /** How the code under test is pointed at the temporary directory. */
 export type CwdMode = 'chdir' | 'mock' | 'none';
 
-/** Options for a temp-directory test API. */
+/** Options for a temporary-directory handle. */
 export interface TempDirOptions {
   /** Prefix for the `mkdtemp` name, which identifies the suite among the temp directories it leaves behind. */
   prefix: string;
@@ -27,44 +27,58 @@ export interface TempDirOptions {
   cwd?: CwdMode;
   /** `file` builds one directory for the whole file; `test` builds one per test. */
   scope?: 'file' | 'test';
-  /** Scaffolds fixture files into the directory before the tests that use it run. */
-  setup?: (temp: TempDir) => void;
-}
-
-/** A fixture definition in the tuple form `test.extend` accepts, carrying its own scope. */
-type TempDirFixture = [
-  (context: object, use: (value: TempDir) => Promise<void>) => Promise<void>,
-  { scope: 'file' | 'test'; auto: boolean },
-];
-
-/** Returns a test API whose `temp` fixture is a scaffolded temporary directory, removed on teardown. */
-export function createTempDirTest(options: TempDirOptions): TestAPI<{ temp: TempDir }> {
-  return baseIt.extend<{ temp: TempDir }>({ temp: createTempDirFixture(options) });
+  /**
+   * Scaffolds fixture files into the directory before the tests that use it run.
+   *
+   * It runs from within a hook, so it may write through the handle the suite binds this call to.
+   */
+  setup?: () => void;
 }
 
 /**
- * Returns a temporary-directory fixture, for a suite that needs a second one alongside its `temp`.
+ * Registers a scaffolded temporary directory for the enclosing suite and returns a handle to it.
  *
- * Any `cwd` redirection makes the fixture automatic. A test asserting that a file is absent never names
- * the fixture, and a lazily created one would leave it reading the real working directory.
+ * The handle is bound once at module level and delegates to whichever directory the current scope built, so
+ * a test reads the directory belonging to its own run without naming it in its signature.
  */
-export function createTempDirFixture(options: TempDirOptions): TempDirFixture {
+export function useTempDir(options: TempDirOptions): TempDir {
   const { prefix, cwd = 'none', scope = 'test', setup } = options;
+  const [onSetup, onTeardown] = scope === 'file' ? [beforeAll, afterAll] : [beforeEach, afterEach];
 
-  return [
-    // eslint-disable-next-line no-empty-pattern -- Vitest parses this pattern to detect fixture dependencies.
-    async ({}, use) => {
-      const temp = createTempDir(prefix);
-      const restoreCwd = pointCwdAt(temp.dir, cwd);
-      setup?.(temp);
+  let current: TempDir | undefined;
+  let restoreCwd = restoreNothing;
 
-      await use(temp);
+  onSetup(() => {
+    current = createTempDir(prefix);
+    restoreCwd = pointCwdAt(current.dir, cwd);
+    setup?.();
+  });
 
-      restoreCwd();
-      rmSync(temp.dir, { recursive: true, force: true });
+  onTeardown(() => {
+    restoreCwd();
+    restoreCwd = restoreNothing;
+    if (current !== undefined) {
+      rmSync(current.dir, { recursive: true, force: true });
+      current = undefined;
+    }
+  });
+
+  /** Answers with the directory the current scope built, or reports a read that arrived outside it. */
+  function requireCurrent(): TempDir {
+    if (current === undefined) {
+      throw new Error(`The "${prefix}" temporary directory was read outside the scope that builds it.`);
+    }
+    return current;
+  }
+
+  return {
+    get dir() {
+      return requireCurrent().dir;
     },
-    { scope, auto: cwd !== 'none' },
-  ];
+    mkdir: (relativePath) => requireCurrent().mkdir(relativePath),
+    write: (relativePath, contents) => requireCurrent().write(relativePath, contents),
+    writeJson: (relativePath, value) => requireCurrent().writeJson(relativePath, value),
+  };
 }
 
 // region | Helpers

--- a/packages/readyup/__tests__/helpers/tempDir.ts
+++ b/packages/readyup/__tests__/helpers/tempDir.ts
@@ -1,0 +1,111 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { it as baseIt, type TestAPI, vi } from 'vitest';
+
+/** A temporary directory and the writes a suite makes against it. */
+export interface TempDir {
+  readonly dir: string;
+  /** Creates a directory-relative directory and its parents, and returns the absolute path. */
+  mkdir(relativePath: string): string;
+  /** Writes `contents` at a directory-relative path, creating parents, and returns the absolute path. */
+  write(relativePath: string, contents: string): string;
+  /** Writes `value` as JSON at a directory-relative path, creating parents, and returns the absolute path. */
+  writeJson(relativePath: string, value: unknown): string;
+}
+
+/** How the code under test is pointed at the temporary directory. */
+export type CwdMode = 'chdir' | 'mock' | 'none';
+
+/** Options for a temp-directory test API. */
+export interface TempDirOptions {
+  /** Prefix for the `mkdtemp` name, which identifies the suite among the temp directories it leaves behind. */
+  prefix: string;
+  /** `chdir` moves the process into the directory; `mock` makes `process.cwd()` report it. */
+  cwd?: CwdMode;
+  /** `file` builds one directory for the whole file; `test` builds one per test. */
+  scope?: 'file' | 'test';
+  /** Scaffolds fixture files into the directory before the tests that use it run. */
+  setup?: (temp: TempDir) => void;
+}
+
+/**
+ * Returns a test API whose `temp` fixture is a scaffolded temporary directory, removed on teardown.
+ *
+ * Any `cwd` redirection makes the fixture automatic. A test asserting that a file is absent never names
+ * `temp`, and a lazily created fixture would leave it reading the real working directory.
+ */
+export function createTempDirTest(options: TempDirOptions): TestAPI<{ temp: TempDir }> {
+  const { prefix, cwd = 'none', scope = 'test', setup } = options;
+
+  return baseIt.extend<{ temp: TempDir }>({
+    temp: [
+      // eslint-disable-next-line no-empty-pattern -- Vitest parses this pattern to detect fixture dependencies.
+      async ({}, use) => {
+        const temp = createTempDir(prefix);
+        const restoreCwd = pointCwdAt(temp.dir, cwd);
+        setup?.(temp);
+
+        await use(temp);
+
+        restoreCwd();
+        rmSync(temp.dir, { recursive: true, force: true });
+      },
+      { scope, auto: cwd !== 'none' },
+    ],
+  });
+}
+
+// region | Helpers
+
+/**
+ * Builds a temporary directory and the writes against it.
+ *
+ * The path is resolved through `realpathSync` because macOS reports `/var` for a directory the code
+ * under test resolves as `/private/var`, which breaks any assertion comparing the two.
+ */
+function createTempDir(prefix: string): TempDir {
+  const dir = realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+
+  function mkdir(relativePath: string): string {
+    const absolutePath = path.join(dir, relativePath);
+    mkdirSync(absolutePath, { recursive: true });
+    return absolutePath;
+  }
+
+  function write(relativePath: string, contents: string): string {
+    const absolutePath = path.join(dir, relativePath);
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, contents);
+    return absolutePath;
+  }
+
+  function writeJson(relativePath: string, value: unknown): string {
+    return write(relativePath, JSON.stringify(value));
+  }
+
+  return { dir, mkdir, write, writeJson };
+}
+
+/** Points the code under test at `dir`, returning the undo. */
+function pointCwdAt(dir: string, mode: CwdMode): () => void {
+  if (mode === 'chdir') {
+    const originalCwd = process.cwd();
+    process.chdir(dir);
+    return () => process.chdir(originalCwd);
+  }
+
+  if (mode === 'mock') {
+    const spy = vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    return () => spy.mockRestore();
+  }
+
+  return restoreNothing;
+}
+
+/** Stands in as the undo for a mode that moved nothing. */
+function restoreNothing(): void {}
+
+// endregion | Helpers

--- a/packages/readyup/__tests__/helpers/tempDir.ts
+++ b/packages/readyup/__tests__/helpers/tempDir.ts
@@ -11,7 +11,7 @@ export interface TempDir {
   /** Creates a directory-relative directory and its parents, and returns the absolute path. */
   mkdir(relativePath: string): string;
   /** Writes `contents` at a directory-relative path, creating parents, and returns the absolute path. */
-  write(relativePath: string, contents: string): string;
+  write(relativePath: string, contents: string | Uint8Array): string;
   /** Writes `value` as JSON at a directory-relative path, creating parents, and returns the absolute path. */
   writeJson(relativePath: string, value: unknown): string;
 }
@@ -75,7 +75,7 @@ function createTempDir(prefix: string): TempDir {
     return absolutePath;
   }
 
-  function write(relativePath: string, contents: string): string {
+  function write(relativePath: string, contents: string | Uint8Array): string {
     const absolutePath = path.join(dir, relativePath);
     mkdirSync(path.dirname(absolutePath), { recursive: true });
     writeFileSync(absolutePath, contents);

--- a/packages/readyup/__tests__/packages/discoverKitPackages.test.ts
+++ b/packages/readyup/__tests__/packages/discoverKitPackages.test.ts
@@ -1,67 +1,57 @@
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { discoverKitPackages } from '../../src/packages/discoverKitPackages.ts';
+import { createTempDirFixture, createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
 
-let projectRoot: string;
-let manifestlessRoot: string;
+const it = createTempDirTest({
+  prefix: 'discover-packages-',
+  scope: 'file',
+  setup: (temp) => {
+    temp.writeJson('package.json', {
+      name: 'consumer',
+      dependencies: { 'zebra-kit': '1.0.0' },
+      devDependencies: { '@acme/kits': '1.0.0', kitless: '1.0.0' },
+    });
+
+    installPackage(temp, 'zebra-kit', ['smoke']);
+    installPackage(temp, '@acme/kits', ['drift']);
+    installPackage(temp, 'kitless', []);
+    // Installed and publishing kits, but never declared as a dependency.
+    installPackage(temp, 'undeclared-kit', ['drift']);
+  },
+}).extend<{ manifestless: TempDir }>({
+  manifestless: createTempDirFixture({ prefix: 'discover-no-manifest-', scope: 'file' }),
+});
 
 describe(discoverKitPackages, () => {
-  beforeAll(() => {
-    projectRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'discover-packages-')));
-    writeFileSync(
-      path.join(projectRoot, 'package.json'),
-      JSON.stringify({
-        name: 'consumer',
-        dependencies: { 'zebra-kit': '1.0.0' },
-        devDependencies: { '@acme/kits': '1.0.0', kitless: '1.0.0' },
-      }),
-    );
-
-    installPackage(projectRoot, 'zebra-kit', ['smoke']);
-    installPackage(projectRoot, '@acme/kits', ['drift']);
-    installPackage(projectRoot, 'kitless', []);
-    // Installed and publishing kits, but never declared as a dependency.
-    installPackage(projectRoot, 'undeclared-kit', ['drift']);
-
-    manifestlessRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'discover-no-manifest-')));
+  it('names declared dependencies that publish kits, sorted, across both dependency fields', ({ temp }) => {
+    expect(discoverKitPackages(temp.dir)).toStrictEqual(['@acme/kits', 'zebra-kit']);
   });
 
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
-    rmSync(manifestlessRoot, { recursive: true, force: true });
-  });
-
-  it('names declared dependencies that publish kits, sorted, across both dependency fields', () => {
-    expect(discoverKitPackages(projectRoot)).toStrictEqual(['@acme/kits', 'zebra-kit']);
-  });
-
-  it('omits a declared dependency that publishes no kits', () => {
-    expect(discoverKitPackages(projectRoot)).not.toContain('kitless');
+  it('omits a declared dependency that publishes no kits', ({ temp }) => {
+    expect(discoverKitPackages(temp.dir)).not.toContain('kitless');
   });
 
   // Suggesting a package the reader never chose to depend on is not something they can act on.
-  it('omits an installed package that is not a declared dependency', () => {
-    expect(discoverKitPackages(projectRoot)).not.toContain('undeclared-kit');
+  it('omits an installed package that is not a declared dependency', ({ temp }) => {
+    expect(discoverKitPackages(temp.dir)).not.toContain('undeclared-kit');
   });
 
-  it('answers with nothing when the project manifest cannot be read', () => {
-    expect(discoverKitPackages(manifestlessRoot)).toStrictEqual([]);
+  it('answers with nothing when the project manifest cannot be read', ({ manifestless }) => {
+    expect(discoverKitPackages(manifestless.dir)).toStrictEqual([]);
   });
 });
 
 // region | Helpers
 
 /** Installs a package into a fixture project, optionally publishing kits. */
-function installPackage(root: string, name: string, kits: string[]): void {
-  const packageRoot = path.join(root, 'node_modules', name);
-  mkdirSync(path.join(packageRoot, '.readyup', 'kits'), { recursive: true });
-  writeFileSync(path.join(packageRoot, 'package.json'), JSON.stringify({ name, version: '1.0.0' }));
+function installPackage(temp: TempDir, name: string, kits: string[]): void {
+  temp.writeJson(path.join('node_modules', name, 'package.json'), { name, version: '1.0.0' });
+  temp.mkdir(path.join('node_modules', name, '.readyup', 'kits'));
   for (const kit of kits) {
-    writeFileSync(path.join(packageRoot, '.readyup', 'kits', `${kit}.js`), 'export default {};\n');
+    temp.write(path.join('node_modules', name, '.readyup', 'kits', `${kit}.js`), 'export default {};\n');
   }
 }
 

--- a/packages/readyup/__tests__/packages/discoverKitPackages.test.ts
+++ b/packages/readyup/__tests__/packages/discoverKitPackages.test.ts
@@ -1,45 +1,45 @@
 import path from 'node:path';
 
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { discoverKitPackages } from '../../src/packages/discoverKitPackages.ts';
-import { createTempDirFixture, createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({
+const temp = useTempDir({
   prefix: 'discover-packages-',
   scope: 'file',
-  setup: (temp) => {
+  setup: () => {
     temp.writeJson('package.json', {
       name: 'consumer',
       dependencies: { 'zebra-kit': '1.0.0' },
       devDependencies: { '@acme/kits': '1.0.0', kitless: '1.0.0' },
     });
 
-    installPackage(temp, 'zebra-kit', ['smoke']);
-    installPackage(temp, '@acme/kits', ['drift']);
-    installPackage(temp, 'kitless', []);
+    installPackage('zebra-kit', ['smoke']);
+    installPackage('@acme/kits', ['drift']);
+    installPackage('kitless', []);
     // Installed and publishing kits, but never declared as a dependency.
-    installPackage(temp, 'undeclared-kit', ['drift']);
+    installPackage('undeclared-kit', ['drift']);
   },
-}).extend<{ manifestless: TempDir }>({
-  manifestless: createTempDirFixture({ prefix: 'discover-no-manifest-', scope: 'file' }),
 });
 
+const manifestless = useTempDir({ prefix: 'discover-no-manifest-', scope: 'file' });
+
 describe(discoverKitPackages, () => {
-  it('names declared dependencies that publish kits, sorted, across both dependency fields', ({ temp }) => {
+  it('names declared dependencies that publish kits, sorted, across both dependency fields', () => {
     expect(discoverKitPackages(temp.dir)).toStrictEqual(['@acme/kits', 'zebra-kit']);
   });
 
-  it('omits a declared dependency that publishes no kits', ({ temp }) => {
+  it('omits a declared dependency that publishes no kits', () => {
     expect(discoverKitPackages(temp.dir)).not.toContain('kitless');
   });
 
   // Suggesting a package the reader never chose to depend on is not something they can act on.
-  it('omits an installed package that is not a declared dependency', ({ temp }) => {
+  it('omits an installed package that is not a declared dependency', () => {
     expect(discoverKitPackages(temp.dir)).not.toContain('undeclared-kit');
   });
 
-  it('answers with nothing when the project manifest cannot be read', ({ manifestless }) => {
+  it('answers with nothing when the project manifest cannot be read', () => {
     expect(discoverKitPackages(manifestless.dir)).toStrictEqual([]);
   });
 });
@@ -47,7 +47,7 @@ describe(discoverKitPackages, () => {
 // region | Helpers
 
 /** Installs a package into a fixture project, optionally publishing kits. */
-function installPackage(temp: TempDir, name: string, kits: string[]): void {
+function installPackage(name: string, kits: string[]): void {
   temp.writeJson(path.join('node_modules', name, 'package.json'), { name, version: '1.0.0' });
   temp.mkdir(path.join('node_modules', name, '.readyup', 'kits'));
   for (const kit of kits) {

--- a/packages/readyup/__tests__/packages/expandConfiguredPackages.test.ts
+++ b/packages/readyup/__tests__/packages/expandConfiguredPackages.test.ts
@@ -1,26 +1,26 @@
 import path from 'node:path';
 
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { expandConfiguredPackages } from '../../src/packages/expandConfiguredPackages.ts';
-import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
+import { useTempDir } from '../helpers/tempDir.ts';
 
-const it = createTempDirTest({
+const temp = useTempDir({
   prefix: 'expand-packages-',
   scope: 'file',
-  setup: (temp) => {
-    installPackage(temp, '@acme/kits', '2.1.0', {
+  setup: () => {
+    installPackage('@acme/kits', '2.1.0', {
       kits: ['drift', 'preflight'],
       manifest: JSON.stringify({ version: 1, kits: [{ name: 'drift' }, { name: 'preflight' }] }),
     });
-    installPackage(temp, 'plain-kit', '0.4.0', { kits: ['smoke'] });
-    installPackage(temp, 'kitless', '1.0.0');
-    installPackage(temp, 'broken-manifest', '1.0.0', { kits: ['drift'], manifest: '{ not json' });
+    installPackage('plain-kit', '0.4.0', { kits: ['smoke'] });
+    installPackage('kitless', '1.0.0');
+    installPackage('broken-manifest', '1.0.0', { kits: ['drift'], manifest: '{ not json' });
   },
 });
 
 describe(expandConfiguredPackages, () => {
-  it('expands a scoped package into the kits its manifest declares', ({ temp }) => {
+  it('expands a scoped package into the kits its manifest declares', () => {
     expect(expandConfiguredPackages(['@acme/kits'], '.js', temp.dir)).toStrictEqual([
       {
         packageName: '@acme/kits',
@@ -38,14 +38,14 @@ describe(expandConfiguredPackages, () => {
   });
 
   // The same precedence a local `--from` source follows, so a package and a directory answer alike.
-  it('falls back to the kit directory when a package ships no manifest', ({ temp }) => {
+  it('falls back to the kit directory when a package ships no manifest', () => {
     const [kit] = expandConfiguredPackages(['plain-kit'], '.js', temp.dir);
 
     expect(kit?.kitName).toBe('smoke');
     expect(kit?.version).toBe('0.4.0');
   });
 
-  it('expands every configured package, in configured order', ({ temp }) => {
+  it('expands every configured package, in configured order', () => {
     const kits = expandConfiguredPackages(['plain-kit', '@acme/kits'], '.js', temp.dir);
 
     expect(kits.map((kit) => `${kit.packageName}:${kit.kitName}`)).toStrictEqual([
@@ -55,20 +55,20 @@ describe(expandConfiguredPackages, () => {
     ]);
   });
 
-  it('names the package when it is not installed', ({ temp }) => {
+  it('names the package when it is not installed', () => {
     expect(() => expandConfiguredPackages(['absent-package'], '.js', temp.dir)).toThrow(
       /Configured package "absent-package" is not installed/,
     );
   });
 
-  it('names the package when it publishes no kits', ({ temp }) => {
+  it('names the package when it publishes no kits', () => {
     expect(() => expandConfiguredPackages(['kitless'], '.js', temp.dir)).toThrow(
       /Configured package "kitless" publishes no kits/,
     );
   });
 
   // Falling back here would report a kit list the publisher never declared.
-  it('surfaces a malformed manifest instead of reading around it', ({ temp }) => {
+  it('surfaces a malformed manifest instead of reading around it', () => {
     expect(() => expandConfiguredPackages(['broken-manifest'], '.js', temp.dir)).toThrow(/invalid JSON/);
   });
 });
@@ -77,7 +77,6 @@ describe(expandConfiguredPackages, () => {
 
 /** Installs a package into the fixture project, with the kit files and manifest it publishes. */
 function installPackage(
-  temp: TempDir,
   name: string,
   version: string,
   options: { kits?: string[]; manifest?: string | undefined } = {},

--- a/packages/readyup/__tests__/packages/expandConfiguredPackages.test.ts
+++ b/packages/readyup/__tests__/packages/expandConfiguredPackages.test.ts
@@ -1,57 +1,52 @@
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { expandConfiguredPackages } from '../../src/packages/expandConfiguredPackages.ts';
+import { createTempDirTest, type TempDir } from '../helpers/tempDir.ts';
 
-let projectRoot: string;
-
-describe(expandConfiguredPackages, () => {
-  beforeAll(() => {
-    projectRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'expand-packages-')));
-
-    installPackage('@acme/kits', '2.1.0', {
+const it = createTempDirTest({
+  prefix: 'expand-packages-',
+  scope: 'file',
+  setup: (temp) => {
+    installPackage(temp, '@acme/kits', '2.1.0', {
       kits: ['drift', 'preflight'],
       manifest: JSON.stringify({ version: 1, kits: [{ name: 'drift' }, { name: 'preflight' }] }),
     });
-    installPackage('plain-kit', '0.4.0', { kits: ['smoke'] });
-    installPackage('kitless', '1.0.0');
-    installPackage('broken-manifest', '1.0.0', { kits: ['drift'], manifest: '{ not json' });
-  });
+    installPackage(temp, 'plain-kit', '0.4.0', { kits: ['smoke'] });
+    installPackage(temp, 'kitless', '1.0.0');
+    installPackage(temp, 'broken-manifest', '1.0.0', { kits: ['drift'], manifest: '{ not json' });
+  },
+});
 
-  afterAll(() => {
-    rmSync(projectRoot, { recursive: true, force: true });
-  });
-
-  it('expands a scoped package into the kits its manifest declares', () => {
-    expect(expandConfiguredPackages(['@acme/kits'], '.js', projectRoot)).toStrictEqual([
+describe(expandConfiguredPackages, () => {
+  it('expands a scoped package into the kits its manifest declares', ({ temp }) => {
+    expect(expandConfiguredPackages(['@acme/kits'], '.js', temp.dir)).toStrictEqual([
       {
         packageName: '@acme/kits',
         version: '2.1.0',
         kitName: 'drift',
-        path: path.join(projectRoot, 'node_modules', '@acme/kits', '.readyup', 'kits', 'drift.js'),
+        path: path.join(temp.dir, 'node_modules', '@acme/kits', '.readyup', 'kits', 'drift.js'),
       },
       {
         packageName: '@acme/kits',
         version: '2.1.0',
         kitName: 'preflight',
-        path: path.join(projectRoot, 'node_modules', '@acme/kits', '.readyup', 'kits', 'preflight.js'),
+        path: path.join(temp.dir, 'node_modules', '@acme/kits', '.readyup', 'kits', 'preflight.js'),
       },
     ]);
   });
 
   // The same precedence a local `--from` source follows, so a package and a directory answer alike.
-  it('falls back to the kit directory when a package ships no manifest', () => {
-    const [kit] = expandConfiguredPackages(['plain-kit'], '.js', projectRoot);
+  it('falls back to the kit directory when a package ships no manifest', ({ temp }) => {
+    const [kit] = expandConfiguredPackages(['plain-kit'], '.js', temp.dir);
 
     expect(kit?.kitName).toBe('smoke');
     expect(kit?.version).toBe('0.4.0');
   });
 
-  it('expands every configured package, in configured order', () => {
-    const kits = expandConfiguredPackages(['plain-kit', '@acme/kits'], '.js', projectRoot);
+  it('expands every configured package, in configured order', ({ temp }) => {
+    const kits = expandConfiguredPackages(['plain-kit', '@acme/kits'], '.js', temp.dir);
 
     expect(kits.map((kit) => `${kit.packageName}:${kit.kitName}`)).toStrictEqual([
       'plain-kit:smoke',
@@ -60,21 +55,21 @@ describe(expandConfiguredPackages, () => {
     ]);
   });
 
-  it('names the package when it is not installed', () => {
-    expect(() => expandConfiguredPackages(['absent-package'], '.js', projectRoot)).toThrow(
+  it('names the package when it is not installed', ({ temp }) => {
+    expect(() => expandConfiguredPackages(['absent-package'], '.js', temp.dir)).toThrow(
       /Configured package "absent-package" is not installed/,
     );
   });
 
-  it('names the package when it publishes no kits', () => {
-    expect(() => expandConfiguredPackages(['kitless'], '.js', projectRoot)).toThrow(
+  it('names the package when it publishes no kits', ({ temp }) => {
+    expect(() => expandConfiguredPackages(['kitless'], '.js', temp.dir)).toThrow(
       /Configured package "kitless" publishes no kits/,
     );
   });
 
   // Falling back here would report a kit list the publisher never declared.
-  it('surfaces a malformed manifest instead of reading around it', () => {
-    expect(() => expandConfiguredPackages(['broken-manifest'], '.js', projectRoot)).toThrow(/invalid JSON/);
+  it('surfaces a malformed manifest instead of reading around it', ({ temp }) => {
+    expect(() => expandConfiguredPackages(['broken-manifest'], '.js', temp.dir)).toThrow(/invalid JSON/);
   });
 });
 
@@ -82,19 +77,20 @@ describe(expandConfiguredPackages, () => {
 
 /** Installs a package into the fixture project, with the kit files and manifest it publishes. */
 function installPackage(
+  temp: TempDir,
   name: string,
   version: string,
   options: { kits?: string[]; manifest?: string | undefined } = {},
 ): void {
-  const root = path.join(projectRoot, 'node_modules', name);
-  mkdirSync(path.join(root, '.readyup', 'kits'), { recursive: true });
-  writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name, version }));
+  const root = path.join('node_modules', name);
+  temp.mkdir(path.join(root, '.readyup', 'kits'));
+  temp.writeJson(path.join(root, 'package.json'), { name, version });
 
   for (const kit of options.kits ?? []) {
-    writeFileSync(path.join(root, '.readyup', 'kits', `${kit}.js`), 'export default {};\n');
+    temp.write(path.join(root, '.readyup', 'kits', `${kit}.js`), 'export default {};\n');
   }
   if (options.manifest !== undefined) {
-    writeFileSync(path.join(root, '.readyup', 'manifest.json'), options.manifest);
+    temp.write(path.join(root, '.readyup', 'manifest.json'), options.manifest);
   }
 }
 

--- a/packages/readyup/__tests__/partialResults.test.ts
+++ b/packages/readyup/__tests__/partialResults.test.ts
@@ -1,11 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
-import process from 'node:process';
-
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { describe, expect } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
+import { type CapturedStdio, createStdioFixture } from './helpers/capturedStdio.ts';
+import { createTempDirTest } from './helpers/tempDir.ts';
 
 /** A kit whose single check passes. */
 const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
@@ -13,52 +10,23 @@ const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ na
 /** A kit whose single error-severity check fails. */
 const FAILING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'nope', check: () => false }] }] };\n`;
 
-let cwd: string;
-let originalCwd: string;
-let stdout: string[];
-let stderr: string[];
-let stdoutSpy: MockInstance;
-let stderrSpy: MockInstance;
-
-beforeAll(() => {
-  originalCwd = process.cwd();
-  cwd = mkdtempSync(path.join(tmpdir(), 'readyup-partial-results-'));
-  mkdirSync(path.join(cwd, '.readyup/kits'), { recursive: true });
-  writeFileSync(path.join(cwd, '.readyup/kits/passing.js'), PASSING_KIT);
-  writeFileSync(path.join(cwd, '.readyup/kits/failing.js'), FAILING_KIT);
-  process.chdir(cwd);
-});
-
-beforeEach(() => {
-  stdout = [];
-  stderr = [];
-  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
-    stdout.push(String(chunk));
-    return true;
-  });
-  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
-    stderr.push(String(chunk));
-    return true;
-  });
-});
-
-afterEach(() => {
-  stdoutSpy.mockRestore();
-  stderrSpy.mockRestore();
-});
-
-afterAll(() => {
-  process.chdir(originalCwd);
-  rmSync(cwd, { recursive: true, force: true });
-});
+const it = createTempDirTest({
+  prefix: 'readyup-partial-results-',
+  cwd: 'chdir',
+  scope: 'file',
+  setup: (temp) => {
+    temp.write('.readyup/kits/passing.js', PASSING_KIT);
+    temp.write('.readyup/kits/failing.js', FAILING_KIT);
+  },
+}).extend<{ io: CapturedStdio }>({ io: createStdioFixture() });
 
 describe('partial results when a kit fails after dispatch', () => {
   describe('JSON mode', () => {
-    it('keeps results from the kits on either side of a failed kit', async () => {
+    it('keeps results from the kits on either side of a failed kit', async ({ io }) => {
       const exitCode = await routeCommand(['passing', 'absent', 'failing', '--json']);
 
       expect(exitCode).toBe(2);
-      expect(JSON.parse(readStdout())).toMatchObject({
+      expect(JSON.parse(io.stdout)).toMatchObject({
         kits: [
           { name: 'passing', passed: true, counts: { passed: 1, errors: 0 } },
           { name: 'absent', error: { code: 'kit-load', message: expect.any(String) } },
@@ -67,26 +35,26 @@ describe('partial results when a kit fails after dispatch', () => {
       });
     });
 
-    it('aggregates top-level counts over only the kits that ran', async () => {
+    it('aggregates top-level counts over only the kits that ran', async ({ io }) => {
       await routeCommand(['passing', 'absent', '--json']);
 
-      expect(JSON.parse(readStdout())).toMatchObject({
+      expect(JSON.parse(io.stdout)).toMatchObject({
         counts: { passed: 1, errors: 0, warnings: 0, recommendations: 0, blocked: 0, optional: 0 },
       });
-      expect(JSON.parse(readStdout())).not.toHaveProperty('worstSeverity');
+      expect(JSON.parse(io.stdout)).not.toHaveProperty('worstSeverity');
     });
 
-    it('reports the run as failed when a kit never ran, even though what ran passed', async () => {
+    it('reports the run as failed when a kit never ran, even though what ran passed', async ({ io }) => {
       await routeCommand(['passing', 'absent', '--json']);
 
-      expect(JSON.parse(readStdout())).toMatchObject({ passed: false });
+      expect(JSON.parse(io.stdout)).toMatchObject({ passed: false });
     });
 
-    it('emits a report rather than an envelope when the only kit fails', async () => {
+    it('emits a report rather than an envelope when the only kit fails', async ({ io }) => {
       const exitCode = await routeCommand(['absent', '--json']);
 
       expect(exitCode).toBe(2);
-      expect(JSON.parse(readStdout())).toMatchObject({
+      expect(JSON.parse(io.stdout)).toMatchObject({
         kits: [{ name: 'absent', error: { code: 'kit-load', message: expect.any(String) } }],
       });
     });
@@ -97,41 +65,31 @@ describe('partial results when a kit fails after dispatch', () => {
   });
 
   describe('human mode', () => {
-    it('reports the failure on stderr and continues to the next kit', async () => {
+    it('reports the failure on stderr and continues to the next kit', async ({ io }) => {
       const exitCode = await routeCommand(['absent', 'passing']);
 
       expect(exitCode).toBe(2);
-      expect(readStderr()).toContain('Error [absent]:');
-      expect(readStdout()).toContain('ok');
+      expect(io.stderr).toContain('Error [absent]:');
+      expect(io.stdout).toContain('ok');
     });
 
-    it('heads every requested kit on stdout, including one that never ran', async () => {
+    it('heads every requested kit on stdout, including one that never ran', async ({ io }) => {
       await routeCommand(['passing', 'absent']);
 
-      expect(readStdout()).toContain('\u{2501}\u{2501} passing');
-      expect(readStdout()).toContain('\u{2501}\u{2501} absent');
+      expect(io.stdout).toContain('\u{2501}\u{2501} passing');
+      expect(io.stdout).toContain('\u{2501}\u{2501} absent');
     });
 
-    it('keeps the failure off stdout, where a failed check would appear', async () => {
+    it('keeps the failure off stdout, where a failed check would appear', async ({ io }) => {
       await routeCommand(['passing', 'absent']);
 
-      expect(readStdout()).not.toContain('Error [absent]:');
+      expect(io.stdout).not.toContain('Error [absent]:');
     });
 
-    it('drops the kit label when a lone kit leaves nothing to disambiguate', async () => {
+    it('drops the kit label when a lone kit leaves nothing to disambiguate', async ({ io }) => {
       await routeCommand(['absent']);
 
-      expect(readStderr()).toMatch(/^Error: /);
+      expect(io.stderr).toMatch(/^Error: /);
     });
   });
 });
-
-/** Everything written to stdout during the current test. */
-function readStdout(): string {
-  return stdout.join('');
-}
-
-/** Everything written to stderr during the current test. */
-function readStderr(): string {
-  return stderr.join('');
-}

--- a/packages/readyup/__tests__/partialResults.test.ts
+++ b/packages/readyup/__tests__/partialResults.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
-import { type CapturedStdio, createStdioFixture } from './helpers/capturedStdio.ts';
-import { createTempDirTest } from './helpers/tempDir.ts';
+import { useCapturedStdio } from './helpers/capturedStdio.ts';
+import { useTempDir } from './helpers/tempDir.ts';
 
 /** A kit whose single check passes. */
 const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
@@ -10,19 +10,21 @@ const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ na
 /** A kit whose single error-severity check fails. */
 const FAILING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'nope', check: () => false }] }] };\n`;
 
-const it = createTempDirTest({
+const temp = useTempDir({
   prefix: 'readyup-partial-results-',
   cwd: 'chdir',
   scope: 'file',
-  setup: (temp) => {
+  setup: () => {
     temp.write('.readyup/kits/passing.js', PASSING_KIT);
     temp.write('.readyup/kits/failing.js', FAILING_KIT);
   },
-}).extend<{ io: CapturedStdio }>({ io: createStdioFixture() });
+});
+
+const io = useCapturedStdio();
 
 describe('partial results when a kit fails after dispatch', () => {
   describe('JSON mode', () => {
-    it('keeps results from the kits on either side of a failed kit', async ({ io }) => {
+    it('keeps results from the kits on either side of a failed kit', async () => {
       const exitCode = await routeCommand(['passing', 'absent', 'failing', '--json']);
 
       expect(exitCode).toBe(2);
@@ -35,7 +37,7 @@ describe('partial results when a kit fails after dispatch', () => {
       });
     });
 
-    it('aggregates top-level counts over only the kits that ran', async ({ io }) => {
+    it('aggregates top-level counts over only the kits that ran', async () => {
       await routeCommand(['passing', 'absent', '--json']);
 
       expect(JSON.parse(io.stdout)).toMatchObject({
@@ -44,13 +46,13 @@ describe('partial results when a kit fails after dispatch', () => {
       expect(JSON.parse(io.stdout)).not.toHaveProperty('worstSeverity');
     });
 
-    it('reports the run as failed when a kit never ran, even though what ran passed', async ({ io }) => {
+    it('reports the run as failed when a kit never ran, even though what ran passed', async () => {
       await routeCommand(['passing', 'absent', '--json']);
 
       expect(JSON.parse(io.stdout)).toMatchObject({ passed: false });
     });
 
-    it('emits a report rather than an envelope when the only kit fails', async ({ io }) => {
+    it('emits a report rather than an envelope when the only kit fails', async () => {
       const exitCode = await routeCommand(['absent', '--json']);
 
       expect(exitCode).toBe(2);
@@ -65,7 +67,7 @@ describe('partial results when a kit fails after dispatch', () => {
   });
 
   describe('human mode', () => {
-    it('reports the failure on stderr and continues to the next kit', async ({ io }) => {
+    it('reports the failure on stderr and continues to the next kit', async () => {
       const exitCode = await routeCommand(['absent', 'passing']);
 
       expect(exitCode).toBe(2);
@@ -73,20 +75,20 @@ describe('partial results when a kit fails after dispatch', () => {
       expect(io.stdout).toContain('ok');
     });
 
-    it('heads every requested kit on stdout, including one that never ran', async ({ io }) => {
+    it('heads every requested kit on stdout, including one that never ran', async () => {
       await routeCommand(['passing', 'absent']);
 
       expect(io.stdout).toContain('\u{2501}\u{2501} passing');
       expect(io.stdout).toContain('\u{2501}\u{2501} absent');
     });
 
-    it('keeps the failure off stdout, where a failed check would appear', async ({ io }) => {
+    it('keeps the failure off stdout, where a failed check would appear', async () => {
       await routeCommand(['passing', 'absent']);
 
       expect(io.stdout).not.toContain('Error [absent]:');
     });
 
-    it('drops the kit label when a lone kit leaves nothing to disambiguate', async ({ io }) => {
+    it('drops the kit label when a lone kit leaves nothing to disambiguate', async () => {
       await routeCommand(['absent']);
 
       expect(io.stderr).toMatch(/^Error: /);

--- a/packages/readyup/__tests__/styleSelection.test.ts
+++ b/packages/readyup/__tests__/styleSelection.test.ts
@@ -1,14 +1,14 @@
 import process from 'node:process';
 
-import { afterEach, describe, expect, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
 import { plainFormatter } from '../src/layout/plainFormatter.ts';
 import { STYLE_ENV_VAR } from '../src/layout/resolveStyle.ts';
 import { richFormatter } from '../src/layout/richFormatter.ts';
 import { hashBytes } from '../src/verify/targetHash.ts';
-import { type CapturedStdio, createStdioFixture } from './helpers/capturedStdio.ts';
-import { createTempDirTest } from './helpers/tempDir.ts';
+import { useCapturedStdio } from './helpers/capturedStdio.ts';
+import { useTempDir } from './helpers/tempDir.ts';
 
 /** A kit whose single check passes. */
 const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
@@ -34,11 +34,11 @@ const RENDERING_COMMANDS = [
   { name: 'init', args: ['init', '--dry-run'], expected: /^PASS {2}\.config\/readyup\.config\.ts/mu },
 ] as const;
 
-const it = createTempDirTest({
+const temp = useTempDir({
   prefix: 'readyup-style-',
   cwd: 'chdir',
   scope: 'file',
-  setup: (temp) => {
+  setup: () => {
     temp.write('.readyup/kits/passing.js', PASSING_KIT);
     temp.write('src/passing.ts', PASSING_KIT);
     temp.write('passing.js', COMPILED_BYTES);
@@ -47,15 +47,17 @@ const it = createTempDirTest({
       kits: [{ name: 'passing', path: 'passing.js', source: 'src/passing.ts', targetHash: hashBytes(COMPILED_BYTES) }],
     });
   },
-  // `init` reports through the console rather than the streams directly, so both channels are captured.
-}).extend<{ io: CapturedStdio }>({ io: createStdioFixture({ console: true }) });
+});
+
+// `init` reports through the console rather than the streams directly, so both channels are captured.
+const io = useCapturedStdio({ console: true });
 
 afterEach(() => {
   vi.unstubAllEnvs();
 });
 
 describe('--style plain', () => {
-  it.for(RENDERING_COMMANDS)('renders $name without leaving the ASCII range', async ({ args }, { io }) => {
+  it.for(RENDERING_COMMANDS)('renders $name without leaving the ASCII range', async ({ args }) => {
     await routeCommand([...args, '--style', 'plain']);
 
     const rendered = io.stdout + io.stderr;
@@ -63,13 +65,13 @@ describe('--style plain', () => {
     expect(rendered).toMatch(/^[\u{20}-\u{7E}\n]*$/u);
   });
 
-  it.for(RENDERING_COMMANDS)('renders $name through the plain vocabulary', async ({ args, expected }, { io }) => {
+  it.for(RENDERING_COMMANDS)('renders $name through the plain vocabulary', async ({ args, expected }) => {
     await routeCommand([...args, '--style', 'plain']);
 
     expect(io.stdout + io.stderr).toMatch(expected);
   });
 
-  it('is accepted as an assigned value too', async ({ io }) => {
+  it('is accepted as an assigned value too', async () => {
     await routeCommand(['verify', '--manifest', 'manifest.json', '--style=plain']);
 
     expect(io.stdout).toContain(`${PLAIN_PASS}  passing`);
@@ -77,27 +79,27 @@ describe('--style plain', () => {
 });
 
 describe('a style named ahead of the command', () => {
-  it.for(RENDERING_COMMANDS)('reaches $name without being taken for a kit name', async ({ args }, { io }) => {
+  it.for(RENDERING_COMMANDS)('reaches $name without being taken for a kit name', async ({ args }) => {
     const exitCode = await routeCommand(['--style', 'plain', ...args]);
 
     expect(io.stderr).not.toContain('not found');
     expect(exitCode).not.toBe(2);
   });
 
-  it('is accepted as an assigned value too', async ({ io }) => {
+  it('is accepted as an assigned value too', async () => {
     const exitCode = await routeCommand(['--style=plain', 'verify', '--manifest', 'manifest.json']);
 
     expect(exitCode).toBe(0);
     expect(io.stdout).toContain(`${PLAIN_PASS}  passing`);
   });
 
-  it('leaves --help showing the top-level help rather than the run subcommand\u{2019}s', async ({ io }) => {
+  it('leaves --help showing the top-level help rather than the run subcommand\u{2019}s', async () => {
     await routeCommand(['--style', 'plain', '--help']);
 
     expect(io.stdout).toContain('rdy <command> [options]');
   });
 
-  it('leaves --version reporting the version', async ({ io }) => {
+  it('leaves --version reporting the version', async () => {
     await routeCommand(['--style', 'plain', '--version']);
 
     expect(io.stdout).toMatch(/^\d+\.\d+\.\d+/u);
@@ -111,7 +113,7 @@ describe('a style named ahead of the command', () => {
 });
 
 describe('--style rich', () => {
-  it('renders glyphs even when the environment would detect otherwise', async ({ io }) => {
+  it('renders glyphs even when the environment would detect otherwise', async () => {
     vi.stubEnv('CI', 'true');
     process.stdout.isTTY = false;
 
@@ -122,14 +124,14 @@ describe('--style rich', () => {
 });
 
 describe('an unrecognized style', () => {
-  it('fails the invocation and names the valid set', async ({ io }) => {
+  it('fails the invocation and names the valid set', async () => {
     const exitCode = await routeCommand(['verify', '--style', 'emoji']);
 
     expect(exitCode).toBe(2);
     expect(io.stderr).toContain('--style must be one of: auto, plain, rich (got "emoji")');
   });
 
-  it('is rejected from the environment variable as well', async ({ io }) => {
+  it('is rejected from the environment variable as well', async () => {
     vi.stubEnv(STYLE_ENV_VAR, 'text');
 
     const exitCode = await routeCommand(['verify', '--manifest', 'manifest.json']);
@@ -142,7 +144,7 @@ describe('an unrecognized style', () => {
 describe('detection', () => {
   // The suite pins RDY_STYLE so rendering never depends on the environment it runs in. These tests
   // deliberately unpin it: they are the only coverage of the wiring that reads CI and the terminal.
-  it('chooses plain under CI', async ({ io }) => {
+  it('chooses plain under CI', async () => {
     vi.stubEnv(STYLE_ENV_VAR, undefined);
     vi.stubEnv('CI', 'true');
     process.stdout.isTTY = true;
@@ -152,7 +154,7 @@ describe('detection', () => {
     expect(io.stdout).toContain(`${PLAIN_PASS}  passing`);
   });
 
-  it('chooses plain when the output is not a terminal', async ({ io }) => {
+  it('chooses plain when the output is not a terminal', async () => {
     vi.stubEnv(STYLE_ENV_VAR, undefined);
     vi.stubEnv('CI', undefined);
     process.stdout.isTTY = false;
@@ -162,7 +164,7 @@ describe('detection', () => {
     expect(io.stdout).toContain(`${PLAIN_PASS}  passing`);
   });
 
-  it('chooses rich for a terminal outside CI', async ({ io }) => {
+  it('chooses rich for a terminal outside CI', async () => {
     vi.stubEnv(STYLE_ENV_VAR, undefined);
     vi.stubEnv('CI', undefined);
     process.stdout.isTTY = true;
@@ -172,7 +174,7 @@ describe('detection', () => {
     expect(io.stdout).toContain(`${RICH_PASS} passing`);
   });
 
-  it('is outranked by the environment variable', async ({ io }) => {
+  it('is outranked by the environment variable', async () => {
     vi.stubEnv(STYLE_ENV_VAR, 'rich');
     vi.stubEnv('CI', 'true');
 
@@ -183,7 +185,7 @@ describe('detection', () => {
 });
 
 describe('an explicitly chosen style', () => {
-  it.for(['plain', 'rich'] as const)('renders %s identically with and without a terminal', async (style, { io }) => {
+  it.for(['plain', 'rich'] as const)('renders %s identically with and without a terminal', async (style) => {
     process.stdout.isTTY = true;
     await routeCommand(['verify', '--manifest', 'manifest.json', '--style', style]);
     const attached = io.stdout;
@@ -197,7 +199,7 @@ describe('an explicitly chosen style', () => {
 });
 
 describe('alongside --json', () => {
-  it('leaves the JSON document on stdout and styles the prose on stderr', async ({ io }) => {
+  it('leaves the JSON document on stdout and styles the prose on stderr', async () => {
     await routeCommand(['verify', '--manifest', 'manifest.json', '--json', '--style', 'plain']);
 
     const document: unknown = JSON.parse(io.stdout);
@@ -206,7 +208,7 @@ describe('alongside --json', () => {
     expect(io.stderr).not.toContain(RICH_PASS);
   });
 
-  it('emits the same JSON whichever style is selected', async ({ io }) => {
+  it('emits the same JSON whichever style is selected', async () => {
     await routeCommand(['verify', '--manifest', 'manifest.json', '--json', '--style', 'plain']);
     const plain = io.stdout;
 

--- a/packages/readyup/__tests__/styleSelection.test.ts
+++ b/packages/readyup/__tests__/styleSelection.test.ts
@@ -1,15 +1,14 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
 import process from 'node:process';
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
 import { plainFormatter } from '../src/layout/plainFormatter.ts';
 import { STYLE_ENV_VAR } from '../src/layout/resolveStyle.ts';
 import { richFormatter } from '../src/layout/richFormatter.ts';
 import { hashBytes } from '../src/verify/targetHash.ts';
+import { type CapturedStdio, createStdioFixture } from './helpers/capturedStdio.ts';
+import { createTempDirTest } from './helpers/tempDir.ts';
 
 /** A kit whose single check passes. */
 const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
@@ -35,109 +34,73 @@ const RENDERING_COMMANDS = [
   { name: 'init', args: ['init', '--dry-run'], expected: /^PASS {2}\.config\/readyup\.config\.ts/mu },
 ] as const;
 
-let cwd: string;
-let originalCwd: string;
-let originalIsTty: boolean;
-let stdout: string[];
-let stderr: string[];
-
-beforeAll(() => {
-  originalCwd = process.cwd();
-  cwd = mkdtempSync(path.join(tmpdir(), 'readyup-style-'));
-  mkdirSync(path.join(cwd, '.readyup/kits'), { recursive: true });
-  mkdirSync(path.join(cwd, 'src'), { recursive: true });
-  writeFileSync(path.join(cwd, '.readyup/kits/passing.js'), PASSING_KIT);
-  writeFileSync(path.join(cwd, 'src/passing.ts'), PASSING_KIT);
-  writeFileSync(path.join(cwd, 'passing.js'), COMPILED_BYTES);
-  writeFileSync(
-    path.join(cwd, 'manifest.json'),
-    JSON.stringify({
+const it = createTempDirTest({
+  prefix: 'readyup-style-',
+  cwd: 'chdir',
+  scope: 'file',
+  setup: (temp) => {
+    temp.write('.readyup/kits/passing.js', PASSING_KIT);
+    temp.write('src/passing.ts', PASSING_KIT);
+    temp.write('passing.js', COMPILED_BYTES);
+    temp.writeJson('manifest.json', {
       version: 1,
       kits: [{ name: 'passing', path: 'passing.js', source: 'src/passing.ts', targetHash: hashBytes(COMPILED_BYTES) }],
-    }),
-  );
-  process.chdir(cwd);
-});
-
-beforeEach(() => {
-  stdout = [];
-  stderr = [];
-  originalIsTty = process.stdout.isTTY;
-  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
-    stdout.push(String(chunk));
-    return true;
-  });
-  vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
-    stderr.push(String(chunk));
-    return true;
-  });
+    });
+  },
   // `init` reports through the console rather than the streams directly, so both channels are captured.
-  vi.spyOn(console, 'info').mockImplementation((chunk: unknown) => {
-    stdout.push(`${String(chunk)}\n`);
-  });
-  vi.spyOn(console, 'error').mockImplementation((chunk: unknown) => {
-    stderr.push(`${String(chunk)}\n`);
-  });
-});
+}).extend<{ io: CapturedStdio }>({ io: createStdioFixture({ console: true }) });
 
 afterEach(() => {
-  process.stdout.isTTY = originalIsTty;
   vi.unstubAllEnvs();
-  vi.restoreAllMocks();
-});
-
-afterAll(() => {
-  process.chdir(originalCwd);
-  rmSync(cwd, { recursive: true, force: true });
 });
 
 describe('--style plain', () => {
-  it.each(RENDERING_COMMANDS)('renders $name without leaving the ASCII range', async ({ args }) => {
+  it.for(RENDERING_COMMANDS)('renders $name without leaving the ASCII range', async ({ args }, { io }) => {
     await routeCommand([...args, '--style', 'plain']);
 
-    const rendered = [...stdout, ...stderr].join('');
+    const rendered = io.stdout + io.stderr;
     expect(rendered).not.toBe('');
     expect(rendered).toMatch(/^[\u{20}-\u{7E}\n]*$/u);
   });
 
-  it.each(RENDERING_COMMANDS)('renders $name through the plain vocabulary', async ({ args, expected }) => {
+  it.for(RENDERING_COMMANDS)('renders $name through the plain vocabulary', async ({ args, expected }, { io }) => {
     await routeCommand([...args, '--style', 'plain']);
 
-    expect([...stdout, ...stderr].join('')).toMatch(expected);
+    expect(io.stdout + io.stderr).toMatch(expected);
   });
 
-  it('is accepted as an assigned value too', async () => {
+  it('is accepted as an assigned value too', async ({ io }) => {
     await routeCommand(['verify', '--manifest', 'manifest.json', '--style=plain']);
 
-    expect(stdout.join('')).toContain(`${PLAIN_PASS}  passing`);
+    expect(io.stdout).toContain(`${PLAIN_PASS}  passing`);
   });
 });
 
 describe('a style named ahead of the command', () => {
-  it.each(RENDERING_COMMANDS)('reaches $name without being taken for a kit name', async ({ args }) => {
+  it.for(RENDERING_COMMANDS)('reaches $name without being taken for a kit name', async ({ args }, { io }) => {
     const exitCode = await routeCommand(['--style', 'plain', ...args]);
 
-    expect(stderr.join('')).not.toContain('not found');
+    expect(io.stderr).not.toContain('not found');
     expect(exitCode).not.toBe(2);
   });
 
-  it('is accepted as an assigned value too', async () => {
+  it('is accepted as an assigned value too', async ({ io }) => {
     const exitCode = await routeCommand(['--style=plain', 'verify', '--manifest', 'manifest.json']);
 
     expect(exitCode).toBe(0);
-    expect(stdout.join('')).toContain(`${PLAIN_PASS}  passing`);
+    expect(io.stdout).toContain(`${PLAIN_PASS}  passing`);
   });
 
-  it('leaves --help showing the top-level help rather than the run subcommand\u{2019}s', async () => {
+  it('leaves --help showing the top-level help rather than the run subcommand\u{2019}s', async ({ io }) => {
     await routeCommand(['--style', 'plain', '--help']);
 
-    expect(stdout.join('')).toContain('rdy <command> [options]');
+    expect(io.stdout).toContain('rdy <command> [options]');
   });
 
-  it('leaves --version reporting the version', async () => {
+  it('leaves --version reporting the version', async ({ io }) => {
     await routeCommand(['--style', 'plain', '--version']);
 
-    expect(stdout.join('')).toMatch(/^\d+\.\d+\.\d+/u);
+    expect(io.stdout).toMatch(/^\d+\.\d+\.\d+/u);
   });
 
   it('still rejects a trailing --style that carries no value', async () => {
@@ -148,108 +111,108 @@ describe('a style named ahead of the command', () => {
 });
 
 describe('--style rich', () => {
-  it('renders glyphs even when the environment would detect otherwise', async () => {
+  it('renders glyphs even when the environment would detect otherwise', async ({ io }) => {
     vi.stubEnv('CI', 'true');
     process.stdout.isTTY = false;
 
     await routeCommand(['verify', '--manifest', 'manifest.json', '--style', 'rich']);
 
-    expect(stdout.join('')).toContain(`${RICH_PASS} passing`);
+    expect(io.stdout).toContain(`${RICH_PASS} passing`);
   });
 });
 
 describe('an unrecognized style', () => {
-  it('fails the invocation and names the valid set', async () => {
+  it('fails the invocation and names the valid set', async ({ io }) => {
     const exitCode = await routeCommand(['verify', '--style', 'emoji']);
 
     expect(exitCode).toBe(2);
-    expect(stderr.join('')).toContain('--style must be one of: auto, plain, rich (got "emoji")');
+    expect(io.stderr).toContain('--style must be one of: auto, plain, rich (got "emoji")');
   });
 
-  it('is rejected from the environment variable as well', async () => {
+  it('is rejected from the environment variable as well', async ({ io }) => {
     vi.stubEnv(STYLE_ENV_VAR, 'text');
 
     const exitCode = await routeCommand(['verify', '--manifest', 'manifest.json']);
 
     expect(exitCode).toBe(2);
-    expect(stderr.join('')).toContain(`${STYLE_ENV_VAR} must be one of: auto, plain, rich (got "text")`);
+    expect(io.stderr).toContain(`${STYLE_ENV_VAR} must be one of: auto, plain, rich (got "text")`);
   });
 });
 
 describe('detection', () => {
   // The suite pins RDY_STYLE so rendering never depends on the environment it runs in. These tests
   // deliberately unpin it: they are the only coverage of the wiring that reads CI and the terminal.
-  it('chooses plain under CI', async () => {
+  it('chooses plain under CI', async ({ io }) => {
     vi.stubEnv(STYLE_ENV_VAR, undefined);
     vi.stubEnv('CI', 'true');
     process.stdout.isTTY = true;
 
     await routeCommand(['verify', '--manifest', 'manifest.json']);
 
-    expect(stdout.join('')).toContain(`${PLAIN_PASS}  passing`);
+    expect(io.stdout).toContain(`${PLAIN_PASS}  passing`);
   });
 
-  it('chooses plain when the output is not a terminal', async () => {
+  it('chooses plain when the output is not a terminal', async ({ io }) => {
     vi.stubEnv(STYLE_ENV_VAR, undefined);
     vi.stubEnv('CI', undefined);
     process.stdout.isTTY = false;
 
     await routeCommand(['verify', '--manifest', 'manifest.json']);
 
-    expect(stdout.join('')).toContain(`${PLAIN_PASS}  passing`);
+    expect(io.stdout).toContain(`${PLAIN_PASS}  passing`);
   });
 
-  it('chooses rich for a terminal outside CI', async () => {
+  it('chooses rich for a terminal outside CI', async ({ io }) => {
     vi.stubEnv(STYLE_ENV_VAR, undefined);
     vi.stubEnv('CI', undefined);
     process.stdout.isTTY = true;
 
     await routeCommand(['verify', '--manifest', 'manifest.json']);
 
-    expect(stdout.join('')).toContain(`${RICH_PASS} passing`);
+    expect(io.stdout).toContain(`${RICH_PASS} passing`);
   });
 
-  it('is outranked by the environment variable', async () => {
+  it('is outranked by the environment variable', async ({ io }) => {
     vi.stubEnv(STYLE_ENV_VAR, 'rich');
     vi.stubEnv('CI', 'true');
 
     await routeCommand(['verify', '--manifest', 'manifest.json']);
 
-    expect(stdout.join('')).toContain(`${RICH_PASS} passing`);
+    expect(io.stdout).toContain(`${RICH_PASS} passing`);
   });
 });
 
 describe('an explicitly chosen style', () => {
-  it.each(['plain', 'rich'] as const)('renders %s identically with and without a terminal', async (style) => {
+  it.for(['plain', 'rich'] as const)('renders %s identically with and without a terminal', async (style, { io }) => {
     process.stdout.isTTY = true;
     await routeCommand(['verify', '--manifest', 'manifest.json', '--style', style]);
-    const attached = stdout.join('');
+    const attached = io.stdout;
 
-    stdout = [];
+    io.reset();
     process.stdout.isTTY = false;
     await routeCommand(['verify', '--manifest', 'manifest.json', '--style', style]);
 
-    expect(stdout.join('')).toBe(attached);
+    expect(io.stdout).toBe(attached);
   });
 });
 
 describe('alongside --json', () => {
-  it('leaves the JSON document on stdout and styles the prose on stderr', async () => {
+  it('leaves the JSON document on stdout and styles the prose on stderr', async ({ io }) => {
     await routeCommand(['verify', '--manifest', 'manifest.json', '--json', '--style', 'plain']);
 
-    const document: unknown = JSON.parse(stdout.join(''));
+    const document: unknown = JSON.parse(io.stdout);
     expect(document).toMatchObject({ passed: true });
-    expect(stderr.join('')).toContain(PLAIN_PASS);
-    expect(stderr.join('')).not.toContain(RICH_PASS);
+    expect(io.stderr).toContain(PLAIN_PASS);
+    expect(io.stderr).not.toContain(RICH_PASS);
   });
 
-  it('emits the same JSON whichever style is selected', async () => {
+  it('emits the same JSON whichever style is selected', async ({ io }) => {
     await routeCommand(['verify', '--manifest', 'manifest.json', '--json', '--style', 'plain']);
-    const plain = stdout.join('');
+    const plain = io.stdout;
 
-    stdout = [];
+    io.reset();
     await routeCommand(['verify', '--manifest', 'manifest.json', '--json', '--style', 'rich']);
 
-    expect(stdout.join('')).toBe(plain);
+    expect(io.stdout).toBe(plain);
   });
 });

--- a/packages/readyup/src/layout/engine.ts
+++ b/packages/readyup/src/layout/engine.ts
@@ -25,5 +25,6 @@ export function getLayout(): LayoutEngine {
 
 /** Binds every later render to `style`. */
 export function setStyle(style: Style): void {
+  // eslint-disable-next-line unicorn/no-top-level-assignment-in-function -- The engine is a process singleton.
   active = engines[style];
 }

--- a/packages/readyup/src/readyupResolverHook.ts
+++ b/packages/readyup/src/readyupResolverHook.ts
@@ -52,6 +52,7 @@ function isReadyupSpecifier(specifier: string): boolean {
  * Called exactly once when the hook is registered.
  */
 export function initialize(data: ReadyupResolverHookData): void {
+  // eslint-disable-next-line unicorn/no-top-level-assignment-in-function -- `module.register()` supplies this once.
   readyupParentURL = data.readyupParentURL;
 }
 


### PR DESCRIPTION
## What

Refactors test code to use shared helpers to create a temporary working directory or capture command output; the helpers handle directory cleanup, working-directory redirection, and stream restoration automatically.

## Why

Every check-utils, command-level, and package-discovery suite carried its own copy of the same scaffolding, so the same setup drifted apart across fourteen files and each new suite paid to write it again. Directories left behind and spies never restored were a standing hazard, since correctness depended on each suite remembering its own teardown.

## Details

### ♻️ Refactoring

- `useTempDir` builds a scaffolded temporary directory for the enclosing suite, points the code under test at it through either `process.chdir` or a `process.cwd` spy, and removes it on teardown. A `scope` of `file` or `test` selects the hook pair the helper registers.
- `useCapturedStdio` buffers writes to `process.stdout` and `process.stderr`, exposes them as text, and restores the streams on teardown. This retires the per-suite `readStdout` and `readStderr` helpers.
- Both helpers return a handle that suites bind once at module level, delegating to whatever the current scope built. A test reads the directory or the captured streams from module scope, so cases keep vitest's ordinary `it` and nothing is destructured from a test context parameter.
- A suite that scaffolds files passes `setup` a callback taking no argument, which runs from within the hook and writes through the bound handle.
- Generic per-file write helpers give way to the handle's own `write` and `writeJson`. Domain-named helpers survive, taking the handle as a parameter.
- Table-driven cases in the command-level suites move from `it.each` to `it.for`.
- `discoverKitPackages` reaches its second, manifest-less root through a second `useTempDir` call, the shape that supports a suite needing more than one directory.

### ⚙️ Tooling

- `unicorn/no-top-level-assignment-in-function` leaves the deferred-rule allowlist and is enforced as an error under `lint:strict`. The allowlist keeps its other eight entries.
- The layout engine's `active` binding and the resolver hook's `initialize` are deliberate module singletons and carry inline disables naming why.

Closes #156
