### PR TITLE
#165 Add tier provenance to the plan schema and share the traversal helpers

### DIFF
--- a/packages/compositor/README.md
+++ b/packages/compositor/README.md
@@ -26,12 +26,14 @@ A plan is the engine's output: the complete rendered result of a composition, be
 
 - **What the output looks like.** Every file for every target, with its body available, so the whole result can be inspected before apply.
 - **How it differs from what is there now.** Each artifact and file is classified `added`, `changed`, `removed`, or `unchanged`.
-- **Why each part of it is there.** Which source an artifact resolved from, which sources lost, what pulled it into the closure, and which artifacts and transcluded partials contributed to each output file.
+- **Why each part of it is there.** Which source an artifact resolved from, which sources lost, which config tier decided it, what pulled it into the closure, and which artifacts and transcluded partials contributed to each output file.
 - **What it was computed from.** Digests of the config, the sources, and the target's own state, so staleness is a comparison rather than a file watch.
 
 The payload is normalized: cross-references between tables are opaque ids, because the provenance graph has diamonds and JSON holds no references. The per-target directory tree follows from the paths in `files`, and file bodies live in a content-addressed `blobs` table keyed by hash, so a body shared across targets is carried once.
 
 Ordering is part of the contract. Id-keyed tables run lexicographically, `files` runs by target then path, and `blobs` is keyed in hash order, so two plans of the same shape diff cleanly. `sources` and each list of shadowed candidates run in precedence order, where the order is the meaning.
+
+`tiers` names the config tiers a seed can be decided by, and runs lowest precedence first: that is the order a fold applies them in, so the last tier to speak wins. It is deliberately the reverse of `sources`, where the first entry wins, because a source's position encodes precedence directly while a tier's encodes application. An artifact several tiers seed carries one seed record each, which is what tells a project-level opt-in from an inherited one.
 
 ## What the schema checks, and what it does not
 
@@ -47,7 +49,9 @@ The invariants therefore live outside it, in `assertPlanIsConsistent`:
 
 A consumer parsing with `PlanSchema` alone has checked none of these. Call the assertion too, or treat a dangling reference as possible.
 
-Two derived views also live outside the payload, in `buildTraversalIndex` and `resolveInclusionPaths`. The plan stores dependency edges forwards only: paths from a seed to an artifact are enumerated on demand, because a diamond-heavy graph grows them faster than a plan recomputed on every toggle can carry, and the reverse "used by" direction is indexed per plan rather than written twice.
+The derived views also live outside the payload. Dependency edges are stored forwards only: paths from a seed to an artifact are enumerated on demand by `resolveInclusionPaths`, because a diamond-heavy graph grows them faster than a plan recomputed on every toggle can carry, and the reverse "used by" direction is indexed by `buildDependentsIndex` rather than written twice.
+
+Both take any document carrying artifacts and edges, not a plan specifically, so the closure the engine computes from a config uses them unchanged. `buildTraversalIndex` adds the artifact-to-file direction on top, which is a plan's alone: a closure has no files to point at.
 
 ## Evolution
 
