### PR TITLE
#198 Apply comment discipline to the schema modules

### DIFF
--- a/packages/compositor/src/schemas/__tests__/catalog-schemas.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/catalog-schemas.unit.test.ts
@@ -69,7 +69,6 @@ describe('CatalogSchema', () => {
 });
 
 describe('ResolveKindSchema', () => {
-  // The extension is what keeps the two tables from drifting: a catalog's kinds are readable as a plan's.
   it('produces a kind a plan accepts in its own kinds table', () => {
     const resolveKind = ResolveKindSchema.parse(directoryKind);
 
@@ -142,7 +141,7 @@ describe('catalog schema evolution', () => {
 
 // region | Helpers
 
-/** The smallest catalog that satisfies the schema: one kind, one source, one entry. */
+/** Builds the smallest catalog that satisfies the schema: one kind, one source, one entry. */
 function buildMinimalCatalog(): z.infer<typeof CatalogSchema> {
   return {
     schemaVersion: CATALOG_SCHEMA_VERSION,

--- a/packages/compositor/src/schemas/__tests__/config-schemas.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/config-schemas.unit.test.ts
@@ -33,7 +33,6 @@ describe('TierBodySchema', () => {
     });
   });
 
-  // Strict, so a misspelled key fails rather than declaring nothing at all.
   it('rejects an unrecognized top-level key, naming it', () => {
     const result = TierBodySchema.safeParse({ selects: {} });
 
@@ -74,7 +73,6 @@ describe('CompositorConfigSchema', () => {
     expect(CompositorConfigSchema.parse({})).toStrictEqual({ tiers: [] });
   });
 
-  // A What-if pass mutates a config it already holds and re-parses it, so normalizing twice must change nothing.
   it('parses its own output unchanged', () => {
     const config = CompositorConfigSchema.parse({ tiers: [authoredTier] });
 

--- a/packages/compositor/src/schemas/__tests__/selection-schemas.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/selection-schemas.unit.test.ts
@@ -15,7 +15,6 @@ describe('SelectorSchema', () => {
     expect(SelectorSchema.parse(selector)).toStrictEqual(selector);
   });
 
-  // Rejecting rather than stripping is the point: a strip would discard half of what the author wrote.
   it('rejects an entry naming both an artifact and a source', () => {
     expect(findIssuePaths(SelectorSchema, { artifact: 'lint', source: 'acme' })).toBeDefined();
   });

--- a/packages/compositor/src/schemas/catalog-schemas.ts
+++ b/packages/compositor/src/schemas/catalog-schemas.ts
@@ -35,8 +35,8 @@ export const KindLayoutSchema = z
 /**
  * One artifact kind as resolution needs it: the plan's descriptor, plus where a source keeps artifacts of that kind.
  *
- * Extends the plan's descriptor rather than paralleling it, so a catalog's `kinds` entry parses as a plan's and the two
- * cannot drift. The layout rides along because a consumer rendering a source's tree has no other way to learn it.
+ * Extends the plan's descriptor, so a catalog's `kinds` entry parses as a plan's and the two cannot drift. The layout
+ * rides along because a consumer rendering a source's tree has no other way to learn it.
  */
 export const ResolveKindSchema = KindDescriptorSchema.extend({ layout: KindLayoutSchema }).meta({ id: 'ResolveKind' });
 
@@ -52,7 +52,7 @@ export const SourceSpecSchema = SourceEntrySchema.extend({ dir: z.string() }).me
  * One artifact some source carries, and how precedence settled it.
  *
  * `id` composes `kindId` and `slug`, matching the id a plan gives the same artifact, so a plan entry addresses its
- * catalog entry. It stays opaque on the read side: a slug carrying the separator makes splitting it wrong.
+ * catalog entry.
  */
 export const CatalogEntrySchema = z
   .object({

--- a/packages/compositor/src/schemas/descriptor-schemas.ts
+++ b/packages/compositor/src/schemas/descriptor-schemas.ts
@@ -30,8 +30,7 @@ export const SourceOriginSchema = z
 /**
  * One declared content source.
  *
- * The `sources` array is ordered highest precedence first, and that order is the only encoding of precedence. A
- * consumer's bundled library holds no special status here: it enters as an ordinary directory source declared last.
+ * The `sources` array is ordered highest precedence first, and that order is the only encoding of precedence.
  */
 export const SourceEntrySchema = z
   .object({

--- a/packages/compositor/src/schemas/graph-schemas.ts
+++ b/packages/compositor/src/schemas/graph-schemas.ts
@@ -35,8 +35,7 @@ export const DependencyEdgeSchema = z
  * How an artifact entered the closure as a root.
  *
  * `declaration` is a tier naming the artifact itself. `source-catalog` is a tier taking everything one source carries,
- * which names no artifact and so cannot say which one it meant. Nothing here is particular to a package: taking a
- * source whole is a selection any source can be the object of.
+ * which names no artifact and so cannot say which one it meant.
  */
 export const SeedOriginSchema = z.enum(['declaration', 'source-catalog']).meta({ id: 'SeedOrigin' });
 

--- a/packages/compositor/src/schemas/source-declaration-schemas.ts
+++ b/packages/compositor/src/schemas/source-declaration-schemas.ts
@@ -45,8 +45,7 @@ export const DeclaredSourceSchema = z.union([
 /**
  * One tier's source declarations: the sources it adds, and the inherited names it drops.
  *
- * `drop` names sources rather than carrying entries, because a name is the whole of what identifies one. Dropping is
- * what the port could do to a package and not to a source; unifying the two lists keeps the stronger semantics.
+ * `drop` names sources rather than carrying entries, because a name is the whole of what identifies one.
  */
 export const SourceDeclarationSchema = z.strictObject({
   use: z.array(DeclaredSourceSchema).default([]),

--- a/packages/compositor/src/schemas/test-utils/findIssuePaths.ts
+++ b/packages/compositor/src/schemas/test-utils/findIssuePaths.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod';
 
 /**
- * The path of each validation issue `value` raises against `schema`, or `undefined` when it validates.
+ * Collects the path of each validation issue `value` raises against `schema`, or nothing when it validates.
  *
  * Asserting on paths pins a rejection to the field that caused it, so a test cannot pass because some unrelated part of
  * the fixture happened to be malformed.


### PR DESCRIPTION
## What

Tightens comments by removing narration of development history and focusing them on the code itself. Function descriptions are now aligned with house style.

## Why

The schema modules had never been audited against the comment-discipline tests, and their prose was written during a run of decomposition work that left behind references to project episodes a later reader has no way to reconstruct. A comment that only a witness to the change can interpret costs the reader time and teaches the next author to write more of them.

## Details

### 📝 Documentation

Every file under `packages/compositor/src/schemas/` was read in full and each comment decided on its merits, applying the stranger, deletion, and one-location tests together with the verb-led register.

Deletions fell into two groups. Three comments introduced an outside concept only to deny it held special status, including one turning on a prior porting effort that no longer names anything in the codebase. Four restated a fact already documented on the schema being tested or described.

Contrastive clauses that define the code's present shape were kept throughout: they decode Zod constructs, `z.never().optional()` and `strictObject` among them, that a reader cannot otherwise interpret. Noun-phrase descriptions on schema constants were left as written, since the verb-led register governs functions rather than the constants that carry this package's type definitions.

Closes #198
