### PR TITLE
#187 Decompose the representative sample builder

### DIFF
--- a/packages/compositor/src/samples/__tests__/samples.unit.test.ts
+++ b/packages/compositor/src/samples/__tests__/samples.unit.test.ts
@@ -1,15 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveInclusionPaths } from '../../graph/traversal.ts';
 import { assertPlanIsConsistent } from '../../plan/assertPlanIsConsistent.ts';
-import type { FileEntry } from '../../schemas/file-schemas.ts';
-import type { ArtifactEntry } from '../../schemas/graph-schemas.ts';
 import { PlanSchema } from '../../schemas/plan-schemas.ts';
-import { buildRepresentativeSample } from '../buildRepresentativeSample.ts';
 import { buildSampleDocuments } from '../sample-documents.ts';
 
 const documents = buildSampleDocuments().map((document) => [document.fileName, document] as const);
-const representative = buildRepresentativeSample();
 
 describe('published samples', () => {
   it.each(documents)('%s validates against the plan schema', (_fileName, { plan }) => {
@@ -22,116 +17,3 @@ describe('published samples', () => {
     }).not.toThrow();
   });
 });
-
-describe(buildRepresentativeSample, () => {
-  it('reaches one artifact by three routes, two of them from the same seed', () => {
-    expect(resolveInclusionPaths(representative, 'skill:lint')).toStrictEqual([
-      ['collection:core', 'skill:review', 'skill:lint'],
-      ['collection:core', 'skill:lint'],
-      ['subagent:auditor', 'skill:review', 'skill:lint'],
-    ]);
-  });
-
-  it('records two losing candidates for an artifact three sources carry', () => {
-    expect(findArtifact('skill:review').resolution?.shadowed.map((candidate) => candidate.sourceId)).toStrictEqual([
-      'packaged',
-      'library',
-    ]);
-  });
-
-  it('lets the lowest-precedence source win where no other source carries the artifact', () => {
-    expect(findArtifact('skill:lint').resolution?.winner.sourceId).toBe('library');
-  });
-
-  it('aggregates three artifacts into one region, each behind its own marker', () => {
-    const aggregated = findFile('CLAUDE.md');
-
-    expect(aggregated.ownership).toStrictEqual({
-      kind: 'region',
-      open: '<!-- ambient:start -->',
-      close: '<!-- ambient:end -->',
-    });
-    expect(aggregated.contributors.artifacts).toHaveLength(3);
-    expect(aggregated.contributors.artifacts.every((contribution) => contribution.marker !== undefined)).toBe(true);
-  });
-
-  it('owns individual entries within a structured config', () => {
-    expect(findFile('settings.json').ownership).toStrictEqual({
-      kind: 'entries',
-      sentinel: 'codeassembly',
-      format: 'json',
-    });
-  });
-
-  it('marks each owned entry with the sentinel it declares, beside an item it must not touch', () => {
-    const config = findFile('settings.json');
-    const sentinel = readEntriesSentinel(config);
-    const parsed: { hooks: Array<{ command: string; source?: string }> } = JSON.parse(readPlannedBody(config));
-
-    expect(parsed.hooks.filter((hook) => hook.source === sentinel)).toHaveLength(2);
-    expect(parsed.hooks.filter((hook) => hook.source === undefined)).toHaveLength(1);
-  });
-
-  it('carries a byte-encoded body for an asset copied verbatim', () => {
-    const asset = findFile('skills/review/diagram.png');
-    const blob = asset.planned === undefined ? undefined : representative.blobs[asset.planned.hash];
-
-    expect(blob?.encoding).toBe('base64');
-  });
-
-  it('records a file apply will skip, with the reason beside its diff', () => {
-    const skipped = findFile('subagents/auditor.md');
-
-    expect(skipped.blocked?.reason).toBe('the destination is owned by another tool');
-    expect(skipped.status).toBe('changed');
-  });
-
-  it('exhibits every diff status across its files', () => {
-    expect(new Set(representative.files.map((file) => file.status))).toStrictEqual(
-      new Set(['added', 'changed', 'removed', 'unchanged']),
-    );
-  });
-
-  it('carries an artifact that is no longer part of the closure', () => {
-    expect(findArtifact('skill:retired').status).toBe('removed');
-  });
-});
-
-// region | Helpers
-
-/** The representative sample's artifact with the given id, failing the test when it carries none. */
-function findArtifact(id: string): ArtifactEntry {
-  const artifact = representative.artifacts.find((entry) => entry.id === id);
-  if (artifact === undefined) {
-    throw new Error(`The representative sample carries no artifact "${id}".`);
-  }
-  return artifact;
-}
-
-/** The representative sample's file at the given path, failing the test when it carries none. */
-function findFile(filePath: string): FileEntry {
-  const file = representative.files.find((entry) => entry.path === filePath);
-  if (file === undefined) {
-    throw new Error(`The representative sample carries no file "${filePath}".`);
-  }
-  return file;
-}
-
-/** The sentinel `file` declares for the entries it owns, failing the test when it is not entry-owned. */
-function readEntriesSentinel(file: FileEntry): string {
-  if (file.ownership.kind !== 'entries') {
-    throw new Error(`The sample file "${file.path}" does not declare entry ownership.`);
-  }
-  return file.ownership.sentinel;
-}
-
-/** The body the representative sample plans to write for `file`, failing the test when it carries none. */
-function readPlannedBody(file: FileEntry): string {
-  const blob = file.planned === undefined ? undefined : representative.blobs[file.planned.hash];
-  if (blob === undefined) {
-    throw new Error(`The representative sample carries no planned body for "${file.path}".`);
-  }
-  return blob.data;
-}
-
-// endregion | Helpers

--- a/packages/compositor/src/samples/buildRepresentativeSample.ts
+++ b/packages/compositor/src/samples/buildRepresentativeSample.ts
@@ -1,31 +1,14 @@
-import { Buffer } from 'node:buffer';
-
-import { hashBytes, hashUtf8 } from '../portable/hash-content.ts';
-import type { Blob, FileSide } from '../schemas/file-schemas.ts';
 import type { Plan } from '../schemas/plan-schemas.ts';
 import { PLAN_SCHEMA_VERSION } from '../schemas/plan-schemas.ts';
