### PR TITLE
#199 Revise comments in the config and resolution modules

### DIFF
--- a/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
@@ -29,7 +29,6 @@ describe(loadConfig, () => {
     expect(config.tiers.map(({ id }) => id)).toStrictEqual(['global', 'project']);
   });
 
-  // An absent file is a tier a consumer looked for and did not find; an empty one is a tier that declares nothing.
   it('skips a tier whose file is absent, and keeps one whose file is empty', async () => {
     const dir = await buildConfigDir({ 'global.yaml': '# every entry commented out\n' });
 
@@ -48,7 +47,6 @@ describe(loadConfig, () => {
     });
   });
 
-  // A relative path resolves against where it was written, not against the directory the process runs in.
   it('takes each tier’s base directory from the file that declared it', async () => {
     const dir = await buildConfigDir({ 'nested/project.yaml': projectTier });
 

--- a/packages/compositor/src/config/__tests__/locatePackage.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/locatePackage.unit.test.ts
@@ -28,7 +28,7 @@ describe(locatePackage, () => {
     ).resolves.toBe(path.join(baseDir, 'node_modules/guidance/share'));
   });
 
-  // Whether the directory exists is the caller's source validation to answer, so both source forms fail through it.
+  // A package source and a hand-declared one both fail through the caller's source validation.
   it('does not require the content directory to exist', async () => {
     const baseDir = await buildConfigDir({
       'node_modules/guidance/package.json': JSON.stringify({ compositor: { content: 'nowhere' } }),
@@ -67,7 +67,6 @@ describe(locatePackage, () => {
     );
   });
 
-  // A relative specifier would otherwise resolve to the anchor directory, opening a second directory-source route.
   it.each(['./content', '../sibling', '/srv/content'])(
     'rejects "%s" as a filesystem path, not a package name',
     (name) => expect(locatePackage(name, { baseDir: '/srv/app', contentKeyPath })).rejects.toThrow(/filesystem path/),

--- a/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
@@ -101,7 +101,6 @@ describe(resolveSources, () => {
     ]);
   });
 
-  // The declaration a consumer wrote is what a plan reports, so resolving must not overwrite it.
   it('keeps the origin as declared beside the directory it resolved to', async () => {
     const config = buildConfig([{ baseDir: '/srv/tier', sources: { use: [{ name: 'x', path: './content' }] } }]);
 

--- a/packages/compositor/src/config/loadConfig.ts
+++ b/packages/compositor/src/config/loadConfig.ts
@@ -21,16 +21,12 @@ export type TierFile = z.infer<typeof TierFileSchema>;
  * Reads the config the given tier files declare, lowest precedence first.
  *
  * Tier identity is the consumer's to supply: a file does not know which tier it is, that follows from where the
- * consumer looked for it, and keeping the decision outside means no particular project layout is compiled in here. Two
- * tiers sharing an id are rejected, because that id is what every seed and diagnostic downstream names the tier by.
+ * consumer looked for it. Two tiers sharing an id are rejected, because that id is what every seed and diagnostic
+ * downstream names the tier by.
  *
  * A tier whose file is absent contributes no tier at all, while one whose file is present but empty contributes a tier
  * declaring nothing. That distinction is what lets a consumer tell "no config here" from "config here, saying nothing".
- * A chain where every file is absent yields a config with no tiers, which already expresses "nothing declared" without
- * a second sentinel.
- *
- * Loading is one way to obtain a config, not the only one: the value this returns is the same shape a consumer can
- * build in memory and hand straight to the flows downstream.
+ * A chain where every file is absent yields a config with no tiers.
  */
 export async function loadConfig(tiers: ReadonlyArray<TierFile>): Promise<CompositorConfig> {
   const validated = tiers.map((tier) => TierFileSchema.parse(tier));
@@ -79,8 +75,8 @@ function parseTierBody(raw: string, filePath: string): TierBody {
 /**
  * Reads one tier from its file, resolving to nothing when that file is absent.
  *
- * `baseDir` is the file's own directory, so a relative path a tier declares resolves against where it was written
- * rather than against whatever directory the process happens to be run from.
+ * `baseDir` is the file's own directory, so a relative path a tier declares resolves against where it was written, not
+ * against the process's working directory.
  */
 async function readTier(tier: TierFile): Promise<ConfigTier | undefined> {
   const raw = await readFileIfPresent(tier.path);

--- a/packages/compositor/src/config/locatePackage.ts
+++ b/packages/compositor/src/config/locatePackage.ts
@@ -9,7 +9,7 @@ export interface LocatePackageOptions {
   readonly baseDir: string;
   /**
    * The key path into a package's own `package.json` that names its content directory, such as
-   * `['compositor', 'content']`. Supplied rather than fixed, so no consumer's namespace is compiled in here.
+   * `['compositor', 'content']`.
    */
   readonly contentKeyPath: ReadonlyArray<string>;
 }
@@ -18,14 +18,11 @@ export interface LocatePackageOptions {
  * Locates the directory `name` ships its content in.
  *
  * Resolution walks the `node_modules` chain Node itself would search from `baseDir`, so it holds under pnpm's symlinked
- * layout and under workspace links, which is what lets a producing repo consume its own content through the declaration
- * a third party would write. Probing the filesystem rather than resolving a package subpath is deliberate: a modern
- * `exports` map does not expose `./package.json`, and a content-only package has no importable entry to resolve
- * instead.
+ * layout and under workspace links. The manifest is read from disk, because a modern `exports` map need not expose
+ * `./package.json` and a content-only package has no importable entry.
  *
  * Throws when the name is a filesystem path rather than a package name, when the package is not installed, or when it
- * declares no content directory. Whether that directory exists is left to the caller's source validation, so a package
- * source and a hand-declared one fail through one path.
+ * declares no content directory. Whether that directory exists is the caller's source validation to answer.
  */
 export async function locatePackage(name: string, options: LocatePackageOptions): Promise<string> {
   assertPackageName(name);
@@ -91,8 +88,7 @@ function parseManifest(name: string, raw: string): unknown {
 /**
  * Reads the content directory `manifest` declares at `keyPath`.
  *
- * The key has no default, because a default location would claim a directory name in every producer's package root. A
- * producer states where its content lives and can nest it under a directory it already owns.
+ * The key has no default, because a default location would claim a directory name in every producer's package root.
  */
 function readContentPath(name: string, manifest: unknown, keyPath: ReadonlyArray<string>): string {
   let current: unknown = manifest;
@@ -101,8 +97,6 @@ function readContentPath(name: string, manifest: unknown, keyPath: ReadonlyArray
       current = undefined;
       break;
     }
-    // A key the manifest does not carry reads as `undefined`, which the check below rejects along with every other
-    // value that is not a directory name.
     const next: unknown = Reflect.get(current, key);
     current = next;
   }

--- a/packages/compositor/src/config/resolveSources.ts
+++ b/packages/compositor/src/config/resolveSources.ts
@@ -9,7 +9,7 @@ import { locatePackage } from './locatePackage.ts';
 export interface ResolveSourcesOptions {
   /**
    * The key path into a package's own `package.json` that names its content directory, such as
-   * `['compositor', 'content']`. Supplied rather than fixed, so no consumer's namespace is compiled in here.
+   * `['compositor', 'content']`.
    */
   readonly contentKeyPath: ReadonlyArray<string>;
 }
@@ -37,7 +37,7 @@ export interface SourceResolution {
  *
  * A package name is located here; a path is resolved against the tier that declared it. The location a consumer wrote
  * stays on the origin either way, so a plan reports the declaration rather than where it landed. Whether a resolved
- * directory exists is `assertSourceIsReadable`'s question, so a package source and a hand-declared one fail alike.
+ * directory exists is `assertSourceIsReadable`'s question.
  */
 export async function resolveSources(
   config: CompositorConfig,

--- a/packages/compositor/src/config/test-utils/buildConfigDir.ts
+++ b/packages/compositor/src/config/test-utils/buildConfigDir.ts
@@ -1,6 +1,6 @@
 import { buildTempTree } from '../../test-utils/buildTempTree.ts';
 
-/** A directory holding each path in `files` with the given content, removed when the test ends. */
+/** Builds a directory holding each path in `files` with the given content, removed when the test ends. */
 export async function buildConfigDir(files: Record<string, string>): Promise<string> {
   return buildTempTree(files, 'compositor-config');
 }

--- a/packages/compositor/src/resolution/__tests__/assertSourceIsReadable.unit.test.ts
+++ b/packages/compositor/src/resolution/__tests__/assertSourceIsReadable.unit.test.ts
@@ -35,8 +35,6 @@ describe(assertSourceIsReadable, () => {
     await chmod(source.dir, 0o000);
 
     try {
-      // A source behind an unreadable parent must not read as one that does not exist: the declaration is fine, and
-      // reporting it as missing would send the reader looking for a typo.
       await expect(assertSourceIsReadable({ ...source, dir: unreachable })).rejects.toThrow(/EACCES/);
     } finally {
       // Restored before the fixture is removed, since the cleanup cannot descend into an unreadable directory.

--- a/packages/compositor/src/resolution/__tests__/enumerateSource.unit.test.ts
+++ b/packages/compositor/src/resolution/__tests__/enumerateSource.unit.test.ts
@@ -125,7 +125,6 @@ describe(enumerateSource, () => {
     await chmod(skillsDir, 0o000);
 
     try {
-      // An unreadable root must not read as an empty one: that would silently hand the artifact to a lower source.
       await expect(enumerateSource(source, [skillKind])).rejects.toThrow(/EACCES/);
     } finally {
       // Restored before the fixture is removed, since the cleanup cannot descend into an unreadable directory.
@@ -177,12 +176,12 @@ describe('artifact digests', () => {
 
 // region | Helpers
 
-/** The slugs the source carries across `kinds`, in enumeration order. */
+/** Collects the slugs the source carries across `kinds`, in enumeration order. */
 async function collectSlugs(source: SourceSpec, kinds: ReadonlyArray<ResolveKind>): Promise<Array<string>> {
   return (await enumerateSource(source, kinds)).map((artifact: SourceArtifact) => artifact.slug);
 }
 
-/** The digest of the source's single artifact of `kind`, failing the test when it carries none. */
+/** Reads the digest of the source's single artifact of `kind`, failing the test when it carries none. */
 async function requireArtifactHash(source: SourceSpec, kind: ResolveKind): Promise<string> {
   const artifact = (await enumerateSource(source, [kind])).at(0);
   if (artifact === undefined) {

--- a/packages/compositor/src/resolution/__tests__/resolveCatalog.unit.test.ts
+++ b/packages/compositor/src/resolution/__tests__/resolveCatalog.unit.test.ts
@@ -172,7 +172,7 @@ describe(resolveCatalog, () => {
 
 // region | Helpers
 
-/** One source directory per named entry, in the order given, highest precedence first. */
+/** Builds one source directory per named entry, in the order given, highest precedence first. */
 async function buildSources(byName: Record<string, Record<string, string>>): Promise<ReadonlyArray<SourceSpec>> {
   const sources: Array<SourceSpec> = [];
   for (const [name, files] of Object.entries(byName)) {
@@ -182,7 +182,7 @@ async function buildSources(byName: Record<string, Record<string, string>>): Pro
   return sources;
 }
 
-/** The catalog's single entry, failing the test when it carries any other number. */
+/** Reads the catalog's single entry, failing the test when it carries any other number. */
 async function requireOnlyEntry(sources: ReadonlyArray<SourceSpec>): Promise<CatalogEntry> {
   const { entries } = await resolveCatalog({ kinds, sources });
   const entry = entries.at(0);

--- a/packages/compositor/src/resolution/assertCatalogIsConsistent.ts
+++ b/packages/compositor/src/resolution/assertCatalogIsConsistent.ts
@@ -29,8 +29,8 @@ export class CatalogConsistencyError extends ConsistencyError {
  * output. It is for a catalog that arrived as data, which is the case a reader rendering a payload it did not compute
  * is in.
  *
- * The checks live here rather than as schema refinements because a refinement would be invisible to `z.toJSONSchema`,
- * leaving a generated JSON Schema accepting catalogs this package rejects.
+ * A schema refinement would be invisible to `z.toJSONSchema`, so a generated JSON Schema would accept catalogs this
+ * package rejects.
  *
  * Every violation is collected before throwing, so one run reports all of them. The order of the checks below is the
  * order they are reported in.

--- a/packages/compositor/src/resolution/checks/findRepeatedCandidateSources.ts
+++ b/packages/compositor/src/resolution/checks/findRepeatedCandidateSources.ts
@@ -5,7 +5,7 @@ import type { Catalog } from '../../schemas/catalog-schemas.ts';
  * Reports each entry naming one source more than once among its candidates.
  *
  * A source carries an artifact at one path, so it either wins resolution or loses it. Appearing twice would let one
- * source both shadow and be shadowed by itself, and would render a source explaining its own defeat.
+ * source both shadow and be shadowed by itself.
  */
 export function findRepeatedCandidateSources(catalog: Catalog): Array<Violation> {
   const violations: Array<Violation> = [];

--- a/packages/compositor/src/resolution/composeArtifactId.ts
+++ b/packages/compositor/src/resolution/composeArtifactId.ts
@@ -1,7 +1,7 @@
 import type { Id, KindId } from '../schemas/scalar-schemas.ts';
 
 /**
- * The id identifying one artifact, composed from its kind and slug.
+ * Composes the id identifying one artifact from its kind and slug.
  *
  * A catalog entry and the plan artifact describing the same artifact compose their id the same way, which is what lets
  * a plan entry address its catalog entry. The result is opaque to a reader: a slug carrying the separator makes

--- a/packages/compositor/src/resolution/enumerateSource.ts
+++ b/packages/compositor/src/resolution/enumerateSource.ts
@@ -21,12 +21,12 @@ export interface SourceArtifact {
 }
 
 /**
- * Every artifact `source` carries, across every kind in `kinds`.
+ * Enumerates every artifact `source` carries, across every kind in `kinds`.
  *
- * Enumerates rather than probes for a named slug, which is what makes shadowed candidates and "what does this source
- * carry" answerable at all. A kind whose root is absent from this source contributes nothing, because a source is free
- * to carry only some of the kinds in play; an unreadable root is a failure, so a permission problem cannot pass for an
- * empty one and let a lower-precedence source win by default.
+ * Resolution ranks shadowed candidates across sources, so it needs the whole of what each source carries. A kind whose
+ * root is absent from this source contributes nothing, because a source is free to carry only some of the kinds in
+ * play; an unreadable root is a failure, so a permission problem cannot pass for an empty one and let a
+ * lower-precedence source win by default.
  *
  * Results run by kind, in the order `kinds` gives, then by slug.
  */
@@ -40,7 +40,7 @@ export async function enumerateSource(
 
 // region | Helpers
 
-/** Every artifact of one kind under `sourceDir`, ordered by slug. */
+/** Enumerates every artifact of one kind under `sourceDir`, ordered by slug. */
 async function enumerateKind(sourceDir: string, kind: ResolveKind): Promise<Array<SourceArtifact>> {
   const rootDir = path.join(sourceDir, kind.layout.root);
   const names = (await readDirNames(rootDir)).filter((name) => isArtifactName(name));
@@ -63,11 +63,10 @@ function isArtifactName(name: string): boolean {
 }
 
 /**
- * One artifact at `name` under `rootDir`, or nothing when the entry is not one.
+ * Reads one artifact at `name` under `rootDir`, or nothing when the entry is not one.
  *
  * A `file` kind's entry must be a file carrying the declared extension. A `directory` kind's must be a directory whose
- * entry file exists and is itself a file: a directory bearing the entry file's own name is not an artifact, and reading
- * a body that is not there is the failure that check prevents.
+ * entry file exists and is itself a file, since a directory bearing the entry file's own name is not an artifact.
  */
 async function readArtifact(rootDir: string, name: string, kind: ResolveKind): Promise<SourceArtifact | undefined> {
   const { layout } = kind;

--- a/packages/compositor/src/resolution/resolveCatalog.ts
+++ b/packages/compositor/src/resolution/resolveCatalog.ts
@@ -14,7 +14,7 @@ export interface ResolveCatalogInput {
 }
 
 /**
- * Every artifact the sources carry, each resolved to the source that won it and the sources that lost.
+ * Resolves every artifact the sources carry, each to the source that won it and the sources that lost.
  *
  * Precedence is `sources` order and nothing else: the first source carrying an artifact wins it, and a consumer's
  * bundled library shadows nothing by declaring itself last. Resolution reads no config and computes no closure, so what
@@ -22,9 +22,6 @@ export interface ResolveCatalogInput {
  *
  * Every source is checked before any is read, so a mistyped source fails the call rather than half-populating a catalog
  * and letting the artifacts it should have carried resolve from somewhere else.
- *
- * The result satisfies `assertCatalogIsConsistent` by construction, which is why this does not call it: a replan would
- * pay for the checks on every pass, and the assertion is for a catalog that arrived as data.
  */
 export async function resolveCatalog(input: ResolveCatalogInput): Promise<Catalog> {
   const { kinds, sources } = input;
@@ -61,7 +58,7 @@ export async function resolveCatalog(input: ResolveCatalogInput): Promise<Catalo
 // region | Helpers
 
 /**
- * One entry from the candidates carrying its artifact, the first being the winner.
+ * Builds one entry from the candidates carrying its artifact, the first being the winner.
  *
  * The candidates arrive in source order because the merge walks the sources in precedence order, so the winner needs no
  * comparison: it is the one that got there first.

--- a/packages/compositor/src/resolution/test-utils/buildCatalog.ts
+++ b/packages/compositor/src/resolution/test-utils/buildCatalog.ts
@@ -2,7 +2,7 @@ import type { Catalog } from '../../schemas/catalog-schemas.ts';
 import { CATALOG_SCHEMA_VERSION } from '../../schemas/catalog-schemas.ts';
 
 /**
- * A small catalog that satisfies both the schema and every consistency invariant.
+ * Builds a small catalog that satisfies both the schema and every consistency invariant.
  *
  * Exercises the shapes a trivial catalog would leave untested: three sources rather than two, so a mis-ordered pair of
  * losers is distinguishable from a reversed one; both layout forms; an artifact two sources shadow; and an artifact the

--- a/packages/compositor/src/resolution/test-utils/buildSource.ts
+++ b/packages/compositor/src/resolution/test-utils/buildSource.ts
@@ -2,7 +2,7 @@ import type { SourceSpec } from '../../schemas/catalog-schemas.ts';
 import { buildTempTree } from '../../test-utils/buildTempTree.ts';
 
 /**
- * A source directory holding each path in `files` with the given content, removed when the test ends.
+ * Builds a source directory holding each path in `files` with the given content, removed when the test ends.
  *
  * `name` becomes the source's id, its name, and its temp-directory prefix, so a test resolving several sources can
  * tell which directory belongs to which.


### PR DESCRIPTION
## What

Tightens comments by reducing duplication, removing narration of development history, and focusing on the code itself. Function descriptions are now aligned with house style.

## Why

The comment layer had drifted in two directions at once. Function descriptions were split between a verb-led form and a verbless noun phrase, and the rationale prose accumulated during the package's decomposition had never been audited, so comments arguing with a reviewer sat beside comments carrying live constraints. Both cost the reader, and both teach the next contributor the wrong pattern by example.

## Details

### 📚 Documentation

- Thirteen function descriptions that were verbless noun phrases now lead with a third-person indicative verb. Types, interfaces, constants (Zod schema objects included), and error classes keep their noun phrase.
- Every comment in the 28 files was judged against the stranger, deletion, and one-location tests. Deletions outnumber additions: 34 insertions against 55 deletions, a net 21 lines lighter.
- Comments carrying a live constraint were kept and restated without their self-defense. The note explaining that a package manifest is read from disk survives, with the `exports`-map limitation that forces it intact and the "is deliberate" argument gone.
- Over half the deletions were a single fact documented twice, once on a function and again in the test covering it.

No behavior changes and no file reorganization; the diff touches no line outside a comment.

Closes #199
