### PR TITLE
#176 Port the config model and tiered selection

### DIFF
--- a/packages/compositor/README.md
+++ b/packages/compositor/README.md
@@ -2,7 +2,17 @@
 
 Content-agnostic engine that resolves declaratively opted-in content across precedence-ordered sources, computes the transitive dependency closure, and plans idempotent writes to per-target destinations.
 
-Private and unreleased: the name is provisional, and most of the engine does not exist yet. What ships today is the plan schema, the contract the engine's output will satisfy, and source resolution, the first flow built against it. The requirements it is built to are tracked in [issue #158](https://github.com/williamthorsen/workshop/issues/158).
+Private and unreleased: the name is provisional, and most of the engine does not exist yet. What ships today is the plan schema, the contract the engine's output will satisfy, and the flows built against it so far: the config model, source resolution, and selection. The requirements it is built to are tracked in [issue #158](https://github.com/williamthorsen/workshop/issues/158).
+
+## Config
+
+A config is a list of tiers, lowest precedence first, the order a fold applies them. Each tier declares the sources it adds or drops, and per artifact kind the artifacts it uses or drops. `loadConfig` reads one file per tier, but files are one way to obtain a config rather than the only one: what it returns is the same shape a caller can build in memory and hand straight to the flows downstream, which is what lets an edited config be evaluated without touching disk.
+
+Tier identity -- an id, a label, and the directory a relative path resolves against -- is the consumer's to supply. A file does not know which tier it is; that follows from where the consumer looked for it, which is what keeps any particular project layout out of the package. A tier whose file is absent contributes nothing, while one whose file is present and empty contributes a tier declaring nothing, so an absent tier stays distinguishable from a silent one.
+
+Parsing normalizes: a bare slug becomes an entry, `path` or `package` becomes a source origin, and a kind-keyed mapping becomes an array ordered by kind. Every schema also accepts its own output, so a config already parsed can be modified and re-parsed without being converted back first. These schemas therefore carry transforms and do not render to JSON Schema, unlike the plan and catalog contracts; config is authored input rather than an emitted payload, which is also why it carries no version.
+
+Sources and packages are one declaration list: a package is a source whose location is a package name, which the plan schema's source origin already allows. `resolveSources` folds the tiers into the ordered list resolution reads, locating each package by walking the `node_modules` chain from the tier that declared it and reading the content directory that package declares under a key the consumer names. Precedence runs higher tier first, and author order within a tier, so a config reads with precedence descending down the page. The names a tier dropped and no higher tier re-adopted come back beside the sources, which is what distinguishes a source a consumer turned down from one it never mentioned.
 
 ## Resolution
 
@@ -19,6 +29,18 @@ An entry's id composes its kind and slug, the same way a plan names the artifact
 `assertCatalogIsConsistent` is to a catalog what `assertPlanIsConsistent` is to a plan, and for the same reason: the schema is purely structural, so id references, entry-id composition, and shadowed-candidate ordering are checked outside it. A catalog `resolveCatalog` produced satisfies all of it by construction, so resolution does not pay for the checks; call the assertion on a catalog that arrived as data.
 
 No sample catalogs ship. The plan schema needed them because no engine existed to produce a plan; a catalog comes from calling the resolver.
+
+## Selection
+
+`selectArtifacts` folds a config against a catalog and answers which artifacts were asked for. It is pure: the catalog is the only view of the filesystem, so re-running it over a changed config reads nothing, which is what makes a toggle-and-recompute loop free.
+
+An entry names one artifact or takes everything a source carries, and either form is valid in `use` and in `drop`, so "all of this source except that one" is expressible. Taking a source whole selects the artifacts that source carries, including those a higher-precedence source shadows: shadowing settles which copy an artifact resolves from, and selection settles which artifacts are in play. Indexing winners alone would make a source's contribution shrink as higher-precedence sources were declared above it.
+
+Seeds and declines stay disjoint per artifact. A `drop` clears the seeds beneath it and records the tier that dropped it; a later `use` clears the decline and seeds afresh. What survives to the end is what decided the final state, which is what tells a project-level opt-in from an inherited one, and it is recorded in the plan schema's own seed shape rather than a parallel one.
+
+A selection is a plain value, not a versioned document like a catalog. A document earns its cost when re-deriving the payload is expensive or impossible; a selection is a cheap pure function of two documents that already exist, so nothing can hold one it cannot recompute. A declined artifact has no plan representation yet -- `removed` means deployed and no longer selected, which is a different fact.
+
+A selector matching nothing yields a diagnostic naming the tier, kind, list, and position that produced it, rather than throwing, so validation reports every mistake in a config at once and a reader can attach each to the line an author wrote.
 
 ## The plan
 

--- a/packages/compositor/README.md
+++ b/packages/compositor/README.md
@@ -40,7 +40,7 @@ Seeds and declines stay disjoint per artifact. A `drop` clears the seeds beneath
 
 A selection is a plain value, not a versioned document like a catalog. A document earns its cost when re-deriving the payload is expensive or impossible; a selection is a cheap pure function of two documents that already exist, so nothing can hold one it cannot recompute. A declined artifact has no plan representation yet -- `removed` means deployed and no longer selected, which is a different fact.
 
-A selector matching nothing yields a diagnostic naming the tier, kind, list, and position that produced it, rather than throwing, so validation reports every mistake in a config at once and a reader can attach each to the line an author wrote.
+A selector matching nothing yields a diagnostic naming the tier, kind, list, and position that produced it, rather than throwing, so validation reports every mistake in a config at once and a reader can attach each to the line an author wrote. A block naming a kind the catalog does not carry faults the whole block, so its diagnostic names the tier and kind alone.
 
 ## The plan
 