-import type { Hash } from '../schemas/scalar-schemas.ts';
-
-const REGION_OPEN = '<!-- ambient:start -->';
-const REGION_CLOSE = '<!-- ambient:end -->';
-
-const CLAUDE_MD_CURRENT = `# Guidance\n\n${REGION_OPEN}\n<!-- rulebook:style -->\nUse sentence case.\n<!-- /rulebook:style -->\n${REGION_CLOSE}\n`;
-const CLAUDE_MD_PLANNED = `# Guidance\n\n${REGION_OPEN}\n<!-- rulebook:naming -->\nName functions with a leading verb.\n<!-- /rulebook:naming -->\n\n<!-- rulebook:style -->\nUse sentence case.\n<!-- /rulebook:style -->\n\n<!-- rulebook:tests -->\nName tests for the behavior they pin.\n<!-- /rulebook:tests -->\n${REGION_CLOSE}\n`;
-
-const REVIEW_SKILL_CURRENT = '# Review\n\nRead the diff.\n';
-const REVIEW_SKILL_PLANNED = '# Review\n\nRead the diff, then the tests.\n';
-const RETIRED_SKILL_CURRENT = '# Retired\n\nSuperseded.\n';
-const LINT_SKILL = '# Lint\n\nRun the linter.\n';
-// The first hook belongs to another tool and carries no sentinel; the engine owns only the entries marked with one.
-const SETTINGS_JSON_CURRENT =
-  '{\n  "hooks": [\n    { "command": "vendor-tool sync" },\n    { "command": "relay --on=stop", "source": "codeassembly" }\n  ]\n}\n';
-const SETTINGS_JSON_PLANNED =
-  '{\n  "hooks": [\n    { "command": "vendor-tool sync" },\n    { "command": "relay --on=stop", "source": "codeassembly" },\n    { "command": "relay --on=review", "source": "codeassembly" }\n  ]\n}\n';
-const AUDITOR_CURRENT = '# Auditor\n\nAudit the change.\n';
-const AUDITOR_PLANNED = '# Auditor\n\nAudit the change against its ticket.\n';
-
-// A PNG signature stands in for a skill asset the engine copies byte for byte.
-const DIAGRAM_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]);
+import { buildArtifacts } from './representative/buildArtifacts.ts';
+import { buildFiles } from './representative/buildFiles.ts';
+import { buildFingerprint } from './representative/buildFingerprint.ts';
+import { buildKinds } from './representative/buildKinds.ts';
+import { buildPartials } from './representative/buildPartials.ts';
+import { buildSources } from './representative/buildSources.ts';
+import { buildTargets } from './representative/buildTargets.ts';
+import { buildTiers } from './representative/buildTiers.ts';
+import { createBlobStore } from './representative/createBlobStore.ts';
 
 /**
  * A plan exercising every shape the contract has to carry.
@@ -34,304 +17,25 @@ const DIAGRAM_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0
  * reached by three routes, an artifact shadowing two losers beside one the lowest-precedence source wins, three
  * rulebooks aggregated into one region with per-artifact markers, entry-level ownership of a structured config, a
  * byte-copied asset, a file apply will skip, an artifact two tiers both seed, and all four diff statuses.
- *
- * Tables are authored in the order the contract documents: id-keyed tables lexicographically, files by target then
- * path, and `sources` and each `shadowed` list in precedence order, where the order is the meaning.
  */
 export function buildRepresentativeSample(): Plan {
-  const blobs = new Map<Hash, Blob>();
-
-  const files = [
-    {
-      targetId: 'claude',
-      path: 'CLAUDE.md',
-      status: 'changed' as const,
-      ownership: { kind: 'region' as const, open: REGION_OPEN, close: REGION_CLOSE },
-      current: addUtf8(blobs, CLAUDE_MD_CURRENT),
-      planned: addUtf8(blobs, CLAUDE_MD_PLANNED),
-      contributors: {
-        artifacts: [
-          {
-            artifactId: 'rulebook:naming',
-            marker: { open: '<!-- rulebook:naming -->', close: '<!-- /rulebook:naming -->' },
-          },
-          {
-            artifactId: 'rulebook:style',
-            marker: { open: '<!-- rulebook:style -->', close: '<!-- /rulebook:style -->' },
-          },
-          {
-            artifactId: 'rulebook:tests',
-            marker: { open: '<!-- rulebook:tests -->', close: '<!-- /rulebook:tests -->' },
-          },
-        ],
-        partials: [],
-      },
-    },
-    {
-      targetId: 'claude',
-      path: 'settings.json',
-      status: 'changed' as const,
-      ownership: { kind: 'entries' as const, sentinel: 'codeassembly', format: 'json' as const },
-      current: addUtf8(blobs, SETTINGS_JSON_CURRENT),
-      planned: addUtf8(blobs, SETTINGS_JSON_PLANNED),
-      contributors: { artifacts: [{ artifactId: 'skill:review' }], partials: [] },
-    },
-    {
-      targetId: 'claude',
-      path: 'skills/lint/SKILL.md',
-      status: 'unchanged' as const,
-      ownership: { kind: 'full' as const },
-      current: addUtf8(blobs, LINT_SKILL),
-      planned: addUtf8(blobs, LINT_SKILL),
-      contributors: { artifacts: [{ artifactId: 'skill:lint' }], partials: [] },
-    },
-    {
-      targetId: 'claude',
-      path: 'skills/retired/SKILL.md',
-      status: 'removed' as const,
-      ownership: { kind: 'full' as const },
-      current: addUtf8(blobs, RETIRED_SKILL_CURRENT),
-      contributors: { artifacts: [{ artifactId: 'skill:retired' }], partials: [] },
-    },
-    {
-      targetId: 'claude',
-      path: 'skills/review/SKILL.md',
-      status: 'changed' as const,
-      ownership: { kind: 'full' as const },
-      current: addUtf8(blobs, REVIEW_SKILL_CURRENT),
-      planned: addUtf8(blobs, REVIEW_SKILL_PLANNED),
-      contributors: { artifacts: [{ artifactId: 'skill:review' }], partials: ['team:_data/shared.md'] },
-    },
-    {
-      targetId: 'claude',
-      path: 'skills/review/diagram.png',
-      status: 'added' as const,
-      ownership: { kind: 'full' as const },
-      planned: addBytes(blobs, DIAGRAM_BYTES),
-      contributors: { artifacts: [{ artifactId: 'skill:review' }], partials: [] },
-    },
-    {
-      targetId: 'rovodev',
-      path: 'subagents/auditor.md',
-      status: 'changed' as const,
-      ownership: { kind: 'full' as const },
-      blocked: { reason: 'the destination is owned by another tool' },
-      current: addUtf8(blobs, AUDITOR_CURRENT),
-      planned: addUtf8(blobs, AUDITOR_PLANNED),
-      contributors: { artifacts: [{ artifactId: 'subagent:auditor' }], partials: ['team:_data/shared.md'] },
-    },
-  ];
-
-  const configDigest = hashUtf8('codeassembly.yaml');
-  const sourceDigests = [
-    { sourceId: 'team', digest: hashUtf8('source:team') },
-    { sourceId: 'packaged', digest: hashUtf8('source:packaged') },
-    { sourceId: 'library', digest: hashUtf8('source:library') },
-  ];
-  const targetDigests = [
-    { targetId: 'claude', digest: hashUtf8('target:claude') },
-    { targetId: 'rovodev', digest: hashUtf8('target:rovodev') },
-  ];
+  const blobs = createBlobStore();
+  const files = buildFiles(blobs);
+  const sources = buildSources();
+  const targets = buildTargets();
 
   return {
     schemaVersion: PLAN_SCHEMA_VERSION,
     engineVersion: '0.0.0',
     contentAvailability: 'complete',
-    fingerprint: {
-      config: configDigest,
-      sources: sourceDigests,
-      targetState: targetDigests,
-      composite: hashUtf8(
-        [configDigest, ...sourceDigests.map((s) => s.digest), ...targetDigests.map((t) => t.digest)].join('\n'),
-      ),
-    },
-    kinds: [
-      { id: 'collection', label: 'Collection', emitsFiles: false },
-      { id: 'rulebook', label: 'Rulebook', emitsFiles: true },
-      { id: 'skill', label: 'Skill', emitsFiles: true },
-      { id: 'subagent', label: 'Subagent', emitsFiles: true },
-    ],
-    sources: [
-      { id: 'team', name: 'team', origin: { kind: 'directory', location: '/srv/team-guidance' } },
-      { id: 'packaged', name: 'packaged', origin: { kind: 'package', location: '@acme/guidance' } },
-      { id: 'library', name: 'library', origin: { kind: 'directory', location: '/opt/compositor/library' } },
-    ],
-    targets: [
-      {
-        id: 'claude',
-        label: 'Claude',
-        root: '~/.claude',
-        tokenMappings: [
-          {
-            kindId: 'tool',
-            entries: [
-              { from: 'Edit', to: 'Edit' },
-              { from: 'Read', to: 'Read' },
-            ],
-          },
-        ],
-        variables: [
-          { name: 'guidanceFile', value: 'CLAUDE.md' },
-          { name: 'skillSigil', value: '/' },
-        ],
-      },
-      {
-        id: 'rovodev',
-        label: 'Rovo Dev',
-        root: '~/.rovodev',
-        tokenMappings: [
-          {
-            kindId: 'tool',
-            entries: [
-              { from: 'Edit', to: 'edit_file' },
-              { from: 'Read', to: 'open_files' },
-            ],
-          },
-        ],
-        variables: [
-          { name: 'guidanceFile', value: 'AGENTS.md' },
-          { name: 'skillSigil', value: '!' },
-        ],
-      },
-    ],
-    tiers: [
-      { id: 'user', label: 'User' },
-      { id: 'project', label: 'Project' },
-    ],
-    artifacts: [
-      {
-        id: 'collection:core',
-        kindId: 'collection',
-        slug: 'core',
-        status: 'unchanged',
-        seededBy: [
-          { via: 'declaration', tierId: 'user' },
-          { via: 'declaration', tierId: 'project' },
-        ],
-        dependsOn: [
-          { to: 'rulebook:style', via: 'member' },
-          { to: 'skill:review', via: 'member' },
-          { to: 'skill:lint', via: 'member' },
-        ],
-        resolution: {
-          winner: { sourceId: 'team', path: 'collections/core.md', hash: hashUtf8('collections/core.md') },
-          shadowed: [],
-        },
-      },
-      {
-        id: 'rulebook:naming',
-        kindId: 'rulebook',
-        slug: 'naming',
-        status: 'added',
-        seededBy: [{ via: 'source-catalog', tierId: 'project' }],
-        dependsOn: [],
-        resolution: {
-          winner: { sourceId: 'packaged', path: 'rulebooks/naming.md', hash: hashUtf8('rulebooks/naming.md') },
-          shadowed: [],
-        },
-      },
-      {
-        id: 'rulebook:style',
-        kindId: 'rulebook',
-        slug: 'style',
-        status: 'unchanged',
-        seededBy: [],
-        dependsOn: [],
-        resolution: {
-          winner: { sourceId: 'team', path: 'rulebooks/style.md', hash: hashUtf8('rulebooks/style.md') },
-          shadowed: [],
-        },
-      },
-      {
-        id: 'rulebook:tests',
-        kindId: 'rulebook',
-        slug: 'tests',
-        status: 'added',
-        seededBy: [{ via: 'source-catalog', tierId: 'project' }],
-        dependsOn: [],
-        resolution: {
-          winner: { sourceId: 'packaged', path: 'rulebooks/tests.md', hash: hashUtf8('rulebooks/tests.md') },
-          shadowed: [],
-        },
-      },
-      {
-        id: 'skill:lint',
-        kindId: 'skill',
-        slug: 'lint',
-        status: 'unchanged',
-        seededBy: [],
-        dependsOn: [],
-        resolution: {
-          winner: { sourceId: 'library', path: 'skills/lint/SKILL.md', hash: hashUtf8('library/skills/lint') },
-          shadowed: [],
-        },
-      },
-      {
-        id: 'skill:retired',
-        kindId: 'skill',
-        slug: 'retired',
-        status: 'removed',
-        dependsOn: [],
-        resolution: {
-          winner: { sourceId: 'team', path: 'skills/retired/SKILL.md', hash: hashUtf8('team/skills/retired') },
-          shadowed: [],
-        },
-      },
-      {
-        id: 'skill:review',
-        kindId: 'skill',
-        slug: 'review',
-        status: 'changed',
-        seededBy: [],
-        dependsOn: [{ to: 'skill:lint', via: 'token', partialId: 'team:_data/shared.md' }],
-        resolution: {
-          winner: { sourceId: 'team', path: 'skills/review/SKILL.md', hash: hashUtf8('team/skills/review') },
-          shadowed: [
-            { sourceId: 'packaged', path: 'skills/review/SKILL.md', hash: hashUtf8('packaged/skills/review') },
-            { sourceId: 'library', path: 'skills/review/SKILL.md', hash: hashUtf8('library/skills/review') },
-          ],
-        },
-      },
-      {
-        id: 'subagent:auditor',
-        kindId: 'subagent',
-        slug: 'auditor',
-        status: 'changed',
-        seededBy: [{ via: 'declaration', tierId: 'user' }],
-        dependsOn: [{ to: 'skill:review', via: 'injected' }],
-        resolution: {
-          winner: { sourceId: 'team', path: 'subagents/auditor.md', hash: hashUtf8('subagents/auditor.md') },
-          shadowed: [],
-        },
-      },
-    ],
-    partials: [
-      {
-        id: 'team:_data/shared.md',
-        sourceId: 'team',
-        path: '_data/shared.md',
-        hash: hashUtf8('team/_data/shared.md'),
-      },
-    ],
+    fingerprint: buildFingerprint(sources, targets),
+    kinds: buildKinds(),
+    sources,
+    targets,
+    tiers: buildTiers(),
+    artifacts: buildArtifacts(),
+    partials: buildPartials(),
     files,
-    blobs: Object.fromEntries([...blobs].toSorted(([left], [right]) => (left < right ? -1 : 1))),
+    blobs: blobs.toTable(),
   };
 }
