### PR TITLE
#184 Give the flow modules' helpers their own modules

### DIFF
--- a/packages/compositor/src/__tests__/index.unit.test.ts
+++ b/packages/compositor/src/__tests__/index.unit.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import * as loadConfig from '../config/loadConfig.ts';
+import * as locatePackage from '../config/locatePackage.ts';
+import * as resolveSources from '../config/resolveSources.ts';
 import * as consistencyError from '../consistency/ConsistencyError.ts';
 import * as graphTraversal from '../graph/traversal.ts';
 import * as entry from '../index.ts';
@@ -10,17 +13,21 @@ import * as composeArtifactId from '../resolution/composeArtifactId.ts';
 import * as enumerateSource from '../resolution/enumerateSource.ts';
 import * as resolveCatalog from '../resolution/resolveCatalog.ts';
 import * as commonSchemas from '../schemas/common.ts';
+import * as configSchemas from '../schemas/config-schemas.ts';
 import * as descriptorSchemas from '../schemas/descriptor-schemas.ts';
 import * as fileSchemas from '../schemas/file-schemas.ts';
 import * as graphSchemas from '../schemas/graph-schemas.ts';
 import * as planSchema from '../schemas/plan-schema.ts';
 import * as resolutionSchemas from '../schemas/resolution-schemas.ts';
+import * as selectArtifacts from '../selection/selectArtifacts.ts';
 
-// Every module the entry publishes in full. `portable/`, `plan/checks/`, `resolution/checks/`,
+// Every module the entry publishes a runtime member from. `portable/`, `plan/checks/`, `resolution/checks/`,
 // `resolution/assertSourceIsReadable.ts`, and every `consistency/` module but `ConsistencyError` are engine internals
