### PR TITLE
#200 Apply comment discipline to the plan, consistency, graph, and selection modules

### DIFF
--- a/packages/compositor/src/consistency/ConsistencyError.ts
+++ b/packages/compositor/src/consistency/ConsistencyError.ts
@@ -3,8 +3,8 @@ import type { Violation } from './Violation.ts';
 /**
  * Raised when a structurally valid document contradicts itself.
  *
- * Published so a consumer validating both a plan and a catalog catches one type rather than naming each subclass. The
- * subject word composes the message, so each subclass names the document it guards.
+ * Published so a consumer validating both a plan and a catalog catches one type. The subject word composes the
+ * message, so each subclass names the document it guards.
  */
 export class ConsistencyError extends Error {
   override readonly name: string = 'ConsistencyError';

--- a/packages/compositor/src/consistency/__tests__/findResolutionOrderViolations.unit.test.ts
+++ b/packages/compositor/src/consistency/__tests__/findResolutionOrderViolations.unit.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import type { ResolutionCandidate } from '../../schemas/artifact-resolution-schemas.ts';
 import { findResolutionOrderViolations } from '../findResolutionOrderViolations.ts';
 
-// Highest precedence first, which is the order the rule reads.
 const sources = [{ id: 'local' }, { id: 'team' }, { id: 'library' }];
 
 describe(findResolutionOrderViolations, () => {

--- a/packages/compositor/src/consistency/createRequireKnown.ts
+++ b/packages/compositor/src/consistency/createRequireKnown.ts
@@ -1,10 +1,10 @@
 import type { Violation } from './Violation.ts';
 
-/** Records a violation for an id reference naming no entry in the table it points at. */
+/** A recorder for id references naming no entry in the table they point at. */
 export type RequireKnown = (known: ReadonlySet<string>, id: string | undefined, path: string, table: string) => void;
 
 /**
- * Creates a recorder that appends to `violations` for each id reference naming no entry in the table it points at.
+ * Creates a recorder appending to `violations`.
  *
  * Shared by the plan and catalog dangling-reference checks, which walk different documents but apply one rule. The
  * accumulator stays with the traversal so a check still returns its own violations; only the rule is shared.

--- a/packages/compositor/src/consistency/findResolutionOrderViolations.ts
+++ b/packages/compositor/src/consistency/findResolutionOrderViolations.ts
@@ -14,8 +14,8 @@ export interface ResolutionAt {
  * descend from there. Nothing else validates this: the schema cannot express an ordering, and a payload listing losers
  * arbitrarily would otherwise render "shadowing Z" from data no check had looked at.
  *
- * Shared by the plan and catalog assertions, which carry the same resolution sub-shape and would otherwise each hold a
- * copy of this rule. Only the reported path differs, which is what `basePath` supplies.
+ * Shared by the plan and catalog assertions, which carry the same resolution sub-shape and differ only in the reported
+ * path, which `basePath` supplies.
  *
  * A candidate naming an unknown source is skipped here, because each caller reports the dangling reference itself. A
  * repeated source id ranks at its first occurrence, which is the one that would win resolution; the repeat itself is

--- a/packages/compositor/src/graph/__tests__/traversal.unit.test.ts
+++ b/packages/compositor/src/graph/__tests__/traversal.unit.test.ts
@@ -101,10 +101,10 @@ describe(buildDependentsIndex, () => {
 // region | Helpers
 
 /**
- * A graph carrying only what traversal reads, standing in for a closure before one exists.
+ * Builds a graph carrying only what traversal reads, standing in for a closure before one exists.
  *
- * Nothing here is a plan: no status, no resolution, no kind. That is the point, because the helpers take this shape and
- * the closure ticket therefore adds no second copy of them.
+ * Nothing here is a plan: no status, no resolution, no kind. Traversal reads none of them, so a fixture that carried
+ * them could pass while depending on a field a closure does not have.
  */
 function buildClosureShaped(): DependencyGraphView {
   return {
@@ -120,7 +120,7 @@ function buildClosureShaped(): DependencyGraphView {
   };
 }
 
-/** The fixture plan with a second route to `skill:lint`, so one artifact is reached by two paths. */
+/** Builds the fixture plan with a second route to `skill:lint`, so one artifact is reached by two paths. */
 function buildDiamond(): Plan {
   const plan = buildPlan();
   const core = requireEntry(plan.artifacts, 0);

--- a/packages/compositor/src/graph/__tests__/traversal.unit.test.ts
+++ b/packages/compositor/src/graph/__tests__/traversal.unit.test.ts
@@ -101,7 +101,7 @@ describe(buildDependentsIndex, () => {
 // region | Helpers
 
 /**
- * Builds a graph carrying only what traversal reads, standing in for a closure before one exists.
+ * Builds a graph carrying only what traversal reads.
  *
  * Nothing here is a plan: no status, no resolution, no kind. Traversal reads none of them, so a fixture that carried
  * them could pass while depending on a field a closure does not have.

--- a/packages/compositor/src/graph/traversal.ts
+++ b/packages/compositor/src/graph/traversal.ts
@@ -41,10 +41,10 @@ export function buildDependentsIndex(view: DependencyGraphView): DependentsIndex
 }
 
 /**
- * Every path from a seeded artifact to `artifactId`, following dependency edges.
+ * Derives every path from a seeded artifact to `artifactId`, following dependency edges.
  *
- * A diamond yields one path per route. Paths are derived on demand because enumerating them is exponential in a
- * diamond-heavy graph, and a document recomputed on every toggle cannot afford to carry them; one lookup covers one
+ * A diamond yields one path per route. Precomputing them is not an option: enumerating paths is exponential in a
+ * diamond-heavy graph, and a document recomputed on every toggle cannot afford to carry them. One lookup covers one
  * artifact, at the moment a reader asks why it is present.
  *
  * Each path runs seed-first and ends at `artifactId`, so a seeded artifact yields a single one-element path. Ordering
@@ -85,7 +85,7 @@ export function resolveInclusionPaths(view: DependencyGraphView, artifactId: Art
 
 // region | Helpers
 
-/** The outgoing edge targets of each artifact, in the order the document records them. */
+/** Maps each artifact to its outgoing edge targets, in the order the document records them. */
 function buildForwardEdges(view: DependencyGraphView): ReadonlyMap<ArtifactId, ReadonlyArray<ArtifactId>> {
   const edges = new Map<ArtifactId, Array<ArtifactId>>();
   for (const artifact of view.artifacts) {
@@ -97,7 +97,7 @@ function buildForwardEdges(view: DependencyGraphView): ReadonlyMap<ArtifactId, R
   return edges;
 }
 
-/** The artifacts a path can start from: those something seeded, in table order. */
+/** Finds the artifacts a path can start from: those something seeded, in table order. */
 function findSeeds(view: DependencyGraphView): ReadonlyArray<ArtifactId> {
   return view.artifacts
     .filter((artifact) => artifact.status !== 'removed' && (artifact.seededBy ?? []).length > 0)

--- a/packages/compositor/src/plan/buildTraversalIndex.ts
+++ b/packages/compositor/src/plan/buildTraversalIndex.ts
@@ -6,10 +6,10 @@ import type { ArtifactId } from '../schemas/scalar-schemas.ts';
 
 /** Reverse lookups over a plan's graph, answering the two "used by" directions the payload stores only forwards. */
 export interface TraversalIndex {
-  /** The artifacts whose edges point at `artifactId`. */
+  /** Finds the artifacts whose edges point at `artifactId`. */
   findDependents(artifactId: ArtifactId): ReadonlyArray<ArtifactId>;
 
-  /** The files `artifactId` contributes content to. */
+  /** Finds the files `artifactId` contributes content to. */
   findContributedFiles(artifactId: ArtifactId): ReadonlyArray<FileEntry>;
 }
 
@@ -18,8 +18,8 @@ export interface TraversalIndex {
  *
  * The file-to-artifact edge is written only on the file, so the artifact-to-file direction exists nowhere in the
  * payload until it is derived here. That half is plan-only, having no counterpart in a closure, which is why the
- * artifact-to-artifact half lives in `buildDependentsIndex` and is composed rather than repeated. Build once per plan: a
- * provenance pane issues many lookups against one plan.
+ * artifact-to-artifact half lives in `buildDependentsIndex` and is composed here. Build once per plan: a provenance
+ * pane issues many lookups against one plan.
  */
 export function buildTraversalIndex(plan: Plan): TraversalIndex {
   const findDependents = buildDependentsIndex(plan);

--- a/packages/compositor/src/plan/checks/findDanglingReferences.ts
+++ b/packages/compositor/src/plan/checks/findDanglingReferences.ts
@@ -30,8 +30,7 @@ export function findDanglingReferences(plan: Plan): Array<Violation> {
       requireKnown(artifactIds, edge.to, `${at}.dependsOn[${edgeIndex}].to`, 'artifacts');
       requireKnown(partialIds, edge.partialId, `${at}.dependsOn[${edgeIndex}].partialId`, 'partials');
     }
-    // A removed artifact is seeded by nothing and carries no `seededBy` at all, so the narrowing is what reaches the
-    // field rather than a fallback for an absent one.
+    // A removed artifact carries no `seededBy` at all, so the status narrowing is what reaches the field.
     const seeds = artifact.status === 'removed' ? [] : artifact.seededBy;
     for (const [seedIndex, seed] of seeds.entries()) {
       requireKnown(tierIds, seed.tierId, `${at}.seededBy[${seedIndex}].tierId`, 'tiers');

--- a/packages/compositor/src/selection/__tests__/buildCatalogIndex.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/buildCatalogIndex.unit.test.ts
@@ -34,7 +34,6 @@ describe(buildCatalogIndex, () => {
     expect(buildCatalogIndex(catalog).bySource.get('skill')?.get('acme')).toContain('skill:lint');
   });
 
-  // Shadowing settles which copy resolves; a source a consumer took whole carries the artifact either way.
   it('carries an artifact under a source whose copy is shadowed, not the winner alone', () => {
     expect(buildCatalogIndex(catalog).bySource.get('skill')?.get('local')).toStrictEqual(['skill:review']);
   });

--- a/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
@@ -10,7 +10,7 @@ const catalog = buildCatalogFromSpec({
   entries: [
     { kindId: 'skill', slug: 'lint', carriedBy: ['acme'] },
     { kindId: 'skill', slug: 'format', carriedBy: ['acme'] },
-    // Carried by both, and won by the higher-precedence source: acme still carries it.
+    // The contested entry: local wins it, and acme carries the shadowed copy.
     { kindId: 'skill', slug: 'review', carriedBy: ['local', 'acme'] },
     { kindId: 'rulebook', slug: 'house-style', carriedBy: ['local'] },
   ],
@@ -31,7 +31,6 @@ describe(selectArtifacts, () => {
     expect(collectIds(selection)).toStrictEqual(['skill:format', 'skill:lint', 'skill:review']);
   });
 
-  // Shadowing settles which copy an artifact resolves from; selection settles which artifacts are in play.
   it('takes an artifact a higher-precedence source shadows, because the named source still carries it', () => {
     const selection = select([{ id: 'project', select: { skill: { use: [{ source: 'acme' }] } } }]);
 
@@ -78,7 +77,6 @@ describe(selectArtifacts, () => {
     ]);
   });
 
-  // What survives the fold is what decided the final state, not every tier that ever mentioned the artifact.
   it('names only the deciding tier after a use, a drop, and a use again', () => {
     const selection = select([
       { id: 'global', select: { skill: { use: ['lint'] } } },
@@ -161,7 +159,7 @@ describe(selectArtifacts, () => {
     expect(selection.diagnostics).toHaveLength(2);
   });
 
-  // Every source in the fixture points at a directory that does not exist, so a filesystem read would fail here.
+  // Asserting the dirs is what keeps the claim honest: a source pointing somewhere real would let this pass by accident.
   it('selects without reading anything from disk', () => {
     const selection = select([{ id: 'project', select: { skill: { use: [{ source: 'acme' }] } } }]);
 

--- a/packages/compositor/src/selection/selectArtifacts.ts
+++ b/packages/compositor/src/selection/selectArtifacts.ts
@@ -44,8 +44,8 @@ export interface Selection {
  * beneath it and records the decline, and a later `use` clears the decline and seeds afresh. What survives to the end
  * is therefore what decided the final state, which is what tells a project-level opt-in from an inherited one.
  *
- * A selector matching nothing is a diagnostic rather than a failure, so validation can report every mistake in a config
- * at once instead of stopping at the first.
+ * A selector matching nothing is a diagnostic rather than a failure, so validation reports every mistake in a config at
+ * once.
  */
 export function selectArtifacts(config: CompositorConfig, catalog: Catalog): Selection {
   const index = buildCatalogIndex(catalog);


### PR DESCRIPTION
## What

Tightens comments by reducing duplication, removing narration of development history, and focusing on the code itself. Function descriptions are now aligned with house style.

## Why

The verb-led form was already dominant across the package, which is what made the noun-led remainder self-propagating: an agent writing new code matches its nearest neighbour, and an earlier change reproduced 22 noun-led descriptions before review caught them. These modules' comment sites had also never had a discipline audit, so several facts had accumulated in two and three places at once, each free to drift from the others.

## Details

### 📚 Documentation

Seven function, method, and test-helper descriptions took a third-person indicative verb in place of a noun phrase naming the return value. Types, interfaces, properties, and classes keep their noun phrases; the callable type alias in `consistency/` moved to a noun phrase to match its counterpart in `graph/`, and the factory that builds it dropped the contract it restated.

Five comments were deleted, all of them a fact documented on a function and repeated in the test covering it. Four contrastive clauses were rewritten to keep the constraint and drop the defense of the code's shape.

One recursive closure in `graph/traversal.ts` stays undescribed by explicit decision: its enclosing function's description already states the ordering, multiplicity, and cycle-termination rules a description on the closure would restate.

No behavior changed and no file moved; the diff contains no line outside a comment.

Closes #200