-
-// region | Helpers
-
-/** Registers `data` as a byte-encoded blob and returns the file side naming it. */
-function addBytes(blobs: Map<Hash, Blob>, data: Uint8Array): FileSide {
-  const hash = hashBytes(data);
-  blobs.set(hash, { encoding: 'base64', data: Buffer.from(data).toString('base64') });
-  return { hash };
-}
-
-/** Registers `data` as a UTF-8 blob and returns the file side naming it. */
-function addUtf8(blobs: Map<Hash, Blob>, data: string): FileSide {
-  const hash = hashUtf8(data);
-  blobs.set(hash, { encoding: 'utf8', data });
-  return { hash };
-}
-
-// endregion | Helpers

--- a/packages/compositor/src/samples/representative/__tests__/buildArtifacts.unit.test.ts
+++ b/packages/compositor/src/samples/representative/__tests__/buildArtifacts.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveInclusionPaths } from '../../../graph/traversal.ts';
+import type { ArtifactEntry } from '../../../schemas/graph-schemas.ts';
+import { buildArtifacts } from '../buildArtifacts.ts';
+
+const artifacts = buildArtifacts();
+
+describe(buildArtifacts, () => {
+  it('reaches one artifact by three routes, two of them from the same seed', () => {
+    expect(resolveInclusionPaths({ artifacts }, 'skill:lint')).toStrictEqual([
+      ['collection:core', 'skill:review', 'skill:lint'],
+      ['collection:core', 'skill:lint'],
+      ['subagent:auditor', 'skill:review', 'skill:lint'],
+    ]);
+  });
+
+  it('records two losing candidates for an artifact three sources carry', () => {
+    expect(findArtifact('skill:review').resolution?.shadowed.map((candidate) => candidate.sourceId)).toStrictEqual([
+      'packaged',
+      'library',
+    ]);
+  });
+
+  it('lets the lowest-precedence source win where no other source carries the artifact', () => {
+    expect(findArtifact('skill:lint').resolution?.winner.sourceId).toBe('library');
+  });
+
+  it('carries an artifact that is no longer part of the closure', () => {
+    expect(findArtifact('skill:retired').status).toBe('removed');
+  });
+});
+
+// region | Helpers
+
+/** The artifact with the given id, failing the test when the table carries none. */
+function findArtifact(id: string): ArtifactEntry {
+  const artifact = artifacts.find((entry) => entry.id === id);
+  if (artifact === undefined) {
+    throw new Error(`The representative sample carries no artifact "${id}".`);
+  }
+  return artifact;
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/samples/representative/__tests__/buildFiles.unit.test.ts
+++ b/packages/compositor/src/samples/representative/__tests__/buildFiles.unit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FileEntry } from '../../../schemas/file-schemas.ts';
+import { buildFiles } from '../buildFiles.ts';
+import { createBlobStore } from '../createBlobStore.ts';
+
+const blobs = createBlobStore();
+const files = buildFiles(blobs);
+const bodies = blobs.toTable();
+
+describe(buildFiles, () => {
+  it('aggregates three artifacts into one region, each behind its own marker', () => {
+    const aggregated = findFile('CLAUDE.md');
+
+    expect(aggregated.ownership).toStrictEqual({
+      kind: 'region',
+      open: '<!-- ambient:start -->',
+      close: '<!-- ambient:end -->',
+    });
+    expect(aggregated.contributors.artifacts).toHaveLength(3);
+    expect(aggregated.contributors.artifacts.every((contribution) => contribution.marker !== undefined)).toBe(true);
+  });
+
+  it('owns individual entries within a structured config', () => {
+    expect(findFile('settings.json').ownership).toStrictEqual({
+      kind: 'entries',
+      sentinel: 'codeassembly',
+      format: 'json',
+    });
+  });
+
+  it('marks each owned entry with the sentinel it declares, beside an item it must not touch', () => {
+    const config = findFile('settings.json');
+    const sentinel = readEntriesSentinel(config);
+    const parsed: { hooks: Array<{ command: string; source?: string }> } = JSON.parse(readPlannedBody(config));
+
+    expect(parsed.hooks.filter((hook) => hook.source === sentinel)).toHaveLength(2);
+    expect(parsed.hooks.filter((hook) => hook.source === undefined)).toHaveLength(1);
+  });
+
+  it('carries a byte-encoded body for an asset copied verbatim', () => {
+    const asset = findFile('skills/review/diagram.png');
+    const blob = asset.planned === undefined ? undefined : bodies[asset.planned.hash];
+
+    expect(blob?.encoding).toBe('base64');
+  });
+
+  it('records a file apply will skip, with the reason beside its diff', () => {
+    const skipped = findFile('subagents/auditor.md');
+
+    expect(skipped.blocked?.reason).toBe('the destination is owned by another tool');
+    expect(skipped.status).toBe('changed');
+  });
+
+  it('exhibits every diff status across its files', () => {
+    expect(new Set(files.map((file) => file.status))).toStrictEqual(
+      new Set(['added', 'changed', 'removed', 'unchanged']),
+    );
+  });
+});
+
+// region | Helpers
+
+/** The file at the given path, failing the test when the table carries none. */
+function findFile(filePath: string): FileEntry {
+  const file = files.find((entry) => entry.path === filePath);
+  if (file === undefined) {
+    throw new Error(`The representative sample carries no file "${filePath}".`);
+  }
+  return file;
+}
+
+/** The sentinel `file` declares for the entries it owns, failing the test when it is not entry-owned. */
+function readEntriesSentinel(file: FileEntry): string {
+  if (file.ownership.kind !== 'entries') {
+    throw new Error(`The sample file "${file.path}" does not declare entry ownership.`);
+  }
+  return file.ownership.sentinel;
+}
+
+/** The body planned for `file`, failing the test when the store carries none. */
+function readPlannedBody(file: FileEntry): string {
+  const blob = file.planned === undefined ? undefined : bodies[file.planned.hash];
+  if (blob === undefined) {
+    throw new Error(`The representative sample carries no planned body for "${file.path}".`);
+  }
+  return blob.data;
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/samples/representative/__tests__/createBlobStore.unit.test.ts
+++ b/packages/compositor/src/samples/representative/__tests__/createBlobStore.unit.test.ts
@@ -1,0 +1,53 @@
+import { Buffer } from 'node:buffer';
+
+import { describe, expect, it } from 'vitest';
+
+import { compareStrings } from '../../../portable/compareStrings.ts';
+import { hashBytes, hashUtf8 } from '../../../portable/hash-content.ts';
+import { createBlobStore } from '../createBlobStore.ts';
+
+describe(createBlobStore, () => {
+  it('addresses a UTF-8 body by the digest of its bytes', () => {
+    const blobs = createBlobStore();
+
+    expect(blobs.addUtf8('# Lint\n')).toStrictEqual({ hash: hashUtf8('# Lint\n') });
+  });
+
+  it('carries a UTF-8 body as text, so a consumer reads it without decoding', () => {
+    const blobs = createBlobStore();
+    const side = blobs.addUtf8('# Lint\n');
+
+    expect(blobs.toTable()[side.hash]).toStrictEqual({ encoding: 'utf8', data: '# Lint\n' });
+  });
+
+  it('base64-encodes a byte body, whose bytes would not survive a round trip through a UTF-8 string', () => {
+    const blobs = createBlobStore();
+    const data = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const side = blobs.addBytes(data);
+
+    expect(side).toStrictEqual({ hash: hashBytes(data) });
+    expect(blobs.toTable()[side.hash]).toStrictEqual({ encoding: 'base64', data: 'iVBORw==' });
+  });
+
+  it('emits its entries in hash order, whatever order they were registered in', () => {
+    const blobs = createBlobStore();
+    const bodies = ['third\n', 'first\n', 'second\n'];
+    for (const body of bodies) {
+      blobs.addUtf8(body);
+    }
+
+    expect(Object.keys(blobs.toTable())).toStrictEqual(bodies.map(hashUtf8).toSorted(compareStrings));
+  });
+
+  it('registers one entry for a body added twice, so a body two files share is carried once', () => {
+    const blobs = createBlobStore();
+    blobs.addUtf8('# Lint\n');
+    blobs.addUtf8('# Lint\n');
+
+    expect(Object.keys(blobs.toTable())).toHaveLength(1);
+  });
+
+  it('emits an empty table when nothing is registered', () => {
+    expect(createBlobStore().toTable()).toStrictEqual({});
+  });
+});

--- a/packages/compositor/src/samples/representative/buildArtifacts.ts
+++ b/packages/compositor/src/samples/representative/buildArtifacts.ts
@@ -1,0 +1,117 @@
+import { hashUtf8 } from '../../portable/hash-content.ts';
+import type { ArtifactEntry } from '../../schemas/graph-schemas.ts';
+
+/**
+ * Builds the artifacts the representative sample resolves, in lexicographic id order.
+ *
+ * Each `shadowed` list runs in precedence order, so the candidate the winner displaced first comes first.
+ */
+export function buildArtifacts(): Array<ArtifactEntry> {
+  return [
+    {
+      id: 'collection:core',
+      kindId: 'collection',
+      slug: 'core',
+      status: 'unchanged',
+      seededBy: [
+        { via: 'declaration', tierId: 'user' },
+        { via: 'declaration', tierId: 'project' },
+      ],
+      dependsOn: [
+        { to: 'rulebook:style', via: 'member' },
+        { to: 'skill:review', via: 'member' },
+        { to: 'skill:lint', via: 'member' },
+      ],
+      resolution: {
+        winner: { sourceId: 'team', path: 'collections/core.md', hash: hashUtf8('collections/core.md') },
+        shadowed: [],
+      },
+    },
+    {
+      id: 'rulebook:naming',
+      kindId: 'rulebook',
+      slug: 'naming',
+      status: 'added',
+      seededBy: [{ via: 'source-catalog', tierId: 'project' }],
+      dependsOn: [],
+      resolution: {
+        winner: { sourceId: 'packaged', path: 'rulebooks/naming.md', hash: hashUtf8('rulebooks/naming.md') },
+        shadowed: [],
+      },
+    },
+    {
+      id: 'rulebook:style',
+      kindId: 'rulebook',
+      slug: 'style',
+      status: 'unchanged',
+      seededBy: [],
+      dependsOn: [],
+      resolution: {
+        winner: { sourceId: 'team', path: 'rulebooks/style.md', hash: hashUtf8('rulebooks/style.md') },
+        shadowed: [],
+      },
+    },
+    {
+      id: 'rulebook:tests',
+      kindId: 'rulebook',
+      slug: 'tests',
+      status: 'added',
+      seededBy: [{ via: 'source-catalog', tierId: 'project' }],
+      dependsOn: [],
+      resolution: {
+        winner: { sourceId: 'packaged', path: 'rulebooks/tests.md', hash: hashUtf8('rulebooks/tests.md') },
+        shadowed: [],
+      },
+    },
+    {
+      id: 'skill:lint',
+      kindId: 'skill',
+      slug: 'lint',
+      status: 'unchanged',
+      seededBy: [],
+      dependsOn: [],
+      resolution: {
+        winner: { sourceId: 'library', path: 'skills/lint/SKILL.md', hash: hashUtf8('library/skills/lint') },
+        shadowed: [],
+      },
+    },
+    {
+      id: 'skill:retired',
+      kindId: 'skill',
+      slug: 'retired',
+      status: 'removed',
+      dependsOn: [],
+      resolution: {
+        winner: { sourceId: 'team', path: 'skills/retired/SKILL.md', hash: hashUtf8('team/skills/retired') },
+        shadowed: [],
+      },
+    },
+    {
+      id: 'skill:review',
+      kindId: 'skill',
+      slug: 'review',
+      status: 'changed',
+      seededBy: [],
+      dependsOn: [{ to: 'skill:lint', via: 'token', partialId: 'team:_data/shared.md' }],
+      resolution: {
+        winner: { sourceId: 'team', path: 'skills/review/SKILL.md', hash: hashUtf8('team/skills/review') },
+        shadowed: [
+          { sourceId: 'packaged', path: 'skills/review/SKILL.md', hash: hashUtf8('packaged/skills/review') },
+          { sourceId: 'library', path: 'skills/review/SKILL.md', hash: hashUtf8('library/skills/review') },
+        ],
+      },
+    },
+    {
+      id: 'subagent:auditor',
+      kindId: 'subagent',
+      slug: 'auditor',
+      status: 'changed',
+      seededBy: [{ via: 'declaration', tierId: 'user' }],
+      dependsOn: [{ to: 'skill:review', via: 'injected' }],
+      resolution: {
+        winner: { sourceId: 'team', path: 'subagents/auditor.md', hash: hashUtf8('subagents/auditor.md') },
+        shadowed: [],
+      },
+    },
+  ];
+}

--- a/packages/compositor/src/samples/representative/buildFiles.ts
+++ b/packages/compositor/src/samples/representative/buildFiles.ts
@@ -1,0 +1,105 @@
+import type { FileEntry } from '../../schemas/file-schemas.ts';
+import type { BlobStore } from './createBlobStore.ts';
+import {
+  AUDITOR_CURRENT,
+  AUDITOR_PLANNED,
+  CLAUDE_MD_CURRENT,
+  CLAUDE_MD_PLANNED,
+  DIAGRAM_BYTES,
+  LINT_SKILL,
+  REGION_CLOSE,
+  REGION_OPEN,
+  RETIRED_SKILL_CURRENT,
+  REVIEW_SKILL_CURRENT,
+  REVIEW_SKILL_PLANNED,
+  SETTINGS_JSON_CURRENT,
+  SETTINGS_JSON_PLANNED,
+} from './file-bodies.ts';
+
+/**
+ * Builds the files the representative sample plans, ordered by target and then by path.
+ *
+ * Registers each side's body in `blobs`, so the store holds every body the returned files name.
+ */
+export function buildFiles(blobs: BlobStore): Array<FileEntry> {
+  return [
+    {
+      targetId: 'claude',
+      path: 'CLAUDE.md',
+      status: 'changed',
+      ownership: { kind: 'region', open: REGION_OPEN, close: REGION_CLOSE },
+      current: blobs.addUtf8(CLAUDE_MD_CURRENT),
+      planned: blobs.addUtf8(CLAUDE_MD_PLANNED),
+      contributors: {
+        artifacts: [
+          {
+            artifactId: 'rulebook:naming',
+            marker: { open: '<!-- rulebook:naming -->', close: '<!-- /rulebook:naming -->' },
+          },
+          {
+            artifactId: 'rulebook:style',
+            marker: { open: '<!-- rulebook:style -->', close: '<!-- /rulebook:style -->' },
+          },
+          {
+            artifactId: 'rulebook:tests',
+            marker: { open: '<!-- rulebook:tests -->', close: '<!-- /rulebook:tests -->' },
+          },
+        ],
+        partials: [],
+      },
+    },
+    {
+      targetId: 'claude',
+      path: 'settings.json',
+      status: 'changed',
+      ownership: { kind: 'entries', sentinel: 'codeassembly', format: 'json' },
+      current: blobs.addUtf8(SETTINGS_JSON_CURRENT),
+      planned: blobs.addUtf8(SETTINGS_JSON_PLANNED),
+      contributors: { artifacts: [{ artifactId: 'skill:review' }], partials: [] },
+    },
+    {
+      targetId: 'claude',
+      path: 'skills/lint/SKILL.md',
+      status: 'unchanged',
+      ownership: { kind: 'full' },
+      current: blobs.addUtf8(LINT_SKILL),
+      planned: blobs.addUtf8(LINT_SKILL),
+      contributors: { artifacts: [{ artifactId: 'skill:lint' }], partials: [] },
+    },
+    {
+      targetId: 'claude',
+      path: 'skills/retired/SKILL.md',
+      status: 'removed',
+      ownership: { kind: 'full' },
+      current: blobs.addUtf8(RETIRED_SKILL_CURRENT),
+      contributors: { artifacts: [{ artifactId: 'skill:retired' }], partials: [] },
+    },
+    {
+      targetId: 'claude',
+      path: 'skills/review/SKILL.md',
+      status: 'changed',
+      ownership: { kind: 'full' },
+      current: blobs.addUtf8(REVIEW_SKILL_CURRENT),
+      planned: blobs.addUtf8(REVIEW_SKILL_PLANNED),
+      contributors: { artifacts: [{ artifactId: 'skill:review' }], partials: ['team:_data/shared.md'] },
+    },
+    {
+      targetId: 'claude',
+      path: 'skills/review/diagram.png',
+      status: 'added',
+      ownership: { kind: 'full' },
+      planned: blobs.addBytes(DIAGRAM_BYTES),
+      contributors: { artifacts: [{ artifactId: 'skill:review' }], partials: [] },
+    },
+    {
+      targetId: 'rovodev',
+      path: 'subagents/auditor.md',
+      status: 'changed',
+      ownership: { kind: 'full' },
+      blocked: { reason: 'the destination is owned by another tool' },
+      current: blobs.addUtf8(AUDITOR_CURRENT),
+      planned: blobs.addUtf8(AUDITOR_PLANNED),
+      contributors: { artifacts: [{ artifactId: 'subagent:auditor' }], partials: ['team:_data/shared.md'] },
+    },
+  ];
+}

--- a/packages/compositor/src/samples/representative/buildFingerprint.ts
+++ b/packages/compositor/src/samples/representative/buildFingerprint.ts
@@ -1,0 +1,29 @@
+import { hashUtf8 } from '../../portable/hash-content.ts';
+import type { SourceEntry } from '../../schemas/descriptor-schemas.ts';
+import type { PlanFingerprint } from '../../schemas/plan-schemas.ts';
+import type { TargetEntry } from '../../schemas/target-schemas.ts';
+
+/**
+ * Builds the fingerprint of the inputs the representative sample was computed from.
+ *
+ * Each digest is derived from the table it covers, so a source or target added to one cannot go unrecorded here.
+ */
+export function buildFingerprint(
+  sources: ReadonlyArray<SourceEntry>,
+  targets: ReadonlyArray<TargetEntry>,
+): PlanFingerprint {
+  const configDigest = hashUtf8('codeassembly.yaml');
+  const sourceDigests = sources.map((source) => ({ sourceId: source.id, digest: hashUtf8(`source:${source.id}`) }));
+  const targetDigests = targets.map((target) => ({ targetId: target.id, digest: hashUtf8(`target:${target.id}`) }));
+
+  return {
+    config: configDigest,
+    sources: sourceDigests,
+    targetState: targetDigests,
+    composite: hashUtf8(
+      [configDigest, ...sourceDigests.map((entry) => entry.digest), ...targetDigests.map((entry) => entry.digest)].join(
+        '\n',
+      ),
+    ),
+  };
+}

--- a/packages/compositor/src/samples/representative/buildKinds.ts
+++ b/packages/compositor/src/samples/representative/buildKinds.ts
@@ -1,0 +1,11 @@
+import type { KindDescriptor } from '../../schemas/descriptor-schemas.ts';
+
+/** Builds the kinds the representative sample's artifacts belong to. */
+export function buildKinds(): Array<KindDescriptor> {
+  return [
+    { id: 'collection', label: 'Collection', emitsFiles: false },
+    { id: 'rulebook', label: 'Rulebook', emitsFiles: true },
+    { id: 'skill', label: 'Skill', emitsFiles: true },
+    { id: 'subagent', label: 'Subagent', emitsFiles: true },
+  ];
+}

--- a/packages/compositor/src/samples/representative/buildPartials.ts
+++ b/packages/compositor/src/samples/representative/buildPartials.ts
@@ -1,0 +1,14 @@
+import { hashUtf8 } from '../../portable/hash-content.ts';
+import type { PartialEntry } from '../../schemas/graph-schemas.ts';
+
+/** Builds the partials the representative sample's files draw shared content from. */
+export function buildPartials(): Array<PartialEntry> {
+  return [
+    {
+      id: 'team:_data/shared.md',
+      sourceId: 'team',
+      path: '_data/shared.md',
+      hash: hashUtf8('team/_data/shared.md'),
+    },
+  ];
+}

--- a/packages/compositor/src/samples/representative/buildSources.ts
+++ b/packages/compositor/src/samples/representative/buildSources.ts
@@ -1,0 +1,10 @@
+import type { SourceEntry } from '../../schemas/descriptor-schemas.ts';
+
+/** Builds the sources the representative sample resolves from, in precedence order, where the order is the meaning. */
+export function buildSources(): Array<SourceEntry> {
+  return [
+    { id: 'team', name: 'team', origin: { kind: 'directory', location: '/srv/team-guidance' } },
+    { id: 'packaged', name: 'packaged', origin: { kind: 'package', location: '@acme/guidance' } },
+    { id: 'library', name: 'library', origin: { kind: 'directory', location: '/opt/compositor/library' } },
+  ];
+}

--- a/packages/compositor/src/samples/representative/buildTargets.ts
+++ b/packages/compositor/src/samples/representative/buildTargets.ts
@@ -1,0 +1,43 @@
+import type { TargetEntry } from '../../schemas/target-schemas.ts';
+
+/** Builds the targets the representative sample renders into. */
+export function buildTargets(): Array<TargetEntry> {
+  return [
+    {
+      id: 'claude',
+      label: 'Claude',
+      root: '~/.claude',
+      tokenMappings: [
+        {
+          kindId: 'tool',
+          entries: [
+            { from: 'Edit', to: 'Edit' },
+            { from: 'Read', to: 'Read' },
+          ],
+        },
+      ],
+      variables: [
+        { name: 'guidanceFile', value: 'CLAUDE.md' },
+        { name: 'skillSigil', value: '/' },
+      ],
+    },
+    {
+      id: 'rovodev',
+      label: 'Rovo Dev',
+      root: '~/.rovodev',
+      tokenMappings: [
+        {
+          kindId: 'tool',
+          entries: [
+            { from: 'Edit', to: 'edit_file' },
+            { from: 'Read', to: 'open_files' },
+          ],
+        },
+      ],
+      variables: [
+        { name: 'guidanceFile', value: 'AGENTS.md' },
+        { name: 'skillSigil', value: '!' },
+      ],
+    },
+  ];
+}

--- a/packages/compositor/src/samples/representative/buildTiers.ts
+++ b/packages/compositor/src/samples/representative/buildTiers.ts
@@ -1,0 +1,9 @@
+import type { TierDescriptor } from '../../schemas/descriptor-schemas.ts';
+
+/** Builds the tiers the representative sample's artifacts are seeded from, in precedence order. */
+export function buildTiers(): Array<TierDescriptor> {
+  return [
+    { id: 'user', label: 'User' },
+    { id: 'project', label: 'Project' },
+  ];
+}

--- a/packages/compositor/src/samples/representative/createBlobStore.ts
+++ b/packages/compositor/src/samples/representative/createBlobStore.ts
@@ -1,0 +1,45 @@
+import { Buffer } from 'node:buffer';
+
+import { compareStrings } from '../../portable/compareStrings.ts';
+import { hashBytes, hashUtf8 } from '../../portable/hash-content.ts';
+import type { Blob, FileSide } from '../../schemas/file-schemas.ts';
+import type { Hash } from '../../schemas/scalar-schemas.ts';
+
+/**
+ * The bodies a sample's files name, addressed by content as each one is registered.
+ *
+ * Write-only: a plan's `blobs` record is the readable form, which `toTable` emits once construction is done.
+ */
+export interface BlobStore {
+  /** Registers `data` as a byte-encoded blob and returns the file side naming it. */
+  addBytes(data: Uint8Array): FileSide;
+
+  /** Registers `data` as a UTF-8 blob and returns the file side naming it. */
+  addUtf8(data: string): FileSide;
+
+  /** Every registered blob, keyed by hash in hash order. */
+  toTable(): Record<Hash, Blob>;
+}
+
+/** Creates an empty blob store. */
+export function createBlobStore(): BlobStore {
+  const blobs = new Map<Hash, Blob>();
+
+  return {
+    addBytes(data) {
+      const hash = hashBytes(data);
+      blobs.set(hash, { encoding: 'base64', data: Buffer.from(data).toString('base64') });
+      return { hash };
+    },
+
+    addUtf8(data) {
+      const hash = hashUtf8(data);
+      blobs.set(hash, { encoding: 'utf8', data });
+      return { hash };
+    },
+
+    toTable() {
+      return Object.fromEntries([...blobs].toSorted(([left], [right]) => compareStrings(left, right)));
+    },
+  };
+}

--- a/packages/compositor/src/samples/representative/file-bodies.ts
+++ b/packages/compositor/src/samples/representative/file-bodies.ts
@@ -1,0 +1,22 @@
+/** File bodies: the content the representative sample's files carry on each side of their diffs. */
+
+import { Buffer } from 'node:buffer';
+
+export const REGION_CLOSE = '<!-- ambient:end -->';
+export const REGION_OPEN = '<!-- ambient:start -->';
+
+export const AUDITOR_CURRENT = '# Auditor\n\nAudit the change.\n';
+export const AUDITOR_PLANNED = '# Auditor\n\nAudit the change against its ticket.\n';
+export const CLAUDE_MD_CURRENT = `# Guidance\n\n${REGION_OPEN}\n<!-- rulebook:style -->\nUse sentence case.\n<!-- /rulebook:style -->\n${REGION_CLOSE}\n`;
+export const CLAUDE_MD_PLANNED = `# Guidance\n\n${REGION_OPEN}\n<!-- rulebook:naming -->\nName functions with a leading verb.\n<!-- /rulebook:naming -->\n\n<!-- rulebook:style -->\nUse sentence case.\n<!-- /rulebook:style -->\n\n<!-- rulebook:tests -->\nName tests for the behavior they pin.\n<!-- /rulebook:tests -->\n${REGION_CLOSE}\n`;
+// A PNG signature stands in for a skill asset the engine copies byte for byte.
+export const DIAGRAM_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]);
+export const LINT_SKILL = '# Lint\n\nRun the linter.\n';
+export const RETIRED_SKILL_CURRENT = '# Retired\n\nSuperseded.\n';
+export const REVIEW_SKILL_CURRENT = '# Review\n\nRead the diff.\n';
+export const REVIEW_SKILL_PLANNED = '# Review\n\nRead the diff, then the tests.\n';
+// The first hook belongs to another tool and carries no sentinel; the engine owns only the entries marked with one.
+export const SETTINGS_JSON_CURRENT =
+  '{\n  "hooks": [\n    { "command": "vendor-tool sync" },\n    { "command": "relay --on=stop", "source": "codeassembly" }\n  ]\n}\n';
+export const SETTINGS_JSON_PLANNED =
+  '{\n  "hooks": [\n    { "command": "vendor-tool sync" },\n    { "command": "relay --on=stop", "source": "codeassembly" },\n    { "command": "relay --on=review", "source": "codeassembly" }\n  ]\n}\n';