-// the entry publishes nothing from, so they are absent rather than overlooked.
+// the entry publishes nothing from, so they are absent rather than overlooked. `selection/SelectionDiagnostic.ts` is
+// published but declares only types, so it contributes no runtime member for this check to compare.
 const publishedModules: ReadonlyArray<readonly [string, Record<string, unknown>]> = [
   ['common', commonSchemas],
+  ['config-schemas', configSchemas],
   ['descriptor-schemas', descriptorSchemas],
   ['file-schemas', fileSchemas],
   ['graph-schemas', graphSchemas],
@@ -32,8 +39,12 @@ const publishedModules: ReadonlyArray<readonly [string, Record<string, unknown>]
   ['ConsistencyError', consistencyError],
   ['enumerateSource', enumerateSource],
   ['graph/traversal', graphTraversal],
+  ['loadConfig', loadConfig],
+  ['locatePackage', locatePackage],
   ['plan/traversal', planTraversal],
   ['resolveCatalog', resolveCatalog],
+  ['resolveSources', resolveSources],
+  ['selectArtifacts', selectArtifacts],
 ];
 
 describe('package entry', () => {

--- a/packages/compositor/src/__tests__/index.unit.test.ts
+++ b/packages/compositor/src/__tests__/index.unit.test.ts
@@ -1,57 +1,48 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
-import * as loadConfig from '../config/loadConfig.ts';
-import * as locatePackage from '../config/locatePackage.ts';
-import * as resolveSources from '../config/resolveSources.ts';
-import * as consistencyError from '../consistency/ConsistencyError.ts';
-import * as graphTraversal from '../graph/traversal.ts';
 import * as entry from '../index.ts';
-import * as assertPlanIsConsistent from '../plan/assertPlanIsConsistent.ts';
-import * as planTraversal from '../plan/traversal.ts';
-import * as assertCatalogIsConsistent from '../resolution/assertCatalogIsConsistent.ts';
-import * as composeArtifactId from '../resolution/composeArtifactId.ts';
-import * as enumerateSource from '../resolution/enumerateSource.ts';
-import * as resolveCatalog from '../resolution/resolveCatalog.ts';
-import * as commonSchemas from '../schemas/common.ts';
-import * as configSchemas from '../schemas/config-schemas.ts';
-import * as descriptorSchemas from '../schemas/descriptor-schemas.ts';
-import * as fileSchemas from '../schemas/file-schemas.ts';
-import * as graphSchemas from '../schemas/graph-schemas.ts';
-import * as planSchema from '../schemas/plan-schema.ts';
-import * as resolutionSchemas from '../schemas/resolution-schemas.ts';
-import * as selectArtifacts from '../selection/selectArtifacts.ts';
 
-// Every module the entry publishes a runtime member from. `portable/`, `plan/checks/`, `resolution/checks/`,
-// `resolution/assertSourceIsReadable.ts`, and every `consistency/` module but `ConsistencyError` are engine internals
-// the entry publishes nothing from, so they are absent rather than overlooked. `selection/SelectionDiagnostic.ts` is
-// published but declares only types, so it contributes no runtime member for this check to compare.
-const publishedModules: ReadonlyArray<readonly [string, Record<string, unknown>]> = [
-  ['common', commonSchemas],
-  ['config-schemas', configSchemas],
-  ['descriptor-schemas', descriptorSchemas],
-  ['file-schemas', fileSchemas],
-  ['graph-schemas', graphSchemas],
-  ['plan-schema', planSchema],
-  ['resolution-schemas', resolutionSchemas],
-  ['assertCatalogIsConsistent', assertCatalogIsConsistent],
-  ['assertPlanIsConsistent', assertPlanIsConsistent],
-  ['composeArtifactId', composeArtifactId],
-  ['ConsistencyError', consistencyError],
-  ['enumerateSource', enumerateSource],
-  ['graph/traversal', graphTraversal],
-  ['loadConfig', loadConfig],
-  ['locatePackage', locatePackage],
-  ['plan/traversal', planTraversal],
-  ['resolveCatalog', resolveCatalog],
-  ['resolveSources', resolveSources],
-  ['selectArtifacts', selectArtifacts],
-];
+const entryPath = path.join(import.meta.dirname, '../index.ts');
+
+// The entry's own re-export specifiers name every module it publishes from, so the list is read from the source. A
+// module declaring only types contributes no runtime member and passes trivially.
+const publishedModules = await readPublishedModules();
 
 describe('package entry', () => {
-  it.each(publishedModules)('re-exports every runtime member of %s', (_label, module) => {
+  it.each(publishedModules)('re-exports every runtime member of %s', (_specifier, module) => {
     const exported = new Set(Object.keys(entry));
     const missing = Object.keys(module).filter((name) => !exported.has(name));
 
     expect(missing).toStrictEqual([]);
   });
+
+  // An empty list would make every case above vanish, leaving the suite green having checked nothing.
+  it('finds modules to check', () => {
+    expect(publishedModules.length).toBeGreaterThan(0);
+  });
 });
+
+// region | Helpers
+
+/** Every module the entry re-exports from, paired with its namespace, ordered by specifier. */
+async function readPublishedModules(): Promise<Array<readonly [string, Record<string, unknown>]>> {
+  const source = await readFile(entryPath, 'utf8');
+  const matched = source
+    .matchAll(/ from '(\.\/[^']+)'/g)
+    .map((match) => match.at(1))
+    .filter((specifier) => specifier !== undefined)
+    .toArray();
+  const specifiers = [...new Set(matched)];
+
+  return Promise.all(
+    specifiers.toSorted().map(async (specifier) => {
+      const module: Record<string, unknown> = await import(specifier.replace(/^\.\//, '../'));
+      return [specifier, module] as const;
+    }),
+  );
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
@@ -1,4 +1,3 @@
-import { homedir } from 'node:os';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -85,18 +84,6 @@ describe(resolveSources, () => {
 
     await expect(resolveSources(config, options)).resolves.toMatchObject({ declined: [] });
     await expect(collectNames(config)).resolves.toStrictEqual(['local']);
-  });
-
-  it.each([
-    ['a relative path against the declaring tier', './content', path.join('/srv/tier', 'content')],
-    ['an absolute path unchanged', '/srv/elsewhere', '/srv/elsewhere'],
-    ['a home-relative path', '~/guidance', path.join(homedir(), 'guidance')],
-  ])('resolves %s', async (_label, location, expected) => {
-    const config = buildConfig([{ baseDir: '/srv/tier', sources: { use: [{ name: 'x', path: location }] } }]);
-
-    const { sources } = await resolveSources(config, options);
-
-    expect(sources.at(0)?.dir).toBe(expected);
   });
 
   // Both tiers declare the same relative path, so anchoring every tier at one base directory collapses the two answers.

--- a/packages/compositor/src/config/resolveSources.ts
+++ b/packages/compositor/src/config/resolveSources.ts
@@ -1,7 +1,5 @@
-import { homedir } from 'node:os';
-import path from 'node:path';
-
 import { compareStrings } from '../portable/compareStrings.ts';
+import { expandPath } from '../portable/expandPath.ts';
 import type { CompositorConfig } from '../schemas/config-schemas.ts';
 import type { SourceOrigin } from '../schemas/descriptor-schemas.ts';
 import type { SourceSpec } from '../schemas/resolution-schemas.ts';
@@ -87,7 +85,7 @@ async function buildSpec(name: string, folded: FoldedSource, options: ResolveSou
     const dir =
       origin.kind === 'package'
         ? await locatePackage(origin.location, { baseDir, contentKeyPath: options.contentKeyPath })
-        : resolveDirectory(origin.location, baseDir);
+        : expandPath(origin.location, baseDir);
     return { id: name, name, origin, dir };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
@@ -98,22 +96,6 @@ async function buildSpec(name: string, folded: FoldedSource, options: ResolveSou
 /** Orders two sources higher tier first, then by author order, which is precedence descending. */
 function comparePrecedence(left: FoldedSource, right: FoldedSource): number {
   return left.tierIndex === right.tierIndex ? left.order - right.order : right.tierIndex - left.tierIndex;
-}
-
-/**
- * Resolves an authored directory location to an absolute path.
- *
- * A leading `~` expands to the home directory, an already-absolute path stands, and a relative path resolves against
- * the tier that declared it rather than against wherever the process happens to be running.
- */
-function resolveDirectory(location: string, baseDir: string): string {
-  if (location === '~' || location.startsWith('~/')) {
-    return path.join(homedir(), location.slice(1));
-  }
-  if (path.isAbsolute(location)) {
-    return location;
-  }
-  return path.resolve(baseDir, location);
 }
 
 // endregion | Helpers

--- a/packages/compositor/src/config/test-utils/buildConfigDir.ts
+++ b/packages/compositor/src/config/test-utils/buildConfigDir.ts
@@ -1,26 +1,6 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
+import { buildTempTree } from '../../test-utils/buildTempTree.ts';
 
-import { onTestFinished } from 'vitest';
-
-/**
- * Creates a directory holding each path in `files` with the given content, removed when the test ends.
- *
- * Writes a real tree rather than mocking the filesystem, because what loading answers is how Node reports an absent
- * file against a present one -- the very layer a mock would replace with an assumption.
- */
+/** A directory holding each path in `files` with the given content, removed when the test ends. */
 export async function buildConfigDir(files: Record<string, string>): Promise<string> {
-  const dir = await mkdtemp(path.join(tmpdir(), 'compositor-config-'));
-  onTestFinished(async () => {
-    await rm(dir, { recursive: true, force: true });
-  });
-
-  for (const [relativePath, content] of Object.entries(files)) {
-    const filePath = path.join(dir, relativePath);
-    await mkdir(path.dirname(filePath), { recursive: true });
-    await writeFile(filePath, content, 'utf8');
-  }
-
-  return dir;
+  return buildTempTree(files, 'compositor-config');
 }

--- a/packages/compositor/src/index.ts
+++ b/packages/compositor/src/index.ts
@@ -118,11 +118,6 @@ export {
   ResolveKindSchema,
   SourceSpecSchema,
 } from './schemas/resolution-schemas.ts';
-export type {
-  ConfigEntryRef,
-  DeclinedArtifact,
-  SeededArtifact,
-  Selection,
-  SelectionDiagnostic,
-} from './selection/selectArtifacts.ts';
+export type { DeclinedArtifact, SeededArtifact, Selection } from './selection/selectArtifacts.ts';
 export { selectArtifacts } from './selection/selectArtifacts.ts';
+export type { ConfigEntryRef, SelectionDiagnostic } from './selection/SelectionDiagnostic.ts';

--- a/packages/compositor/src/portable/__tests__/appendTo.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/appendTo.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendTo } from '../appendTo.ts';
+
+describe(appendTo, () => {
+  it('starts a list when the key is new', () => {
+    const index = new Map<string, Array<number>>();
+
+    appendTo(index, 'skill', 1);
+
+    expect(index.get('skill')).toStrictEqual([1]);
+  });
+
+  it('appends to the list a key already maps to, keeping insertion order', () => {
+    const index = new Map<string, Array<number>>([['skill', [1]]]);
+
+    appendTo(index, 'skill', 2);
+    appendTo(index, 'skill', 3);
+
+    expect(index.get('skill')).toStrictEqual([1, 2, 3]);
+  });
+
+  it('keeps a repeated value, since sameness is the caller’s question rather than the index’s', () => {
+    const index = new Map<string, Array<number>>();
+
+    appendTo(index, 'skill', 1);
+    appendTo(index, 'skill', 1);
+
+    expect(index.get('skill')).toStrictEqual([1, 1]);
+  });
+
+  it('leaves other keys untouched', () => {
+    const index = new Map<string, Array<number>>([['rulebook', [9]]]);
+
+    appendTo(index, 'skill', 1);
+
+    expect(index.get('rulebook')).toStrictEqual([9]);
+  });
+});

--- a/packages/compositor/src/portable/__tests__/expandPath.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/expandPath.unit.test.ts
@@ -1,0 +1,32 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { expandPath } from '../expandPath.ts';
+
+describe(expandPath, () => {
+  it('resolves a relative location against the base directory, not the working directory', () => {
+    expect(expandPath('./content', '/srv/tier')).toBe(path.join('/srv/tier', 'content'));
+  });
+
+  it('resolves a relative location that climbs out of the base directory', () => {
+    expect(expandPath('../shared', '/srv/tier')).toBe(path.join('/srv', 'shared'));
+  });
+
+  it('leaves an absolute location unchanged, so the base directory cannot move it', () => {
+    expect(expandPath('/srv/elsewhere', '/srv/tier')).toBe('/srv/elsewhere');
+  });
+
+  it('expands a home-relative location', () => {
+    expect(expandPath('~/guidance', '/srv/tier')).toBe(path.join(homedir(), 'guidance'));
+  });
+
+  it('expands a bare tilde to the home directory itself', () => {
+    expect(expandPath('~', '/srv/tier')).toBe(homedir());
+  });
+
+  it('resolves a ~user location as relative, since only the current user’s home is expanded', () => {
+    expect(expandPath('~other/guidance', '/srv/tier')).toBe(path.join('/srv/tier', '~other/guidance'));
+  });
+});

--- a/packages/compositor/src/portable/__tests__/hash-content.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/hash-content.unit.test.ts
@@ -1,0 +1,37 @@
+import { Buffer } from 'node:buffer';
+
+import { describe, expect, it } from 'vitest';
+
+import { hashBytes, hashUtf8 } from '../hash-content.ts';
+
+describe(hashBytes, () => {
+  it('names the algorithm that produced the digest, so a stored hash stays readable when another is added', () => {
+    expect(hashBytes(Buffer.from('lint', 'utf8'))).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it('gives equal bytes equal digests', () => {
+    expect(hashBytes(Buffer.from('lint', 'utf8'))).toBe(hashBytes(Buffer.from('lint', 'utf8')));
+  });
+
+  it('gives differing bytes differing digests', () => {
+    expect(hashBytes(Buffer.from('lint', 'utf8'))).not.toBe(hashBytes(Buffer.from('format', 'utf8')));
+  });
+
+  it('digests empty input rather than refusing it', () => {
+    expect(hashBytes(new Uint8Array())).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});
+
+describe(hashUtf8, () => {
+  it('digests text over its UTF-8 bytes, which is the relationship the two functions promise', () => {
+    expect(hashUtf8('lint')).toBe(hashBytes(Buffer.from('lint', 'utf8')));
+  });
+
+  it('holds that relationship for text outside ASCII, where the byte count exceeds the character count', () => {
+    expect(hashUtf8('naïve — ✅')).toBe(hashBytes(Buffer.from('naïve — ✅', 'utf8')));
+  });
+
+  it('gives differing text differing digests', () => {
+    expect(hashUtf8('lint')).not.toBe(hashUtf8('format'));
+  });
+});

--- a/packages/compositor/src/portable/__tests__/hashDirectory.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/hashDirectory.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildTempTree } from '../../test-utils/buildTempTree.ts';
+import { hashDirectory } from '../hashDirectory.ts';
+
+describe(hashDirectory, () => {
+  it('gives two trees holding the same files the same digest', async () => {
+    const here = await buildTempTree({ 'SKILL.md': 'lint', 'run.mjs': 'v1' });
+    const there = await buildTempTree({ 'SKILL.md': 'lint', 'run.mjs': 'v1' });
+
+    await expect(hashDirectory(here)).resolves.toBe(await hashDirectory(there));
+  });
+
+  it('moves the digest when a file’s content changes', async () => {
+    const before = await buildTempTree({ 'run.mjs': 'v1' });
+    const after = await buildTempTree({ 'run.mjs': 'v2' });
+
+    await expect(hashDirectory(before)).resolves.not.toBe(await hashDirectory(after));
+  });
+
+  it('moves the digest when a file is renamed but its bytes are not, so paths take part', async () => {
+    const before = await buildTempTree({ 'run.mjs': 'v1' });
+    const after = await buildTempTree({ 'start.mjs': 'v1' });
+
+    await expect(hashDirectory(before)).resolves.not.toBe(await hashDirectory(after));
+  });
+
+  it('reaches files nested below the directory', async () => {
+    const before = await buildTempTree({ 'data/rules.json': '{"a":1}' });
+    const after = await buildTempTree({ 'data/rules.json': '{"a":2}' });
+
+    await expect(hashDirectory(before)).resolves.not.toBe(await hashDirectory(after));
+  });
+
+  it('leaves a dotfile out, so tool state cannot move the digest', async () => {
+    const bare = await buildTempTree({ 'SKILL.md': 'lint' });
+    const withToolState = await buildTempTree({ '.DS_Store': 'tool state', 'SKILL.md': 'lint' });
+
+    await expect(hashDirectory(bare)).resolves.toBe(await hashDirectory(withToolState));
+  });
+
+  it('leaves a dot directory’s contents out as well as the directory itself', async () => {
+    const bare = await buildTempTree({ 'SKILL.md': 'lint' });
+    const withToolState = await buildTempTree({ '.git/objects/deadbeef': 'object', 'SKILL.md': 'lint' });
+
+    await expect(hashDirectory(bare)).resolves.toBe(await hashDirectory(withToolState));
+  });
+
+  it('digests an empty directory rather than failing on it', async () => {
+    const dir = await buildTempTree({});
+
+    await expect(hashDirectory(dir)).resolves.toMatch(/^sha256:/);
+  });
+});

--- a/packages/compositor/src/portable/__tests__/listFilesRecursively.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/listFilesRecursively.unit.test.ts
@@ -1,3 +1,4 @@
+import { symlink } from 'node:fs/promises';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -47,6 +48,13 @@ describe(listFilesRecursively, () => {
     const dir = await buildTempTree({});
 
     await expect(sorted(path.join(dir, 'never-created'))).resolves.toStrictEqual([]);
+  });
+
+  it('leaves out a symlink whose target is gone, rather than naming a file nothing can read', async () => {
+    const dir = await buildTempTree({ 'notes.md': 'notes' });
+    await symlink(path.join(dir, 'never-created'), path.join(dir, 'dangling'));
+
+    await expect(sorted(dir)).resolves.toStrictEqual(['notes.md']);
   });
 });
 

--- a/packages/compositor/src/portable/__tests__/listFilesRecursively.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/listFilesRecursively.unit.test.ts
@@ -1,0 +1,60 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildTempTree } from '../../test-utils/buildTempTree.ts';
+import { listFilesRecursively } from '../listFilesRecursively.ts';
+
+describe(listFilesRecursively, () => {
+  it('names every file relative to the directory the walk started at', async () => {
+    const dir = await buildTempTree({ 'notes.md': 'notes', 'style.md': 'style' });
+
+    await expect(sorted(dir)).resolves.toStrictEqual(['notes.md', 'style.md']);
+  });
+
+  it('reaches files nested below the walk root, joining segments with a posix separator', async () => {
+    const dir = await buildTempTree({ 'deeply/nested/asset.json': '{}' });
+
+    await expect(sorted(dir)).resolves.toStrictEqual(['deeply/nested/asset.json']);
+  });
+
+  it('names files rather than the directories holding them', async () => {
+    const dir = await buildTempTree({ 'nested/inner.md': 'inner' });
+
+    await expect(sorted(dir)).resolves.toStrictEqual(['nested/inner.md']);
+  });
+
+  it('skips nothing by default, so a dotfile is listed like any other content', async () => {
+    const dir = await buildTempTree({ '.hidden': 'hidden', 'notes.md': 'notes' });
+
+    await expect(sorted(dir)).resolves.toStrictEqual(['.hidden', 'notes.md']);
+  });
+
+  it('leaves out an entry the caller skips by name', async () => {
+    const dir = await buildTempTree({ '.hidden': 'hidden', 'notes.md': 'notes' });
+
+    await expect(sorted(dir, (name) => name.startsWith('.'))).resolves.toStrictEqual(['notes.md']);
+  });
+
+  it('does not descend into a skipped directory, so its contents cost nothing to leave out', async () => {
+    const dir = await buildTempTree({ '.git/objects/deadbeef': 'object', 'notes.md': 'notes' });
+
+    // The nested file's own name matches no skip rule, so listing it would mean the walk entered `.git` anyway.
+    await expect(sorted(dir, (name) => name.startsWith('.'))).resolves.toStrictEqual(['notes.md']);
+  });
+
+  it('reports an absent directory as carrying nothing', async () => {
+    const dir = await buildTempTree({});
+
+    await expect(sorted(path.join(dir, 'never-created'))).resolves.toStrictEqual([]);
+  });
+});
+
+// region | Helpers
+
+/** The files beneath `dir` in a stable order, so a test states content rather than filesystem enumeration order. */
+async function sorted(dir: string, skipName?: (name: string) => boolean): Promise<Array<string>> {
+  return (await listFilesRecursively(dir, skipName === undefined ? {} : { skipName })).toSorted();
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/portable/__tests__/readDirNames.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/readDirNames.unit.test.ts
@@ -1,0 +1,41 @@
+import { chmod } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildTempTree } from '../../test-utils/buildTempTree.ts';
+import { readDirNames } from '../readDirNames.ts';
+
+describe(readDirNames, () => {
+  it('names the entries directly under the directory, files and directories alike', async () => {
+    const dir = await buildTempTree({ 'notes.md': 'notes', 'nested/inner.md': 'inner' });
+
+    await expect(readDirNames(dir)).resolves.toStrictEqual(expect.arrayContaining(['notes.md', 'nested']));
+  });
+
+  it('does not descend, so a nested entry is absent from the result', async () => {
+    const dir = await buildTempTree({ 'nested/inner.md': 'inner' });
+
+    await expect(readDirNames(dir)).resolves.toStrictEqual(['nested']);
+  });
+
+  it('reports an absent directory as carrying nothing', async () => {
+    const dir = await buildTempTree({});
+
+    await expect(readDirNames(path.join(dir, 'never-created'))).resolves.toStrictEqual([]);
+  });
+
+  it('fails rather than reporting an absence when the directory cannot be read', async () => {
+    const dir = await buildTempTree({ 'locked/inner.md': 'inner' });
+    const lockedDir = path.join(dir, 'locked');
+    await chmod(lockedDir, 0o000);
+
+    try {
+      // A permission problem must not read as an empty directory: a caller would take the absence at face value.
+      await expect(readDirNames(lockedDir)).rejects.toThrow(/EACCES/);
+    } finally {
+      // Restored before the fixture is removed, since the cleanup cannot descend into an unreadable directory.
+      await chmod(lockedDir, 0o755);
+    }
+  });
+});

--- a/packages/compositor/src/portable/__tests__/readFileIfPresent.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/readFileIfPresent.unit.test.ts
@@ -1,0 +1,46 @@
+import { chmod } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildTempTree } from '../../test-utils/buildTempTree.ts';
+import { readFileIfPresent } from '../readFileIfPresent.ts';
+
+describe(readFileIfPresent, () => {
+  it('reads a file that is there, as text', async () => {
+    const dir = await buildTempTree({ 'notes.md': 'notes' });
+
+    await expect(readFileIfPresent(path.join(dir, 'notes.md'))).resolves.toBe('notes');
+  });
+
+  it('reports nothing for an absent file', async () => {
+    const dir = await buildTempTree({});
+
+    await expect(readFileIfPresent(path.join(dir, 'never-created.md'))).resolves.toBeUndefined();
+  });
+
+  it('reports nothing for a path below a regular file, which fails as ENOTDIR rather than ENOENT', async () => {
+    const dir = await buildTempTree({ 'notes.md': 'notes' });
+
+    await expect(readFileIfPresent(path.join(dir, 'notes.md', 'below'))).resolves.toBeUndefined();
+  });
+
+  it('distinguishes an empty file from an absent one', async () => {
+    const dir = await buildTempTree({ 'empty.md': '' });
+
+    await expect(readFileIfPresent(path.join(dir, 'empty.md'))).resolves.toBe('');
+  });
+
+  it('fails rather than reporting an absence when the file cannot be read', async () => {
+    const dir = await buildTempTree({ 'locked.md': 'locked' });
+    const lockedFile = path.join(dir, 'locked.md');
+    await chmod(lockedFile, 0o000);
+
+    try {
+      // A permission problem must not read as an absent file: the caller would carry on as though nothing were there.
+      await expect(readFileIfPresent(lockedFile)).rejects.toThrow(/EACCES/);
+    } finally {
+      await chmod(lockedFile, 0o644);
+    }
+  });
+});

--- a/packages/compositor/src/portable/__tests__/statIfPresent.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/statIfPresent.unit.test.ts
@@ -1,0 +1,40 @@
+import { symlink } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildTempTree } from '../../test-utils/buildTempTree.ts';
+import { statIfPresent } from '../statIfPresent.ts';
+
+describe(statIfPresent, () => {
+  it('stats a file that is there', async () => {
+    const dir = await buildTempTree({ 'notes.md': 'notes' });
+
+    expect((await statIfPresent(path.join(dir, 'notes.md')))?.isFile()).toBe(true);
+  });
+
+  it('stats a directory that is there', async () => {
+    const dir = await buildTempTree({ 'nested/inner.md': 'inner' });
+
+    expect((await statIfPresent(path.join(dir, 'nested')))?.isDirectory()).toBe(true);
+  });
+
+  it('reports nothing for an absent path', async () => {
+    const dir = await buildTempTree({});
+
+    await expect(statIfPresent(path.join(dir, 'never-created'))).resolves.toBeUndefined();
+  });
+
+  it('reports nothing for a path below a regular file, which fails as ENOTDIR rather than ENOENT', async () => {
+    const dir = await buildTempTree({ 'notes.md': 'notes' });
+
+    await expect(statIfPresent(path.join(dir, 'notes.md', 'below'))).resolves.toBeUndefined();
+  });
+
+  it('follows a symlink to the directory it points at, which a linked install layout produces', async () => {
+    const dir = await buildTempTree({ 'elsewhere/shared/SKILL.md': 'shared' });
+    await symlink(path.join(dir, 'elsewhere/shared'), path.join(dir, 'linked'));
+
+    expect((await statIfPresent(path.join(dir, 'linked')))?.isDirectory()).toBe(true);
+  });
+});

--- a/packages/compositor/src/portable/__tests__/statIfPresent.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/statIfPresent.unit.test.ts
@@ -1,4 +1,4 @@
-import { symlink } from 'node:fs/promises';
+import { chmod, symlink } from 'node:fs/promises';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -36,5 +36,26 @@ describe(statIfPresent, () => {
     await symlink(path.join(dir, 'elsewhere/shared'), path.join(dir, 'linked'));
 
     expect((await statIfPresent(path.join(dir, 'linked')))?.isDirectory()).toBe(true);
+  });
+
+  it('reports nothing for a symlink whose target is gone, rather than the link itself', async () => {
+    const dir = await buildTempTree({});
+    await symlink(path.join(dir, 'never-created'), path.join(dir, 'dangling'));
+
+    await expect(statIfPresent(path.join(dir, 'dangling'))).resolves.toBeUndefined();
+  });
+
+  it('fails rather than reporting an absence when the path cannot be reached', async () => {
+    const dir = await buildTempTree({ 'locked/inner.md': 'inner' });
+    const lockedDir = path.join(dir, 'locked');
+    await chmod(lockedDir, 0o000);
+
+    try {
+      // Statting below an unsearchable directory fails with EACCES, which is a problem rather than an absence.
+      await expect(statIfPresent(path.join(lockedDir, 'inner.md'))).rejects.toThrow(/EACCES/);
+    } finally {
+      // Restored before the fixture is removed, since the cleanup cannot descend into an unreadable directory.
+      await chmod(lockedDir, 0o755);
+    }
   });
 });

--- a/packages/compositor/src/portable/__tests__/toPosix.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/toPosix.unit.test.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { toPosix } from '../toPosix.ts';
+
+describe(toPosix, () => {
+  it('renders a natively joined path with posix separators', () => {
+    // Built with `path.join` rather than written with literal backslashes: a literal would assert Windows behavior on
+    // every platform, and pass only where `path.sep` happens to be a backslash.
+    expect(toPosix(path.join('skills', 'lint', 'SKILL.md'))).toBe('skills/lint/SKILL.md');
+  });
+
+  it('leaves an already-posix path unchanged', () => {
+    expect(toPosix('skills/lint/SKILL.md')).toBe('skills/lint/SKILL.md');
+  });
+
+  it('leaves a path with no separator unchanged', () => {
+    expect(toPosix('SKILL.md')).toBe('SKILL.md');
+  });
+});

--- a/packages/compositor/src/portable/expandPath.ts
+++ b/packages/compositor/src/portable/expandPath.ts
@@ -1,0 +1,22 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+/**
+ * Expands an authored location to an absolute path, resolving a relative one against `baseDir`.
+ *
+ * A leading `~` expands to the home directory, an already-absolute path stands, and a relative path resolves against
+ * `baseDir` rather than against wherever the process happens to be running. Computes a path and reads nothing, so
+ * whether the result exists is the caller's question.
+ *
+ * Only the current user's home is expanded. A `~user` form names someone else's, which resolving would require reading
+ * the account database, so it falls through and resolves as the relative path it looks like.
+ */
+export function expandPath(location: string, baseDir: string): string {
+  if (location === '~' || location.startsWith('~/')) {
+    return path.join(homedir(), location.slice(1));
+  }
+  if (path.isAbsolute(location)) {
+    return location;
+  }
+  return path.resolve(baseDir, location);
+}

--- a/packages/compositor/src/portable/hashDirectory.ts
+++ b/packages/compositor/src/portable/hashDirectory.ts
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { Hash } from '../schemas/common.ts';
+import { compareStrings } from './compareStrings.ts';
+import { hashBytes, hashUtf8 } from './hash-content.ts';
+import { listFilesRecursively } from './listFilesRecursively.ts';
+
+/**
+ * A digest over everything under `dir`, keyed by each file's path within it.
+ *
+ * Covers a whole tree rather than any one file, because a directory-shaped artifact ships assets beside the file
+ * carrying its frontmatter and a rebuilt asset is a changed artifact. Paths take part in the digest, so moving a file
+ * within the tree moves the digest too. Dotfiles are left out as tool state rather than shipped content.
+ */
+export async function hashDirectory(dir: string): Promise<Hash> {
+  const relativePaths = (await listFilesRecursively(dir, { skipName: isToolState })).toSorted(compareStrings);
+  const perFile = await Promise.all(
+    relativePaths.map(async (relativePath) => {
+      const bytes = await readFile(path.join(dir, relativePath));
+      return `${relativePath}\n${hashBytes(bytes)}`;
+    }),
+  );
+  return hashUtf8(perFile.join('\n'));
+}
+
+// region | Helpers
+
+/** Reports whether `name` is a tool's own state rather than content the tree ships. */
+function isToolState(name: string): boolean {
+  return name.startsWith('.');
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/portable/listFilesRecursively.ts
+++ b/packages/compositor/src/portable/listFilesRecursively.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+
+import { readDirNames } from './readDirNames.ts';
+import { statIfPresent } from './statIfPresent.ts';
+
+/** What walking a tree needs beyond the directory to walk. */
+export interface ListFilesRecursivelyOptions {
+  /**
+   * Names to leave out, tested against each entry's own name rather than against its path.
+   *
+   * Applied during the walk, so a skipped directory is never descended into. Nothing is skipped by default: what
+   * counts as content is the caller's to decide, and a walker that dropped entries on its own would hide them from
+   * every caller that wanted them.
+   */
+  readonly skipName?: (name: string) => boolean;
+}
+
+/** Every file beneath `dir`, as posix paths relative to `dir` itself. */
+export async function listFilesRecursively(
+  dir: string,
+  options: ListFilesRecursivelyOptions = {},
+): Promise<Array<string>> {
+  return listFrom(dir, '', options.skipName);
+}
+
+// region | Helpers
+
+/** Every file beneath `dir`, as posix paths carrying `prefix`, the walk's position relative to where it started. */
+async function listFrom(
+  dir: string,
+  prefix: string,
+  skipName: ((name: string) => boolean) | undefined,
+): Promise<Array<string>> {
+  const names = (await readDirNames(dir)).filter((name) => skipName?.(name) !== true);
+  const nested = await Promise.all(
+    names.map(async (name) => {
+      const relativePath = prefix === '' ? name : `${prefix}/${name}`;
+      const entry = await statIfPresent(path.join(dir, name));
+      if (entry === undefined) {
+        return [];
+      }
+      return entry.isDirectory() ? await listFrom(path.join(dir, name), relativePath, skipName) : [relativePath];
+    }),
+  );
+  return nested.flat();
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/portable/readDirNames.ts
+++ b/packages/compositor/src/portable/readDirNames.ts
@@ -1,0 +1,20 @@
+import { readdir } from 'node:fs/promises';
+
+import { isMissingFile } from './isMissingFile.ts';
+
+/**
+ * The entry names directly under `dir`, or none when `dir` is absent.
+ *
+ * Any other failure rethrows, so a permission problem surfaces instead of reading as an empty directory and sending
+ * the caller on as though nothing were there.
+ */
+export async function readDirNames(dir: string): Promise<Array<string>> {
+  try {
+    return await readdir(dir);
+  } catch (error: unknown) {
+    if (isMissingFile(error)) {
+      return [];
+    }
+    throw error;
+  }
+}

--- a/packages/compositor/src/portable/statIfPresent.ts
+++ b/packages/compositor/src/portable/statIfPresent.ts
@@ -1,0 +1,21 @@
+import type { Stats } from 'node:fs';
+import { stat } from 'node:fs/promises';
+
+import { isMissingFile } from './isMissingFile.ts';
+
+/**
+ * The stats of `filePath`, or nothing when it is absent.
+ *
+ * Follows symlinks, which `readdir`'s own file types do not: a symlinked directory reports as a link rather than as
+ * the directory it points at, and under a linked layout that would hide its contents entirely.
+ */
+export async function statIfPresent(filePath: string): Promise<Stats | undefined> {
+  try {
+    return await stat(filePath);
+  } catch (error: unknown) {
+    if (isMissingFile(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}

--- a/packages/compositor/src/portable/toPosix.ts
+++ b/packages/compositor/src/portable/toPosix.ts
@@ -1,0 +1,6 @@
+import path from 'node:path';
+
+/** A path rendered with posix separators, so a value built on Windows matches one built anywhere else. */
+export function toPosix(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}

--- a/packages/compositor/src/resolution/__tests__/enumerateSource.unit.test.ts
+++ b/packages/compositor/src/resolution/__tests__/enumerateSource.unit.test.ts
@@ -106,6 +106,13 @@ describe(enumerateSource, () => {
     await expect(collectSlugs(source, [skillKind])).resolves.toStrictEqual(['lint', 'shared']);
   });
 
+  it('skips a symlinked artifact whose target is gone, rather than carrying one nothing can read', async () => {
+    const source = await buildSource({ 'skills/lint/SKILL.md': 'lint' });
+    await symlink(path.join(source.dir, 'skills/never-created'), path.join(source.dir, 'skills/dangling'));
+
+    await expect(collectSlugs(source, [skillKind])).resolves.toStrictEqual(['lint']);
+  });
+
   it('carries nothing for a kind whose root the source does not have', async () => {
     const source = await buildSource({ 'skills/lint/SKILL.md': 'lint' });
 

--- a/packages/compositor/src/resolution/__tests__/enumerateSource.unit.test.ts
+++ b/packages/compositor/src/resolution/__tests__/enumerateSource.unit.test.ts
@@ -160,20 +160,6 @@ describe('artifact digests', () => {
     await expect(requireArtifactHash(before, skillKind)).resolves.not.toBe(await requireArtifactHash(after, skillKind));
   });
 
-  it('moves a directory kind digest when an asset is renamed but its bytes are not', async () => {
-    const before = await buildSource({ 'skills/lint/SKILL.md': 'lint', 'skills/lint/run.mjs': 'v1' });
-    const after = await buildSource({ 'skills/lint/SKILL.md': 'lint', 'skills/lint/start.mjs': 'v1' });
-
-    await expect(requireArtifactHash(before, skillKind)).resolves.not.toBe(await requireArtifactHash(after, skillKind));
-  });
-
-  it('reaches assets nested below the artifact root', async () => {
-    const before = await buildSource({ 'skills/lint/SKILL.md': 'lint', 'skills/lint/data/rules.json': '{"a":1}' });
-    const after = await buildSource({ 'skills/lint/SKILL.md': 'lint', 'skills/lint/data/rules.json': '{"a":2}' });
-
-    await expect(requireArtifactHash(before, skillKind)).resolves.not.toBe(await requireArtifactHash(after, skillKind));
-  });
-
   it('gives the same artifact the same digest in two sources, so an identical copy is recognizable', async () => {
     const here = await buildSource({ 'skills/lint/SKILL.md': 'lint', 'skills/lint/run.mjs': 'v1' });
     const there = await buildSource({ 'skills/lint/SKILL.md': 'lint', 'skills/lint/run.mjs': 'v1' });

--- a/packages/compositor/src/resolution/enumerateSource.ts
+++ b/packages/compositor/src/resolution/enumerateSource.ts
@@ -1,9 +1,12 @@
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { compareStrings } from '../portable/compareStrings.ts';
-import { hashBytes, hashUtf8 } from '../portable/hash-content.ts';
-import { isMissingFile } from '../portable/isMissingFile.ts';
+import { hashBytes } from '../portable/hash-content.ts';
+import { hashDirectory } from '../portable/hashDirectory.ts';
+import { readDirNames } from '../portable/readDirNames.ts';
+import { statIfPresent } from '../portable/statIfPresent.ts';
+import { toPosix } from '../portable/toPosix.ts';
 import type { Hash, KindId } from '../schemas/common.ts';
 import type { ResolveKind, SourceSpec } from '../schemas/resolution-schemas.ts';
 
@@ -49,24 +52,6 @@ async function enumerateKind(sourceDir: string, kind: ResolveKind): Promise<Arra
 }
 
 /**
- * A digest over everything under `dir`, keyed by each file's path within it.
- *
- * Covers the whole artifact rather than its entry file alone, because a directory-shaped artifact ships assets beside
- * the file carrying its frontmatter and a rebuilt asset is a changed artifact. Paths take part in the digest, so moving
- * a file within the artifact moves the digest too. Dotfiles are left out as tool state rather than shipped content.
- */
-async function hashDirectory(dir: string): Promise<Hash> {
-  const relativePaths = (await listFilesRecursively(dir, '')).toSorted(compareStrings);
-  const perFile = await Promise.all(
-    relativePaths.map(async (relativePath) => {
-      const bytes = await readFile(path.join(dir, relativePath));
-      return `${relativePath}\n${hashBytes(bytes)}`;
-    }),
-  );
-  return hashUtf8(perFile.join('\n'));
-}
-
-/**
  * Reports whether `name` can name an artifact.
  *
  * A dot prefix is tool state and an underscore prefix is support content: an include target, a shared data directory,
@@ -75,22 +60,6 @@ async function hashDirectory(dir: string): Promise<Hash> {
  */
 function isArtifactName(name: string): boolean {
   return !name.startsWith('.') && !name.startsWith('_');
-}
-
-/** Every file beneath `dir`, as posix paths relative to the walk's root. */
-async function listFilesRecursively(dir: string, prefix: string): Promise<Array<string>> {
-  const names = (await readDirNames(dir)).filter((name) => !name.startsWith('.'));
-  const nested = await Promise.all(
-    names.map(async (name) => {
-      const relativePath = prefix === '' ? name : `${prefix}/${name}`;
-      const entry = await statOrUndefined(path.join(dir, name));
-      if (entry === undefined) {
-        return [];
-      }
-      return entry.isDirectory() ? await listFilesRecursively(path.join(dir, name), relativePath) : [relativePath];
-    }),
-  );
-  return nested.flat();
 }
 
 /**
@@ -102,7 +71,7 @@ async function listFilesRecursively(dir: string, prefix: string): Promise<Array<
  */
 async function readArtifact(rootDir: string, name: string, kind: ResolveKind): Promise<SourceArtifact | undefined> {
   const { layout } = kind;
-  const entry = await statOrUndefined(path.join(rootDir, name));
+  const entry = await statIfPresent(path.join(rootDir, name));
   if (entry === undefined) {
     return undefined;
   }
@@ -119,7 +88,7 @@ async function readArtifact(rootDir: string, name: string, kind: ResolveKind): P
     };
   }
 
-  const entryFile = await statOrUndefined(path.join(rootDir, name, layout.entryFile));
+  const entryFile = await statIfPresent(path.join(rootDir, name, layout.entryFile));
   if (!entry.isDirectory() || entryFile?.isFile() !== true) {
     return undefined;
   }
@@ -129,40 +98,6 @@ async function readArtifact(rootDir: string, name: string, kind: ResolveKind): P
     path: toPosix(path.join(layout.root, name, layout.entryFile)),
     hash: await hashDirectory(path.join(rootDir, name)),
   };
-}
-
-/** The entry names directly under `dir`, or none when `dir` is absent. */
-async function readDirNames(dir: string): Promise<Array<string>> {
-  try {
-    return await readdir(dir);
-  } catch (error: unknown) {
-    if (isMissingFile(error)) {
-      return [];
-    }
-    throw error;
-  }
-}
-
-/**
- * The stats of `filePath`, or nothing when it is absent.
- *
- * Follows symlinks, which `readdir`'s own file types do not: a symlinked artifact reports as a link rather than as the
- * directory it points at, and under a linked layout that would hide the artifact entirely.
- */
-async function statOrUndefined(filePath: string): Promise<Awaited<ReturnType<typeof stat>> | undefined> {
-  try {
-    return await stat(filePath);
-  } catch (error: unknown) {
-    if (isMissingFile(error)) {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-/** A path rendered with posix separators, so a catalog built on Windows matches one built anywhere else. */
-function toPosix(filePath: string): string {
-  return filePath.split(path.sep).join('/');
 }
 
 // endregion | Helpers

--- a/packages/compositor/src/resolution/test-utils/buildSource.ts
+++ b/packages/compositor/src/resolution/test-utils/buildSource.ts
@@ -1,31 +1,14 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
-
-import { onTestFinished } from 'vitest';
-
 import type { SourceSpec } from '../../schemas/resolution-schemas.ts';
+import { buildTempTree } from '../../test-utils/buildTempTree.ts';
 
 /**
  * A source directory holding each path in `files` with the given content, removed when the test ends.
- *
- * Writes a real tree rather than mocking the filesystem, because what enumeration and readability checking answer is
- * how Node reports directories, extensions, and absences -- the very layer a mock would replace with an assumption.
  *
  * `name` becomes the source's id, its name, and its temp-directory prefix, so a test resolving several sources can
  * tell which directory belongs to which.
  */
 export async function buildSource(files: Record<string, string>, name = 'fixture'): Promise<SourceSpec> {
-  const dir = await mkdtemp(path.join(tmpdir(), `compositor-${name}-`));
-  onTestFinished(async () => {
-    await rm(dir, { recursive: true, force: true });
-  });
-
-  for (const [relativePath, content] of Object.entries(files)) {
-    const filePath = path.join(dir, relativePath);
-    await mkdir(path.dirname(filePath), { recursive: true });
-    await writeFile(filePath, content, 'utf8');
-  }
+  const dir = await buildTempTree(files, `compositor-${name}`);
 
   return { id: name, name, origin: { kind: 'directory', location: dir }, dir };
 }

--- a/packages/compositor/src/selection/SelectionDiagnostic.ts
+++ b/packages/compositor/src/selection/SelectionDiagnostic.ts
@@ -1,0 +1,20 @@
+import type { Id, KindId } from '../schemas/common.ts';
+
+/**
+ * Where in a config something was declared, so a diagnostic reaches the entry an author wrote.
+ *
+ * `list` and `index` are absent together when the whole block is at fault rather than one entry in it.
+ */
+export interface ConfigEntryRef {
+  readonly tierId: Id;
+  readonly kindId: KindId;
+  readonly list?: 'use' | 'drop';
+  readonly index?: number;
+}
+
+/** One selector that named something the catalog does not carry. */
+export interface SelectionDiagnostic {
+  readonly code: 'unknown-artifact' | 'unknown-kind' | 'unknown-source' | 'empty-source';
+  readonly message: string;
+  readonly at: ConfigEntryRef;
+}

--- a/packages/compositor/src/selection/__tests__/buildCatalogIndex.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/buildCatalogIndex.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCatalogIndex } from '../buildCatalogIndex.ts';
+import { buildCatalog } from '../test-utils/buildCatalog.ts';
+
+const catalog = buildCatalog({
+  kinds: ['rulebook', 'skill', 'partial'],
+  sources: ['local', 'acme'],
+  entries: [
+    { kindId: 'skill', slug: 'lint', carriedBy: ['acme'] },
+    { kindId: 'skill', slug: 'review', carriedBy: ['local', 'acme'] },
+    { kindId: 'rulebook', slug: 'house-style', carriedBy: ['local'] },
+  ],
+});
+
+describe(buildCatalogIndex, () => {
+  it('names every kind the catalog declares, including one carrying no entries', () => {
+    expect([...buildCatalogIndex(catalog).kindIds].toSorted()).toStrictEqual(['partial', 'rulebook', 'skill']);
+  });
+
+  it('names every source the catalog declares', () => {
+    expect([...buildCatalogIndex(catalog).sourceIds].toSorted()).toStrictEqual(['acme', 'local']);
+  });
+
+  it('maps a slug to its artifact id, keyed by kind', () => {
+    expect(buildCatalogIndex(catalog).bySlug.get('skill')?.get('lint')).toBe('skill:lint');
+  });
+
+  it('keeps one kind’s slugs out of another’s, so two kinds may share a slug', () => {
+    expect(buildCatalogIndex(catalog).bySlug.get('rulebook')?.get('lint')).toBeUndefined();
+  });
+
+  it('carries an artifact under the source that won it', () => {
+    expect(buildCatalogIndex(catalog).bySource.get('skill')?.get('acme')).toContain('skill:lint');
+  });
+
+  // Shadowing settles which copy resolves; a source a consumer took whole carries the artifact either way.
+  it('carries an artifact under a source whose copy is shadowed, not the winner alone', () => {
+    expect(buildCatalogIndex(catalog).bySource.get('skill')?.get('local')).toStrictEqual(['skill:review']);
+  });
+
+  it('carries nothing for a kind a source has no entries of', () => {
+    expect(buildCatalogIndex(catalog).bySource.get('rulebook')?.get('acme')).toBeUndefined();
+  });
+});

--- a/packages/compositor/src/selection/__tests__/expandSelector.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/expandSelector.unit.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ArtifactId } from '../../schemas/common.ts';
+import type { Selector } from '../../schemas/config-schemas.ts';
+import { buildCatalogIndex } from '../buildCatalogIndex.ts';
+import { expandSelector } from '../expandSelector.ts';
+import type { ConfigEntryRef, SelectionDiagnostic } from '../SelectionDiagnostic.ts';
+import { buildCatalog } from '../test-utils/buildCatalog.ts';
+
+const index = buildCatalogIndex(
+  buildCatalog({
+    kinds: ['rulebook', 'skill'],
+    sources: ['local', 'acme'],
+    entries: [
+      { kindId: 'skill', slug: 'lint', carriedBy: ['acme'] },
+      { kindId: 'skill', slug: 'format', carriedBy: ['acme'] },
+      { kindId: 'skill', slug: 'review', carriedBy: ['local', 'acme'] },
+      { kindId: 'rulebook', slug: 'house-style', carriedBy: ['local'] },
+    ],
+  }),
+);
+const at: ConfigEntryRef = { tierId: 'project', kindId: 'skill', list: 'use', index: 0 };
+
+describe(expandSelector, () => {
+  it('expands a named artifact to its id', () => {
+    expect(expand({ artifact: 'lint' }).matched).toStrictEqual(['skill:lint']);
+  });
+
+  it('expands a source to every artifact that source carries of the kind', () => {
+    expect(expand({ source: 'acme' }).matched.toSorted()).toStrictEqual(['skill:format', 'skill:lint', 'skill:review']);
+  });
+
+  it('expands a source to an artifact a higher-precedence source shadows', () => {
+    expect(expand({ source: 'local' }).matched).toStrictEqual(['skill:review']);
+  });
+
+  it.each([
+    ['an artifact no source carries', { artifact: 'absent' }, 'unknown-artifact'],
+    ['a source that is not declared', { source: 'nowhere' }, 'unknown-source'],
+  ])('matches nothing and reports %s', (_label, selector, code) => {
+    const { matched, diagnostics } = expand(selector);
+
+    expect(matched).toStrictEqual([]);
+    expect(diagnostics.at(0)?.code).toBe(code);
+  });
+
+  it('reports a source carrying nothing of the kind, having matched nothing to report', () => {
+    const { matched, diagnostics } = expand({ source: 'acme' }, 'rulebook');
+
+    expect(matched).toStrictEqual([]);
+    expect(diagnostics.at(0)?.code).toBe('empty-source');
+  });
+
+  it('says nothing when the selector matches, so a diagnostic marks a mistake rather than a step', () => {
+    expect(expand({ artifact: 'lint' }).diagnostics).toStrictEqual([]);
+  });
+
+  it('locates its diagnostic at the config entry it was handed', () => {
+    expect(expand({ artifact: 'absent' }).diagnostics.at(0)?.at).toStrictEqual(at);
+  });
+
+  it('appends to the diagnostics it is given, so a caller expanding several selectors keeps every one', () => {
+    const diagnostics: Array<SelectionDiagnostic> = [];
+
+    expandSelector({ artifact: 'absent' }, 'skill', index, at, diagnostics);
+    expandSelector({ artifact: 'missing' }, 'skill', index, at, diagnostics);
+
+    expect(diagnostics).toHaveLength(2);
+  });
+});
+
+// region | Helpers
+
+/** Expands one selector against the shared index, returning what it matched beside what it reported. */
+function expand(
+  selector: Selector,
+  kindId = 'skill',
+): { matched: ReadonlyArray<ArtifactId>; diagnostics: Array<SelectionDiagnostic> } {
+  const diagnostics: Array<SelectionDiagnostic> = [];
+  const matched = expandSelector(selector, kindId, index, at, diagnostics);
+
+  return { matched, diagnostics };
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
@@ -120,16 +120,12 @@ describe(selectArtifacts, () => {
     expect(collectIds(selection)).toStrictEqual(['rulebook:house-style', 'skill:lint', 'skill:review']);
   });
 
-  it.each([
-    ['an artifact no source carries', { skill: { use: ['absent'] } }, 'unknown-artifact'],
-    ['a source that is not declared', { skill: { use: [{ source: 'nowhere' }] } }, 'unknown-source'],
-    ['a source carrying nothing of the kind', { rulebook: { use: [{ source: 'acme' }] } }, 'empty-source'],
-    ['a kind the catalog does not carry', { partial: { use: ['x'] } }, 'unknown-kind'],
-  ])('reports %s as a diagnostic rather than a failure', (_label, block, code) => {
-    const selection = select([{ id: 'project', select: block }]);
+  // A block naming an absent kind faults whole: every entry under it would name the same missing kind.
+  it('reports a kind the catalog does not carry as one diagnostic, rather than one per entry', () => {
+    const selection = select([{ id: 'project', select: { partial: { use: ['x', 'y'] } } }]);
 
     expect(selection.diagnostics).toHaveLength(1);
-    expect(selection.diagnostics.at(0)?.code).toBe(code);
+    expect(selection.diagnostics.at(0)?.code).toBe('unknown-kind');
   });
 
   it('locates a diagnostic at the config entry responsible', () => {

--- a/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
@@ -102,6 +102,15 @@ describe(selectArtifacts, () => {
     expect(selection.seeded).toStrictEqual([]);
   });
 
+  it('runs declined artifacts in id order, whatever order the tiers dropped them', () => {
+    const selection = select([
+      { id: 'global', select: { skill: { use: ['lint', 'review'] } } },
+      { id: 'project', select: { skill: { drop: ['review', 'lint'] } } },
+    ]);
+
+    expect(selection.declined.map(({ artifactId }) => artifactId)).toStrictEqual(['skill:lint', 'skill:review']);
+  });
+
   it('discards every lower tier’s seeds and declines at a tier declaring reset', () => {
     const selection = select([
       { id: 'global', select: { skill: { use: ['lint'], drop: ['format'] } } },

--- a/packages/compositor/src/selection/buildCatalogIndex.ts
+++ b/packages/compositor/src/selection/buildCatalogIndex.ts
@@ -1,0 +1,44 @@
+import { appendTo } from '../portable/appendTo.ts';
+import type { ArtifactId, Id, KindId } from '../schemas/common.ts';
+import type { Catalog } from '../schemas/resolution-schemas.ts';
+
+/** The catalog as selection reads it: what exists, and which artifacts each source carries. */
+export interface CatalogIndex {
+  readonly kindIds: ReadonlySet<KindId>;
+  readonly sourceIds: ReadonlySet<Id>;
+  /** Keyed by kind, then slug. */
+  readonly bySlug: ReadonlyMap<KindId, ReadonlyMap<string, ArtifactId>>;
+  /** Keyed by kind, then source, in catalog order. Carries an artifact under every source that has a copy of it. */
+  readonly bySource: ReadonlyMap<KindId, ReadonlyMap<Id, ReadonlyArray<ArtifactId>>>;
+}
+
+/**
+ * Indexes the catalog for lookup by slug and by source.
+ *
+ * The by-source index carries an artifact under every source that has a copy, shadowed as well as winning. Shadowing
+ * decides which copy an artifact resolves from; selection decides which artifacts are in play, and a source a consumer
+ * took whole carries the artifact whether or not it won it.
+ */
+export function buildCatalogIndex(catalog: Catalog): CatalogIndex {
+  const bySlug = new Map<KindId, Map<string, ArtifactId>>();
+  const bySource = new Map<KindId, Map<Id, Array<ArtifactId>>>();
+
+  for (const entry of catalog.entries) {
+    const slugs = bySlug.get(entry.kindId) ?? new Map<string, ArtifactId>();
+    slugs.set(entry.slug, entry.id);
+    bySlug.set(entry.kindId, slugs);
+
+    const sources = bySource.get(entry.kindId) ?? new Map<Id, Array<ArtifactId>>();
+    for (const candidate of [entry.resolution.winner, ...entry.resolution.shadowed]) {
+      appendTo(sources, candidate.sourceId, entry.id);
+    }
+    bySource.set(entry.kindId, sources);
+  }
+
+  return {
+    kindIds: new Set(catalog.kinds.map(({ id }) => id)),
+    sourceIds: new Set(catalog.sources.map(({ id }) => id)),
+    bySlug,
+    bySource,
+  };
+}

--- a/packages/compositor/src/selection/expandSelector.ts
+++ b/packages/compositor/src/selection/expandSelector.ts
@@ -1,0 +1,41 @@
+import type { ArtifactId, KindId } from '../schemas/common.ts';
+import type { Selector } from '../schemas/config-schemas.ts';
+import type { CatalogIndex } from './buildCatalogIndex.ts';
+import type { ConfigEntryRef, SelectionDiagnostic } from './SelectionDiagnostic.ts';
+
+/** Expands `selector` to the artifacts it names, appending a diagnostic and matching nothing when it names none. */
+export function expandSelector(
+  selector: Selector,
+  kindId: KindId,
+  index: CatalogIndex,
+  at: ConfigEntryRef,
+  diagnostics: Array<SelectionDiagnostic>,
+): ReadonlyArray<ArtifactId> {
+  if ('artifact' in selector) {
+    const artifactId = index.bySlug.get(kindId)?.get(selector.artifact);
+    if (artifactId === undefined) {
+      diagnostics.push({
+        code: 'unknown-artifact',
+        message: `No source carries "${selector.artifact}" of kind "${kindId}".`,
+        at,
+      });
+      return [];
+    }
+    return [artifactId];
+  }
+
+  if (!index.sourceIds.has(selector.source)) {
+    diagnostics.push({ code: 'unknown-source', message: `Source "${selector.source}" is not declared.`, at });
+    return [];
+  }
+
+  const carried = index.bySource.get(kindId)?.get(selector.source) ?? [];
+  if (carried.length === 0) {
+    diagnostics.push({
+      code: 'empty-source',
+      message: `Source "${selector.source}" carries nothing of kind "${kindId}".`,
+      at,
+    });
+  }
+  return carried;
+}

--- a/packages/compositor/src/selection/selectArtifacts.ts
+++ b/packages/compositor/src/selection/selectArtifacts.ts
@@ -1,21 +1,11 @@
-import { appendTo } from '../portable/appendTo.ts';
 import { compareStrings } from '../portable/compareStrings.ts';
-import type { ArtifactId, Id, KindId } from '../schemas/common.ts';
+import type { ArtifactId, Id } from '../schemas/common.ts';
 import type { CompositorConfig, Selector } from '../schemas/config-schemas.ts';
 import type { Seed, SeedOrigin } from '../schemas/graph-schemas.ts';
 import type { Catalog } from '../schemas/resolution-schemas.ts';
-
-/**
- * Where in a config something was declared, so a diagnostic reaches the entry an author wrote.
- *
- * `list` and `index` are absent together when the whole block is at fault rather than one entry in it.
- */
-export interface ConfigEntryRef {
-  readonly tierId: Id;
-  readonly kindId: KindId;
-  readonly list?: 'use' | 'drop';
-  readonly index?: number;
-}
+import { buildCatalogIndex } from './buildCatalogIndex.ts';
+import { expandSelector } from './expandSelector.ts';
+import type { ConfigEntryRef, SelectionDiagnostic } from './SelectionDiagnostic.ts';
 
 /** One artifact a tier dropped and no higher tier re-adopted. */
 export interface DeclinedArtifact {
@@ -28,13 +18,6 @@ export interface DeclinedArtifact {
 export interface SeededArtifact {
   readonly artifactId: ArtifactId;
   readonly seededBy: ReadonlyArray<Seed>;
-}
-
-/** One selector that named something the catalog does not carry. */
-export interface SelectionDiagnostic {
-  readonly code: 'unknown-artifact' | 'unknown-kind' | 'unknown-source' | 'empty-source';
-  readonly message: string;
-  readonly at: ConfigEntryRef;
 }
 
 /**
@@ -120,16 +103,6 @@ export function selectArtifacts(config: CompositorConfig, catalog: Catalog): Sel
 
 // region | Helpers
 
-/** The catalog as selection reads it: what exists, and which artifacts each source carries. */
-interface CatalogIndex {
-  readonly kindIds: ReadonlySet<KindId>;
-  readonly sourceIds: ReadonlySet<Id>;
-  /** Keyed by kind, then slug. */
-  readonly bySlug: ReadonlyMap<KindId, ReadonlyMap<string, ArtifactId>>;
-  /** Keyed by kind, then source, in catalog order. Carries an artifact under every source that has a copy of it. */
-  readonly bySource: ReadonlyMap<KindId, ReadonlyMap<Id, ReadonlyArray<ArtifactId>>>;
-}
-
 /** Records one seed against an artifact, unless that tier already seeded it the same way. */
 function addSeed(seeds: Map<ArtifactId, Array<Seed>>, artifactId: ArtifactId, seed: Seed): void {
   const existing = seeds.get(artifactId) ?? [];
@@ -138,74 +111,6 @@ function addSeed(seeds: Map<ArtifactId, Array<Seed>>, artifactId: ArtifactId, se
   }
   existing.push(seed);
   seeds.set(artifactId, existing);
-}
-
-/**
- * Indexes the catalog for lookup by slug and by source.
- *
- * The by-source index carries an artifact under every source that has a copy, shadowed as well as winning. Shadowing
- * decides which copy an artifact resolves from; selection decides which artifacts are in play, and a source a consumer
- * took whole carries the artifact whether or not it won it.
- */
-function buildCatalogIndex(catalog: Catalog): CatalogIndex {
-  const bySlug = new Map<KindId, Map<string, ArtifactId>>();
-  const bySource = new Map<KindId, Map<Id, Array<ArtifactId>>>();
-
-  for (const entry of catalog.entries) {
-    const slugs = bySlug.get(entry.kindId) ?? new Map<string, ArtifactId>();
-    slugs.set(entry.slug, entry.id);
-    bySlug.set(entry.kindId, slugs);
-
-    const sources = bySource.get(entry.kindId) ?? new Map<Id, Array<ArtifactId>>();
-    for (const candidate of [entry.resolution.winner, ...entry.resolution.shadowed]) {
-      appendTo(sources, candidate.sourceId, entry.id);
-    }
-    bySource.set(entry.kindId, sources);
-  }
-
-  return {
-    kindIds: new Set(catalog.kinds.map(({ id }) => id)),
-    sourceIds: new Set(catalog.sources.map(({ id }) => id)),
-    bySlug,
-    bySource,
-  };
-}
-
-/** Expands `selector` to the artifacts it names, appending a diagnostic and matching nothing when it names none. */
-function expandSelector(
-  selector: Selector,
-  kindId: KindId,
-  index: CatalogIndex,
-  at: ConfigEntryRef,
-  diagnostics: Array<SelectionDiagnostic>,
-): ReadonlyArray<ArtifactId> {
-  if ('artifact' in selector) {
-    const artifactId = index.bySlug.get(kindId)?.get(selector.artifact);
-    if (artifactId === undefined) {
-      diagnostics.push({
-        code: 'unknown-artifact',
-        message: `No source carries "${selector.artifact}" of kind "${kindId}".`,
-        at,
-      });
-      return [];
-    }
-    return [artifactId];
-  }
-
-  if (!index.sourceIds.has(selector.source)) {
-    diagnostics.push({ code: 'unknown-source', message: `Source "${selector.source}" is not declared.`, at });
-    return [];
-  }
-
-  const carried = index.bySource.get(kindId)?.get(selector.source) ?? [];
-  if (carried.length === 0) {
-    diagnostics.push({
-      code: 'empty-source',
-      message: `Source "${selector.source}" carries nothing of kind "${kindId}".`,
-      at,
-    });
-  }
-  return carried;
 }
 
 /** Reads how a selector named what it named, which is the origin a seed or a decline records. */

--- a/packages/compositor/src/test-utils/__tests__/buildTempTree.unit.test.ts
+++ b/packages/compositor/src/test-utils/__tests__/buildTempTree.unit.test.ts
@@ -1,0 +1,38 @@
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildTempTree } from '../buildTempTree.ts';
+
+describe(buildTempTree, () => {
+  it('writes each entry at its path, with the content given', async () => {
+    const dir = await buildTempTree({ 'skills/lint/SKILL.md': 'lint' });
+
+    await expect(readFile(path.join(dir, 'skills/lint/SKILL.md'), 'utf8')).resolves.toBe('lint');
+  });
+
+  it('creates the parent directories an entry names, so a caller states paths rather than order', async () => {
+    const dir = await buildTempTree({ 'deeply/nested/asset.json': '{}' });
+
+    await expect(stat(path.join(dir, 'deeply/nested'))).resolves.toMatchObject({});
+  });
+
+  it('builds an empty directory when given no entries', async () => {
+    const dir = await buildTempTree({});
+
+    await expect(stat(dir)).resolves.toMatchObject({});
+  });
+
+  it('names the directory for the prefix, so a leaked one identifies the suite that made it', async () => {
+    const dir = await buildTempTree({}, 'compositor-example');
+
+    expect(path.basename(dir).startsWith('compositor-example-')).toBe(true);
+  });
+
+  it('gives two trees separate directories, so one suite cannot read another’s fixture', async () => {
+    const [first, second] = await Promise.all([buildTempTree({ 'a.md': 'a' }), buildTempTree({ 'b.md': 'b' })]);
+
+    expect(first).not.toBe(second);
+  });
+});

--- a/packages/compositor/src/test-utils/__tests__/buildTempTree.unit.test.ts
+++ b/packages/compositor/src/test-utils/__tests__/buildTempTree.unit.test.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from 'node:fs/promises';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -15,19 +15,19 @@ describe(buildTempTree, () => {
   it('creates the parent directories an entry names, so a caller states paths rather than order', async () => {
     const dir = await buildTempTree({ 'deeply/nested/asset.json': '{}' });
 
-    await expect(stat(path.join(dir, 'deeply/nested'))).resolves.toMatchObject({});
+    expect((await stat(path.join(dir, 'deeply/nested'))).isDirectory()).toBe(true);
   });
 
   it('builds an empty directory when given no entries', async () => {
     const dir = await buildTempTree({});
 
-    await expect(stat(dir)).resolves.toMatchObject({});
+    await expect(readdir(dir)).resolves.toStrictEqual([]);
   });
 
   it('names the directory for the prefix, so a leaked one identifies the suite that made it', async () => {
     const dir = await buildTempTree({}, 'compositor-example');
 
-    expect(path.basename(dir).startsWith('compositor-example-')).toBe(true);
+    expect(path.basename(dir)).toMatch(/^compositor-example-/);
   });
 
   it('gives two trees separate directories, so one suite cannot read another’s fixture', async () => {

--- a/packages/compositor/src/test-utils/buildTempTree.ts
+++ b/packages/compositor/src/test-utils/buildTempTree.ts
@@ -1,0 +1,29 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { onTestFinished } from 'vitest';
+
+/**
+ * A temporary directory holding each path in `files` with the given content, removed when the test ends.
+ *
+ * Writes a real tree rather than mocking the filesystem, because what the code under test answers is how Node reports
+ * directories, extensions, and absences -- the very layer a mock would replace with an assumption.
+ *
+ * `prefix` names the temp directory, so a test building several trees can tell which directory belongs to which, and a
+ * directory left behind by a crashed run still names the suite that made it.
+ */
+export async function buildTempTree(files: Record<string, string>, prefix = 'compositor'): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), `${prefix}-`));
+  onTestFinished(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(dir, relativePath);
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, content, 'utf8');
+  }
+
+  return dir;
+}


### PR DESCRIPTION
## What

Generic filesystem and path helpers are now grouped under `portable/`, identifying them as candidates for extraction and reuse.

## Why

`enumerateSource` had accumulated five filesystem primitives with nothing resolution-specific about them, and `selectArtifacts` held a catalog indexer and a selector expander that were each a coherent unit in their own right. The engine's later phases need those primitives, and a contributor who cannot find one writes a second. Applies the structure and standards defined in #180.

## Details

### ♻️ Refactoring

- Six generic helpers move to `portable/`, each in a module named for it: `readDirNames`, `statIfPresent`, `listFilesRecursively`, `toPosix`, and `hashDirectory` from `resolution/enumerateSource.ts`, and `expandPath` from `config/resolveSources.ts`. `enumerateSource.ts` drops from 168 lines to 104, retaining only what is specific to enumerating a source's artifacts.
- `statOrUndefined` becomes `statIfPresent`, so `portable/` no longer carries two names for the same pattern alongside `readFileIfPresent`.
- `resolveDirectory` becomes `expandPath`, named for what it does: it computes a path and touches no disk.
- The recursive walker sheds its content policy. `listFilesRecursively` skips nothing by default and takes the names to leave out from its caller; `hashDirectory` passes the dotfile rule and states the "tool state, not shipped content" rationale at the point that decides it. A later target-side caller therefore gets hidden files unless it asks otherwise, which matters in a package whose own sample targets are `~/.claude` and `~/.rovodev`.
- `selection/selectArtifacts.ts` splits into four modules: `buildCatalogIndex.ts`, `expandSelector.ts`, a types-only `SelectionDiagnostic.ts` holding `ConfigEntryRef` and `SelectionDiagnostic`, and the fold itself. The diagnostic vocabulary now sits in a shared module mirroring `consistency/Violation.ts` rather than being type-imported from the fold it serves.
- The mkdtemp-and-write-tree body that `buildConfigDir` and `buildSource` had each held is now `test-utils/buildTempTree.ts`. Both keep their names, signatures, and per-suite directory prefixes, so no call site changes.

Behavior and the published API are unchanged. The package declares a single `.` export, so no consumer can observe that two types now originate from a different module.

### 🧪 Tests

- Every module in `portable/` is covered directly rather than only through a caller, including `appendTo`, `hash-content`, and `readFileIfPresent`, which had no tests of their own before.
- The entry's export-drift guard reads the module list from `index.ts`'s own re-export specifiers instead of restating it by hand, so a module added to the entry cannot slip past the check. A companion assertion fails the suite if that list ever comes back empty, since an empty list would make every case vanish and leave the suite green having checked nothing.
- Assertions moved to the level that owns them: path participation, nested reach, and dotfile exclusion now sit on `hashDirectory`, while the resolution-level guarantee that identical copies in two sources stay recognizable stays on `enumerateSource`.
- New coverage for dangling symlinks in `listFilesRecursively` and `enumerateSource`, for declined-artifact ordering in `selectArtifacts`, and for the unreadable-file case in `readFileIfPresent`.

Closes #184