@@ -55,11 +59,13 @@ Two derived views also live outside the payload, in `buildTraversalIndex` and `r
 
 That promise holds because objects in this schema are open: an unrecognized field parses and is dropped, so a consumer pinned to one version accepts a payload from a later one. Making any object strict would break it the first time a field was added.
 
+The contract is at version 2. Version 2 added the `tiers` table and re-typed each `seededBy` entry from a bare origin into a record naming the tier that decided the seed; the origin `package-catalog` became `source-catalog` in the same change, because taking everything a source carries is a selection any source can be the object of.
+
 ## Samples
 
 Two plans ship as JSON, both validating against the schema and satisfying every invariant:
 
 - `samples/minimal.json` is the smallest plan the contract allows, for a consumer rendering its first view.
-- `samples/representative.json` exercises every shape the contract carries: an artifact reached by three dependency routes, shadowed candidates beside an artifact the lowest-precedence source wins, three artifacts aggregated into one region behind per-artifact markers, entry-level ownership of a structured config, a byte-encoded asset, a file apply will skip, and all four diff statuses.
+- `samples/representative.json` exercises every shape the contract carries: an artifact reached by three dependency routes, shadowed candidates beside an artifact the lowest-precedence source wins, three artifacts aggregated into one region behind per-artifact markers, entry-level ownership of a structured config, a byte-encoded asset, a file apply will skip, an artifact two tiers both seed, and all four diff statuses.
 
 Both are generated from typed builders that digest their own content, so no hash is written by hand, and both are committed and pinned byte for byte by a drift test. Regenerate them with `pnpm exec tsx config/generateSamples.ts`, which also runs as part of `prepare`.

--- a/packages/compositor/README.md
+++ b/packages/compositor/README.md
@@ -31,7 +31,7 @@ A plan is the engine's output: the complete rendered result of a composition, be
 
 The payload is normalized: cross-references between tables are opaque ids, because the provenance graph has diamonds and JSON holds no references. The per-target directory tree follows from the paths in `files`, and file bodies live in a content-addressed `blobs` table keyed by hash, so a body shared across targets is carried once.
 
-Ordering is part of the contract. Id-keyed tables run lexicographically, `files` runs by target then path, and `blobs` is keyed in hash order, so two plans of the same shape diff cleanly. `sources` and each list of shadowed candidates run in precedence order, where the order is the meaning.
+Ordering is part of the contract. Id-keyed tables run lexicographically, `files` runs by target then path, and `blobs` is keyed in hash order, so two plans of the same shape diff cleanly. `sources`, `tiers`, and each list of shadowed candidates run in precedence order instead, where the order is the meaning, and each artifact's `seededBy` follows `tiers`.
 
 `tiers` names the config tiers a seed can be decided by, and runs lowest precedence first: that is the order a fold applies them in, so the last tier to speak wins. It is deliberately the reverse of `sources`, where the first entry wins, because a source's position encodes precedence directly while a tier's encodes application. An artifact several tiers seed carries one seed record each, which is what tells a project-level opt-in from an inherited one.
 

--- a/packages/compositor/samples/minimal.json
+++ b/packages/compositor/samples/minimal.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "engineVersion": "0.0.0",
   "contentAvailability": "complete",
   "fingerprint": {
@@ -44,6 +44,12 @@
       "variables": []
     }
   ],
+  "tiers": [
+    {
+      "id": "project",
+      "label": "Project"
+    }
+  ],
   "artifacts": [
     {
       "id": "skill:review",
@@ -51,7 +57,10 @@
       "slug": "review",
       "status": "added",
       "seededBy": [
-        "declaration"
+        {
+          "via": "declaration",
+          "tierId": "project"
+        }
       ],
       "dependsOn": [],
       "resolution": {

--- a/packages/compositor/samples/representative.json
+++ b/packages/compositor/samples/representative.json
@@ -142,12 +142,12 @@
   ],
   "tiers": [
     {
-      "id": "project",
-      "label": "Project"
+      "id": "user",
+      "label": "User"
     },
     {
-      "id": "project-local",
-      "label": "Local override"
+      "id": "project",
+      "label": "Project"
     }
   ],
   "artifacts": [
@@ -159,11 +159,11 @@
       "seededBy": [
         {
           "via": "declaration",
-          "tierId": "project"
+          "tierId": "user"
         },
         {
           "via": "declaration",
-          "tierId": "project-local"
+          "tierId": "project"
         }
       ],
       "dependsOn": [
@@ -319,7 +319,7 @@
       "seededBy": [
         {
           "via": "declaration",
-          "tierId": "project-local"
+          "tierId": "user"
         }
       ],
       "dependsOn": [

--- a/packages/compositor/samples/representative.json
+++ b/packages/compositor/samples/representative.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "engineVersion": "0.0.0",
   "contentAvailability": "complete",
   "fingerprint": {
@@ -140,6 +140,16 @@
       ]
     }
   ],
+  "tiers": [
+    {
+      "id": "project",
+      "label": "Project"
+    },
+    {
+      "id": "project-local",
+      "label": "Local override"
+    }
+  ],
   "artifacts": [
     {
       "id": "collection:core",
@@ -147,7 +157,14 @@
       "slug": "core",
       "status": "unchanged",
       "seededBy": [
-        "declaration"
+        {
+          "via": "declaration",
+          "tierId": "project"
+        },
+        {
+          "via": "declaration",
+          "tierId": "project-local"
+        }
       ],
       "dependsOn": [
         {
@@ -178,7 +195,10 @@
       "slug": "naming",
       "status": "added",
       "seededBy": [
-        "package-catalog"
+        {
+          "via": "source-catalog",
+          "tierId": "project"
+        }
       ],
       "dependsOn": [],
       "resolution": {
@@ -212,7 +232,10 @@
       "slug": "tests",
       "status": "added",
       "seededBy": [
-        "package-catalog"
+        {
+          "via": "source-catalog",
+          "tierId": "project"
+        }
       ],
       "dependsOn": [],
       "resolution": {
@@ -294,7 +317,10 @@
       "slug": "auditor",
       "status": "changed",
       "seededBy": [
-        "declaration"
+        {
+          "via": "declaration",
+          "tierId": "project-local"
+        }
       ],
       "dependsOn": [
         {

--- a/packages/compositor/src/__tests__/index.unit.test.ts
+++ b/packages/compositor/src/__tests__/index.unit.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import * as graphTraversal from '../graph/traversal.ts';
 import * as entry from '../index.ts';
 import * as assertPlanIsConsistent from '../plan/assertPlanIsConsistent.ts';
-import * as traversal from '../plan/traversal.ts';
+import * as planTraversal from '../plan/traversal.ts';
 import * as assertCatalogIsConsistent from '../resolution/assertCatalogIsConsistent.ts';
 import * as composeArtifactId from '../resolution/composeArtifactId.ts';
 import * as enumerateSource from '../resolution/enumerateSource.ts';
@@ -28,8 +29,9 @@ const publishedModules: ReadonlyArray<readonly [string, Record<string, unknown>]
   ['assertPlanIsConsistent', assertPlanIsConsistent],
   ['composeArtifactId', composeArtifactId],
   ['enumerateSource', enumerateSource],
+  ['graph/traversal', graphTraversal],
+  ['plan/traversal', planTraversal],
   ['resolveCatalog', resolveCatalog],
-  ['traversal', traversal],
 ];
 
 describe('package entry', () => {

--- a/packages/compositor/src/graph/__tests__/traversal.unit.test.ts
+++ b/packages/compositor/src/graph/__tests__/traversal.unit.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Plan } from '../../schemas/plan-schema.ts';
+import { buildPlan } from '../../test-utils/buildPlan.ts';
+import { requireEntry } from '../../test-utils/requireEntry.ts';
+import { buildDependentsIndex, type DependencyGraphView, resolveInclusionPaths } from '../traversal.ts';
+
+describe(resolveInclusionPaths, () => {
+  it('returns one path per route when an artifact is reached two ways', () => {
+    const plan = buildDiamond();
+
+    expect(resolveInclusionPaths(plan, 'skill:lint')).toStrictEqual([
+      ['collection:core', 'skill:review', 'skill:lint'],
+      ['collection:core', 'skill:lint'],
+    ]);
+  });
+
+  it("orders paths by the document's own edge order, so the same document always answers the same way", () => {
+    const plan = buildDiamond();
+
+    expect(resolveInclusionPaths(plan, 'skill:lint')).toStrictEqual(
+      resolveInclusionPaths(buildDiamond(), 'skill:lint'),
+    );
+  });
+
+  it('returns a single one-element path for a seeded artifact', () => {
+    expect(resolveInclusionPaths(buildPlan(), 'collection:core')).toStrictEqual([['collection:core']]);
+  });
+
+  it('returns no path for an artifact nothing reaches', () => {
+    const plan = buildPlan();
+    requireEntry(plan.artifacts, 0).dependsOn = [];
+
+    expect(resolveInclusionPaths(plan, 'skill:review')).toStrictEqual([]);
+  });
+
+  it('traverses an edge a token contributed through a partial', () => {
+    expect(resolveInclusionPaths(buildPlan(), 'skill:lint')).toStrictEqual([
+      ['collection:core', 'skill:review', 'skill:lint'],
+    ]);
+  });
+
+  it('terminates on a document whose edges form a cycle', () => {
+    const plan = buildPlan();
+    requireEntry(plan.artifacts, 2).dependsOn = [{ to: 'skill:review', via: 'declared' }];
+
+    // Searching for an artifact the cycle does not reach forces the walk through the back edge rather than stopping at
+    // the target, which is the only way the guard is exercised.
+    expect(resolveInclusionPaths(plan, 'skill:absent')).toStrictEqual([]);
+  });
+
+  it('still finds the paths that exist on a document whose edges form a cycle', () => {
+    const plan = buildPlan();
+    requireEntry(plan.artifacts, 2).dependsOn = [{ to: 'skill:review', via: 'declared' }];
+
+    expect(resolveInclusionPaths(plan, 'skill:lint')).toStrictEqual([
+      ['collection:core', 'skill:review', 'skill:lint'],
+    ]);
+  });
+
+  it('resolves paths through a document carrying only ids, edges, and seeds', () => {
+    expect(resolveInclusionPaths(buildClosureShaped(), 'skill:lint')).toStrictEqual([
+      ['collection:core', 'skill:review', 'skill:lint'],
+    ]);
+  });
+
+  it('starts no path at an artifact a document records as removed', () => {
+    const plan = buildPlan();
+    const core = requireEntry(plan.artifacts, 0);
+
+    expect(resolveInclusionPaths({ artifacts: [{ ...core, status: 'removed' }] }, 'collection:core')).toStrictEqual([]);
+  });
+});
+
+describe(buildDependentsIndex, () => {
+  it('names the artifact whose token edge reached a dependency', () => {
+    const findDependents = buildDependentsIndex(buildPlan());
+
+    expect(findDependents('skill:lint')).toStrictEqual(['skill:review']);
+  });
+
+  it('returns each dependent once per edge that reaches the artifact', () => {
+    const findDependents = buildDependentsIndex(buildDiamond());
+
+    expect(findDependents('skill:lint')).toStrictEqual(['collection:core', 'skill:review']);
+  });
+
+  it('returns nothing for an artifact no edge reaches', () => {
+    const findDependents = buildDependentsIndex(buildPlan());
+
+    expect(findDependents('collection:core')).toStrictEqual([]);
+  });
+
+  it('indexes a document carrying only ids and edges', () => {
+    const findDependents = buildDependentsIndex(buildClosureShaped());
+
+    expect(findDependents('skill:review')).toStrictEqual(['collection:core']);
+  });
+});
+
+// region | Helpers
+
+/**
+ * A graph carrying only what traversal reads, standing in for a closure before one exists.
+ *
+ * Nothing here is a plan: no status, no resolution, no kind. That is the point, because the helpers take this shape and
+ * the closure ticket therefore adds no second copy of them.
+ */
+function buildClosureShaped(): DependencyGraphView {
+  return {
+    artifacts: [
+      {
+        id: 'collection:core',
+        seededBy: [{ via: 'declaration', tierId: 'project' }],
+        dependsOn: [{ to: 'skill:review', via: 'member' }],
+      },
+      { id: 'skill:review', seededBy: [], dependsOn: [{ to: 'skill:lint', via: 'declared' }] },
+      { id: 'skill:lint', seededBy: [], dependsOn: [] },
+    ],
+  };
+}
+
+/** The fixture plan with a second route to `skill:lint`, so one artifact is reached by two paths. */
+function buildDiamond(): Plan {
+  const plan = buildPlan();
+  const core = requireEntry(plan.artifacts, 0);
+  core.dependsOn = [...(core.dependsOn ?? []), { to: 'skill:lint', via: 'member' }];
+  return plan;
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/graph/traversal.ts
+++ b/packages/compositor/src/graph/traversal.ts
@@ -1,0 +1,107 @@
+import { appendTo } from '../portable/appendTo.ts';
+import type { ArtifactId, DiffStatus } from '../schemas/common.ts';
+import type { DependencyEdge, Seed } from '../schemas/graph-schemas.ts';
+
+/**
+ * One artifact as traversal reads it: an identity, the edges leaving it, and what seeded it.
+ *
+ * Every field but the id is optional, because a removed artifact carries no seeds and, once the source carrying it is
+ * gone, no edges either. A plan's entry and a closure's both satisfy this shape without an adapter, which is what keeps
+ * one implementation serving both documents.
+ */
+export interface TraversableArtifact {
+  readonly id: ArtifactId;
+  readonly dependsOn?: ReadonlyArray<DependencyEdge> | undefined;
+  readonly seededBy?: ReadonlyArray<Seed> | undefined;
+  readonly status?: DiffStatus | undefined;
+}
+
+/** Any document carrying a dependency graph: a plan, or the closure a plan is computed from. */
+export interface DependencyGraphView {
+  readonly artifacts: ReadonlyArray<TraversableArtifact>;
+}
+
+/** The artifacts whose edges point at `artifactId`, in the order the document records them. */
+export type DependentsIndex = (artifactId: ArtifactId) => ReadonlyArray<ArtifactId>;
+
+/**
+ * Builds the reverse index for one document, answering the "used by" direction the payload stores only forwards.
+ *
+ * Build once per document: a provenance pane issues many lookups against one of them.
+ */
+export function buildDependentsIndex(view: DependencyGraphView): DependentsIndex {
+  const dependents = new Map<ArtifactId, Array<ArtifactId>>();
+  for (const artifact of view.artifacts) {
+    const edges = artifact.dependsOn ?? [];
+    for (const edge of edges) {
+      appendTo(dependents, edge.to, artifact.id);
+    }
+  }
+  return (artifactId) => dependents.get(artifactId) ?? [];
+}
+
+/**
+ * Every path from a seeded artifact to `artifactId`, following dependency edges.
+ *
+ * A diamond yields one path per route. Paths are derived on demand because enumerating them is exponential in a
+ * diamond-heavy graph, and a document recomputed on every toggle cannot afford to carry them; one lookup covers one
+ * artifact, at the moment a reader asks why it is present.
+ *
+ * Each path runs seed-first and ends at `artifactId`, so a seeded artifact yields a single one-element path. Ordering
+ * follows the document's own table and edge order, which makes the result deterministic. A cycle terminates the walk
+ * that reached it: a valid document holds none, and a malformed one must not hang the caller.
+ */
+export function resolveInclusionPaths(view: DependencyGraphView, artifactId: ArtifactId): Array<Array<ArtifactId>> {
+  const edges = buildForwardEdges(view);
+  const paths: Array<Array<ArtifactId>> = [];
+  const trail: Array<ArtifactId> = [];
+  const onTrail = new Set<ArtifactId>();
+
+  function walk(from: ArtifactId): void {
+    if (onTrail.has(from)) {
+      return;
+    }
+    trail.push(from);
+    onTrail.add(from);
+
+    if (from === artifactId) {
+      paths.push([...trail]);
+    } else {
+      const outgoing = edges.get(from) ?? [];
+      for (const to of outgoing) {
+        walk(to);
+      }
+    }
+
+    trail.pop();
+    onTrail.delete(from);
+  }
+
+  for (const seed of findSeeds(view)) {
+    walk(seed);
+  }
+  return paths;
+}
+
+// region | Helpers
+
+/** The outgoing edge targets of each artifact, in the order the document records them. */
+function buildForwardEdges(view: DependencyGraphView): ReadonlyMap<ArtifactId, ReadonlyArray<ArtifactId>> {
+  const edges = new Map<ArtifactId, Array<ArtifactId>>();
+  for (const artifact of view.artifacts) {
+    edges.set(
+      artifact.id,
+      (artifact.dependsOn ?? []).map((edge) => edge.to),
+    );
+  }
+  return edges;
+}
+
+/** The artifacts a path can start from: those something seeded, in table order. */
+function findSeeds(view: DependencyGraphView): ReadonlyArray<ArtifactId> {
+  return view.artifacts
+    .filter((artifact) => artifact.status !== 'removed' && (artifact.seededBy ?? []).length > 0)
+    .map((artifact) => artifact.id);
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/index.ts
+++ b/packages/compositor/src/index.ts
@@ -1,7 +1,9 @@
+export type { DependencyGraphView, DependentsIndex, TraversableArtifact } from './graph/traversal.ts';
+export { buildDependentsIndex, resolveInclusionPaths } from './graph/traversal.ts';
 export type { PlanViolation } from './plan/assertPlanIsConsistent.ts';
 export { assertPlanIsConsistent, PlanConsistencyError } from './plan/assertPlanIsConsistent.ts';
 export type { TraversalIndex } from './plan/traversal.ts';
-export { buildTraversalIndex, resolveInclusionPaths } from './plan/traversal.ts';
+export { buildTraversalIndex } from './plan/traversal.ts';
 export type { CatalogViolation } from './resolution/assertCatalogIsConsistent.ts';
 export { assertCatalogIsConsistent, CatalogConsistencyError } from './resolution/assertCatalogIsConsistent.ts';
 export { composeArtifactId } from './resolution/composeArtifactId.ts';
@@ -17,6 +19,7 @@ export type {
   SourceOrigin,
   TargetEntry,
   TargetVariable,
+  TierDescriptor,
   TokenMapping,
   TokenMappingEntry,
 } from './schemas/descriptor-schemas.ts';
@@ -26,6 +29,7 @@ export {
   SourceOriginSchema,
   TargetEntrySchema,
   TargetVariableSchema,
+  TierDescriptorSchema,
   TokenMappingEntrySchema,
   TokenMappingSchema,
 } from './schemas/descriptor-schemas.ts';
@@ -56,6 +60,7 @@ export type {
   PresentArtifact,
   RemovedArtifact,
   ResolutionCandidate,
+  Seed,
   SeedOrigin,
 } from './schemas/graph-schemas.ts';
 export {
@@ -68,6 +73,7 @@ export {
   RemovedArtifactSchema,
   ResolutionCandidateSchema,
   SeedOriginSchema,
+  SeedSchema,
 } from './schemas/graph-schemas.ts';
 export type { Plan, PlanFingerprint, SourceDigest, TargetDigest } from './schemas/plan-schema.ts';
 export {

--- a/packages/compositor/src/plan/__tests__/assertPlanIsConsistent.unit.test.ts
+++ b/packages/compositor/src/plan/__tests__/assertPlanIsConsistent.unit.test.ts
@@ -36,6 +36,25 @@ describe(assertPlanIsConsistent, () => {
     ]);
   });
 
+  it('if a seed names a tier no table carries, locates the dangling reference', () => {
+    const plan = buildPlan();
+    plan.tiers = [];
+
+    expect(findViolations(plan)).toStrictEqual([
+      {
+        path: 'artifacts[0].seededBy[0].tierId',
+        message: 'references "project", which is not an entry in tiers',
+      },
+    ]);
+  });
+
+  it('if the tier table carries one id twice, names the repeated id', () => {
+    const plan = buildPlan();
+    plan.tiers = [...plan.tiers, { id: 'project', label: 'Project, again' }];
+
+    expect(findViolations(plan)).toStrictEqual([{ path: 'tiers', message: 'carries "project" more than once' }]);
+  });
+
   it('if a table carries one id twice, names the repeated id', () => {
     const plan = buildPlan();
     plan.sources = [...plan.sources, { id: 'team', name: 'team-again', origin: { kind: 'directory', location: '/x' } }];

--- a/packages/compositor/src/plan/__tests__/traversal.unit.test.ts
+++ b/packages/compositor/src/plan/__tests__/traversal.unit.test.ts
@@ -1,71 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Plan } from '../../schemas/plan-schema.ts';
 import { buildPlan } from '../../test-utils/buildPlan.ts';
-import { requireEntry } from '../../test-utils/requireEntry.ts';
-import { buildTraversalIndex, resolveInclusionPaths } from '../traversal.ts';
-
-describe(resolveInclusionPaths, () => {
-  it('returns one path per route when an artifact is reached two ways', () => {
-    const plan = buildDiamond();
-
-    expect(resolveInclusionPaths(plan, 'skill:lint')).toStrictEqual([
-      ['collection:core', 'skill:review', 'skill:lint'],
-      ['collection:core', 'skill:lint'],
-    ]);
-  });
-
-  it("orders paths by the plan's own edge order, so the same plan always answers the same way", () => {
-    const plan = buildDiamond();
-
-    expect(resolveInclusionPaths(plan, 'skill:lint')).toStrictEqual(
-      resolveInclusionPaths(buildDiamond(), 'skill:lint'),
-    );
-  });
-
-  it('returns a single one-element path for a seeded artifact', () => {
-    expect(resolveInclusionPaths(buildPlan(), 'collection:core')).toStrictEqual([['collection:core']]);
-  });
-
-  it('returns no path for an artifact nothing reaches', () => {
-    const plan = buildPlan();
-    requireEntry(plan.artifacts, 0).dependsOn = [];
-
-    expect(resolveInclusionPaths(plan, 'skill:review')).toStrictEqual([]);
-  });
-
-  it('traverses an edge a token contributed through a partial', () => {
-    expect(resolveInclusionPaths(buildPlan(), 'skill:lint')).toStrictEqual([
-      ['collection:core', 'skill:review', 'skill:lint'],
-    ]);
-  });
-
-  it('terminates on a plan whose edges form a cycle', () => {
-    const plan = buildPlan();
-    requireEntry(plan.artifacts, 2).dependsOn = [{ to: 'skill:review', via: 'declared' }];
-
-    // Searching for an artifact the cycle does not reach forces the walk through the back edge rather than stopping at
-    // the target, which is the only way the guard is exercised.
-    expect(resolveInclusionPaths(plan, 'skill:absent')).toStrictEqual([]);
-  });
-
-  it('still finds the paths that exist on a plan whose edges form a cycle', () => {
-    const plan = buildPlan();
-    requireEntry(plan.artifacts, 2).dependsOn = [{ to: 'skill:review', via: 'declared' }];
-
-    expect(resolveInclusionPaths(plan, 'skill:lint')).toStrictEqual([
-      ['collection:core', 'skill:review', 'skill:lint'],
-    ]);
-  });
-});
+import { buildTraversalIndex } from '../traversal.ts';
 
 describe(buildTraversalIndex, () => {
-  it('names the artifact whose token edge reached a dependency', () => {
-    const index = buildTraversalIndex(buildPlan());
-
-    expect(index.findDependents('skill:lint')).toStrictEqual(['skill:review']);
-  });
-
   it('returns every file an artifact contributes content to', () => {
     const index = buildTraversalIndex(buildPlan());
 
@@ -74,28 +12,15 @@ describe(buildTraversalIndex, () => {
     ]);
   });
 
-  it('returns each dependent once per edge that reaches the artifact', () => {
-    const index = buildTraversalIndex(buildDiamond());
-
-    expect(index.findDependents('skill:lint')).toStrictEqual(['collection:core', 'skill:review']);
-  });
-
-  it('returns nothing for an artifact no edge and no file reaches', () => {
+  it('returns nothing for an artifact no file reaches', () => {
     const index = buildTraversalIndex(buildPlan());
 
-    expect(index.findDependents('collection:core')).toStrictEqual([]);
     expect(index.findContributedFiles('collection:core')).toStrictEqual([]);
   });
+
+  it('answers the artifact-to-artifact direction it composes from the shared index', () => {
+    const index = buildTraversalIndex(buildPlan());
+
+    expect(index.findDependents('skill:lint')).toStrictEqual(['skill:review']);
+  });
 });
-
-// region | Helpers
-
-/** The fixture plan with a second route to `skill:lint`, so one artifact is reached by two paths. */
-function buildDiamond(): Plan {
-  const plan = buildPlan();
-  const core = requireEntry(plan.artifacts, 0);
-  core.dependsOn = [...(core.dependsOn ?? []), { to: 'skill:lint', via: 'member' }];
-  return plan;
-}
-
-// endregion | Helpers

--- a/packages/compositor/src/plan/assertPlanIsConsistent.ts
+++ b/packages/compositor/src/plan/assertPlanIsConsistent.ts
@@ -58,6 +58,7 @@ function findDanglingReferences(plan: Plan): Array<PlanViolation> {
   const partialIds = collectIds(plan.partials);
   const sourceIds = collectIds(plan.sources);
   const targetIds = collectIds(plan.targets);
+  const tierIds = collectIds(plan.tiers);
 
   const violations: Array<PlanViolation> = [];
   const requireKnown = (known: ReadonlySet<string>, id: string | undefined, path: string, table: string): void => {
@@ -80,6 +81,12 @@ function findDanglingReferences(plan: Plan): Array<PlanViolation> {
     for (const [edgeIndex, edge] of edges.entries()) {
       requireKnown(artifactIds, edge.to, `${at}.dependsOn[${edgeIndex}].to`, 'artifacts');
       requireKnown(partialIds, edge.partialId, `${at}.dependsOn[${edgeIndex}].partialId`, 'partials');
+    }
+    // A removed artifact is seeded by nothing and carries no `seededBy` at all, so the narrowing is what reaches the
+    // field rather than a fallback for an absent one.
+    const seeds = artifact.status === 'removed' ? [] : artifact.seededBy;
+    for (const [seedIndex, seed] of seeds.entries()) {
+      requireKnown(tierIds, seed.tierId, `${at}.seededBy[${seedIndex}].tierId`, 'tiers');
     }
     if (artifact.resolution !== undefined) {
       requireKnown(sourceIds, artifact.resolution.winner.sourceId, `${at}.resolution.winner.sourceId`, 'sources');
@@ -142,6 +149,7 @@ function findDuplicateIds(plan: Plan): Array<PlanViolation> {
     ['partials', plan.partials],
     ['sources', plan.sources],
     ['targets', plan.targets],
+    ['tiers', plan.tiers],
   ] as const;
 
   return tables.flatMap(([name, entries]) => {

--- a/packages/compositor/src/plan/traversal.ts
+++ b/packages/compositor/src/plan/traversal.ts
@@ -1,8 +1,10 @@
+import { buildDependentsIndex } from '../graph/traversal.ts';
+import { appendTo } from '../portable/appendTo.ts';
 import type { ArtifactId } from '../schemas/common.ts';
 import type { FileEntry } from '../schemas/file-schemas.ts';
 import type { Plan } from '../schemas/plan-schema.ts';
 
-/** Reverse lookups over a plan's graph, answering the "used by" direction the payload stores only forwards. */
+/** Reverse lookups over a plan's graph, answering the two "used by" directions the payload stores only forwards. */
 export interface TraversalIndex {
   /** The artifacts whose edges point at `artifactId`. */
   findDependents(artifactId: ArtifactId): ReadonlyArray<ArtifactId>;
@@ -15,16 +17,12 @@ export interface TraversalIndex {
  * Builds the reverse index for one plan.
  *
  * The file-to-artifact edge is written only on the file, so the artifact-to-file direction exists nowhere in the
- * payload until it is derived here. Build once per plan: a provenance pane issues many lookups against one plan.
+ * payload until it is derived here. That half is plan-only, having no counterpart in a closure, which is why the
+ * artifact-to-artifact half lives in `buildDependentsIndex` and is composed rather than repeated. Build once per plan: a
+ * provenance pane issues many lookups against one plan.
  */
 export function buildTraversalIndex(plan: Plan): TraversalIndex {
-  const dependents = new Map<ArtifactId, Array<ArtifactId>>();
-  for (const artifact of plan.artifacts) {
-    const edges = artifact.dependsOn ?? [];
-    for (const edge of edges) {
-      appendTo(dependents, edge.to, artifact.id);
-    }
-  }
+  const findDependents = buildDependentsIndex(plan);
 
   const contributedFiles = new Map<ArtifactId, Array<FileEntry>>();
   for (const file of plan.files) {
@@ -34,84 +32,7 @@ export function buildTraversalIndex(plan: Plan): TraversalIndex {
   }
 
   return {
-    findDependents: (artifactId) => dependents.get(artifactId) ?? [],
+    findDependents,
     findContributedFiles: (artifactId) => contributedFiles.get(artifactId) ?? [],
   };
 }
-
-/**
- * Every path from a seeded artifact to `artifactId`, following dependency edges.
- *
- * A diamond yields one path per route. Paths are derived on demand because enumerating them is exponential in a
- * diamond-heavy graph, and a plan recomputed on every toggle cannot afford to carry them; one lookup covers one
- * artifact, at the moment a reader asks why it is present.
- *
- * Each path runs seed-first and ends at `artifactId`, so a seeded artifact yields a single one-element path. Ordering
- * follows the plan's own table and edge order, which makes the result deterministic. A cycle terminates the walk that
- * reached it: a valid plan holds none, and a malformed one must not hang the caller.
- */
-export function resolveInclusionPaths(plan: Plan, artifactId: ArtifactId): Array<Array<ArtifactId>> {
-  const edges = buildForwardEdges(plan);
-  const paths: Array<Array<ArtifactId>> = [];
-  const trail: Array<ArtifactId> = [];
-  const onTrail = new Set<ArtifactId>();
-
-  function walk(from: ArtifactId): void {
-    if (onTrail.has(from)) {
-      return;
-    }
-    trail.push(from);
-    onTrail.add(from);
-
-    if (from === artifactId) {
-      paths.push([...trail]);
-    } else {
-      const outgoing = edges.get(from) ?? [];
-      for (const to of outgoing) {
-        walk(to);
-      }
-    }
-
-    trail.pop();
-    onTrail.delete(from);
-  }
-
-  for (const seed of findSeeds(plan)) {
-    walk(seed);
-  }
-  return paths;
-}
-
-// region | Helpers
-
-/** Appends `value` to the list `key` maps to, starting one when the key is new. */
-function appendTo<K, V>(index: Map<K, Array<V>>, key: K, value: V): void {
-  const existing = index.get(key);
-  if (existing === undefined) {
-    index.set(key, [value]);
-  } else {
-    existing.push(value);
-  }
-}
-
-/** The outgoing edge targets of each artifact, in the order the plan records them. */
-function buildForwardEdges(plan: Plan): ReadonlyMap<ArtifactId, ReadonlyArray<ArtifactId>> {
-  const edges = new Map<ArtifactId, Array<ArtifactId>>();
-  for (const artifact of plan.artifacts) {
-    const outgoing = artifact.dependsOn ?? [];
-    edges.set(
-      artifact.id,
-      outgoing.map((edge) => edge.to),
-    );
-  }
-  return edges;
-}
-
-/** The artifacts a path can start from: those something seeded, in table order. */
-function findSeeds(plan: Plan): ReadonlyArray<ArtifactId> {
-  return plan.artifacts
-    .filter((artifact) => artifact.status !== 'removed' && artifact.seededBy.length > 0)
-    .map((artifact) => artifact.id);
-}
-
-// endregion | Helpers

--- a/packages/compositor/src/portable/appendTo.ts
+++ b/packages/compositor/src/portable/appendTo.ts
@@ -1,0 +1,9 @@
+/** Appends `value` to the list `key` maps to, starting one when the key is new. */
+export function appendTo<K, V>(index: Map<K, Array<V>>, key: K, value: V): void {
+  const existing = index.get(key);
+  if (existing === undefined) {
+    index.set(key, [value]);
+  } else {
+    existing.push(value);
+  }
+}

--- a/packages/compositor/src/samples/__tests__/samples.roundtrip.unit.test.ts
+++ b/packages/compositor/src/samples/__tests__/samples.roundtrip.unit.test.ts
@@ -30,9 +30,31 @@ describe('determinism', () => {
 
     expect(hashes).toStrictEqual(hashes.toSorted(compareStrings));
   });
+
+  it.each(documents)("%s orders each artifact's seed records by tier", (_fileName, plan) => {
+    expect(collectMisorderedSeeds(plan)).toStrictEqual([]);
+  });
 });
 
 // region | Helpers
+
+/**
+ * The id of each artifact whose seed records do not follow the plan's tier order.
+ *
+ * `tiers` runs in precedence order rather than lexicographically, so a seed list sorted by tier id would satisfy no rule
+ * the contract states.
+ */
+function collectMisorderedSeeds(plan: Plan): Array<string> {
+  const precedence = new Map(plan.tiers.map((tier, index) => [tier.id, index]));
+
+  return plan.artifacts
+    .filter((artifact) => {
+      const seeds = artifact.status === 'removed' ? [] : artifact.seededBy;
+      const ranks = seeds.map((seed) => precedence.get(seed.tierId) ?? -1);
+      return ranks.some((rank, index) => rank !== ranks.toSorted((left, right) => left - right).at(index));
+    })
+    .map((artifact) => artifact.id);
+}
 
 /** The name of each id-keyed table whose entries are not in lexicographic id order. */
 function collectUnsortedTables(plan: Plan): Array<string> {

--- a/packages/compositor/src/samples/__tests__/samples.unit.test.ts
+++ b/packages/compositor/src/samples/__tests__/samples.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { resolveInclusionPaths } from '../../graph/traversal.ts';
 import { assertPlanIsConsistent } from '../../plan/assertPlanIsConsistent.ts';
-import { resolveInclusionPaths } from '../../plan/traversal.ts';
 import type { FileEntry } from '../../schemas/file-schemas.ts';
 import type { ArtifactEntry } from '../../schemas/graph-schemas.ts';
 import { PlanSchema } from '../../schemas/plan-schema.ts';

--- a/packages/compositor/src/samples/buildMinimalSample.ts
+++ b/packages/compositor/src/samples/buildMinimalSample.ts
@@ -28,13 +28,14 @@ export function buildMinimalSample(): Plan {
     kinds: [{ id: 'skill', label: 'Skill', emitsFiles: true }],
     sources: [{ id: 'team', name: 'team', origin: { kind: 'directory', location: '/srv/team-guidance' } }],
     targets: [{ id: 'claude', label: 'Claude', root: '~/.claude', tokenMappings: [], variables: [] }],
+    tiers: [{ id: 'project', label: 'Project' }],
     artifacts: [
       {
         id: 'skill:review',
         kindId: 'skill',
         slug: 'review',
         status: 'added',
-        seededBy: ['declaration'],
+        seededBy: [{ via: 'declaration', tierId: 'project' }],
         dependsOn: [],
         resolution: {
           winner: { sourceId: 'team', path: 'skills/review/SKILL.md', hash: hashUtf8('team/skills/review') },

--- a/packages/compositor/src/samples/buildRepresentativeSample.ts
+++ b/packages/compositor/src/samples/buildRepresentativeSample.ts
@@ -195,8 +195,8 @@ export function buildRepresentativeSample(): Plan {
       },
     ],
     tiers: [
+      { id: 'user', label: 'User' },
       { id: 'project', label: 'Project' },
-      { id: 'project-local', label: 'Local override' },
     ],
     artifacts: [
       {
@@ -205,8 +205,8 @@ export function buildRepresentativeSample(): Plan {
         slug: 'core',
         status: 'unchanged',
         seededBy: [
+          { via: 'declaration', tierId: 'user' },
           { via: 'declaration', tierId: 'project' },
-          { via: 'declaration', tierId: 'project-local' },
         ],
         dependsOn: [
           { to: 'rulebook:style', via: 'member' },
@@ -297,7 +297,7 @@ export function buildRepresentativeSample(): Plan {
         kindId: 'subagent',
         slug: 'auditor',
         status: 'changed',
-        seededBy: [{ via: 'declaration', tierId: 'project-local' }],
+        seededBy: [{ via: 'declaration', tierId: 'user' }],
         dependsOn: [{ to: 'skill:review', via: 'injected' }],
         resolution: {
           winner: { sourceId: 'team', path: 'subagents/auditor.md', hash: hashUtf8('subagents/auditor.md') },

--- a/packages/compositor/src/samples/buildRepresentativeSample.ts
+++ b/packages/compositor/src/samples/buildRepresentativeSample.ts
@@ -33,7 +33,7 @@ const DIAGRAM_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0
  * Modelled on a guidance-distribution run: three precedence-ordered sources feeding two targets, with an artifact
  * reached by three routes, an artifact shadowing two losers beside one the lowest-precedence source wins, three
  * rulebooks aggregated into one region with per-artifact markers, entry-level ownership of a structured config, a
- * byte-copied asset, a file apply will skip, and all four diff statuses.
+ * byte-copied asset, a file apply will skip, an artifact two tiers both seed, and all four diff statuses.
  *
  * Tables are authored in the order the contract documents: id-keyed tables lexicographically, files by target then
  * path, and `sources` and each `shadowed` list in precedence order, where the order is the meaning.
@@ -194,13 +194,20 @@ export function buildRepresentativeSample(): Plan {
         ],
       },
     ],
+    tiers: [
+      { id: 'project', label: 'Project' },
+      { id: 'project-local', label: 'Local override' },
+    ],
     artifacts: [
       {
         id: 'collection:core',
         kindId: 'collection',
         slug: 'core',
         status: 'unchanged',
-        seededBy: ['declaration'],
+        seededBy: [
+          { via: 'declaration', tierId: 'project' },
+          { via: 'declaration', tierId: 'project-local' },
+        ],
         dependsOn: [
           { to: 'rulebook:style', via: 'member' },
           { to: 'skill:review', via: 'member' },
@@ -216,7 +223,7 @@ export function buildRepresentativeSample(): Plan {
         kindId: 'rulebook',
         slug: 'naming',
         status: 'added',
-        seededBy: ['package-catalog'],
+        seededBy: [{ via: 'source-catalog', tierId: 'project' }],
         dependsOn: [],
         resolution: {
           winner: { sourceId: 'packaged', path: 'rulebooks/naming.md', hash: hashUtf8('rulebooks/naming.md') },
@@ -240,7 +247,7 @@ export function buildRepresentativeSample(): Plan {
         kindId: 'rulebook',
         slug: 'tests',
         status: 'added',
-        seededBy: ['package-catalog'],
+        seededBy: [{ via: 'source-catalog', tierId: 'project' }],
         dependsOn: [],
         resolution: {
           winner: { sourceId: 'packaged', path: 'rulebooks/tests.md', hash: hashUtf8('rulebooks/tests.md') },
@@ -290,7 +297,7 @@ export function buildRepresentativeSample(): Plan {
         kindId: 'subagent',
         slug: 'auditor',
         status: 'changed',
-        seededBy: ['declaration'],
+        seededBy: [{ via: 'declaration', tierId: 'project-local' }],
         dependsOn: [{ to: 'skill:review', via: 'injected' }],
         resolution: {
           winner: { sourceId: 'team', path: 'subagents/auditor.md', hash: hashUtf8('subagents/auditor.md') },

--- a/packages/compositor/src/schemas/__tests__/descriptor-schemas.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/descriptor-schemas.unit.test.ts
@@ -7,17 +7,20 @@ import {
   SourceEntrySchema,
   SourceOriginSchema,
   TargetEntrySchema,
+  TierDescriptorSchema,
 } from '../descriptor-schemas.ts';
 import { findIssuePaths } from '../test-utils/findIssuePaths.ts';
 
 const kind = { id: 'skill', label: 'Skill', emitsFiles: true };
 const source = { id: 'team', name: 'team', origin: { kind: 'directory', location: '/srv/team' } };
 const target = { id: 'claude', label: 'Claude', root: '~/.claude', tokenMappings: [], variables: [] };
+const tier = { id: 'project', label: 'Project' };
 
 const openCases: ReadonlyArray<readonly [string, z.ZodType, Record<string, unknown>]> = [
   ['KindDescriptorSchema', KindDescriptorSchema, kind],
   ['SourceEntrySchema', SourceEntrySchema, source],
   ['TargetEntrySchema', TargetEntrySchema, target],
+  ['TierDescriptorSchema', TierDescriptorSchema, tier],
 ];
 
 describe('descriptor schema evolution', () => {
@@ -58,6 +61,16 @@ describe('TargetEntrySchema', () => {
     const withoutMappings = { id: 'claude', label: 'Claude', root: '~/.claude', variables: [] };
 
     expect(findIssuePaths(TargetEntrySchema, withoutMappings)).toStrictEqual([['tokenMappings']]);
+  });
+});
+
+describe('TierDescriptorSchema', () => {
+  it('accepts a tier carrying the label a reader shows for it', () => {
+    expect(TierDescriptorSchema.parse(tier)).toStrictEqual(tier);
+  });
+
+  it('if the tier carries no label, rejects it for that field', () => {
+    expect(findIssuePaths(TierDescriptorSchema, { id: 'project' })).toStrictEqual([['label']]);
   });
 });
 

--- a/packages/compositor/src/schemas/__tests__/graph-schemas.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/graph-schemas.unit.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { ArtifactEntrySchema, DependencyEdgeSchema, type EdgeOrigin, PartialEntrySchema } from '../graph-schemas.ts';
+import {
+  ArtifactEntrySchema,
+  DependencyEdgeSchema,
+  type EdgeOrigin,
+  PartialEntrySchema,
+  type SeedOrigin,
+  SeedSchema,
+} from '../graph-schemas.ts';
 import { findIssuePaths } from '../test-utils/findIssuePaths.ts';
 
 const winner = { sourceId: 'team', path: 'skills/review/SKILL.md', hash: 'h1' };
@@ -10,13 +17,14 @@ const present = {
   kindId: 'skill',
   slug: 'review',
   status: 'changed',
-  seededBy: ['declaration'],
+  seededBy: [{ via: 'declaration', tierId: 'project' }],
   dependsOn: [],
   resolution,
 };
 const removed = { id: 'skill:retired', kindId: 'skill', slug: 'retired', status: 'removed' };
 
 const edgeOrigins: ReadonlyArray<EdgeOrigin> = ['declared', 'enumerated', 'injected', 'member', 'token'];
+const seedOrigins: ReadonlyArray<SeedOrigin> = ['declaration', 'source-catalog'];
 
 describe('ArtifactEntrySchema', () => {
   it('accepts a present artifact carrying its resolution and edges', () => {
@@ -43,6 +51,18 @@ describe('ArtifactEntrySchema', () => {
     const pureDependency = { ...present, seededBy: [] };
 
     expect(ArtifactEntrySchema.parse(pureDependency)).toStrictEqual(pureDependency);
+  });
+
+  it('records one seed per tier for an artifact several tiers declared', () => {
+    const seededTwice = {
+      ...present,
+      seededBy: [
+        { via: 'declaration', tierId: 'project' },
+        { via: 'declaration', tierId: 'project-local' },
+      ],
+    };
+
+    expect(ArtifactEntrySchema.parse(seededTwice)).toStrictEqual(seededTwice);
   });
 
   it('if the status is outside the known set, rejects the artifact', () => {
@@ -82,5 +102,19 @@ describe('PartialEntrySchema', () => {
     const partial = { id: 'team:_data/shared.md', sourceId: 'team', path: '_data/shared.md', hash: 'h4' };
 
     expect(PartialEntrySchema.parse(partial)).toStrictEqual(partial);
+  });
+});
+
+describe('SeedSchema', () => {
+  it.each(seedOrigins)('accepts a seed a tier decided by %s', (via) => {
+    expect(SeedSchema.parse({ via, tierId: 'project' })).toStrictEqual({ via, tierId: 'project' });
+  });
+
+  it('if the seed names no tier, rejects it for that field', () => {
+    expect(findIssuePaths(SeedSchema, { via: 'declaration' })).toStrictEqual([['tierId']]);
+  });
+
+  it('rejects the retired "package-catalog" origin, so taking a source whole is no longer a package privilege', () => {
+    expect(findIssuePaths(SeedSchema, { via: 'package-catalog', tierId: 'project' })).toStrictEqual([['via']]);
   });
 });

--- a/packages/compositor/src/schemas/__tests__/graph-schemas.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/graph-schemas.unit.test.ts
@@ -114,7 +114,7 @@ describe('SeedSchema', () => {
     expect(findIssuePaths(SeedSchema, { via: 'declaration' })).toStrictEqual([['tierId']]);
   });
 
-  it('rejects the retired "package-catalog" origin, so taking a source whole is no longer a package privilege', () => {
-    expect(findIssuePaths(SeedSchema, { via: 'package-catalog', tierId: 'project' })).toStrictEqual([['via']]);
+  it('if the origin is outside the known set, rejects the seed for that field', () => {
+    expect(findIssuePaths(SeedSchema, { via: 'inherited', tierId: 'project' })).toStrictEqual([['via']]);
   });
 });

--- a/packages/compositor/src/schemas/__tests__/plan-schema.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/plan-schema.unit.test.ts
@@ -4,7 +4,17 @@ import { buildPlan } from '../../test-utils/buildPlan.ts';
 import { PLAN_SCHEMA_VERSION, PlanSchema } from '../plan-schema.ts';
 import { findIssuePaths } from '../test-utils/findIssuePaths.ts';
 
-const tables = ['artifacts', 'blobs', 'files', 'fingerprint', 'kinds', 'partials', 'sources', 'targets'] as const;
+const tables = [
+  'artifacts',
+  'blobs',
+  'files',
+  'fingerprint',
+  'kinds',
+  'partials',
+  'sources',
+  'targets',
+  'tiers',
+] as const;
 
 describe('PlanSchema', () => {
   it('accepts a plan carrying every table', () => {

--- a/packages/compositor/src/schemas/descriptor-schemas.ts
+++ b/packages/compositor/src/schemas/descriptor-schemas.ts
@@ -1,4 +1,4 @@
-/** Descriptors: the kinds, sources, and targets a plan is computed over. */
+/** Descriptors: the kinds, sources, tiers, and targets a plan is computed over. */
 
 import { z } from 'zod';
 
@@ -40,6 +40,20 @@ export const SourceEntrySchema = z
     origin: SourceOriginSchema,
   })
   .meta({ id: 'SourceEntry' });
+
+/**
+ * One config tier a seed can be decided by.
+ *
+ * The `tiers` array runs lowest precedence first, the order a fold applies them in, so the last tier to speak wins. That
+ * is deliberately the reverse of `sources`, where the first entry wins: a source's position encodes precedence directly,
+ * and a tier's encodes application.
+ */
+export const TierDescriptorSchema = z
+  .object({
+    id: IdSchema,
+    label: z.string(),
+  })
+  .meta({ id: 'TierDescriptor' });
 
 /** One canonical-name-to-rendered-name pair within a token kind's mapping. */
 export const TokenMappingEntrySchema = z
@@ -90,5 +104,6 @@ export type SourceEntry = z.infer<typeof SourceEntrySchema>;
 export type SourceOrigin = z.infer<typeof SourceOriginSchema>;
 export type TargetEntry = z.infer<typeof TargetEntrySchema>;
 export type TargetVariable = z.infer<typeof TargetVariableSchema>;
+export type TierDescriptor = z.infer<typeof TierDescriptorSchema>;
 export type TokenMapping = z.infer<typeof TokenMappingSchema>;
 export type TokenMappingEntry = z.infer<typeof TokenMappingEntrySchema>;

--- a/packages/compositor/src/schemas/graph-schemas.ts
+++ b/packages/compositor/src/schemas/graph-schemas.ts
@@ -51,8 +51,27 @@ export const ArtifactResolutionSchema = z
   })
   .meta({ id: 'ArtifactResolution' });
 
-/** How an artifact entered the closure as a root; an artifact reached only as a dependency is seeded by nothing. */
-export const SeedOriginSchema = z.enum(['declaration', 'package-catalog']).meta({ id: 'SeedOrigin' });
+/**
+ * How an artifact entered the closure as a root.
+ *
+ * `declaration` is a tier naming the artifact itself. `source-catalog` is a tier taking everything one source carries,
+ * which names no artifact and so cannot say which one it meant. Nothing here is particular to a package: taking a
+ * source whole is a selection any source can be the object of.
+ */
+export const SeedOriginSchema = z.enum(['declaration', 'source-catalog']).meta({ id: 'SeedOrigin' });
+
+/**
+ * One reason an artifact is a closure root, with the config tier that decided it.
+ *
+ * An artifact seeded by several tiers carries one record each, which is what lets a consumer tell a project-level opt-in
+ * from an inherited one. An artifact reached only as a dependency carries none.
+ */
+export const SeedSchema = z
+  .object({
+    via: SeedOriginSchema,
+    tierId: IdSchema,
+  })
+  .meta({ id: 'Seed' });
 
 /**
  * An artifact the plan deploys or traverses.
@@ -66,7 +85,7 @@ export const PresentArtifactSchema = z
     kindId: IdSchema,
     slug: z.string(),
     status: z.enum(['added', 'changed', 'unchanged']),
-    seededBy: z.array(SeedOriginSchema),
+    seededBy: z.array(SeedSchema),
     dependsOn: z.array(DependencyEdgeSchema),
     resolution: ArtifactResolutionSchema,
   })
@@ -118,4 +137,5 @@ export type PartialEntry = z.infer<typeof PartialEntrySchema>;
 export type PresentArtifact = z.infer<typeof PresentArtifactSchema>;
 export type RemovedArtifact = z.infer<typeof RemovedArtifactSchema>;
 export type ResolutionCandidate = z.infer<typeof ResolutionCandidateSchema>;
+export type Seed = z.infer<typeof SeedSchema>;
 export type SeedOrigin = z.infer<typeof SeedOriginSchema>;

--- a/packages/compositor/src/schemas/plan-schema.ts
+++ b/packages/compositor/src/schemas/plan-schema.ts
@@ -3,7 +3,12 @@
 import { z } from 'zod';
 
 import { HashSchema, IdSchema } from './common.ts';
-import { KindDescriptorSchema, SourceEntrySchema, TargetEntrySchema } from './descriptor-schemas.ts';
+import {
+  KindDescriptorSchema,
+  SourceEntrySchema,
+  TargetEntrySchema,
+  TierDescriptorSchema,
+} from './descriptor-schemas.ts';
 import { BlobSchema, FileEntrySchema } from './file-schemas.ts';
 import { ArtifactEntrySchema, PartialEntrySchema } from './graph-schemas.ts';
 
@@ -13,7 +18,7 @@ import { ArtifactEntrySchema, PartialEntrySchema } from './graph-schemas.ts';
  * Bumped when a field is removed, renamed, or re-typed, never when an optional field is added. Objects in this schema
  * are open, which is what lets an added field reach a consumer pinned to an earlier version without breaking it.
  */
-export const PLAN_SCHEMA_VERSION = 1;
+export const PLAN_SCHEMA_VERSION = 2;
 
 /** One source's content digest, covering everything under it that could contribute to a plan. */
 export const SourceDigestSchema = z.object({ sourceId: IdSchema, digest: HashSchema }).meta({ id: 'SourceDigest' });
@@ -59,6 +64,7 @@ export const PlanSchema = z
     kinds: z.array(KindDescriptorSchema),
     sources: z.array(SourceEntrySchema),
     targets: z.array(TargetEntrySchema),
+    tiers: z.array(TierDescriptorSchema),
     artifacts: z.array(ArtifactEntrySchema),
     partials: z.array(PartialEntrySchema),
     files: z.array(FileEntrySchema),

--- a/packages/compositor/src/test-utils/buildPlan.ts
+++ b/packages/compositor/src/test-utils/buildPlan.ts
@@ -5,8 +5,9 @@ import { PLAN_SCHEMA_VERSION } from '../schemas/plan-schema.ts';
  * A small plan that satisfies both the schema and every consistency invariant.
  *
  * Exercises the shapes a trivial plan would leave untested: a traversal-only kind, an artifact reached through a
- * dependency edge, a shadowed candidate, a transcluded partial, and a file whose two sides differ. Each call returns a
- * fresh structure, so a test may break one field to show that the invariant guarding it holds.
+ * dependency edge, a shadowed candidate, a transcluded partial, a seed naming the tier that decided it, and a file whose
+ * two sides differ. Each call returns a fresh structure, so a test may break one field to show that the invariant
+ * guarding it holds.
  */
 export function buildPlan(): Plan {
   return {
@@ -39,13 +40,14 @@ export function buildPlan(): Plan {
         variables: [{ name: 'homeDir', value: '.claude' }],
       },
     ],
+    tiers: [{ id: 'project', label: 'Project' }],
     artifacts: [
       {
         id: 'collection:core',
         kindId: 'collection',
         slug: 'core',
         status: 'unchanged',
-        seededBy: ['declaration'],
+        seededBy: [{ via: 'declaration', tierId: 'project' }],
         dependsOn: [{ to: 'skill:review', via: 'member' }],
         resolution: {
           winner: { sourceId: 'team', path: 'collections/core.md', hash: 'hash:core' },


### PR DESCRIPTION
## What

A plan now records which configuration tier decided each artifact's presence, so that a consumer can tell a project-level opt-in from an inherited one. An artifact's reason for inclusion and its dependents can now be determined from any document that records artifacts and the links between them, not a plan alone.

## Why

A plan recorded that an artifact had been seeded but not which config tier decided it, so a UI rendering provenance could show that an artifact was opted into without showing where the opt-in came from. Separately, the helpers that recover dependency paths and the reverse "used by" direction took a whole `Plan`, so the dependency-closure document that follows in #177 would have had to carry a second copy of them.

## Details

### 🏗️ Internal features

- `PLAN_SCHEMA_VERSION` goes to 2. Each entry in an artifact's `seededBy` is now a `Seed` record pairing the origin with the tier that decided it, in place of the bare `SeedOrigin` it carried before, and the origin `package-catalog` is now `source-catalog` -- taking everything a source carries is a selection any source can be the object of, not a privilege packages hold.
- A `tiers` descriptor table joins `kinds`, `sources`, and `targets` on the plan. It runs lowest precedence first, the order a fold applies them in, which is deliberately the reverse of `sources`, where the first entry wins.
- `assertPlanIsConsistent` resolves each seed's `tierId` against the tier table and rejects a table carrying one tier id twice, keeping the check out of the schema so a generated JSON Schema stays faithful (per #163).
- The README documents the tier table, its ordering rule, the seed-record ordering that follows from it, and what version 2 changed.

### ♻️ Refactoring

- `resolveInclusionPaths` and a new `buildDependentsIndex` move to `src/graph/traversal.ts`, taking a `DependencyGraphView` that carries only ids, edges, and seeds. A plan entry and a closure entry both satisfy it structurally, so neither needs an adapter.
- `buildTraversalIndex` stays plan-side and composes the shared dependents index, keeping only the artifact-to-file direction, which a closure has no counterpart for.
- The `appendTo` helper both traversal modules now need moves to `src/portable/`, which the package entry publishes nothing from.

### 🧪 Tests

- `SeedSchema` shape, a multi-tier `seededBy`, a dangling `tierId`, and a duplicate tier id are each covered; `tiers` joins the required-table list, so dropping it from a payload is asserted to fail parsing.
- A closure-shaped fixture carrying no `status`, `resolution`, or `kind` exercises both shared helpers, proving the "no adapter" claim structurally rather than in prose.
- A determinism case pins each artifact's seed records against the tier table, and the representative sample's tiers are named so precedence order and lexicographic order differ -- the sample demonstrates the ordering rule instead of satisfying both at once.

Closes #165