--- a/packages/compositor/src/samples/representative/file-bodies.ts
+++ b/packages/compositor/src/samples/representative/file-bodies.ts
@@ -2,6 +2,7 @@
 
 import { Buffer } from 'node:buffer';
 
+// The bodies below interpolate these markers, so alphabetizing the module would break its initialization.
 export const REGION_CLOSE = '<!-- ambient:end -->';
 export const REGION_OPEN = '<!-- ambient:start -->';
 


### PR DESCRIPTION
## What

Decomposes compositor's monolithic sample plan into one module per table. The fingerprint's source and target ids are no longer duplicated, but derived directly from those tables. The published sample JSON is unchanged.

## Why

`buildRepresentativeSample.ts` was 337 lines, of which 283 were one function body returning a single plan literal. It was the package's worst case for append-by-default: an agent asked to add a shape to the sample had exactly one place to put it, and every shape competed for the same screen.

## Details

### ♻️ Refactoring

- The plan is composed from one builder per plan table, each in its own module under `src/samples/representative/`: `buildArtifacts`, `buildFiles`, `buildFingerprint`, `buildKinds`, `buildPartials`, `buildSources`, `buildTargets`, and `buildTiers`. `buildRepresentativeSample` is reduced to the composition and the envelope's three scalar fields.
- The file bodies move to `file-bodies.ts`, and the blob accumulator becomes a `createBlobStore()` factory that closes over its `Map`, so hash-ordered emission is part of `toTable`'s contract rather than a detail of the plan literal.
- `buildFingerprint` derives its source and target digests by mapping over the `sources` and `targets` tables it is passed, restating no id.
- `toTable` sorts through `portable/compareStrings` in place of an inline comparator.
- Contextual typing from the declared return types retires fifteen `as const` annotations across the file entries.
- `buildMinimalSample` is untouched: it exists to be read end to end in one screen.
- `samples/representative.json` is byte-identical, which the existing drift test pins.

### 🧪 Tests

- The ten shape assertions in `samples.unit.test.ts` split to sit with their subjects: four to `buildArtifacts.unit.test.ts`, six to `buildFiles.unit.test.ts`. `samples.unit.test.ts` keeps the schema and consistency properties every published sample satisfies.
- `createBlobStore.unit.test.ts` covers the store's own behavior: content addressing, `base64` for bytes and `utf8` for text, hash-ordered emission regardless of insertion order, deduplication of a shared body, and the empty table.

Closes #187
