### PR TITLE
#201 Apply comment discipline to the portable, samples, and scaffolding modules

### DIFF
--- a/packages/compositor/config/generateSamples.ts
+++ b/packages/compositor/config/generateSamples.ts
@@ -1,4 +1,4 @@
-/** Generate `samples/*.json` from the sample plan builders. */
+/** Generates `samples/*.json` from the sample plan builders. */
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';

--- a/packages/compositor/src/__tests__/index.unit.test.ts
+++ b/packages/compositor/src/__tests__/index.unit.test.ts
@@ -27,7 +27,7 @@ describe('package entry', () => {
 
 // region | Helpers
 
-/** Every module the entry re-exports from, paired with its namespace, ordered by specifier. */
+/** Collects every module the entry re-exports from, paired with its namespace, ordered by specifier. */
 async function readPublishedModules(): Promise<Array<readonly [string, Record<string, unknown>]>> {
   const source = await readFile(entryPath, 'utf8');
   const matched = source

--- a/packages/compositor/src/portable/__tests__/listFilesRecursively.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/listFilesRecursively.unit.test.ts
@@ -60,7 +60,7 @@ describe(listFilesRecursively, () => {
 
 // region | Helpers
 
-/** The files beneath `dir` in a stable order, so a test states content rather than filesystem enumeration order. */
+/** Lists the files beneath `dir` in a stable order, so a test states content rather than enumeration order. */
 async function sorted(dir: string, skipName?: (name: string) => boolean): Promise<Array<string>> {
   return (await listFilesRecursively(dir, skipName === undefined ? {} : { skipName })).toSorted();
 }

--- a/packages/compositor/src/portable/__tests__/readDirNames.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/readDirNames.unit.test.ts
@@ -31,7 +31,6 @@ describe(readDirNames, () => {
     await chmod(lockedDir, 0o000);
 
     try {
-      // A permission problem must not read as an empty directory: a caller would take the absence at face value.
       await expect(readDirNames(lockedDir)).rejects.toThrow(/EACCES/);
     } finally {
       // Restored before the fixture is removed, since the cleanup cannot descend into an unreadable directory.

--- a/packages/compositor/src/portable/__tests__/readFileIfPresent.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/readFileIfPresent.unit.test.ts
@@ -37,7 +37,6 @@ describe(readFileIfPresent, () => {
     await chmod(lockedFile, 0o000);
 
     try {
-      // A permission problem must not read as an absent file: the caller would carry on as though nothing were there.
       await expect(readFileIfPresent(lockedFile)).rejects.toThrow(/EACCES/);
     } finally {
       await chmod(lockedFile, 0o644);

--- a/packages/compositor/src/portable/__tests__/statIfPresent.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/statIfPresent.unit.test.ts
@@ -51,7 +51,7 @@ describe(statIfPresent, () => {
     await chmod(lockedDir, 0o000);
 
     try {
-      // Statting below an unsearchable directory fails with EACCES, which is a problem rather than an absence.
+      // Statting below an unsearchable directory fails with EACCES.
       await expect(statIfPresent(path.join(lockedDir, 'inner.md'))).rejects.toThrow(/EACCES/);
     } finally {
       // Restored before the fixture is removed, since the cleanup cannot descend into an unreadable directory.

--- a/packages/compositor/src/portable/__tests__/toPosix.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/toPosix.unit.test.ts
@@ -6,8 +6,8 @@ import { toPosix } from '../toPosix.ts';
 
 describe(toPosix, () => {
   it('renders a natively joined path with posix separators', () => {
-    // Built with `path.join` rather than written with literal backslashes: a literal would assert Windows behavior on
-    // every platform, and pass only where `path.sep` happens to be a backslash.
+    // A literal backslash would assert Windows behavior on every platform, and pass only where `path.sep` happens to
+    // be a backslash.
     expect(toPosix(path.join('skills', 'lint', 'SKILL.md'))).toBe('skills/lint/SKILL.md');
   });
 

--- a/packages/compositor/src/portable/compareStrings.ts
+++ b/packages/compositor/src/portable/compareStrings.ts
@@ -1,7 +1,7 @@
 /**
  * Orders two strings by UTF-16 code unit, which is what a consumer diffing two payloads reproduces.
  *
- * Not `localeCompare`, whose order depends on the locale data the runtime happens to ship.
+ * `localeCompare`'s order depends on the locale data the runtime happens to ship.
  */
 export function compareStrings(left: string, right: string): number {
   if (left === right) {

--- a/packages/compositor/src/portable/expandPath.ts
+++ b/packages/compositor/src/portable/expandPath.ts
@@ -4,8 +4,8 @@ import path from 'node:path';
 /**
  * Expands an authored location to an absolute path, resolving a relative one against `baseDir`.
  *
- * Resolving against `baseDir` rather than the working directory is what makes an authored path mean the same thing
- * wherever the process runs. Computes a path and reads nothing, so whether the result exists is the caller's question.
+ * `baseDir` anchors a relative path, so an authored location means the same thing wherever the process runs. Computes
+ * a path and reads nothing, so whether the result exists is the caller's question.
  *
  * Only the current user's home is expanded. A `~user` form names someone else's, which resolving would require reading
  * the account database, so it falls through and resolves as the relative path it looks like.

--- a/packages/compositor/src/portable/expandPath.ts
+++ b/packages/compositor/src/portable/expandPath.ts
@@ -4,9 +4,8 @@ import path from 'node:path';
 /**
  * Expands an authored location to an absolute path, resolving a relative one against `baseDir`.
  *
- * A leading `~` expands to the home directory, an already-absolute path stands, and a relative path resolves against
- * `baseDir` rather than against wherever the process happens to be running. Computes a path and reads nothing, so
- * whether the result exists is the caller's question.
+ * Resolving against `baseDir` rather than the working directory is what makes an authored path mean the same thing
+ * wherever the process runs. Computes a path and reads nothing, so whether the result exists is the caller's question.
  *
  * Only the current user's home is expanded. A `~user` form names someone else's, which resolving would require reading
  * the account database, so it falls through and resolves as the relative path it looks like.

--- a/packages/compositor/src/portable/hash-content.ts
+++ b/packages/compositor/src/portable/hash-content.ts
@@ -3,12 +3,12 @@ import { createHash } from 'node:crypto';
 
 import type { Hash } from '../schemas/scalar-schemas.ts';
 
-/** A digest of `data`, prefixed with the algorithm that produced it. */
+/** Hashes `data`, prefixing the digest with the algorithm that produced it. */
 export function hashBytes(data: Uint8Array): Hash {
   return `sha256:${createHash('sha256').update(data).digest('hex')}`;
 }
 
-/** A digest of `text` taken over its UTF-8 bytes. */
+/** Hashes `text` over its UTF-8 bytes. */
 export function hashUtf8(text: string): Hash {
   return hashBytes(Buffer.from(text, 'utf8'));
 }

--- a/packages/compositor/src/portable/hashDirectory.ts
+++ b/packages/compositor/src/portable/hashDirectory.ts
@@ -10,8 +10,8 @@ import { listFilesRecursively } from './listFilesRecursively.ts';
  * Hashes everything under `dir`, keying each file by its path within the tree.
  *
  * A directory-shaped artifact ships assets beside the file carrying its frontmatter, and a rebuilt asset is a changed
- * artifact, so covering one file would miss changes. Paths take part in the digest, so moving a file within the tree
- * moves the digest too. Dotfiles are left out as tool state rather than shipped content.
+ * artifact. Paths take part in the digest, so moving a file within the tree moves the digest too. Dotfiles are left
+ * out as tool state rather than shipped content.
  */
 export async function hashDirectory(dir: string): Promise<Hash> {
   const relativePaths = (await listFilesRecursively(dir, { skipName: isToolState })).toSorted(compareStrings);

--- a/packages/compositor/src/portable/hashDirectory.ts
+++ b/packages/compositor/src/portable/hashDirectory.ts
@@ -7,11 +7,11 @@ import { hashBytes, hashUtf8 } from './hash-content.ts';
 import { listFilesRecursively } from './listFilesRecursively.ts';
 
 /**
- * A digest over everything under `dir`, keyed by each file's path within it.
+ * Hashes everything under `dir`, keying each file by its path within the tree.
  *
- * Covers a whole tree rather than any one file, because a directory-shaped artifact ships assets beside the file
- * carrying its frontmatter and a rebuilt asset is a changed artifact. Paths take part in the digest, so moving a file
- * within the tree moves the digest too. Dotfiles are left out as tool state rather than shipped content.
+ * A directory-shaped artifact ships assets beside the file carrying its frontmatter, and a rebuilt asset is a changed
+ * artifact, so covering one file would miss changes. Paths take part in the digest, so moving a file within the tree
+ * moves the digest too. Dotfiles are left out as tool state rather than shipped content.
  */
 export async function hashDirectory(dir: string): Promise<Hash> {
   const relativePaths = (await listFilesRecursively(dir, { skipName: isToolState })).toSorted(compareStrings);

--- a/packages/compositor/src/portable/listFilesRecursively.ts
+++ b/packages/compositor/src/portable/listFilesRecursively.ts
@@ -3,19 +3,17 @@ import path from 'node:path';
 import { readDirNames } from './readDirNames.ts';
 import { statIfPresent } from './statIfPresent.ts';
 
-/** What walking a tree needs beyond the directory to walk. */
 export interface ListFilesRecursivelyOptions {
   /**
    * Names to leave out, tested against each entry's own name rather than against its path.
    *
    * Applied during the walk, so a skipped directory is never descended into. Nothing is skipped by default: what
-   * counts as content is the caller's to decide, and a walker that dropped entries on its own would hide them from
-   * every caller that wanted them.
+   * counts as content is the caller's to decide.
    */
   readonly skipName?: (name: string) => boolean;
 }
 
-/** Every file beneath `dir`, as posix paths relative to `dir` itself. */
+/** Lists every file beneath `dir`, as posix paths relative to `dir` itself. */
 export async function listFilesRecursively(
   dir: string,
   options: ListFilesRecursivelyOptions = {},
@@ -25,7 +23,7 @@ export async function listFilesRecursively(
 
 // region | Helpers
 
-/** Every file beneath `dir`, as posix paths carrying `prefix`, the walk's position relative to where it started. */
+/** Lists files beneath `dir` as posix paths carrying `prefix`, the walk's position relative to where it started. */
 async function listFrom(
   dir: string,
   prefix: string,

--- a/packages/compositor/src/portable/readDirNames.ts
+++ b/packages/compositor/src/portable/readDirNames.ts
@@ -3,7 +3,7 @@ import { readdir } from 'node:fs/promises';
 import { isMissingFile } from './isMissingFile.ts';
 
 /**
- * The entry names directly under `dir`, or none when `dir` is absent.
+ * Lists the entry names directly under `dir`, or none when `dir` is absent.
  *
  * Any other failure rethrows, so a permission problem surfaces instead of reading as an empty directory and sending
  * the caller on as though nothing were there.

--- a/packages/compositor/src/portable/statIfPresent.ts
+++ b/packages/compositor/src/portable/statIfPresent.ts
@@ -4,7 +4,7 @@ import { stat } from 'node:fs/promises';
 import { isMissingFile } from './isMissingFile.ts';
 
 /**
- * The stats of `filePath`, or nothing when it is absent.
+ * Reads the stats of `filePath`, or nothing when it is absent.
  *
  * Follows symlinks, which `readdir`'s own file types do not: a symlinked directory reports as a link rather than as
  * the directory it points at, and under a linked layout that would hide its contents entirely.

--- a/packages/compositor/src/portable/toPosix.ts
+++ b/packages/compositor/src/portable/toPosix.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-/** A path rendered with posix separators, so a value built on Windows matches one built anywhere else. */
+/** Renders a path with posix separators, so a value built on Windows matches one built anywhere else. */
 export function toPosix(filePath: string): string {
   return filePath.split(path.sep).join('/');
 }

--- a/packages/compositor/src/samples/__tests__/samples.roundtrip.unit.test.ts
+++ b/packages/compositor/src/samples/__tests__/samples.roundtrip.unit.test.ts
@@ -39,7 +39,7 @@ describe('determinism', () => {
 // region | Helpers
 
 /**
- * The id of each artifact whose seed records do not follow the plan's tier order.
+ * Collects the id of each artifact whose seed records do not follow the plan's tier order.
  *
  * `tiers` runs in precedence order rather than lexicographically, so a seed list sorted by tier id would satisfy no rule
  * the contract states.
@@ -56,7 +56,7 @@ function collectMisorderedSeeds(plan: Plan): Array<string> {
     .map((artifact) => artifact.id);
 }
 
-/** The name of each id-keyed table whose entries are not in lexicographic id order. */
+/** Collects the name of each id-keyed table whose entries are not in lexicographic id order. */
 function collectUnsortedTables(plan: Plan): Array<string> {
   const tables = [
     ['artifacts', plan.artifacts],

--- a/packages/compositor/src/samples/buildMinimalSample.ts
+++ b/packages/compositor/src/samples/buildMinimalSample.ts
@@ -5,7 +5,7 @@ import { PLAN_SCHEMA_VERSION } from '../schemas/plan-schemas.ts';
 const SKILL_BODY = '# Review\n\nRead the diff.\n';
 
 /**
- * The smallest plan that satisfies the contract: one source, one target, one artifact, one added file.
+ * Builds the smallest plan that satisfies the contract: one source, one target, one artifact, one added file.
  *
  * A consumer wiring up its first render has something to hold before taking on the representative sample's shapes.
  */

--- a/packages/compositor/src/samples/buildRepresentativeSample.ts
+++ b/packages/compositor/src/samples/buildRepresentativeSample.ts
@@ -11,7 +11,7 @@ import { buildTiers } from './representative/buildTiers.ts';
 import { createBlobStore } from './representative/createBlobStore.ts';
 
 /**
- * A plan exercising every shape the contract has to carry.
+ * Builds a plan exercising every shape the contract has to carry.
  *
  * Modelled on a guidance-distribution run: three precedence-ordered sources feeding two targets, with an artifact
  * reached by three routes, an artifact shadowing two losers beside one the lowest-precedence source wins, three

--- a/packages/compositor/src/samples/representative/__tests__/buildArtifacts.unit.test.ts
+++ b/packages/compositor/src/samples/representative/__tests__/buildArtifacts.unit.test.ts
@@ -33,7 +33,7 @@ describe(buildArtifacts, () => {
 
 // region | Helpers
 
-/** The artifact with the given id, failing the test when the table carries none. */
+/** Finds the artifact with the given id, failing the test when the table carries none. */
 function findArtifact(id: string): ArtifactEntry {
   const artifact = artifacts.find((entry) => entry.id === id);
   if (artifact === undefined) {

--- a/packages/compositor/src/samples/representative/__tests__/buildFiles.unit.test.ts
+++ b/packages/compositor/src/samples/representative/__tests__/buildFiles.unit.test.ts
@@ -61,7 +61,7 @@ describe(buildFiles, () => {
 
 // region | Helpers
 
-/** The file at the given path, failing the test when the table carries none. */
+/** Finds the file at the given path, failing the test when the table carries none. */
 function findFile(filePath: string): FileEntry {
   const file = files.find((entry) => entry.path === filePath);
   if (file === undefined) {
@@ -70,7 +70,7 @@ function findFile(filePath: string): FileEntry {
   return file;
 }
 
-/** The sentinel `file` declares for the entries it owns, failing the test when it is not entry-owned. */
+/** Reads the sentinel `file` declares for the entries it owns, failing the test when it is not entry-owned. */
 function readEntriesSentinel(file: FileEntry): string {
   if (file.ownership.kind !== 'entries') {
     throw new Error(`The sample file "${file.path}" does not declare entry ownership.`);
@@ -78,7 +78,7 @@ function readEntriesSentinel(file: FileEntry): string {
   return file.ownership.sentinel;
 }
 
-/** The body planned for `file`, failing the test when the store carries none. */
+/** Reads the body planned for `file`, failing the test when the store carries none. */
 function readPlannedBody(file: FileEntry): string {
   const blob = file.planned === undefined ? undefined : bodies[file.planned.hash];
   if (blob === undefined) {

--- a/packages/compositor/src/samples/representative/createBlobStore.ts
+++ b/packages/compositor/src/samples/representative/createBlobStore.ts
@@ -17,7 +17,7 @@ export interface BlobStore {
   /** Registers `data` as a UTF-8 blob and returns the file side naming it. */
   addUtf8(data: string): FileSide;
 
-  /** Every registered blob, keyed by hash in hash order. */
+  /** Collects every registered blob, keyed by hash in hash order. */
   toTable(): Record<Hash, Blob>;
 }
 

--- a/packages/compositor/src/samples/sample-documents.ts
+++ b/packages/compositor/src/samples/sample-documents.ts
@@ -8,7 +8,7 @@ export interface SampleDocument {
   readonly plan: Plan;
 }
 
-/** Every published sample, in the order they are emitted. */
+/** Builds every published sample, in the order they are emitted. */
 export function buildSampleDocuments(): ReadonlyArray<SampleDocument> {
   return [
     { fileName: 'minimal.json', plan: buildMinimalSample() },
@@ -17,7 +17,7 @@ export function buildSampleDocuments(): ReadonlyArray<SampleDocument> {
 }
 
 /**
- * One sample rendered as the JSON file it is published as.
+ * Renders one sample as the JSON file it is published as.
  *
  * The writer script and the drift test share this, so a mismatch between what is committed and what the builders
  * produce cannot be an artifact of how each side formatted the document.

--- a/packages/compositor/src/test-utils/buildPlan.ts
+++ b/packages/compositor/src/test-utils/buildPlan.ts
@@ -2,7 +2,7 @@ import type { Plan } from '../schemas/plan-schemas.ts';
 import { PLAN_SCHEMA_VERSION } from '../schemas/plan-schemas.ts';
 
 /**
- * A small plan that satisfies both the schema and every consistency invariant.
+ * Builds a small plan that satisfies both the schema and every consistency invariant.
  *
  * Exercises the shapes a trivial plan would leave untested: a traversal-only kind, an artifact reached through a
  * dependency edge, a shadowed candidate, a transcluded partial, a seed naming the tier that decided it, and a file whose

--- a/packages/compositor/src/test-utils/buildTempTree.ts
+++ b/packages/compositor/src/test-utils/buildTempTree.ts
@@ -7,8 +7,8 @@ import { onTestFinished } from 'vitest';
 /**
  * Builds a temporary directory holding each path in `files` with the given content, removed when the test ends.
  *
- * Writes a real tree rather than mocking the filesystem, because what the code under test answers is how Node reports
- * directories, extensions, and absences -- the very layer a mock would replace with an assumption.
+ * What the code under test answers is how Node reports directories, extensions, and absences -- the very layer a mock
+ * would replace with an assumption.
  *
  * `prefix` names the temp directory, so a test building several trees can tell which directory belongs to which, and a
  * directory left behind by a crashed run still names the suite that made it.

--- a/packages/compositor/src/test-utils/buildTempTree.ts
+++ b/packages/compositor/src/test-utils/buildTempTree.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { onTestFinished } from 'vitest';
 
 /**
- * A temporary directory holding each path in `files` with the given content, removed when the test ends.
+ * Builds a temporary directory holding each path in `files` with the given content, removed when the test ends.
  *
  * Writes a real tree rather than mocking the filesystem, because what the code under test answers is how Node reports
  * directories, extensions, and absences -- the very layer a mock would replace with an assumption.

--- a/packages/compositor/src/test-utils/requireEntry.ts
+++ b/packages/compositor/src/test-utils/requireEntry.ts
@@ -1,5 +1,5 @@
 /**
- * The entry at `index`, throwing when the array is shorter than that.
+ * Reads the entry at `index`, throwing when the array is shorter than that.
  *
  * Indexing a fixture yields `T | undefined` under `noUncheckedIndexedAccess`, and a test that reaches past the end of
  * its own fixture should say so rather than assert the absence away.


### PR DESCRIPTION
## What

Tightens comments by reducing duplication, removing narration of development history, and focusing on the code itself. Function descriptions are now aligned with house style.

## Why

A description naming its return value propagates: an agent writing new code matches its nearest neighbours, so each one left in place makes the next more likely. The prose beside these descriptions had never been audited, so it still carried rationale a reader six months out cannot act on.

## Details

### 📚 Documentation

- Function descriptions across `portable/`, `samples/`, `test-utils/`, and their test suites lead with a third-person indicative verb; type, interface, and constant descriptions keep their noun phrases.
- The sample generator's file header is verb-led.
- Comments restating a fact already documented on the function they cover are removed.
- Comments that justified the code by naming the alternative it rejected state the constraint on its own.
- Comments enumerating branches the code already shows are trimmed.

Closes #201