--- a/packages/compositor/package.json
+++ b/packages/compositor/package.json
@@ -30,6 +30,7 @@
     "prepare": "tsx config/generateSamples.ts && nmr-compile"
   },
   "dependencies": {
+    "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "engines": {

--- a/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
@@ -1,0 +1,103 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { loadConfig, type TierFile } from '../loadConfig.ts';
+import { buildConfigDir } from '../test-utils/buildConfigDir.ts';
+
+const globalTier = `
+select:
+  skill:
+    use: [lint]
+`;
+const projectTier = `
+sources:
+  use:
+    - { name: local, path: ./content }
+select:
+  skill:
+    use: [format]
+    drop: [lint]
+`;
+
+describe(loadConfig, () => {
+  it('reads a chain of tier files, keeping the order it was given', async () => {
+    const dir = await buildConfigDir({ 'global.yaml': globalTier, 'project.yaml': projectTier });
+
+    const config = await loadConfig([tierAt(dir, 'global'), tierAt(dir, 'project')]);
+
+    expect(config.tiers.map(({ id }) => id)).toStrictEqual(['global', 'project']);
+  });
+
+  // An absent file is a tier a consumer looked for and did not find; an empty one is a tier that declares nothing.
+  it('skips a tier whose file is absent, and keeps one whose file is empty', async () => {
+    const dir = await buildConfigDir({ 'global.yaml': '# every entry commented out\n' });
+
+    const config = await loadConfig([tierAt(dir, 'global'), tierAt(dir, 'project')]);
+
+    expect(config.tiers).toStrictEqual([
+      { id: 'global', label: 'global', baseDir: dir, reset: false, sources: { use: [], drop: [] }, select: [] },
+    ]);
+  });
+
+  it('yields a config with no tiers when every file is absent', async () => {
+    const dir = await buildConfigDir({});
+
+    await expect(loadConfig([tierAt(dir, 'global'), tierAt(dir, 'project')])).resolves.toStrictEqual({ tiers: [] });
+  });
+
+  // A relative path resolves against where it was written, not against the directory the process runs in.
+  it('takes each tier’s base directory from the file that declared it', async () => {
+    const dir = await buildConfigDir({ 'nested/project.yaml': projectTier });
+
+    const config = await loadConfig([{ id: 'project', label: 'Project', path: path.join(dir, 'nested/project.yaml') }]);
+
+    expect(config.tiers.at(0)?.baseDir).toBe(path.join(dir, 'nested'));
+  });
+
+  it('normalizes what it reads, so the result needs no further parsing', async () => {
+    const dir = await buildConfigDir({ 'project.yaml': projectTier });
+
+    const config = await loadConfig([tierAt(dir, 'project')]);
+
+    expect(config.tiers.at(0)?.sources.use).toStrictEqual([
+      { name: 'local', origin: { kind: 'directory', location: './content' } },
+    ]);
+  });
+
+  // YAML is a superset of JSON, so a consumer writing config as JSON needs no separate branch here.
+  it('reads a tier written as JSON', async () => {
+    const dir = await buildConfigDir({ 'project.json': '{ "select": { "skill": { "use": ["lint"] } } }' });
+
+    const config = await loadConfig([{ id: 'project', label: 'Project', path: path.join(dir, 'project.json') }]);
+
+    expect(config.tiers.at(0)?.select).toStrictEqual([{ kindId: 'skill', use: [{ artifact: 'lint' }], drop: [] }]);
+  });
+
+  it('fails on malformed YAML, naming the file', async () => {
+    const dir = await buildConfigDir({ 'project.yaml': 'select: [unclosed\n' });
+
+    await expect(loadConfig([tierAt(dir, 'project')])).rejects.toThrow(path.join(dir, 'project.yaml'));
+  });
+
+  it('fails on a tier declaring an unrecognized key, naming the file', async () => {
+    const dir = await buildConfigDir({ 'project.yaml': 'selects: {}\n' });
+
+    await expect(loadConfig([tierAt(dir, 'project')])).rejects.toThrow(path.join(dir, 'project.yaml'));
+  });
+
+  it('fails on a tier whose identity is incomplete', async () => {
+    const dir = await buildConfigDir({ 'project.yaml': projectTier });
+
+    await expect(loadConfig([{ ...tierAt(dir, 'project'), id: '' }])).rejects.toThrow(/id/);
+  });
+});
+
+// region | Helpers
+
+/** The tier a consumer would declare for `<dir>/<name>.yaml`, using the name as its identity. */
+function tierAt(dir: string, name: string): TierFile {
+  return { id: name, label: name, path: path.join(dir, `${name}.yaml`) };
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
@@ -88,6 +88,15 @@ describe(loadConfig, () => {
     await expect(loadConfig([buildTierFile(dir, 'project')])).rejects.toThrow(path.join(dir, 'project.yaml'));
   });
 
+  // Both files are absent, so a check running after the load would see no tiers at all and never notice the repeat.
+  it('fails on two tiers sharing an id, naming the id', async () => {
+    const dir = await buildConfigDir({});
+
+    await expect(loadConfig([buildTierFile(dir, 'project'), buildTierFile(dir, 'project')])).rejects.toThrow(
+      /Tier "project" is declared more than once/,
+    );
+  });
+
   it('fails on a tier whose identity is incomplete', async () => {
     const dir = await buildConfigDir({ 'project.yaml': projectTier });
 

--- a/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
@@ -95,7 +95,7 @@ describe(loadConfig, () => {
 
 // region | Helpers
 
-/** The tier a consumer would declare for `<dir>/<name>.yaml`, using the name as its identity. */
+/** Names the tier a consumer would declare for `<dir>/<name>.yaml`, using the name as its identity. */
 function tierAt(dir: string, name: string): TierFile {
   return { id: name, label: name, path: path.join(dir, `${name}.yaml`) };
 }

--- a/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
@@ -24,7 +24,7 @@ describe(loadConfig, () => {
   it('reads a chain of tier files, keeping the order it was given', async () => {
     const dir = await buildConfigDir({ 'global.yaml': globalTier, 'project.yaml': projectTier });
 
-    const config = await loadConfig([tierAt(dir, 'global'), tierAt(dir, 'project')]);
+    const config = await loadConfig([buildTierFile(dir, 'global'), buildTierFile(dir, 'project')]);
 
     expect(config.tiers.map(({ id }) => id)).toStrictEqual(['global', 'project']);
   });
@@ -33,7 +33,7 @@ describe(loadConfig, () => {
   it('skips a tier whose file is absent, and keeps one whose file is empty', async () => {
     const dir = await buildConfigDir({ 'global.yaml': '# every entry commented out\n' });
 
-    const config = await loadConfig([tierAt(dir, 'global'), tierAt(dir, 'project')]);
+    const config = await loadConfig([buildTierFile(dir, 'global'), buildTierFile(dir, 'project')]);
 
     expect(config.tiers).toStrictEqual([
       { id: 'global', label: 'global', baseDir: dir, reset: false, sources: { use: [], drop: [] }, select: [] },
@@ -43,7 +43,9 @@ describe(loadConfig, () => {
   it('yields a config with no tiers when every file is absent', async () => {
     const dir = await buildConfigDir({});
 
-    await expect(loadConfig([tierAt(dir, 'global'), tierAt(dir, 'project')])).resolves.toStrictEqual({ tiers: [] });
+    await expect(loadConfig([buildTierFile(dir, 'global'), buildTierFile(dir, 'project')])).resolves.toStrictEqual({
+      tiers: [],
+    });
   });
 
   // A relative path resolves against where it was written, not against the directory the process runs in.
@@ -58,7 +60,7 @@ describe(loadConfig, () => {
   it('normalizes what it reads, so the result needs no further parsing', async () => {
     const dir = await buildConfigDir({ 'project.yaml': projectTier });
 
-    const config = await loadConfig([tierAt(dir, 'project')]);
+    const config = await loadConfig([buildTierFile(dir, 'project')]);
 
     expect(config.tiers.at(0)?.sources.use).toStrictEqual([
       { name: 'local', origin: { kind: 'directory', location: './content' } },
@@ -77,26 +79,26 @@ describe(loadConfig, () => {
   it('fails on malformed YAML, naming the file', async () => {
     const dir = await buildConfigDir({ 'project.yaml': 'select: [unclosed\n' });
 
-    await expect(loadConfig([tierAt(dir, 'project')])).rejects.toThrow(path.join(dir, 'project.yaml'));
+    await expect(loadConfig([buildTierFile(dir, 'project')])).rejects.toThrow(path.join(dir, 'project.yaml'));
   });
 
   it('fails on a tier declaring an unrecognized key, naming the file', async () => {
     const dir = await buildConfigDir({ 'project.yaml': 'selects: {}\n' });
 
-    await expect(loadConfig([tierAt(dir, 'project')])).rejects.toThrow(path.join(dir, 'project.yaml'));
+    await expect(loadConfig([buildTierFile(dir, 'project')])).rejects.toThrow(path.join(dir, 'project.yaml'));
   });
 
   it('fails on a tier whose identity is incomplete', async () => {
     const dir = await buildConfigDir({ 'project.yaml': projectTier });
 
-    await expect(loadConfig([{ ...tierAt(dir, 'project'), id: '' }])).rejects.toThrow(/id/);
+    await expect(loadConfig([{ ...buildTierFile(dir, 'project'), id: '' }])).rejects.toThrow(/id/);
   });
 });
 
 // region | Helpers
 
-/** Names the tier a consumer would declare for `<dir>/<name>.yaml`, using the name as its identity. */
-function tierAt(dir: string, name: string): TierFile {
+/** Builds the tier a consumer would declare for `<dir>/<name>.yaml`, using the name as its identity. */
+function buildTierFile(dir: string, name: string): TierFile {
   return { id: name, label: name, path: path.join(dir, `${name}.yaml`) };
 }
 

--- a/packages/compositor/src/config/__tests__/locatePackage.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/locatePackage.unit.test.ts
@@ -1,0 +1,75 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { locatePackage } from '../locatePackage.ts';
+import { buildConfigDir } from '../test-utils/buildConfigDir.ts';
+
+const contentKeyPath = ['compositor', 'content'];
+
+describe(locatePackage, () => {
+  it('joins the installed directory to the content directory the package declares', async () => {
+    const baseDir = await buildConfigDir({
+      'node_modules/guidance/package.json': JSON.stringify({ compositor: { content: 'content' } }),
+    });
+
+    await expect(locatePackage('guidance', { baseDir, contentKeyPath })).resolves.toBe(
+      path.join(baseDir, 'node_modules/guidance/content'),
+    );
+  });
+
+  it('reads the content key at whatever path the consumer names', async () => {
+    const baseDir = await buildConfigDir({
+      'node_modules/guidance/package.json': JSON.stringify({ rulebinder: { guidance: { dir: 'share' } } }),
+    });
+
+    await expect(
+      locatePackage('guidance', { baseDir, contentKeyPath: ['rulebinder', 'guidance', 'dir'] }),
+    ).resolves.toBe(path.join(baseDir, 'node_modules/guidance/share'));
+  });
+
+  // Whether the directory exists is the caller's source validation to answer, so both source forms fail through it.
+  it('does not require the content directory to exist', async () => {
+    const baseDir = await buildConfigDir({
+      'node_modules/guidance/package.json': JSON.stringify({ compositor: { content: 'nowhere' } }),
+    });
+
+    await expect(locatePackage('guidance', { baseDir, contentKeyPath })).resolves.toContain('nowhere');
+  });
+
+  it('fails when the package is not installed, listing where it looked', async () => {
+    const baseDir = await buildConfigDir({});
+
+    await expect(locatePackage('guidance', { baseDir, contentKeyPath })).rejects.toThrow(/is not installed. Searched:/);
+  });
+
+  it('fails when the package declares no content directory, naming the key path', async () => {
+    const baseDir = await buildConfigDir({
+      'node_modules/guidance/package.json': JSON.stringify({ name: 'guidance' }),
+    });
+
+    await expect(locatePackage('guidance', { baseDir, contentKeyPath })).rejects.toThrow(/compositor\.content/);
+  });
+
+  it('fails when the content key holds something other than a directory name', async () => {
+    const baseDir = await buildConfigDir({
+      'node_modules/guidance/package.json': JSON.stringify({ compositor: { content: {} } }),
+    });
+
+    await expect(locatePackage('guidance', { baseDir, contentKeyPath })).rejects.toThrow(/declares no content/);
+  });
+
+  it('fails when the package manifest will not parse, naming the package', async () => {
+    const baseDir = await buildConfigDir({ 'node_modules/guidance/package.json': '{ not json' });
+
+    await expect(locatePackage('guidance', { baseDir, contentKeyPath })).rejects.toThrow(
+      /"guidance" has an unreadable/,
+    );
+  });
+
+  // A relative specifier would otherwise resolve to the anchor directory, opening a second directory-source route.
+  it.each(['./content', '../sibling', '/srv/content'])(
+    'rejects "%s" as a filesystem path, not a package name',
+    (name) => expect(locatePackage(name, { baseDir: '/srv/app', contentKeyPath })).rejects.toThrow(/filesystem path/),
+  );
+});

--- a/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
@@ -134,7 +134,7 @@ describe(resolveSources, () => {
 
 // region | Helpers
 
-/** The resolved source names, in precedence order. */
+/** Collects the resolved source names, in precedence order. */
 async function collectNames(config: Parameters<typeof resolveSources>[0]): Promise<Array<string>> {
   const { sources } = await resolveSources(config, options);
   return sources.map(({ name }) => name);

--- a/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
@@ -3,8 +3,8 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { buildConfig } from '../../test-utils/buildConfig.ts';
 import { resolveSources } from '../resolveSources.ts';
-import { buildConfig } from '../test-utils/buildConfig.ts';
 import { buildConfigDir } from '../test-utils/buildConfigDir.ts';
 
 const options = { contentKeyPath: ['compositor', 'content'] };

--- a/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
@@ -1,0 +1,143 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveSources } from '../resolveSources.ts';
+import { buildConfig } from '../test-utils/buildConfig.ts';
+import { buildConfigDir } from '../test-utils/buildConfigDir.ts';
+
+const options = { contentKeyPath: ['compositor', 'content'] };
+
+describe(resolveSources, () => {
+  it('runs a tier’s own sources in author order, so precedence descends down the page', async () => {
+    const config = buildConfig([
+      {
+        sources: {
+          use: [
+            { name: 'mine', path: './a' },
+            { name: 'theirs', path: './b' },
+          ],
+        },
+      },
+    ]);
+
+    await expect(collectNames(config)).resolves.toStrictEqual(['mine', 'theirs']);
+  });
+
+  it('runs a higher tier’s sources ahead of a lower tier’s', async () => {
+    const config = buildConfig([
+      { id: 'global', sources: { use: [{ name: 'shared', path: './shared' }] } },
+      { id: 'project', sources: { use: [{ name: 'local', path: './local' }] } },
+    ]);
+
+    await expect(collectNames(config)).resolves.toStrictEqual(['local', 'shared']);
+  });
+
+  it('lets a higher tier remap an inherited source, which takes the higher tier’s position', async () => {
+    const config = buildConfig([
+      {
+        id: 'global',
+        sources: {
+          use: [
+            { name: 'shared', path: './shared' },
+            { name: 'other', path: './other' },
+          ],
+        },
+      },
+      { id: 'project', baseDir: '/srv/app', sources: { use: [{ name: 'shared', path: './elsewhere' }] } },
+    ]);
+
+    const { sources } = await resolveSources(config, options);
+
+    expect(sources.map(({ name, dir }) => [name, dir])).toStrictEqual([
+      ['shared', '/srv/app/elsewhere'],
+      ['other', '/srv/app/other'],
+    ]);
+  });
+
+  it('drops an inherited source and records the decline', async () => {
+    const config = buildConfig([
+      { sources: { use: [{ name: 'vendor', path: './vendor' }] } },
+      { sources: { drop: ['vendor'] } },
+    ]);
+
+    await expect(resolveSources(config, options)).resolves.toMatchObject({ sources: [], declined: ['vendor'] });
+  });
+
+  // Adopted and declined stay disjoint, so a re-adoption is not reported as a decline as well.
+  it('clears the decline when a higher tier re-adopts a dropped source', async () => {
+    const config = buildConfig([
+      { sources: { use: [{ name: 'vendor', path: './vendor' }] } },
+      { sources: { drop: ['vendor'] } },
+      { sources: { use: [{ name: 'vendor', path: './vendor' }] } },
+    ]);
+
+    await expect(resolveSources(config, options)).resolves.toMatchObject({ declined: [] });
+    await expect(collectNames(config)).resolves.toStrictEqual(['vendor']);
+  });
+
+  it('discards every lower tier’s sources and declines at a tier declaring reset', async () => {
+    const config = buildConfig([
+      { sources: { use: [{ name: 'shared', path: './shared' }], drop: ['vendor'] } },
+      { reset: true, sources: { use: [{ name: 'local', path: './local' }] } },
+    ]);
+
+    await expect(resolveSources(config, options)).resolves.toMatchObject({ declined: [] });
+    await expect(collectNames(config)).resolves.toStrictEqual(['local']);
+  });
+
+  it.each([
+    ['a relative path against the declaring tier', './content', path.join('/srv/tier', 'content')],
+    ['an absolute path unchanged', '/srv/elsewhere', '/srv/elsewhere'],
+    ['a home-relative path', '~/guidance', path.join(homedir(), 'guidance')],
+  ])('resolves %s', async (_label, location, expected) => {
+    const config = buildConfig([{ baseDir: '/srv/tier', sources: { use: [{ name: 'x', path: location }] } }]);
+
+    const { sources } = await resolveSources(config, options);
+
+    expect(sources.at(0)?.dir).toBe(expected);
+  });
+
+  // The declaration a consumer wrote is what a plan reports, so resolving must not overwrite it.
+  it('keeps the origin as declared beside the directory it resolved to', async () => {
+    const config = buildConfig([{ baseDir: '/srv/tier', sources: { use: [{ name: 'x', path: './content' }] } }]);
+
+    const { sources } = await resolveSources(config, options);
+
+    expect(sources.at(0)?.origin).toStrictEqual({ kind: 'directory', location: './content' });
+  });
+
+  it('locates a declared package at the content directory it ships', async () => {
+    const baseDir = await buildConfigDir({
+      'node_modules/@acme/guidance/package.json': JSON.stringify({
+        name: '@acme/guidance',
+        compositor: { content: 'dist/content' },
+      }),
+    });
+    const config = buildConfig([{ baseDir, sources: { use: [{ name: 'acme', package: '@acme/guidance' }] } }]);
+
+    const { sources } = await resolveSources(config, options);
+
+    expect(sources.at(0)?.dir).toBe(path.join(baseDir, 'node_modules/@acme/guidance/dist/content'));
+  });
+
+  it('fails on a package it cannot locate, naming the source and the tier', async () => {
+    const baseDir = await buildConfigDir({});
+    const config = buildConfig([
+      { id: 'project', baseDir, sources: { use: [{ name: 'acme', package: '@acme/absent' }] } },
+    ]);
+
+    await expect(resolveSources(config, options)).rejects.toThrow(/Source "acme", declared by tier "project"/);
+  });
+});
+
+// region | Helpers
+
+/** The resolved source names, in precedence order. */
+async function collectNames(config: Parameters<typeof resolveSources>[0]): Promise<Array<string>> {
+  const { sources } = await resolveSources(config, options);
+  return sources.map(({ name }) => name);
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
@@ -99,6 +99,21 @@ describe(resolveSources, () => {
     expect(sources.at(0)?.dir).toBe(expected);
   });
 
+  // Both tiers declare the same relative path, so anchoring every tier at one base directory collapses the two answers.
+  it('anchors a relative path at the tier that declared it, not at the last tier', async () => {
+    const config = buildConfig([
+      { id: 'global', baseDir: '/srv/global', sources: { use: [{ name: 'shared', path: './content' }] } },
+      { id: 'project', baseDir: '/srv/project', sources: { use: [{ name: 'local', path: './content' }] } },
+    ]);
+
+    const { sources } = await resolveSources(config, options);
+
+    expect(sources.map(({ name, dir }) => [name, dir])).toStrictEqual([
+      ['local', path.join('/srv/project', 'content')],
+      ['shared', path.join('/srv/global', 'content')],
+    ]);
+  });
+
   // The declaration a consumer wrote is what a plan reports, so resolving must not overwrite it.
   it('keeps the origin as declared beside the directory it resolved to', async () => {
     const config = buildConfig([{ baseDir: '/srv/tier', sources: { use: [{ name: 'x', path: './content' }] } }]);
@@ -120,6 +135,40 @@ describe(resolveSources, () => {
     const { sources } = await resolveSources(config, options);
 
     expect(sources.at(0)?.dir).toBe(path.join(baseDir, 'node_modules/@acme/guidance/dist/content'));
+  });
+
+  // Each tier installs its own copy under the same package name, so a walk anchored at one base directory finds the
+  // wrong copy for the other tier.
+  it('locates a declared package from the tier that declared it, not from the last tier', async () => {
+    const root = await buildConfigDir({
+      'global/node_modules/@acme/guidance/package.json': JSON.stringify({
+        name: '@acme/guidance',
+        compositor: { content: 'global-content' },
+      }),
+      'project/node_modules/@acme/guidance/package.json': JSON.stringify({
+        name: '@acme/guidance',
+        compositor: { content: 'project-content' },
+      }),
+    });
+    const config = buildConfig([
+      {
+        id: 'global',
+        baseDir: path.join(root, 'global'),
+        sources: { use: [{ name: 'inherited', package: '@acme/guidance' }] },
+      },
+      {
+        id: 'project',
+        baseDir: path.join(root, 'project'),
+        sources: { use: [{ name: 'own', package: '@acme/guidance' }] },
+      },
+    ]);
+
+    const { sources } = await resolveSources(config, options);
+
+    expect(sources.map(({ dir }) => dir)).toStrictEqual([
+      path.join(root, 'project/node_modules/@acme/guidance/project-content'),
+      path.join(root, 'global/node_modules/@acme/guidance/global-content'),
+    ]);
   });
 
   it('fails on a package it cannot locate, naming the source and the tier', async () => {

--- a/packages/compositor/src/config/loadConfig.ts
+++ b/packages/compositor/src/config/loadConfig.ts
@@ -19,7 +19,7 @@ export const TierFileSchema = z.strictObject({
 export type TierFile = z.infer<typeof TierFileSchema>;
 
 /**
- * The config the given tier files declare, lowest precedence first.
+ * Reads the config the given tier files declare, lowest precedence first.
  *
  * Tier identity is the consumer's to supply: a file does not know which tier it is, that follows from where the consumer
  * looked for it, and keeping the decision outside means no particular project layout is compiled in here.
@@ -41,7 +41,7 @@ export async function loadConfig(tiers: ReadonlyArray<TierFile>): Promise<Compos
 // region | Helpers
 
 /**
- * The body `raw` declares, with any failure named for the file it came from.
+ * Parses the body `raw` declares, naming the file it came from on any failure.
  *
  * An empty or comment-only file parses to nullish, which is a tier declaring nothing rather than a malformed one.
  */
@@ -64,7 +64,7 @@ function parseTierBody(raw: string, filePath: string): TierBody {
   return result.data;
 }
 
-/** The contents of `filePath`, or nothing when it is absent. */
+/** Reads `filePath`, resolving to nothing when it is absent. */
 async function readFileIfPresent(filePath: string): Promise<string | undefined> {
   try {
     return await readFile(filePath, 'utf8');
@@ -77,7 +77,7 @@ async function readFileIfPresent(filePath: string): Promise<string | undefined> 
 }
 
 /**
- * One tier read from its file, or nothing when that file is absent.
+ * Reads one tier from its file, resolving to nothing when that file is absent.
  *
  * `baseDir` is the file's own directory, so a relative path a tier declares resolves against where it was written rather
  * than against whatever directory the process happens to be run from.

--- a/packages/compositor/src/config/loadConfig.ts
+++ b/packages/compositor/src/config/loadConfig.ts
@@ -1,0 +1,98 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { parse as parseYaml } from 'yaml';
+import { z } from 'zod';
+
+import { isMissingFile } from '../portable/isMissingFile.ts';
+import { IdSchema } from '../schemas/common.ts';
+import type { CompositorConfig, ConfigTier, TierBody } from '../schemas/config-schemas.ts';
+import { TierBodySchema } from '../schemas/config-schemas.ts';
+
+/** One tier to read: the identity a consumer gives it, and the file it reads that tier's declarations from. */
+export const TierFileSchema = z.strictObject({
+  id: IdSchema,
+  label: z.string().min(1),
+  path: z.string().min(1),
+});
+
+export type TierFile = z.infer<typeof TierFileSchema>;
+
+/**
+ * The config the given tier files declare, lowest precedence first.
+ *
+ * Tier identity is the consumer's to supply: a file does not know which tier it is, that follows from where the consumer
+ * looked for it, and keeping the decision outside means no particular project layout is compiled in here.
+ *
+ * A tier whose file is absent contributes no tier at all, while one whose file is present but empty contributes a tier
+ * declaring nothing. That distinction is what lets a consumer tell "no config here" from "config here, saying nothing".
+ * A chain where every file is absent yields a config with no tiers, which already expresses "nothing declared" without a
+ * second sentinel.
+ *
+ * Loading is one way to obtain a config, not the only one: the value this returns is the same shape a consumer can build
+ * in memory and hand straight to the flows downstream.
+ */
+export async function loadConfig(tiers: ReadonlyArray<TierFile>): Promise<CompositorConfig> {
+  const validated = tiers.map((tier) => TierFileSchema.parse(tier));
+  const loaded = await Promise.all(validated.map((tier) => readTier(tier)));
+  return { tiers: loaded.filter((tier): tier is ConfigTier => tier !== undefined) };
+}
+
+// region | Helpers
+
+/**
+ * The body `raw` declares, with any failure named for the file it came from.
+ *
+ * An empty or comment-only file parses to nullish, which is a tier declaring nothing rather than a malformed one.
+ */
+function parseTierBody(raw: string, filePath: string): TierBody {
+  let document: unknown;
+  try {
+    document = parseYaml(raw);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Config file "${filePath}" is not valid YAML: ${message}`, { cause: error });
+  }
+
+  const result = TierBodySchema.safeParse(document ?? {});
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('; ');
+    throw new Error(`Config file "${filePath}" is invalid: ${detail}`);
+  }
+  return result.data;
+}
+
+/** The contents of `filePath`, or nothing when it is absent. */
+async function readFileIfPresent(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (error: unknown) {
+    if (isMissingFile(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+/**
+ * One tier read from its file, or nothing when that file is absent.
+ *
+ * `baseDir` is the file's own directory, so a relative path a tier declares resolves against where it was written rather
+ * than against whatever directory the process happens to be run from.
+ */
+async function readTier(tier: TierFile): Promise<ConfigTier | undefined> {
+  const raw = await readFileIfPresent(tier.path);
+  if (raw === undefined) {
+    return undefined;
+  }
+  return {
+    ...parseTierBody(raw, tier.path),
+    id: tier.id,
+    label: tier.label,
+    baseDir: path.dirname(tier.path),
+  };
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/config/loadConfig.ts
+++ b/packages/compositor/src/config/loadConfig.ts
@@ -1,10 +1,9 @@
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 
-import { isMissingFile } from '../portable/isMissingFile.ts';
+import { readFileIfPresent } from '../portable/readFileIfPresent.ts';
 import { IdSchema } from '../schemas/common.ts';
 import type { CompositorConfig, ConfigTier, TierBody } from '../schemas/config-schemas.ts';
 import { TierBodySchema } from '../schemas/config-schemas.ts';
@@ -21,16 +20,16 @@ export type TierFile = z.infer<typeof TierFileSchema>;
 /**
  * Reads the config the given tier files declare, lowest precedence first.
  *
- * Tier identity is the consumer's to supply: a file does not know which tier it is, that follows from where the consumer
- * looked for it, and keeping the decision outside means no particular project layout is compiled in here.
+ * Tier identity is the consumer's to supply: a file does not know which tier it is, that follows from where the
+ * consumer looked for it, and keeping the decision outside means no particular project layout is compiled in here.
  *
  * A tier whose file is absent contributes no tier at all, while one whose file is present but empty contributes a tier
  * declaring nothing. That distinction is what lets a consumer tell "no config here" from "config here, saying nothing".
- * A chain where every file is absent yields a config with no tiers, which already expresses "nothing declared" without a
- * second sentinel.
+ * A chain where every file is absent yields a config with no tiers, which already expresses "nothing declared" without
+ * a second sentinel.
  *
- * Loading is one way to obtain a config, not the only one: the value this returns is the same shape a consumer can build
- * in memory and hand straight to the flows downstream.
+ * Loading is one way to obtain a config, not the only one: the value this returns is the same shape a consumer can
+ * build in memory and hand straight to the flows downstream.
  */
 export async function loadConfig(tiers: ReadonlyArray<TierFile>): Promise<CompositorConfig> {
   const validated = tiers.map((tier) => TierFileSchema.parse(tier));
@@ -64,23 +63,11 @@ function parseTierBody(raw: string, filePath: string): TierBody {
   return result.data;
 }
 
-/** Reads `filePath`, resolving to nothing when it is absent. */
-async function readFileIfPresent(filePath: string): Promise<string | undefined> {
-  try {
-    return await readFile(filePath, 'utf8');
-  } catch (error: unknown) {
-    if (isMissingFile(error)) {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
 /**
  * Reads one tier from its file, resolving to nothing when that file is absent.
  *
- * `baseDir` is the file's own directory, so a relative path a tier declares resolves against where it was written rather
- * than against whatever directory the process happens to be run from.
+ * `baseDir` is the file's own directory, so a relative path a tier declares resolves against where it was written
+ * rather than against whatever directory the process happens to be run from.
  */
 async function readTier(tier: TierFile): Promise<ConfigTier | undefined> {
   const raw = await readFileIfPresent(tier.path);

--- a/packages/compositor/src/config/loadConfig.ts
+++ b/packages/compositor/src/config/loadConfig.ts
@@ -21,7 +21,8 @@ export type TierFile = z.infer<typeof TierFileSchema>;
  * Reads the config the given tier files declare, lowest precedence first.
  *
  * Tier identity is the consumer's to supply: a file does not know which tier it is, that follows from where the
- * consumer looked for it, and keeping the decision outside means no particular project layout is compiled in here.
+ * consumer looked for it, and keeping the decision outside means no particular project layout is compiled in here. Two
+ * tiers sharing an id are rejected, because that id is what every seed and diagnostic downstream names the tier by.
  *
  * A tier whose file is absent contributes no tier at all, while one whose file is present but empty contributes a tier
  * declaring nothing. That distinction is what lets a consumer tell "no config here" from "config here, saying nothing".
@@ -33,11 +34,23 @@ export type TierFile = z.infer<typeof TierFileSchema>;
  */
 export async function loadConfig(tiers: ReadonlyArray<TierFile>): Promise<CompositorConfig> {
   const validated = tiers.map((tier) => TierFileSchema.parse(tier));
+  assertTierIdsAreUnique(validated);
   const loaded = await Promise.all(validated.map((tier) => readTier(tier)));
   return { tiers: loaded.filter((tier): tier is ConfigTier => tier !== undefined) };
 }
 
 // region | Helpers
+
+/** Throws when two tier files share an id, naming the repeat. */
+function assertTierIdsAreUnique(tiers: ReadonlyArray<TierFile>): void {
+  const seen = new Set<string>();
+  for (const { id } of tiers) {
+    if (seen.has(id)) {
+      throw new Error(`Tier "${id}" is declared more than once; a tier id names one tier.`);
+    }
+    seen.add(id);
+  }
+}
 
 /**
  * Parses the body `raw` declares, naming the file it came from on any failure.

--- a/packages/compositor/src/config/locatePackage.ts
+++ b/packages/compositor/src/config/locatePackage.ts
@@ -1,0 +1,135 @@
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import { isMissingFile } from '../portable/isMissingFile.ts';
+
+/** Where to look for a package, and where that package declares the content directory it ships. */
+export interface LocatePackageOptions {
+  /** The directory package resolution is anchored at, which is the tier that declared the package. */
+  readonly baseDir: string;
+  /**
+   * The key path into a package's own `package.json` that names its content directory, such as
+   * `['compositor', 'content']`. Supplied rather than fixed, so no consumer's namespace is compiled in here.
+   */
+  readonly contentKeyPath: ReadonlyArray<string>;
+}
+
+/**
+ * The directory `name` ships its content in.
+ *
+ * Resolution walks the `node_modules` chain Node itself would search from `baseDir`, so it holds under pnpm's symlinked
+ * layout and under workspace links, which is what lets a producing repo consume its own content through the declaration
+ * a third party would write. Probing the filesystem rather than resolving a package subpath is deliberate: a modern
+ * `exports` map does not expose `./package.json`, and a content-only package has no importable entry to resolve instead.
+ *
+ * Throws when the name is a filesystem path rather than a package name, when the package is not installed, or when it
+ * declares no content directory. Whether that directory exists is left to the caller's source validation, so a package
+ * source and a hand-declared one fail through one path.
+ */
+export async function locatePackage(name: string, options: LocatePackageOptions): Promise<string> {
+  assertPackageName(name);
+
+  const installed = await findInstalledPackage(name, options.baseDir);
+  if (installed === undefined) {
+    const searched = listCandidateDirs(name, options.baseDir).join(', ');
+    throw new Error(`Declared package "${name}" is not installed. Searched: ${searched}.`);
+  }
+  return path.join(installed.dir, readContentPath(name, installed.manifest, options.contentKeyPath));
+}
+
+// region | Helpers
+
+/**
+ * Throws when `name` is a filesystem path rather than a package name.
+ *
+ * Node's resolver answers a relative specifier with the anchor directory itself, so `./content` would otherwise resolve
+ * to `<baseDir>/content` and `../sibling` would escape `baseDir` entirely -- a second, undocumented directory-source
+ * route beside the one a `path` declaration already provides.
+ */
+function assertPackageName(name: string): void {
+  if (name.startsWith('.') || path.isAbsolute(name)) {
+    throw new Error(
+      `Declared package "${name}" is a filesystem path, not a package name. Declare it as a path instead.`,
+    );
+  }
+}
+
+/** The installed directory of `name` with its parsed manifest, or nothing when no candidate directory carries one. */
+async function findInstalledPackage(
+  name: string,
+  baseDir: string,
+): Promise<{ dir: string; manifest: unknown } | undefined> {
+  for (const dir of listCandidateDirs(name, baseDir)) {
+    const raw = await readFileIfPresent(path.join(dir, 'package.json'));
+    if (raw !== undefined) {
+      return { dir, manifest: parseManifest(name, raw) };
+    }
+  }
+  return undefined;
+}
+
+/** The candidate installed directories for `name`, in the order Node's resolver searches them from `baseDir`. */
+function listCandidateDirs(name: string, baseDir: string): ReadonlyArray<string> {
+  // `createRequire` needs only a path to anchor resolution; the file itself need not exist.
+  const requireFromBase = createRequire(path.join(baseDir, 'package.json'));
+  // `resolve.paths` answers null for a core module, which a garbage declaration can produce; an empty candidate list
+  // then reports it as not installed.
+  return (requireFromBase.resolve.paths(name) ?? []).map((nodeModules) => path.join(nodeModules, name));
+}
+
+/** The parsed manifest text, naming the package so a syntax error is attributable. */
+function parseManifest(name: string, raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Package "${name}" has an unreadable package.json: ${message}`, { cause: error });
+  }
+}
+
+/**
+ * The content directory `manifest` declares at `keyPath`.
+ *
+ * The key has no default, because a default location would claim a directory name in every producer's package root. A
+ * producer states where its content lives and can nest it under a directory it already owns.
+ */
+function readContentPath(name: string, manifest: unknown, keyPath: ReadonlyArray<string>): string {
+  let current: unknown = manifest;
+  for (const key of keyPath) {
+    if (typeof current !== 'object' || current === null) {
+      current = undefined;
+      break;
+    }
+    // A key the manifest does not carry reads as `undefined`, which the check below rejects along with every other
+    // value that is not a directory name.
+    const next: unknown = Reflect.get(current, key);
+    current = next;
+  }
+
+  if (typeof current !== 'string' || current === '') {
+    throw new Error(
+      `Package "${name}" declares no content directory at "${keyPath.join('.')}" in its package.json. A package that ships content sets that key to a directory and includes the directory in its published "files".`,
+    );
+  }
+  return current;
+}
+
+/**
+ * The contents of `filePath`, or nothing when it is absent.
+ *
+ * Any other failure rethrows, so a permission problem surfaces instead of reading as a bare absence and sending
+ * resolution on to the next candidate.
+ */
+async function readFileIfPresent(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (error: unknown) {
+    if (isMissingFile(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/config/locatePackage.ts
+++ b/packages/compositor/src/config/locatePackage.ts
@@ -1,8 +1,7 @@
-import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
-import { isMissingFile } from '../portable/isMissingFile.ts';
+import { readFileIfPresent } from '../portable/readFileIfPresent.ts';
 
 /** Where to look for a package, and where that package declares the content directory it ships. */
 export interface LocatePackageOptions {
@@ -21,7 +20,8 @@ export interface LocatePackageOptions {
  * Resolution walks the `node_modules` chain Node itself would search from `baseDir`, so it holds under pnpm's symlinked
  * layout and under workspace links, which is what lets a producing repo consume its own content through the declaration
  * a third party would write. Probing the filesystem rather than resolving a package subpath is deliberate: a modern
- * `exports` map does not expose `./package.json`, and a content-only package has no importable entry to resolve instead.
+ * `exports` map does not expose `./package.json`, and a content-only package has no importable entry to resolve
+ * instead.
  *
  * Throws when the name is a filesystem path rather than a package name, when the package is not installed, or when it
  * declares no content directory. Whether that directory exists is left to the caller's source validation, so a package
@@ -109,27 +109,11 @@ function readContentPath(name: string, manifest: unknown, keyPath: ReadonlyArray
 
   if (typeof current !== 'string' || current === '') {
     throw new Error(
-      `Package "${name}" declares no content directory at "${keyPath.join('.')}" in its package.json. A package that ships content sets that key to a directory and includes the directory in its published "files".`,
+      `Package "${name}" declares no content directory at "${keyPath.join('.')}" in its package.json. ` +
+        `A package that ships content sets that key to a directory and includes it in its published "files".`,
     );
   }
   return current;
-}
-
-/**
- * Reads `filePath`, resolving to nothing when it is absent.
- *
- * Any other failure rethrows, so a permission problem surfaces instead of reading as a bare absence and sending
- * resolution on to the next candidate.
- */
-async function readFileIfPresent(filePath: string): Promise<string | undefined> {
-  try {
-    return await readFile(filePath, 'utf8');
-  } catch (error: unknown) {
-    if (isMissingFile(error)) {
-      return undefined;
-    }
-    throw error;
-  }
 }
 
 // endregion | Helpers

--- a/packages/compositor/src/config/locatePackage.ts
+++ b/packages/compositor/src/config/locatePackage.ts
@@ -16,7 +16,7 @@ export interface LocatePackageOptions {
 }
 
 /**
- * The directory `name` ships its content in.
+ * Locates the directory `name` ships its content in.
  *
  * Resolution walks the `node_modules` chain Node itself would search from `baseDir`, so it holds under pnpm's symlinked
  * layout and under workspace links, which is what lets a producing repo consume its own content through the declaration
@@ -55,7 +55,7 @@ function assertPackageName(name: string): void {
   }
 }
 
-/** The installed directory of `name` with its parsed manifest, or nothing when no candidate directory carries one. */
+/** Finds the installed directory of `name` with its parsed manifest, or nothing when no candidate carries one. */
 async function findInstalledPackage(
   name: string,
   baseDir: string,
@@ -69,7 +69,7 @@ async function findInstalledPackage(
   return undefined;
 }
 
-/** The candidate installed directories for `name`, in the order Node's resolver searches them from `baseDir`. */
+/** Lists the candidate installed directories for `name`, in the order Node's resolver searches them from `baseDir`. */
 function listCandidateDirs(name: string, baseDir: string): ReadonlyArray<string> {
   // `createRequire` needs only a path to anchor resolution; the file itself need not exist.
   const requireFromBase = createRequire(path.join(baseDir, 'package.json'));
@@ -78,7 +78,7 @@ function listCandidateDirs(name: string, baseDir: string): ReadonlyArray<string>
   return (requireFromBase.resolve.paths(name) ?? []).map((nodeModules) => path.join(nodeModules, name));
 }
 
-/** The parsed manifest text, naming the package so a syntax error is attributable. */
+/** Parses the manifest text, naming the package so a syntax error is attributable. */
 function parseManifest(name: string, raw: string): unknown {
   try {
     return JSON.parse(raw);
@@ -89,7 +89,7 @@ function parseManifest(name: string, raw: string): unknown {
 }
 
 /**
- * The content directory `manifest` declares at `keyPath`.
+ * Reads the content directory `manifest` declares at `keyPath`.
  *
  * The key has no default, because a default location would claim a directory name in every producer's package root. A
  * producer states where its content lives and can nest it under a directory it already owns.
@@ -116,7 +116,7 @@ function readContentPath(name: string, manifest: unknown, keyPath: ReadonlyArray
 }
 
 /**
- * The contents of `filePath`, or nothing when it is absent.
+ * Reads `filePath`, resolving to nothing when it is absent.
  *
  * Any other failure rethrows, so a permission problem surfaces instead of reading as a bare absence and sending
  * resolution on to the next candidate.

--- a/packages/compositor/src/config/resolveSources.ts
+++ b/packages/compositor/src/config/resolveSources.ts
@@ -1,0 +1,119 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { compareStrings } from '../portable/compareStrings.ts';
+import type { CompositorConfig } from '../schemas/config-schemas.ts';
+import type { SourceOrigin } from '../schemas/descriptor-schemas.ts';
+import type { SourceSpec } from '../schemas/resolution-schemas.ts';
+import { locatePackage } from './locatePackage.ts';
+
+/** What resolving a config's sources needs beyond the config itself. */
+export interface ResolveSourcesOptions {
+  /**
+   * The key path into a package's own `package.json` that names its content directory, such as
+   * `['compositor', 'content']`. Supplied rather than fixed, so no consumer's namespace is compiled in here.
+   */
+  readonly contentKeyPath: ReadonlyArray<string>;
+}
+
+/** The sources a config declares, and the names it turned down. */
+export interface SourceResolution {
+  /** Highest precedence first, which is the order resolution reads them in. */
+  readonly sources: ReadonlyArray<SourceSpec>;
+  /**
+   * The names a tier dropped and no higher tier re-adopted, in name order.
+   *
+   * Keeping them distinguishes a source a consumer turned down from one it has never mentioned, which is what lets an
+   * advisory scan stay quiet about the former.
+   */
+  readonly declined: ReadonlyArray<string>;
+}
+
+/**
+ * The sources `config` declares, each located on disk, in precedence order.
+ *
+ * The fold runs lowest tier first, keyed by name: a `use` adds the source or remaps an inherited one, a `drop` removes
+ * it and records the decline, and a tier declaring `reset` discards every lower tier's contributions before it applies.
+ * Precedence then runs higher tier first, and author order within a tier, so a config reads with precedence descending
+ * down the page and a consumer's own content outranks a package it listed below.
+ *
+ * A package name is located here; a path is resolved against the tier that declared it. The location a consumer wrote
+ * stays on the origin either way, so a plan reports the declaration rather than where it landed. Whether a resolved
+ * directory exists is `assertSourceIsReadable`'s question, so a package source and a hand-declared one fail alike.
+ */
+export async function resolveSources(
+  config: CompositorConfig,
+  options: ResolveSourcesOptions,
+): Promise<SourceResolution> {
+  const adopted = new Map<string, FoldedSource>();
+  const declined = new Set<string>();
+
+  for (const [tierIndex, tier] of config.tiers.entries()) {
+    if (tier.reset) {
+      adopted.clear();
+      declined.clear();
+    }
+    for (const [order, source] of tier.sources.use.entries()) {
+      adopted.set(source.name, { origin: source.origin, baseDir: tier.baseDir, label: tier.label, tierIndex, order });
+      declined.delete(source.name);
+    }
+    for (const name of tier.sources.drop) {
+      adopted.delete(name);
+      declined.add(name);
+    }
+  }
+
+  const ordered = [...adopted].toSorted(([, left], [, right]) => comparePrecedence(left, right));
+  const sources = await Promise.all(ordered.map(([name, folded]) => buildSpec(name, folded, options)));
+
+  return { sources, declined: [...declined].toSorted(compareStrings) };
+}
+
+// region | Helpers
+
+/** One source as the fold holds it: where it came from, and what decides its precedence. */
+interface FoldedSource {
+  readonly origin: SourceOrigin;
+  readonly baseDir: string;
+  readonly label: string;
+  readonly tierIndex: number;
+  readonly order: number;
+}
+
+/** One source located on disk, with the tier it came from named on any failure. */
+async function buildSpec(name: string, folded: FoldedSource, options: ResolveSourcesOptions): Promise<SourceSpec> {
+  const { origin, baseDir, label } = folded;
+  try {
+    const dir =
+      origin.kind === 'package'
+        ? await locatePackage(origin.location, { baseDir, contentKeyPath: options.contentKeyPath })
+        : resolveDirectory(origin.location, baseDir);
+    return { id: name, name, origin, dir };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Source "${name}", declared by tier "${label}": ${message}`, { cause: error });
+  }
+}
+
+/** Higher tier first, then author order, which is precedence descending. */
+function comparePrecedence(left: FoldedSource, right: FoldedSource): number {
+  return left.tierIndex === right.tierIndex ? left.order - right.order : right.tierIndex - left.tierIndex;
+}
+
+/**
+ * An authored directory location as an absolute path.
+ *
+ * A leading `~` expands to the home directory, an already-absolute path stands, and a relative path resolves against the
+ * tier that declared it rather than against wherever the process happens to be running.
+ */
+function resolveDirectory(location: string, baseDir: string): string {
+  if (location === '~' || location.startsWith('~/')) {
+    return path.join(homedir(), location.slice(1));
+  }
+  if (path.isAbsolute(location)) {
+    return location;
+  }
+  return path.resolve(baseDir, location);
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/config/resolveSources.ts
+++ b/packages/compositor/src/config/resolveSources.ts
@@ -103,8 +103,8 @@ function comparePrecedence(left: FoldedSource, right: FoldedSource): number {
 /**
  * Resolves an authored directory location to an absolute path.
  *
- * A leading `~` expands to the home directory, an already-absolute path stands, and a relative path resolves against the
- * tier that declared it rather than against wherever the process happens to be running.
+ * A leading `~` expands to the home directory, an already-absolute path stands, and a relative path resolves against
+ * the tier that declared it rather than against wherever the process happens to be running.
  */
 function resolveDirectory(location: string, baseDir: string): string {
   if (location === '~' || location.startsWith('~/')) {

--- a/packages/compositor/src/config/resolveSources.ts
+++ b/packages/compositor/src/config/resolveSources.ts
@@ -30,7 +30,7 @@ export interface SourceResolution {
 }
 
 /**
- * The sources `config` declares, each located on disk, in precedence order.
+ * Resolves the sources `config` declares, locating each on disk, in precedence order.
  *
  * The fold runs lowest tier first, keyed by name: a `use` adds the source or remaps an inherited one, a `drop` removes
  * it and records the decline, and a tier declaring `reset` discards every lower tier's contributions before it applies.
@@ -80,7 +80,7 @@ interface FoldedSource {
   readonly order: number;
 }
 
-/** One source located on disk, with the tier it came from named on any failure. */
+/** Locates one source on disk, naming the tier it came from on any failure. */
 async function buildSpec(name: string, folded: FoldedSource, options: ResolveSourcesOptions): Promise<SourceSpec> {
   const { origin, baseDir, label } = folded;
   try {
@@ -95,13 +95,13 @@ async function buildSpec(name: string, folded: FoldedSource, options: ResolveSou
   }
 }
 
-/** Higher tier first, then author order, which is precedence descending. */
+/** Orders two sources higher tier first, then by author order, which is precedence descending. */
 function comparePrecedence(left: FoldedSource, right: FoldedSource): number {
   return left.tierIndex === right.tierIndex ? left.order - right.order : right.tierIndex - left.tierIndex;
 }
 
 /**
- * An authored directory location as an absolute path.
+ * Resolves an authored directory location to an absolute path.
  *
  * A leading `~` expands to the home directory, an already-absolute path stands, and a relative path resolves against the
  * tier that declared it rather than against wherever the process happens to be running.

--- a/packages/compositor/src/config/test-utils/buildConfig.ts
+++ b/packages/compositor/src/config/test-utils/buildConfig.ts
@@ -15,7 +15,7 @@ export interface TierInput {
   readonly select?: unknown;
 }
 
-/** A normalized config whose tiers are `tiers`, lowest precedence first. */
+/** Builds a normalized config whose tiers are `tiers`, lowest precedence first. */
 export function buildConfig(tiers: ReadonlyArray<TierInput>): CompositorConfig {
   return CompositorConfigSchema.parse({
     tiers: tiers.map((tier, index) => ({

--- a/packages/compositor/src/config/test-utils/buildConfig.ts
+++ b/packages/compositor/src/config/test-utils/buildConfig.ts
@@ -1,0 +1,30 @@
+import type { CompositorConfig } from '../../schemas/config-schemas.ts';
+import { CompositorConfigSchema } from '../../schemas/config-schemas.ts';
+
+/**
+ * One tier as a test declares it: an authored body, plus an identity defaulted from its position.
+ *
+ * `sources` and `select` are untyped so a test can write the terse authored spellings the schema normalizes, which is
+ * what most tests here are exercising the far side of.
+ */
+export interface TierInput {
+  readonly id?: string;
+  readonly baseDir?: string;
+  readonly reset?: boolean;
+  readonly sources?: unknown;
+  readonly select?: unknown;
+}
+
+/** A normalized config whose tiers are `tiers`, lowest precedence first. */
+export function buildConfig(tiers: ReadonlyArray<TierInput>): CompositorConfig {
+  return CompositorConfigSchema.parse({
+    tiers: tiers.map((tier, index) => ({
+      id: tier.id ?? `tier-${index}`,
+      label: tier.id ?? `tier-${index}`,
+      baseDir: tier.baseDir ?? '/srv/app',
+      reset: tier.reset,
+      sources: tier.sources,
+      select: tier.select,
+    })),
+  });
+}

--- a/packages/compositor/src/config/test-utils/buildConfigDir.ts
+++ b/packages/compositor/src/config/test-utils/buildConfigDir.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { onTestFinished } from 'vitest';
 
 /**
- * A directory holding each path in `files` with the given content, removed when the test ends.
+ * Creates a directory holding each path in `files` with the given content, removed when the test ends.
  *
  * Writes a real tree rather than mocking the filesystem, because what loading answers is how Node reports an absent
  * file against a present one -- the very layer a mock would replace with an assumption.

--- a/packages/compositor/src/config/test-utils/buildConfigDir.ts
+++ b/packages/compositor/src/config/test-utils/buildConfigDir.ts
@@ -1,0 +1,26 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { onTestFinished } from 'vitest';
+
+/**
+ * A directory holding each path in `files` with the given content, removed when the test ends.
+ *
+ * Writes a real tree rather than mocking the filesystem, because what loading answers is how Node reports an absent
+ * file against a present one -- the very layer a mock would replace with an assumption.
+ */
+export async function buildConfigDir(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'compositor-config-'));
+  onTestFinished(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(dir, relativePath);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, content, 'utf8');
+  }
+
+  return dir;
+}

--- a/packages/compositor/src/index.ts
+++ b/packages/compositor/src/index.ts
@@ -1,3 +1,9 @@
+export type { TierFile } from './config/loadConfig.ts';
+export { loadConfig, TierFileSchema } from './config/loadConfig.ts';
+export type { LocatePackageOptions } from './config/locatePackage.ts';
+export { locatePackage } from './config/locatePackage.ts';
+export type { ResolveSourcesOptions, SourceResolution } from './config/resolveSources.ts';
+export { resolveSources } from './config/resolveSources.ts';
 export type { DependencyGraphView, DependentsIndex, TraversableArtifact } from './graph/traversal.ts';
 export { buildDependentsIndex, resolveInclusionPaths } from './graph/traversal.ts';
 export type { PlanViolation } from './plan/assertPlanIsConsistent.ts';
@@ -13,6 +19,25 @@ export type { ResolveCatalogInput } from './resolution/resolveCatalog.ts';
 export { resolveCatalog } from './resolution/resolveCatalog.ts';
 export type { ArtifactId, DiffStatus, Hash, Id, KindId, PartialId, SourceId, TargetId } from './schemas/common.ts';
 export { DiffStatusSchema, HashSchema, IdSchema } from './schemas/common.ts';
+export type {
+  CompositorConfig,
+  ConfigTier,
+  DeclaredSource,
+  KindSelection,
+  Selector,
+  SourceDeclaration,
+  TierBody,
+} from './schemas/config-schemas.ts';
+export {
+  CompositorConfigSchema,
+  ConfigTierSchema,
+  DeclaredSourceSchema,
+  KindSelectionSchema,
+  SelectorSchema,
+  SelectSchema,
+  SourceDeclarationSchema,
+  TierBodySchema,
+} from './schemas/config-schemas.ts';
 export type {
   KindDescriptor,
   SourceEntry,
@@ -92,3 +117,11 @@ export {
   ResolveKindSchema,
   SourceSpecSchema,
 } from './schemas/resolution-schemas.ts';
+export type {
+  ConfigEntryRef,
+  DeclinedArtifact,
+  SeededArtifact,
+  Selection,
+  SelectionDiagnostic,
+} from './selection/selectArtifacts.ts';
+export { selectArtifacts } from './selection/selectArtifacts.ts';

--- a/packages/compositor/src/portable/readFileIfPresent.ts
+++ b/packages/compositor/src/portable/readFileIfPresent.ts
@@ -1,0 +1,20 @@
+import { readFile } from 'node:fs/promises';
+
+import { isMissingFile } from './isMissingFile.ts';
+
+/**
+ * Reads `filePath`, resolving to nothing when it is absent.
+ *
+ * Any other failure rethrows, so a permission problem surfaces instead of reading as a bare absence and sending the
+ * caller on as though nothing were there.
+ */
+export async function readFileIfPresent(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (error: unknown) {
+    if (isMissingFile(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}

--- a/packages/compositor/src/schemas/__tests__/config-schemas.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/config-schemas.unit.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CompositorConfigSchema,
+  ConfigTierSchema,
+  DeclaredSourceSchema,
+  KindSelectionSchema,
+  SelectorSchema,
+  SelectSchema,
+  SourceDeclarationSchema,
+  TierBodySchema,
+} from '../config-schemas.ts';
+import { findIssuePaths } from '../test-utils/findIssuePaths.ts';
+
+const authoredTier = {
+  id: 'project',
+  label: 'Project',
+  baseDir: '/srv/app/.agents',
+  sources: {
+    use: [
+      { name: 'local', path: './content' },
+      { name: 'acme', package: '@acme/guidance' },
+    ],
+    drop: ['vendor'],
+  },
+  select: {
+    skill: { use: ['lint', { source: 'acme' }], drop: ['legacy'] },
+    rulebook: { use: [{ source: 'local' }] },
+  },
+};
+
+describe('SelectorSchema', () => {
+  it('reads a bare string as the artifact it names', () => {
+    expect(SelectorSchema.parse('lint')).toStrictEqual({ artifact: 'lint' });
+  });
+
+  it.each([
+    ['an artifact', { artifact: 'lint' }],
+    ['a source', { source: 'acme' }],
+  ])('accepts the object form naming %s', (_label, selector) => {
+    expect(SelectorSchema.parse(selector)).toStrictEqual(selector);
+  });
+
+  // Rejecting rather than stripping is the point: a strip would discard half of what the author wrote.
+  it('rejects an entry naming both an artifact and a source', () => {
+    expect(findIssuePaths(SelectorSchema, { artifact: 'lint', source: 'acme' })).toBeDefined();
+  });
+
+  it('rejects an entry naming neither', () => {
+    expect(findIssuePaths(SelectorSchema, {})).toBeDefined();
+  });
+});
+
+describe('DeclaredSourceSchema', () => {
+  it.each([
+    ['path', { name: 'local', path: './content' }, { kind: 'directory', location: './content' }],
+    ['package', { name: 'acme', package: '@acme/guidance' }, { kind: 'package', location: '@acme/guidance' }],
+  ])('normalizes an authored %s into a source origin', (_label, declared, origin) => {
+    expect(DeclaredSourceSchema.parse(declared)).toStrictEqual({ name: declared.name, origin });
+  });
+
+  it('keeps the location as authored, so a plan reports what a consumer wrote', () => {
+    expect(DeclaredSourceSchema.parse({ name: 'home', path: '~/guidance' })).toStrictEqual({
+      name: 'home',
+      origin: { kind: 'directory', location: '~/guidance' },
+    });
+  });
+
+  it('rejects a source declaring both a path and a package', () => {
+    const declared = { name: 'local', path: './content', package: '@acme/guidance' };
+
+    expect(findIssuePaths(DeclaredSourceSchema, declared)).toBeDefined();
+  });
+});
+
+describe('SourceDeclarationSchema', () => {
+  it('defaults both lists to empty', () => {
+    expect(SourceDeclarationSchema.parse({})).toStrictEqual({ use: [], drop: [] });
+  });
+
+  it('drops sources by name', () => {
+    expect(SourceDeclarationSchema.parse({ drop: ['vendor'] })).toStrictEqual({ use: [], drop: ['vendor'] });
+  });
+});
+
+describe('SelectSchema', () => {
+  it('normalizes a kind-keyed mapping into entries sorted by kind', () => {
+    const select = SelectSchema.parse({ skill: { use: ['lint'] }, rulebook: { use: ['house-style'] } });
+
+    expect(select).toStrictEqual([
+      { kindId: 'rulebook', use: [{ artifact: 'house-style' }], drop: [] },
+      { kindId: 'skill', use: [{ artifact: 'lint' }], drop: [] },
+    ]);
+  });
+
+  // A kind key with nothing under it is what an author leaves behind after commenting every entry out.
+  it('reads a kind whose block is null as declaring nothing', () => {
+    expect(SelectSchema.parse({ skill: null })).toStrictEqual([{ kindId: 'skill', use: [], drop: [] }]);
+  });
+
+  it('rejects an array naming one kind twice', () => {
+    const select = [
+      { kindId: 'skill', use: ['lint'] },
+      { kindId: 'skill', use: ['format'] },
+    ];
+
+    expect(findIssuePaths(SelectSchema, select)).toBeDefined();
+  });
+});
+
+describe('KindSelectionSchema', () => {
+  it('defaults both lists to empty', () => {
+    expect(KindSelectionSchema.parse({ kindId: 'skill' })).toStrictEqual({ kindId: 'skill', use: [], drop: [] });
+  });
+});
+
+describe('TierBodySchema', () => {
+  it('reads an empty body as a tier declaring nothing', () => {
+    expect(TierBodySchema.parse({})).toStrictEqual({ reset: false, sources: { use: [], drop: [] }, select: [] });
+  });
+
+  it.each(['sources', 'select'] as const)('reads a null %s block as declaring nothing', (block) => {
+    expect(TierBodySchema.parse({ [block]: null })).toStrictEqual({
+      reset: false,
+      sources: { use: [], drop: [] },
+      select: [],
+    });
+  });
+
+  // Strict, so a misspelled key fails rather than declaring nothing at all.
+  it('rejects an unrecognized top-level key, naming it', () => {
+    const result = TierBodySchema.safeParse({ selects: {} });
+
+    expect(result.error?.issues).toMatchObject([{ code: 'unrecognized_keys', keys: ['selects'] }]);
+  });
+});
+
+describe('ConfigTierSchema', () => {
+  it('normalizes an authored tier', () => {
+    expect(ConfigTierSchema.parse(authoredTier)).toStrictEqual({
+      id: 'project',
+      label: 'Project',
+      baseDir: '/srv/app/.agents',
+      reset: false,
+      sources: {
+        use: [
+          { name: 'local', origin: { kind: 'directory', location: './content' } },
+          { name: 'acme', origin: { kind: 'package', location: '@acme/guidance' } },
+        ],
+        drop: ['vendor'],
+      },
+      select: [
+        { kindId: 'rulebook', use: [{ source: 'local' }], drop: [] },
+        { kindId: 'skill', use: [{ artifact: 'lint' }, { source: 'acme' }], drop: [{ artifact: 'legacy' }] },
+      ],
+    });
+  });
+
+  it.each(['id', 'label', 'baseDir'] as const)('if %s is absent, rejects the tier for that field', (field) => {
+    const { [field]: _dropped, ...incomplete } = authoredTier;
+
+    expect(findIssuePaths(ConfigTierSchema, incomplete)).toStrictEqual([[field]]);
+  });
+});
+
+describe('CompositorConfigSchema', () => {
+  it('reads a config with no tiers as declaring nothing', () => {
+    expect(CompositorConfigSchema.parse({})).toStrictEqual({ tiers: [] });
+  });
+
+  // A What-if pass mutates a config it already holds and re-parses it, so normalizing twice must change nothing.
+  it('parses its own output unchanged', () => {
+    const config = CompositorConfigSchema.parse({ tiers: [authoredTier] });
+
+    expect(CompositorConfigSchema.parse(config)).toStrictEqual(config);
+  });
+
+  it('rejects an unrecognized top-level key, naming it', () => {
+    const result = CompositorConfigSchema.safeParse({ tiers: [], targets: [] });
+
+    expect(result.error?.issues).toMatchObject([{ code: 'unrecognized_keys', keys: ['targets'] }]);
+  });
+});

--- a/packages/compositor/src/schemas/__tests__/config-schemas.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/config-schemas.unit.test.ts
@@ -175,6 +175,12 @@ describe('CompositorConfigSchema', () => {
     expect(CompositorConfigSchema.parse(config)).toStrictEqual(config);
   });
 
+  it('rejects two tiers sharing an id', () => {
+    const tiers = [authoredTier, { ...authoredTier, baseDir: '/srv/other' }];
+
+    expect(findIssuePaths(CompositorConfigSchema, { tiers })).toStrictEqual([['tiers']]);
+  });
+
   it('rejects an unrecognized top-level key, naming it', () => {
     const result = CompositorConfigSchema.safeParse({ tiers: [], targets: [] });
 

--- a/packages/compositor/src/schemas/config-schemas.ts
+++ b/packages/compositor/src/schemas/config-schemas.ts
@@ -1,0 +1,151 @@
+/**
+ * Config: the tiered declaration a consumer folds into sources and a selection.
+ *
+ * These schemas normalize as they parse -- a bare slug becomes an entry, an authored `path` becomes a source origin --
+ * so they carry transforms and do not render to JSON Schema, unlike the plan and catalog contracts. Config is authored
+ * input rather than an emitted payload, which is also why it carries no `schemaVersion`.
+ *
+ * Parsing is idempotent: every schema accepts its own output as well as the authored form, so a consumer holding a
+ * normalized config can mutate it and re-parse it for a What-if pass without denormalizing first.
+ */
+
+import { z } from 'zod';
+
+import { compareStrings } from '../portable/compareStrings.ts';
+import { IdSchema } from './common.ts';
+import { SourceOriginSchema } from './descriptor-schemas.ts';
+
+/**
+ * One `use` or `drop` entry: an artifact named by slug, or everything a source carries.
+ *
+ * A bare string is the artifact form, so the common case stays terse. The object forms are told apart by which key is
+ * present rather than by a sentinel prefix, which would reserve a character out of the slug namespace. An entry naming
+ * both is rejected rather than settled by precedence: the key each form does not own is typed `never`, so a mistake
+ * fails the parse instead of being silently dropped by the strip that would otherwise swallow it.
+ */
+export const SelectorSchema = z.union([
+  z
+    .string()
+    .min(1)
+    .transform((artifact) => ({ artifact })),
+  z.object({ artifact: z.string().min(1), source: z.never().optional() }).transform(({ artifact }) => ({ artifact })),
+  z.object({ source: z.string().min(1), artifact: z.never().optional() }).transform(({ source }) => ({ source })),
+]);
+
+/**
+ * One declared content source, in either the authored or the normalized spelling.
+ *
+ * `path` and `package` are the two authored spellings of the plan schema's source origins, and `origin` is what they
+ * normalize to. A source declares exactly one of the three. The location stays as authored: resolving it against the
+ * declaring tier is `resolveSources`' job, so a plan reports the path a consumer wrote rather than where it landed.
+ */
+export const DeclaredSourceSchema = z.union([
+  z
+    .object({
+      name: z.string().min(1),
+      path: z.string().min(1),
+      package: z.never().optional(),
+      origin: z.never().optional(),
+    })
+    .transform(({ name, path }) => ({ name, origin: { kind: 'directory' as const, location: path } })),
+  z
+    .object({
+      name: z.string().min(1),
+      package: z.string().min(1),
+      path: z.never().optional(),
+      origin: z.never().optional(),
+    })
+    .transform(({ name, package: location }) => ({ name, origin: { kind: 'package' as const, location } })),
+  z
+    .object({
+      name: z.string().min(1),
+      origin: SourceOriginSchema,
+      path: z.never().optional(),
+      package: z.never().optional(),
+    })
+    .transform(({ name, origin }) => ({ name, origin })),
+]);
+
+/**
+ * One tier's source declarations: the sources it adds, and the inherited names it drops.
+ *
+ * `drop` names sources rather than carrying entries, because a name is the whole of what identifies one. Dropping is
+ * what the port could do to a package and not to a source; unifying the two lists keeps the stronger semantics.
+ */
+export const SourceDeclarationSchema = z.strictObject({
+  use: z.array(DeclaredSourceSchema).default([]),
+  drop: z.array(z.string().min(1)).default([]),
+});
+
+/** One kind's selections within a tier. */
+export const KindSelectionSchema = z.strictObject({
+  kindId: IdSchema,
+  use: z.array(SelectorSchema).default([]),
+  drop: z.array(SelectorSchema).default([]),
+});
+
+/**
+ * A tier's selections across every kind it speaks about, as a `kindId`-keyed mapping or as the normalized array.
+ *
+ * The array form is tried first, so an array input never reaches the record branch. Entries sort by `kindId`, which is
+ * what keeps a config authored in two different orders digesting to one value.
+ */
+export const SelectSchema = z
+  .union([
+    z.array(KindSelectionSchema),
+    z
+      .record(
+        IdSchema,
+        z.preprocess(
+          (value) => value ?? undefined,
+          KindSelectionSchema.omit({ kindId: true }).default({ use: [], drop: [] }),
+        ),
+      )
+      .transform((blocks) => Object.entries(blocks).map(([kindId, block]) => ({ kindId, ...block }))),
+  ])
+  .refine((blocks) => new Set(blocks.map(({ kindId }) => kindId)).size === blocks.length, {
+    error: 'names a kind more than once',
+  })
+  .transform((blocks) => blocks.toSorted((left, right) => compareStrings(left.kindId, right.kindId)));
+
+/**
+ * What one tier file carries.
+ *
+ * Strict, so a misspelled key fails rather than declaring nothing. A block that is absent, or whose value is `null`
+ * because every entry under it is commented out, reads as the empty declaration it means.
+ */
+export const TierBodySchema = z.strictObject({
+  reset: z.boolean().default(false),
+  sources: z.preprocess((value) => value ?? undefined, SourceDeclarationSchema.default({ use: [], drop: [] })),
+  select: z.preprocess((value) => value ?? undefined, SelectSchema.default([])),
+});
+
+/**
+ * One tier: what it declares, plus the identity and location a consumer gives it.
+ *
+ * `id`, `label`, and `baseDir` are not authored. A file does not know which tier it is -- that follows from where a
+ * consumer looked for it -- which is what keeps any particular project layout out of this package.
+ */
+export const ConfigTierSchema = TierBodySchema.extend({
+  id: IdSchema,
+  label: z.string().min(1),
+  baseDir: z.string().min(1),
+});
+
+/**
+ * A whole tiered config, the value every flow downstream reads.
+ *
+ * `tiers` runs lowest precedence first, the order a fold applies them and the order a plan's `tiers` table carries. An
+ * empty array is a config declaring nothing, which is the only sentinel that case needs.
+ */
+export const CompositorConfigSchema = z.strictObject({
+  tiers: z.array(ConfigTierSchema).default([]),
+});
+
+export type CompositorConfig = z.infer<typeof CompositorConfigSchema>;
+export type ConfigTier = z.infer<typeof ConfigTierSchema>;
+export type DeclaredSource = z.infer<typeof DeclaredSourceSchema>;
+export type KindSelection = z.infer<typeof KindSelectionSchema>;
+export type Selector = z.infer<typeof SelectorSchema>;
+export type SourceDeclaration = z.infer<typeof SourceDeclarationSchema>;
+export type TierBody = z.infer<typeof TierBodySchema>;

--- a/packages/compositor/src/schemas/config-schemas.ts
+++ b/packages/compositor/src/schemas/config-schemas.ts
@@ -136,10 +136,17 @@ export const ConfigTierSchema = TierBodySchema.extend({
  * A whole tiered config, the value every flow downstream reads.
  *
  * `tiers` runs lowest precedence first, the order a fold applies them and the order a plan's `tiers` table carries. An
- * empty array is a config declaring nothing, which is the only sentinel that case needs.
+ * empty array is a config declaring nothing, which is the only sentinel that case needs. Ids are unique: a tier id is
+ * the identity that leaves this package, naming the tier in every seed and diagnostic, so a repeat makes each of those
+ * references ambiguous.
  */
 export const CompositorConfigSchema = z.strictObject({
-  tiers: z.array(ConfigTierSchema).default([]),
+  tiers: z
+    .array(ConfigTierSchema)
+    .refine((tiers) => new Set(tiers.map(({ id }) => id)).size === tiers.length, {
+      error: 'names a tier more than once',
+    })
+    .default([]),
 });
 
 export type CompositorConfig = z.infer<typeof CompositorConfigSchema>;

--- a/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildConfig, type TierInput } from '../../config/test-utils/buildConfig.ts';
+import { buildConfig, type TierInput } from '../../test-utils/buildConfig.ts';
 import { selectArtifacts, type Selection } from '../selectArtifacts.ts';
 import { buildCatalog } from '../test-utils/buildCatalog.ts';
 

--- a/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
@@ -143,6 +143,13 @@ describe(selectArtifacts, () => {
     });
   });
 
+  // The fixture declares only `drop`, so naming a list here could only name one the author never wrote.
+  it('locates a block-level diagnostic at the block, naming no list or position', () => {
+    const selection = select([{ id: 'project', select: { partial: { drop: ['x'] } } }]);
+
+    expect(selection.diagnostics.at(0)?.at).toStrictEqual({ tierId: 'project', kindId: 'partial' });
+  });
+
   it('collects every diagnostic, rather than stopping at the first', () => {
     const selection = select([{ id: 'project', select: { skill: { use: ['absent', 'missing'] } } }]);
 

--- a/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
@@ -160,12 +160,12 @@ describe(selectArtifacts, () => {
 
 // region | Helpers
 
-/** The ids of the artifacts a selection seeded, in the order it runs them. */
+/** Collects the ids of the artifacts a selection seeded, in the order it runs them. */
 function collectIds(selection: Selection): Array<string> {
   return selection.seeded.map(({ artifactId }) => artifactId);
 }
 
-/** The selection `tiers` makes from the shared catalog. */
+/** Selects from the shared catalog using `tiers`. */
 function select(tiers: ReadonlyArray<TierInput>): Selection {
   return selectArtifacts(buildConfig(tiers), catalog);
 }

--- a/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildConfig, type TierInput } from '../../config/test-utils/buildConfig.ts';
+import { selectArtifacts, type Selection } from '../selectArtifacts.ts';
+import { buildCatalog } from '../test-utils/buildCatalog.ts';
+
+const catalog = buildCatalog({
+  kinds: ['rulebook', 'skill'],
+  sources: ['local', 'acme'],
+  entries: [
+    { kindId: 'skill', slug: 'lint', carriedBy: ['acme'] },
+    { kindId: 'skill', slug: 'format', carriedBy: ['acme'] },
+    // Carried by both, and won by the higher-precedence source: acme still carries it.
+    { kindId: 'skill', slug: 'review', carriedBy: ['local', 'acme'] },
+    { kindId: 'rulebook', slug: 'house-style', carriedBy: ['local'] },
+  ],
+});
+
+describe(selectArtifacts, () => {
+  it('seeds an artifact a tier names', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: ['lint'] } } }]);
+
+    expect(selection.seeded).toStrictEqual([
+      { artifactId: 'skill:lint', seededBy: [{ via: 'declaration', tierId: 'project' }] },
+    ]);
+  });
+
+  it('seeds everything a source carries when a tier takes the source whole', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: [{ source: 'acme' }] } } }]);
+
+    expect(collectIds(selection)).toStrictEqual(['skill:format', 'skill:lint', 'skill:review']);
+  });
+
+  // Shadowing settles which copy an artifact resolves from; selection settles which artifacts are in play.
+  it('takes an artifact a higher-precedence source shadows, because the named source still carries it', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: [{ source: 'acme' }] } } }]);
+
+    expect(collectIds(selection)).toContain('skill:review');
+  });
+
+  it('expresses all of a source except one artifact', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: [{ source: 'acme' }], drop: ['review'] } } }]);
+
+    expect(collectIds(selection)).toStrictEqual(['skill:format', 'skill:lint']);
+  });
+
+  it('records the origin a selector used, so a wholesale opt-in is distinguishable from a named one', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: [{ source: 'acme' }] } } }]);
+
+    expect(selection.seeded.at(0)?.seededBy).toStrictEqual([{ via: 'source-catalog', tierId: 'project' }]);
+  });
+
+  it('carries one seed per tier when several tiers seed one artifact', () => {
+    const selection = select([
+      { id: 'global', select: { skill: { use: ['lint'] } } },
+      { id: 'project', select: { skill: { use: ['lint'] } } },
+    ]);
+
+    expect(selection.seeded.at(0)?.seededBy).toStrictEqual([
+      { via: 'declaration', tierId: 'global' },
+      { via: 'declaration', tierId: 'project' },
+    ]);
+  });
+
+  it('carries one seed when a tier names the same artifact twice', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: ['lint', 'lint'] } } }]);
+
+    expect(selection.seeded.at(0)?.seededBy).toStrictEqual([{ via: 'declaration', tierId: 'project' }]);
+  });
+
+  // Naming an artifact and taking its source whole are two different decisions, so both are recorded.
+  it('carries both seeds when a tier names an artifact and also takes its source whole', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: ['lint', { source: 'acme' }] } } }]);
+
+    expect(selection.seeded.find(({ artifactId }) => artifactId === 'skill:lint')?.seededBy).toStrictEqual([
+      { via: 'declaration', tierId: 'project' },
+      { via: 'source-catalog', tierId: 'project' },
+    ]);
+  });
+
+  // What survives the fold is what decided the final state, not every tier that ever mentioned the artifact.
+  it('names only the deciding tier after a use, a drop, and a use again', () => {
+    const selection = select([
+      { id: 'global', select: { skill: { use: ['lint'] } } },
+      { id: 'team', select: { skill: { drop: ['lint'] } } },
+      { id: 'project', select: { skill: { use: ['lint'] } } },
+    ]);
+
+    expect(selection.seeded).toStrictEqual([
+      { artifactId: 'skill:lint', seededBy: [{ via: 'declaration', tierId: 'project' }] },
+    ]);
+    expect(selection.declined).toStrictEqual([]);
+  });
+
+  it('records the tier that dropped an artifact, distinguishing declined from never mentioned', () => {
+    const selection = select([
+      { id: 'global', select: { skill: { use: ['lint'] } } },
+      { id: 'project', select: { skill: { drop: ['lint'] } } },
+    ]);
+
+    expect(selection.declined).toStrictEqual([{ artifactId: 'skill:lint', via: 'declaration', tierId: 'project' }]);
+    expect(selection.seeded).toStrictEqual([]);
+  });
+
+  it('discards every lower tier’s seeds and declines at a tier declaring reset', () => {
+    const selection = select([
+      { id: 'global', select: { skill: { use: ['lint'], drop: ['format'] } } },
+      { id: 'project', reset: true, select: { skill: { use: ['format'] } } },
+    ]);
+
+    expect(collectIds(selection)).toStrictEqual(['skill:format']);
+    expect(selection.declined).toStrictEqual([]);
+  });
+
+  it('runs seeded artifacts in id order, so two selections of one shape diff cleanly', () => {
+    const selection = select([
+      { id: 'project', select: { skill: { use: ['review', 'lint'] }, rulebook: { use: ['house-style'] } } },
+    ]);
+
+    expect(collectIds(selection)).toStrictEqual(['rulebook:house-style', 'skill:lint', 'skill:review']);
+  });
+
+  it.each([
+    ['an artifact no source carries', { skill: { use: ['absent'] } }, 'unknown-artifact'],
+    ['a source that is not declared', { skill: { use: [{ source: 'nowhere' }] } }, 'unknown-source'],
+    ['a source carrying nothing of the kind', { rulebook: { use: [{ source: 'acme' }] } }, 'empty-source'],
+    ['a kind the catalog does not carry', { partial: { use: ['x'] } }, 'unknown-kind'],
+  ])('reports %s as a diagnostic rather than a failure', (_label, block, code) => {
+    const selection = select([{ id: 'project', select: block }]);
+
+    expect(selection.diagnostics).toHaveLength(1);
+    expect(selection.diagnostics.at(0)?.code).toBe(code);
+  });
+
+  it('locates a diagnostic at the config entry responsible', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: ['lint', 'absent'] } } }]);
+
+    expect(selection.diagnostics.at(0)?.at).toStrictEqual({
+      tierId: 'project',
+      kindId: 'skill',
+      list: 'use',
+      index: 1,
+    });
+  });
+
+  it('collects every diagnostic, rather than stopping at the first', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: ['absent', 'missing'] } } }]);
+
+    expect(selection.diagnostics).toHaveLength(2);
+  });
+
+  // Every source in the fixture points at a directory that does not exist, so a filesystem read would fail here.
+  it('selects without reading anything from disk', () => {
+    const selection = select([{ id: 'project', select: { skill: { use: [{ source: 'acme' }] } } }]);
+
+    expect(catalog.sources.map(({ dir }) => dir)).toStrictEqual(['/nonexistent/local', '/nonexistent/acme']);
+    expect(collectIds(selection)).toHaveLength(3);
+  });
+});
+
+// region | Helpers
+
+/** The ids of the artifacts a selection seeded, in the order it runs them. */
+function collectIds(selection: Selection): Array<string> {
+  return selection.seeded.map(({ artifactId }) => artifactId);
+}
+
+/** The selection `tiers` makes from the shared catalog. */
+function select(tiers: ReadonlyArray<TierInput>): Selection {
+  return selectArtifacts(buildConfig(tiers), catalog);
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/selection/selectArtifacts.ts
+++ b/packages/compositor/src/selection/selectArtifacts.ts
@@ -5,12 +5,15 @@ import type { CompositorConfig, Selector } from '../schemas/config-schemas.ts';
 import type { Seed, SeedOrigin } from '../schemas/graph-schemas.ts';
 import type { Catalog } from '../schemas/resolution-schemas.ts';
 
-/** Where in a config something was declared, so a diagnostic reaches the entry an author wrote. */
+/**
+ * Where in a config something was declared, so a diagnostic reaches the entry an author wrote.
+ *
+ * `list` and `index` are absent together when the whole block is at fault rather than one entry in it.
+ */
 export interface ConfigEntryRef {
   readonly tierId: Id;
   readonly kindId: KindId;
-  readonly list: 'use' | 'drop';
-  /** Absent when the whole block is at fault rather than one entry in it. */
+  readonly list?: 'use' | 'drop';
   readonly index?: number;
 }
 
@@ -77,7 +80,7 @@ export function selectArtifacts(config: CompositorConfig, catalog: Catalog): Sel
         diagnostics.push({
           code: 'unknown-kind',
           message: `Kind "${block.kindId}" is not one the catalog carries.`,
-          at: { tierId: tier.id, kindId: block.kindId, list: 'use' },
+          at: { tierId: tier.id, kindId: block.kindId },
         });
         continue;
       }

--- a/packages/compositor/src/selection/selectArtifacts.ts
+++ b/packages/compositor/src/selection/selectArtifacts.ts
@@ -1,0 +1,214 @@
+import { compareStrings } from '../portable/compareStrings.ts';
+import type { ArtifactId, Id, KindId } from '../schemas/common.ts';
+import type { CompositorConfig, Selector } from '../schemas/config-schemas.ts';
+import type { Seed, SeedOrigin } from '../schemas/graph-schemas.ts';
+import type { Catalog } from '../schemas/resolution-schemas.ts';
+
+/** Where in a config something was declared, so a diagnostic reaches the entry an author wrote. */
+export interface ConfigEntryRef {
+  readonly tierId: Id;
+  readonly kindId: KindId;
+  readonly list: 'use' | 'drop';
+  /** Absent when the whole block is at fault rather than one entry in it. */
+  readonly index?: number;
+}
+
+/** One artifact a tier dropped and no higher tier re-adopted. */
+export interface DeclinedArtifact {
+  readonly artifactId: ArtifactId;
+  readonly via: SeedOrigin;
+  readonly tierId: Id;
+}
+
+/** One artifact a config selected, with the tiers whose seeds survived the fold. */
+export interface SeededArtifact {
+  readonly artifactId: ArtifactId;
+  readonly seededBy: ReadonlyArray<Seed>;
+}
+
+/** One selector that named something the catalog does not carry. */
+export interface SelectionDiagnostic {
+  readonly code: 'unknown-artifact' | 'unknown-kind' | 'unknown-source' | 'empty-source';
+  readonly message: string;
+  readonly at: ConfigEntryRef;
+}
+
+/**
+ * What a tiered config selects from a catalog.
+ *
+ * `seeded` and `declined` run in artifact-id order and `diagnostics` in config order, so two selections of the same
+ * shape diff cleanly. Each artifact's `seededBy` runs in tier order instead, matching the order a plan carries it in.
+ */
+export interface Selection {
+  readonly seeded: ReadonlyArray<SeededArtifact>;
+  readonly declined: ReadonlyArray<DeclinedArtifact>;
+  readonly diagnostics: ReadonlyArray<SelectionDiagnostic>;
+}
+
+/**
+ * The artifacts `config` selects from `catalog`, each with the tier that decided it.
+ *
+ * Pure and free of I/O: the catalog is the only view of the filesystem, so re-running this over a changed config reads
+ * nothing, which is what makes a shadow evaluation of an edited config free.
+ *
+ * The fold runs lowest tier first. Within a tier every `use` applies before every `drop`, and a tier declaring `reset`
+ * discards every lower tier's decisions first. Seeds and declines stay disjoint per artifact: a `drop` clears the seeds
+ * beneath it and records the decline, and a later `use` clears the decline and seeds afresh. What survives to the end is
+ * therefore what decided the final state, which is what tells a project-level opt-in from an inherited one.
+ *
+ * A selector matching nothing is a diagnostic rather than a failure, so validation can report every mistake in a config
+ * at once instead of stopping at the first.
+ */
+export function selectArtifacts(config: CompositorConfig, catalog: Catalog): Selection {
+  const index = buildCatalogIndex(catalog);
+  const seeds = new Map<ArtifactId, Array<Seed>>();
+  const declines = new Map<ArtifactId, DeclinedArtifact>();
+  const diagnostics: Array<SelectionDiagnostic> = [];
+
+  for (const tier of config.tiers) {
+    if (tier.reset) {
+      seeds.clear();
+      declines.clear();
+    }
+
+    for (const block of tier.select) {
+      if (!index.kindIds.has(block.kindId)) {
+        diagnostics.push({
+          code: 'unknown-kind',
+          message: `Kind "${block.kindId}" is not one the catalog carries.`,
+          at: { tierId: tier.id, kindId: block.kindId, list: 'use' },
+        });
+        continue;
+      }
+
+      for (const [list, selectors] of [
+        ['use', block.use],
+        ['drop', block.drop],
+      ] as const) {
+        for (const [entryIndex, selector] of selectors.entries()) {
+          const at: ConfigEntryRef = { tierId: tier.id, kindId: block.kindId, list, index: entryIndex };
+          const matched = expandSelector(selector, block.kindId, index, at, diagnostics);
+          for (const artifactId of matched) {
+            if (list === 'use') {
+              addSeed(seeds, artifactId, { via: readOrigin(selector), tierId: tier.id });
+              declines.delete(artifactId);
+            } else {
+              seeds.delete(artifactId);
+              declines.set(artifactId, { artifactId, via: readOrigin(selector), tierId: tier.id });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    seeded: [...seeds]
+      .map(([artifactId, seededBy]) => ({ artifactId, seededBy }))
+      .toSorted((left, right) => compareStrings(left.artifactId, right.artifactId)),
+    declined: declines
+      .values()
+      .toArray()
+      .toSorted((left, right) => compareStrings(left.artifactId, right.artifactId)),
+    diagnostics,
+  };
+}
+
+// region | Helpers
+
+/** The catalog as selection reads it: what exists, and which artifacts each source carries. */
+interface CatalogIndex {
+  readonly kindIds: ReadonlySet<KindId>;
+  readonly sourceIds: ReadonlySet<Id>;
+  /** Keyed by kind, then slug. */
+  readonly bySlug: ReadonlyMap<KindId, ReadonlyMap<string, ArtifactId>>;
+  /** Keyed by kind, then source, in catalog order. Carries an artifact under every source that has a copy of it. */
+  readonly bySource: ReadonlyMap<KindId, ReadonlyMap<Id, ReadonlyArray<ArtifactId>>>;
+}
+
+/** Records one seed against an artifact, unless that tier already seeded it the same way. */
+function addSeed(seeds: Map<ArtifactId, Array<Seed>>, artifactId: ArtifactId, seed: Seed): void {
+  const existing = seeds.get(artifactId) ?? [];
+  if (existing.some((held) => held.via === seed.via && held.tierId === seed.tierId)) {
+    return;
+  }
+  existing.push(seed);
+  seeds.set(artifactId, existing);
+}
+
+/**
+ * The catalog indexed for lookup by slug and by source.
+ *
+ * The by-source index carries an artifact under every source that has a copy, shadowed as well as winning. Shadowing
+ * decides which copy an artifact resolves from; selection decides which artifacts are in play, and a source a consumer
+ * took whole carries the artifact whether or not it won it.
+ */
+function buildCatalogIndex(catalog: Catalog): CatalogIndex {
+  const bySlug = new Map<KindId, Map<string, ArtifactId>>();
+  const bySource = new Map<KindId, Map<Id, Array<ArtifactId>>>();
+
+  for (const entry of catalog.entries) {
+    const slugs = bySlug.get(entry.kindId) ?? new Map<string, ArtifactId>();
+    slugs.set(entry.slug, entry.id);
+    bySlug.set(entry.kindId, slugs);
+
+    const sources = bySource.get(entry.kindId) ?? new Map<Id, Array<ArtifactId>>();
+    for (const candidate of [entry.resolution.winner, ...entry.resolution.shadowed]) {
+      const carried = sources.get(candidate.sourceId) ?? [];
+      carried.push(entry.id);
+      sources.set(candidate.sourceId, carried);
+    }
+    bySource.set(entry.kindId, sources);
+  }
+
+  return {
+    kindIds: new Set(catalog.kinds.map(({ id }) => id)),
+    sourceIds: new Set(catalog.sources.map(({ id }) => id)),
+    bySlug,
+    bySource,
+  };
+}
+
+/** The artifacts `selector` names, appending a diagnostic and matching nothing when it names something unknown. */
+function expandSelector(
+  selector: Selector,
+  kindId: KindId,
+  index: CatalogIndex,
+  at: ConfigEntryRef,
+  diagnostics: Array<SelectionDiagnostic>,
+): ReadonlyArray<ArtifactId> {
+  if ('artifact' in selector) {
+    const artifactId = index.bySlug.get(kindId)?.get(selector.artifact);
+    if (artifactId === undefined) {
+      diagnostics.push({
+        code: 'unknown-artifact',
+        message: `No source carries "${selector.artifact}" of kind "${kindId}".`,
+        at,
+      });
+      return [];
+    }
+    return [artifactId];
+  }
+
+  if (!index.sourceIds.has(selector.source)) {
+    diagnostics.push({ code: 'unknown-source', message: `Source "${selector.source}" is not declared.`, at });
+    return [];
+  }
+
+  const carried = index.bySource.get(kindId)?.get(selector.source) ?? [];
+  if (carried.length === 0) {
+    diagnostics.push({
+      code: 'empty-source',
+      message: `Source "${selector.source}" carries nothing of kind "${kindId}".`,
+      at,
+    });
+  }
+  return carried;
+}
+
+/** How a selector named what it named, which is the origin a seed or a decline records. */
+function readOrigin(selector: Selector): SeedOrigin {
+  return 'artifact' in selector ? 'declaration' : 'source-catalog';
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/selection/selectArtifacts.ts
+++ b/packages/compositor/src/selection/selectArtifacts.ts
@@ -1,3 +1,4 @@
+import { appendTo } from '../portable/appendTo.ts';
 import { compareStrings } from '../portable/compareStrings.ts';
 import type { ArtifactId, Id, KindId } from '../schemas/common.ts';
 import type { CompositorConfig, Selector } from '../schemas/config-schemas.ts';
@@ -53,8 +54,8 @@ export interface Selection {
  *
  * The fold runs lowest tier first. Within a tier every `use` applies before every `drop`, and a tier declaring `reset`
  * discards every lower tier's decisions first. Seeds and declines stay disjoint per artifact: a `drop` clears the seeds
- * beneath it and records the decline, and a later `use` clears the decline and seeds afresh. What survives to the end is
- * therefore what decided the final state, which is what tells a project-level opt-in from an inherited one.
+ * beneath it and records the decline, and a later `use` clears the decline and seeds afresh. What survives to the end
+ * is therefore what decided the final state, which is what tells a project-level opt-in from an inherited one.
  *
  * A selector matching nothing is a diagnostic rather than a failure, so validation can report every mistake in a config
  * at once instead of stopping at the first.
@@ -154,9 +155,7 @@ function buildCatalogIndex(catalog: Catalog): CatalogIndex {
 
     const sources = bySource.get(entry.kindId) ?? new Map<Id, Array<ArtifactId>>();
     for (const candidate of [entry.resolution.winner, ...entry.resolution.shadowed]) {
-      const carried = sources.get(candidate.sourceId) ?? [];
-      carried.push(entry.id);
-      sources.set(candidate.sourceId, carried);
+      appendTo(sources, candidate.sourceId, entry.id);
     }
     bySource.set(entry.kindId, sources);
   }

--- a/packages/compositor/src/selection/selectArtifacts.ts
+++ b/packages/compositor/src/selection/selectArtifacts.ts
@@ -46,7 +46,7 @@ export interface Selection {
 }
 
 /**
- * The artifacts `config` selects from `catalog`, each with the tier that decided it.
+ * Selects the artifacts `config` asks for from `catalog`, recording the tier that decided each.
  *
  * Pure and free of I/O: the catalog is the only view of the filesystem, so re-running this over a changed config reads
  * nothing, which is what makes a shadow evaluation of an edited config free.
@@ -137,7 +137,7 @@ function addSeed(seeds: Map<ArtifactId, Array<Seed>>, artifactId: ArtifactId, se
 }
 
 /**
- * The catalog indexed for lookup by slug and by source.
+ * Indexes the catalog for lookup by slug and by source.
  *
  * The by-source index carries an artifact under every source that has a copy, shadowed as well as winning. Shadowing
  * decides which copy an artifact resolves from; selection decides which artifacts are in play, and a source a consumer
@@ -169,7 +169,7 @@ function buildCatalogIndex(catalog: Catalog): CatalogIndex {
   };
 }
 
-/** The artifacts `selector` names, appending a diagnostic and matching nothing when it names something unknown. */
+/** Expands `selector` to the artifacts it names, appending a diagnostic and matching nothing when it names none. */
 function expandSelector(
   selector: Selector,
   kindId: KindId,
@@ -206,7 +206,7 @@ function expandSelector(
   return carried;
 }
 
-/** How a selector named what it named, which is the origin a seed or a decline records. */
+/** Reads how a selector named what it named, which is the origin a seed or a decline records. */
 function readOrigin(selector: Selector): SeedOrigin {
   return 'artifact' in selector ? 'declaration' : 'source-catalog';
 }

--- a/packages/compositor/src/selection/test-utils/buildCatalog.ts
+++ b/packages/compositor/src/selection/test-utils/buildCatalog.ts
@@ -19,7 +19,7 @@ export interface CatalogSpec {
 }
 
 /**
- * A catalog carrying exactly what `spec` describes, with entries in the id order a real catalog runs in.
+ * Builds a catalog carrying exactly what `spec` describes, with entries in the id order a real catalog runs in.
  *
  * Every source points at a directory that does not exist. Selection never reads one, so a test that accidentally grew a
  * filesystem dependency fails rather than passing against whatever happened to be on disk.

--- a/packages/compositor/src/selection/test-utils/buildCatalog.ts
+++ b/packages/compositor/src/selection/test-utils/buildCatalog.ts
@@ -1,0 +1,58 @@
+import { compareStrings } from '../../portable/compareStrings.ts';
+import { composeArtifactId } from '../../resolution/composeArtifactId.ts';
+import type { Catalog } from '../../schemas/resolution-schemas.ts';
+import { CATALOG_SCHEMA_VERSION } from '../../schemas/resolution-schemas.ts';
+
+/** One artifact the catalog carries, and the sources carrying a copy of it, highest precedence first. */
+export interface CatalogEntrySpec {
+  readonly kindId: string;
+  readonly slug: string;
+  readonly carriedBy: ReadonlyArray<string>;
+}
+
+/** What a catalog should carry, stated as briefly as a selection test needs. */
+export interface CatalogSpec {
+  /** Defaults to the kinds the entries name. State it to declare a kind that carries no entries. */
+  readonly kinds?: ReadonlyArray<string>;
+  readonly sources: ReadonlyArray<string>;
+  readonly entries: ReadonlyArray<CatalogEntrySpec>;
+}
+
+/**
+ * A catalog carrying exactly what `spec` describes, with entries in the id order a real catalog runs in.
+ *
+ * Every source points at a directory that does not exist. Selection never reads one, so a test that accidentally grew a
+ * filesystem dependency fails rather than passing against whatever happened to be on disk.
+ */
+export function buildCatalog(spec: CatalogSpec): Catalog {
+  const kindIds = spec.kinds ?? [...new Set(spec.entries.map(({ kindId }) => kindId))];
+
+  return {
+    schemaVersion: CATALOG_SCHEMA_VERSION,
+    kinds: kindIds.map((id) => ({
+      id,
+      label: id,
+      emitsFiles: true,
+      layout: { form: 'file' as const, root: id, extension: '.md' },
+    })),
+    sources: spec.sources.map((name) => ({
+      id: name,
+      name,
+      origin: { kind: 'directory' as const, location: `./${name}` },
+      dir: `/nonexistent/${name}`,
+    })),
+    entries: spec.entries
+      .map(({ kindId, slug, carriedBy }) => {
+        const [winner, ...shadowed] = carriedBy.map((sourceId) => ({
+          sourceId,
+          path: `${kindId}/${slug}.md`,
+          hash: `hash:${sourceId}:${slug}`,
+        }));
+        if (winner === undefined) {
+          throw new Error(`Entry "${kindId}:${slug}" names no source carrying it.`);
+        }
+        return { id: composeArtifactId(kindId, slug), kindId, slug, resolution: { winner, shadowed } };
+      })
+      .toSorted((left, right) => compareStrings(left.id, right.id)),
+  };
+}

--- a/packages/compositor/src/test-utils/buildConfig.ts
+++ b/packages/compositor/src/test-utils/buildConfig.ts
@@ -1,5 +1,5 @@
-import type { CompositorConfig } from '../../schemas/config-schemas.ts';
-import { CompositorConfigSchema } from '../../schemas/config-schemas.ts';
+import type { CompositorConfig } from '../schemas/config-schemas.ts';
+import { CompositorConfigSchema } from '../schemas/config-schemas.ts';
 
 /**
  * One tier as a test declares it: an authored body, plus an identity defaulted from its position.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
 
   packages/compositor:
     dependencies:
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
       zod:
         specifier: 4.4.3
         version: 4.4.3


### PR DESCRIPTION
## What

Adds tiered content selection. A consumer declares what it wants (named artifacts, everything from a given source, unwanted artifacts) and gets back exactly what was requested, each item having its provenance attached. Tiers stack the way layered config usually does: A project inherits what the tiers beneath it declared, and can extend that, refuse parts of it, or clear the slate and start fresh. Content selection is generic: The consumer names the tiers and the kinds of artifacts.

## Why

The compositor could already answer what content exists, but nothing let a consumer say which of it they wanted, so the catalog had no consumer and the engine had no input. Config injectability is what the What-if flow and the UI's live recompute loop rest on: both need an edited declaration evaluated without a second pass over the filesystem.

## Details

### 🏗️ Internal features

- `CompositorConfigSchema` and the schemas beneath it define a tiered declaration that normalizes as it parses: a bare slug becomes an entry, `path` or `package` becomes a source origin, and a kind-keyed mapping becomes an array ordered by kind. Every schema accepts its own output, so a config already parsed can be modified and re-parsed without being converted back first.
- `loadConfig` reads one file per tier, in YAML or JSON. A tier whose file is absent contributes no tier; one whose file is present but empty contributes a tier declaring nothing.
- `resolveSources` folds the tiers into the ordered source list resolution reads, and `locatePackage` finds a declared package's content directory by walking the `node_modules` chain from the tier that declared it, reading the content key the consumer names.
- `selectArtifacts` folds a config against a catalog into seeded artifacts, declined artifacts, and diagnostics. It imports nothing from `node:fs`, so the catalog is its only view of the filesystem.
- The configuration and selection surface is reachable from the package entry point.

### ♻️ Refactoring

- `readFileIfPresent` moves to `portable/`, beside the `isMissingFile` it wraps, and `buildConfig` moves to `src/test-utils/` so selection's tests no longer reach into config's private helpers.

### 🧪 Tests

- Four test files covering parsing and normalization, file loading, source resolution, and selection. Coverage discriminates per-tier anchoring: two tiers declaring the same relative path, and the same package name, from different base directories each resolve against the directory that tier declared.

### 📚 Documentation

- The README gains sections stating how a configuration is declared, how tiers combine, and how selecting from a catalog relates to resolving one.

Closes #176
