### PR TITLE
#143 Make readyup's shipped exemplars follow the naming and detail contracts

### DIFF
--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -10,9 +10,8 @@ import {
   fileContains,
   fileExists,
   filesExist,
-  getJsonValue,
   hasDevDependency,
-  readPackageJson
+  readJsonValue
 } from "readyup/check-utils";
 var projectFoundations = {
   name: "project-foundations",
@@ -28,15 +27,16 @@ var projectFoundations = {
     {
       name: "Project is ESM",
       check: () => {
-        const type = getJsonValue(readPackageJson() ?? {}, "type");
-        return { ok: type === "module", detail: `"type": ${JSON.stringify(type ?? null)}` };
+        const type = readJsonValue("package.json", "type");
+        const detail = type === void 0 ? 'no "type" field' : `"type": ${JSON.stringify(type)}`;
+        return { ok: type === "module", detail };
       },
       fix: 'Add "type": "module" to package.json'
     },
     {
       name: "packageManager field is set",
       check: () => {
-        const value = getJsonValue(readPackageJson() ?? {}, "packageManager");
+        const value = readJsonValue("package.json", "packageManager");
         return typeof value === "string" ? { ok: true, detail: value } : { ok: false };
       },
       fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")'

--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -23,10 +23,10 @@ var projectFoundations = {
     }
   ],
   checks: [
-    // The claim goes in the name, the evidence in the detail: `🔴 project is ESM` says what
+    // The claim goes in the name, the evidence in the detail: `🔴 Project is ESM` says what
     // is wrong on its own, and the "type" it found explains why.
     {
-      name: "project is ESM",
+      name: "Project is ESM",
       check: () => {
         const type = getJsonValue(readPackageJson() ?? {}, "type");
         return { ok: type === "module", detail: `"type": ${JSON.stringify(type ?? null)}` };
@@ -47,7 +47,7 @@ var projectFoundations = {
       fix: "Create pnpm-workspace.yaml with workspace package globs",
       checks: [
         {
-          name: "workspace includes packages/*",
+          name: "Workspace includes packages/*",
           check: () => fileContains("pnpm-workspace.yaml", /packages\/\*/)
         }
       ]
@@ -103,7 +103,7 @@ var codeQuality = {
     },
     // A fraction is its own evidence, so this check needs no detail on a pass.
     {
-      name: "root configs are present",
+      name: "Root configs are present",
       check: () => filesExist(["eslint.config.ts", "tsconfig.json", "vitest.config.ts"]),
       fix: "Add the missing config to the repo root"
     },
@@ -113,7 +113,7 @@ var codeQuality = {
       fix: "Add bitbucket-pipelines.yml for CI/CD pipeline configuration",
       checks: [
         {
-          name: "pipeline runs pnpm run check",
+          name: "Pipeline runs pnpm run check",
           check: () => fileContains("bitbucket-pipelines.yml", /pnpm run check/)
         }
       ]
@@ -138,12 +138,12 @@ var publishingPipeline = {
     // Stage 1: Build infrastructure
     [
       {
-        name: "build config exists",
+        name: "Build config exists",
         check: () => fileExists(".config/nmr.config.ts"),
         fix: "Add .config/nmr.config.ts to declare per-repo nmr script overrides"
       },
       {
-        name: "shared Vitest config exists",
+        name: "Shared Vitest config exists",
         check: () => fileExists("config/vitest.config.ts"),
         fix: "Add config/vitest.config.ts \u2014 packages inherit the shared test configuration"
       }
@@ -164,7 +164,7 @@ var publishingPipeline = {
     // Stage 3: Release automation (skipped if compliance fails)
     [
       {
-        name: "release workflow exists",
+        name: "Release workflow exists",
         check: () => fileExists(".github/workflows/release.yaml")
       }
     ]

--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -4,17 +4,16 @@ export const __readyupVersion = "0.23.0";
 
 
 // .readyup/kits/demo.ts
-import { execFileSync } from "node:child_process";
 import { defineRdyKit } from "readyup";
-import { fileContains, fileExists, hasDevDependency, hasPackageJsonField } from "readyup/check-utils";
-function commandExists(name) {
-  try {
-    execFileSync("which", [name], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
+import {
+  commandExists,
+  fileContains,
+  fileExists,
+  filesExist,
+  getJsonValue,
+  hasDevDependency,
+  readPackageJson
+} from "readyup/check-utils";
 var projectFoundations = {
   name: "project-foundations",
   preconditions: [
@@ -24,14 +23,22 @@ var projectFoundations = {
     }
   ],
   checks: [
+    // The claim goes in the name, the evidence in the detail: `🔴 project is ESM` says what
+    // is wrong on its own, and the "type" it found explains why.
     {
-      name: 'ESM project ("type": "module")',
-      check: () => hasPackageJsonField("type", "module"),
+      name: "project is ESM",
+      check: () => {
+        const type = getJsonValue(readPackageJson() ?? {}, "type");
+        return { ok: type === "module", detail: `"type": ${JSON.stringify(type ?? null)}` };
+      },
       fix: 'Add "type": "module" to package.json'
     },
     {
       name: "packageManager field is set",
-      check: () => hasPackageJsonField("packageManager"),
+      check: () => {
+        const value = getJsonValue(readPackageJson() ?? {}, "packageManager");
+        return typeof value === "string" ? { ok: true, detail: value } : { ok: false };
+      },
       fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")'
     },
     {
@@ -51,7 +58,7 @@ var optionalIntegrations = {
   name: "optional-integrations",
   checks: [
     {
-      name: "Docker",
+      name: "Docker is configured",
       skip: () => !fileExists("Dockerfile") ? "no Dockerfile" : false,
       check: () => true,
       checks: [
@@ -62,18 +69,18 @@ var optionalIntegrations = {
       ]
     },
     {
-      name: "Renovate",
+      name: "Renovate is configured",
       skip: () => !fileExists("renovate.json") ? "no renovate.json" : false,
       check: () => true,
       checks: [
         {
-          name: "extends recommended preset",
+          name: "renovate.json extends config:recommended",
           check: () => fileContains("renovate.json", /extends.*config:recommended/)
         }
       ]
     },
     {
-      name: "lefthook in devDependencies",
+      name: "lefthook is a devDependency",
       check: () => hasDevDependency("lefthook"),
       fix: "pnpm add --save-dev lefthook",
       checks: [
@@ -93,6 +100,12 @@ var codeQuality = {
       name: ".editorconfig exists",
       check: () => fileExists(".editorconfig"),
       fix: "Add .editorconfig to repo root"
+    },
+    // A fraction is its own evidence, so this check needs no detail on a pass.
+    {
+      name: "root configs are present",
+      check: () => filesExist(["eslint.config.ts", "tsconfig.json", "vitest.config.ts"]),
+      fix: "Add the missing config to the repo root"
     },
     {
       name: "bitbucket-pipelines.yml exists",

--- a/.readyup/kits/demo.ts
+++ b/.readyup/kits/demo.ts
@@ -14,10 +14,8 @@ import {
   fileContains,
   fileExists,
   filesExist,
-  getJsonValue,
   hasDevDependency,
-  hasPackageJsonField,
-  readPackageJson,
+  readJsonValue,
 } from 'readyup/check-utils';
 
 // -- Flat checklist with preconditions and nested checks --
@@ -37,15 +35,16 @@ const projectFoundations = {
     {
       name: 'Project is ESM',
       check: () => {
-        const type = getJsonValue(readPackageJson() ?? {}, 'type');
-        return { ok: type === 'module', detail: `"type": ${JSON.stringify(type ?? null)}` };
+        const type = readJsonValue('package.json', 'type');
+        const detail = type === undefined ? 'no "type" field' : `"type": ${JSON.stringify(type)}`;
+        return { ok: type === 'module', detail };
       },
       fix: 'Add "type": "module" to package.json',
     },
     {
       name: 'packageManager field is set',
       check: () => {
-        const value = getJsonValue(readPackageJson() ?? {}, 'packageManager');
+        const value = readJsonValue('package.json', 'packageManager');
         return typeof value === 'string' ? { ok: true, detail: value } : { ok: false };
       },
       fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")',

--- a/.readyup/kits/demo.ts
+++ b/.readyup/kits/demo.ts
@@ -2,24 +2,23 @@
  * Moderate demo kit showcasing readyup features.
  *
  * Exercises flat and staged checklists, preconditions, nested checks, skip
- * conditions, mixed severities, and fix messages. Run from the repo root:
+ * conditions, mixed severities, fix messages, and both forms a check may
+ * report alongside its result: a detail explaining the status, and progress
+ * counted as a fraction. Run from the repo root:
  *
  *   rdy run demo
  */
-import { execFileSync } from 'node:child_process';
-
 import { defineRdyKit } from 'readyup';
-import { fileContains, fileExists, hasDevDependency, hasPackageJsonField } from 'readyup/check-utils';
-
-/** Return true if a CLI command is available on PATH. */
-function commandExists(name: string): boolean {
-  try {
-    execFileSync('which', [name], { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
+import {
+  commandExists,
+  fileContains,
+  fileExists,
+  filesExist,
+  getJsonValue,
+  hasDevDependency,
+  hasPackageJsonField,
+  readPackageJson,
+} from 'readyup/check-utils';
 
 // -- Flat checklist with preconditions and nested checks --
 // Demonstrates: precondition gating, nested check hierarchy, fix messages.
@@ -33,14 +32,22 @@ const projectFoundations = {
     },
   ],
   checks: [
+    // The claim goes in the name, the evidence in the detail: `🔴 project is ESM` says what
+    // is wrong on its own, and the "type" it found explains why.
     {
-      name: 'ESM project ("type": "module")',
-      check: () => hasPackageJsonField('type', 'module'),
+      name: 'project is ESM',
+      check: () => {
+        const type = getJsonValue(readPackageJson() ?? {}, 'type');
+        return { ok: type === 'module', detail: `"type": ${JSON.stringify(type ?? null)}` };
+      },
       fix: 'Add "type": "module" to package.json',
     },
     {
       name: 'packageManager field is set',
-      check: () => hasPackageJsonField('packageManager'),
+      check: () => {
+        const value = getJsonValue(readPackageJson() ?? {}, 'packageManager');
+        return typeof value === 'string' ? { ok: true, detail: value } : { ok: false };
+      },
       fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")',
     },
     {
@@ -65,7 +72,7 @@ const optionalIntegrations = {
   name: 'optional-integrations',
   checks: [
     {
-      name: 'Docker',
+      name: 'Docker is configured',
       skip: () => (!fileExists('Dockerfile') ? 'no Dockerfile' : false),
       check: () => true,
       checks: [
@@ -76,18 +83,18 @@ const optionalIntegrations = {
       ],
     },
     {
-      name: 'Renovate',
+      name: 'Renovate is configured',
       skip: () => (!fileExists('renovate.json') ? 'no renovate.json' : false),
       check: () => true,
       checks: [
         {
-          name: 'extends recommended preset',
+          name: 'renovate.json extends config:recommended',
           check: () => fileContains('renovate.json', /extends.*config:recommended/),
         },
       ],
     },
     {
-      name: 'lefthook in devDependencies',
+      name: 'lefthook is a devDependency',
       check: () => hasDevDependency('lefthook'),
       fix: 'pnpm add --save-dev lefthook',
       checks: [
@@ -112,6 +119,12 @@ const codeQuality = {
       name: '.editorconfig exists',
       check: () => fileExists('.editorconfig'),
       fix: 'Add .editorconfig to repo root',
+    },
+    // A fraction is its own evidence, so this check needs no detail on a pass.
+    {
+      name: 'root configs are present',
+      check: () => filesExist(['eslint.config.ts', 'tsconfig.json', 'vitest.config.ts']),
+      fix: 'Add the missing config to the repo root',
     },
     {
       name: 'bitbucket-pipelines.yml exists',

--- a/.readyup/kits/demo.ts
+++ b/.readyup/kits/demo.ts
@@ -32,10 +32,10 @@ const projectFoundations = {
     },
   ],
   checks: [
-    // The claim goes in the name, the evidence in the detail: `🔴 project is ESM` says what
+    // The claim goes in the name, the evidence in the detail: `🔴 Project is ESM` says what
     // is wrong on its own, and the "type" it found explains why.
     {
-      name: 'project is ESM',
+      name: 'Project is ESM',
       check: () => {
         const type = getJsonValue(readPackageJson() ?? {}, 'type');
         return { ok: type === 'module', detail: `"type": ${JSON.stringify(type ?? null)}` };
@@ -56,7 +56,7 @@ const projectFoundations = {
       fix: 'Create pnpm-workspace.yaml with workspace package globs',
       checks: [
         {
-          name: 'workspace includes packages/*',
+          name: 'Workspace includes packages/*',
           check: () => fileContains('pnpm-workspace.yaml', /packages\/\*/),
         },
       ],
@@ -122,7 +122,7 @@ const codeQuality = {
     },
     // A fraction is its own evidence, so this check needs no detail on a pass.
     {
-      name: 'root configs are present',
+      name: 'Root configs are present',
       check: () => filesExist(['eslint.config.ts', 'tsconfig.json', 'vitest.config.ts']),
       fix: 'Add the missing config to the repo root',
     },
@@ -132,7 +132,7 @@ const codeQuality = {
       fix: 'Add bitbucket-pipelines.yml for CI/CD pipeline configuration',
       checks: [
         {
-          name: 'pipeline runs pnpm run check',
+          name: 'Pipeline runs pnpm run check',
           check: () => fileContains('bitbucket-pipelines.yml', /pnpm run check/),
         },
       ],
@@ -163,12 +163,12 @@ const publishingPipeline = {
     // Stage 1: Build infrastructure
     [
       {
-        name: 'build config exists',
+        name: 'Build config exists',
         check: () => fileExists('.config/nmr.config.ts'),
         fix: 'Add .config/nmr.config.ts to declare per-repo nmr script overrides',
       },
       {
-        name: 'shared Vitest config exists',
+        name: 'Shared Vitest config exists',
         check: () => fileExists('config/vitest.config.ts'),
         fix: 'Add config/vitest.config.ts — packages inherit the shared test configuration',
       },
@@ -189,7 +189,7 @@ const publishingPipeline = {
     // Stage 3: Release automation (skipped if compliance fails)
     [
       {
-        name: 'release workflow exists',
+        name: 'Release workflow exists',
         check: () => fileExists('.github/workflows/release.yaml'),
       },
     ],

--- a/.readyup/kits/internal/default.ts
+++ b/.readyup/kits/internal/default.ts
@@ -4,7 +4,10 @@ import { defineRdyKit } from 'readyup';
  * Default readyup kit.
  *
  * Each checklist contains checks that run before a deployment or other operation.
- * Checks run concurrently within a checklist. Use `fix` to provide remediation hints.
+ * Checks run concurrently within a checklist.
+ *
+ * Three fields, three questions: `name` states what must be true, phrased so it reads
+ * true on a pass; `detail` answers why this status; `fix` says what to do about it.
  */
 export default defineRdyKit({
   checklists: [
@@ -12,8 +15,11 @@ export default defineRdyKit({
       name: 'deploy',
       checks: [
         {
-          name: 'environment variables set',
-          check: () => Boolean(process.env['NODE_ENV']),
+          name: 'NODE_ENV is set',
+          check: () => {
+            const value = process.env['NODE_ENV'];
+            return { ok: Boolean(value), detail: value ?? 'no value in the environment' };
+          },
           fix: 'Set NODE_ENV before deploying',
         },
       ],

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -12,8 +12,8 @@
       "path": "kits/demo.js",
       "readyupVersion": "0.23.0",
       "source": "kits/demo.ts",
-      "sourceHash": "b82c1506",
-      "targetHash": "8aaf8524"
+      "sourceHash": "7b456311",
+      "targetHash": "f2b4243f"
     }
   ]
 }

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -12,8 +12,8 @@
       "path": "kits/demo.js",
       "readyupVersion": "0.23.0",
       "source": "kits/demo.ts",
-      "sourceHash": "7b456311",
-      "targetHash": "f2b4243f"
+      "sourceHash": "32c98768",
+      "targetHash": "7630843a"
     }
   ]
 }

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -12,8 +12,8 @@
       "path": "kits/demo.js",
       "readyupVersion": "0.23.0",
       "source": "kits/demo.ts",
-      "sourceHash": "3d21db74",
-      "targetHash": "7fed753a"
+      "sourceHash": "b82c1506",
+      "targetHash": "8aaf8524"
     }
   ]
 }

--- a/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
@@ -89,11 +89,11 @@ describe('default kit', () => {
 
       const results = await runFreshness();
 
-      expect(pickResult(results, 'its source')).toMatchObject({
+      expect(pickResult(results, 'Its source')).toMatchObject({
         status: 'failed',
         detail: expect.stringContaining('expected 0badcafe'),
       });
-      expect(pickResult(results, 'its bundle')).toMatchObject({ status: 'passed' });
+      expect(pickResult(results, 'Its bundle')).toMatchObject({ status: 'passed' });
     });
 
     it('reports a bundle edited by hand', async () => {
@@ -102,7 +102,7 @@ describe('default kit', () => {
 
       const results = await runFreshness();
 
-      expect(pickResult(results, 'its bundle')).toMatchObject({
+      expect(pickResult(results, 'Its bundle')).toMatchObject({
         status: 'failed',
         detail: expect.stringContaining('expected 0badcafe'),
       });
@@ -115,7 +115,7 @@ describe('default kit', () => {
 
       const results = await runFreshness();
 
-      expect(pickResult(results, 'its bundle')).toMatchObject({
+      expect(pickResult(results, 'Its bundle')).toMatchObject({
         status: 'failed',
         detail: expect.stringContaining('is missing'),
       });
@@ -133,8 +133,8 @@ describe('default kit', () => {
         status: 'failed',
         detail: 'no source or bundle hash recorded',
       });
-      expect(pickResult(results, 'its source')).toMatchObject({ status: 'skipped' });
-      expect(pickResult(results, 'its bundle')).toMatchObject({ status: 'skipped' });
+      expect(pickResult(results, 'Its source')).toMatchObject({ status: 'skipped' });
+      expect(pickResult(results, 'Its bundle')).toMatchObject({ status: 'skipped' });
     });
 
     it('stands down when the project compiles nothing', async () => {

--- a/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
@@ -172,7 +172,7 @@ describe('publishing kit', () => {
 
     const results = await runChecklist(await loadOwnKit('publishing'), 'freshness');
 
-    expect(pickResult(results, 'its source')).toMatchObject({ status: 'failed', severity: 'error' });
+    expect(pickResult(results, 'Its source')).toMatchObject({ status: 'failed', severity: 'error' });
   });
 });
 

--- a/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
@@ -28,12 +28,12 @@ function buildEntryCheck(entry: ManifestEntry): RdyCheck {
     fix: `Run 'rdy compile --force' to re-record ${entry.name}`,
     checks: [
       {
-        name: 'its source is unchanged since it was compiled',
+        name: 'Its source is unchanged since it was compiled',
         check: () => compareToRecordedHash(entry.source, entry.sourceHash),
         fix: `Run 'rdy compile' to rebuild ${entry.name} from its source`,
       },
       {
-        name: 'its bundle is unchanged since it was compiled',
+        name: 'Its bundle is unchanged since it was compiled',
         check: () => compareToRecordedHash(entry.path, entry.targetHash),
         fix: `Move the edits into the source and run 'rdy compile --force'`,
       },
@@ -49,7 +49,7 @@ function buildEntryCheck(entry: ManifestEntry): RdyCheck {
  */
 function buildUnrecordedBundlesCheck(): RdyCheck {
   return {
-    name: 'every compiled kit is recorded in the manifest',
+    name: 'Every compiled kit is recorded in the manifest',
     skip: () => (listCompiledBundlePaths().length === 0 ? 'nothing compiled' : false),
     check: () => ({ ok: false, detail: `${DEFAULT_MANIFEST_PATH} records no kit` }),
     fix: `Run 'rdy compile' to record every compiled kit and its hashes`,

--- a/packages/readyup/.readyup/kits/checks/buildSelfContainmentChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildSelfContainmentChecks.ts
@@ -42,7 +42,7 @@ export function buildSelfContainmentChecks(): RdyCheck[] {
   if (bundlePaths.length === 0) {
     return [
       {
-        name: 'every compiled kit imports only what the runner supplies',
+        name: 'Every compiled kit imports only what the runner supplies',
         skip: () => 'nothing compiled',
         check: () => true,
       },

--- a/packages/readyup/.readyup/kits/publishing.ts
+++ b/packages/readyup/.readyup/kits/publishing.ts
@@ -29,7 +29,7 @@ export default defineRdyKit({
       name: 'packaging',
       checks: [
         {
-          name: `the "files" allowlist ships ${MANIFEST_DIR}`,
+          name: `The "files" allowlist ships ${MANIFEST_DIR}`,
           check: describeFilesCoverage,
           fix: `Add "${MANIFEST_DIR}" to the "files" array in package.json`,
         },
@@ -49,7 +49,7 @@ export default defineRdyKit({
           fix: `Name a kit "default" so a bare 'rdy run --from npm:<package>' resolves to it`,
         },
         {
-          name: `every recorded kit sits in ${KITS_DIR} under its own name`,
+          name: `Every recorded kit sits in ${KITS_DIR} under its own name`,
           check: describeLoadablePaths,
           fix: `Compile kits straight into ${KITS_DIR}; a consumer composes the path from the kit's name`,
         },

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -58,7 +58,10 @@ export default defineRdyKit({
       checks: [
         {
           name: 'NODE_ENV is set',
-          check: () => Boolean(process.env['NODE_ENV']),
+          check: () => {
+            const value = process.env['NODE_ENV'];
+            return { ok: Boolean(value), detail: value ?? 'no value in the environment' };
+          },
           fix: 'Set NODE_ENV before deploying',
         },
       ],
@@ -78,6 +81,7 @@ With `NODE_ENV` unset:
 
 ```
 🔴 NODE_ENV is set
+   no value in the environment
 
 🔴 1 error (0ms)
 
@@ -218,14 +222,18 @@ Three fields, three questions:
 
 A name is a claim that reads true on a pass and false on a fail. `🔴 Node >= 24` fails that test: the operator leaves the reader to infer which direction is the violation.
 
-| Poor                    | Better                     | Why                                                 |
-| ----------------------- | -------------------------- | --------------------------------------------------- |
-| `Node >= 24`            | `Node 24 or later`         | words fix the direction without moving the boundary |
-| `outdated dependencies` | `dependencies are current` | a name true on _failure_ inverts the status token   |
-| `check git status`      | `working tree is clean`    | names the action, not the condition                 |
-| `env vars`              | `NODE_ENV is set`          | names the subject, not the claim                    |
+| Poor                         | Better                                     | Why                                                 |
+| ---------------------------- | ------------------------------------------ | --------------------------------------------------- |
+| `Node >= 24`                 | `Node 24 or later`                         | words fix the direction without moving the boundary |
+| `outdated dependencies`      | `dependencies are current`                 | a name true on _failure_ inverts the status token   |
+| `check git status`           | `working tree is clean`                    | names the action, not the condition                 |
+| `env vars`                   | `NODE_ENV is set`                          | names the subject, not the claim                    |
+| `Docker`                     | `Docker is configured`                     | a bare noun asserts nothing to be true or false     |
+| `extends recommended preset` | `renovate.json extends config:recommended` | a verb with no subject leaves the claim half-stated |
 
 Rewriting a name often exposes an ambiguous predicate: an author writing "newer than 24" frequently discovers they meant a floor of 24.
+
+A check that exists only to gate the checks nested beneath it is no exception. It still reports a status of its own, so it still needs a claim.
 
 ### The detail contract
 
@@ -862,6 +870,14 @@ Reusable check functions for common assertions:
 ```ts
 import { fileExists, hasPackageJsonField } from 'readyup/check-utils';
 ```
+
+### Outcomes
+
+| Function                                  | Returns                                                   |
+| ----------------------------------------- | --------------------------------------------------------- |
+| `missingFrom(category, expected, actual)` | `CheckOutcome` with fraction progress over any collection |
+
+`missingFrom` is what `filesExist` and `hasJsonFields` are built from. Reach for it directly to count anything else: it passes when nothing is missing, and otherwise names what was, under a fraction of how many were found.
 
 ### Filesystem
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -222,14 +222,16 @@ Three fields, three questions:
 
 A name is a claim that reads true on a pass and false on a fail. `🔴 Node >= 24` fails that test: the operator leaves the reader to infer which direction is the violation.
 
-| Poor                         | Better                                     | Why                                                 |
-| ---------------------------- | ------------------------------------------ | --------------------------------------------------- |
-| `Node >= 24`                 | `Node 24 or later`                         | words fix the direction without moving the boundary |
-| `outdated dependencies`      | `dependencies are current`                 | a name true on _failure_ inverts the status token   |
-| `check git status`           | `working tree is clean`                    | names the action, not the condition                 |
-| `env vars`                   | `NODE_ENV is set`                          | names the subject, not the claim                    |
-| `Docker`                     | `Docker is configured`                     | a bare noun asserts nothing to be true or false     |
-| `extends recommended preset` | `renovate.json extends config:recommended` | a verb with no subject leaves the claim half-stated |
+State the claim in the third person indicative and capitalize it like a sentence, so a column of names reads as a column of assertions rather than labels.
+
+| Poor                         | Better                                     | Why                                                      |
+| ---------------------------- | ------------------------------------------ | -------------------------------------------------------- |
+| `Node >= 24`                 | `Node.js runtime is v24 or later`          | words fix the direction, and the subject says which Node |
+| `outdated dependencies`      | `Dependencies are current`                 | a name true on _failure_ inverts the status token        |
+| `check git status`           | `Working tree is clean`                    | names the action, not the condition                      |
+| `env vars`                   | `NODE_ENV is set`                          | names the subject, not the claim                         |
+| `Docker`                     | `Docker is configured`                     | a bare noun asserts nothing to be true or false          |
+| `extends recommended preset` | `renovate.json extends config:recommended` | a verb with no subject leaves the claim half-stated      |
 
 Rewriting a name often exposes an ambiguous predicate: an author writing "newer than 24" frequently discovers they meant a floor of 24.
 
@@ -237,7 +239,7 @@ A check that exists only to gate the checks nested beneath it is no exception. I
 
 ### The detail contract
 
-`detail` answers "why this status" -- not "what this check asserts", which the name already says. On a pass it reports the evidence; on a skip, why the check did not apply; on a failure, what went wrong.
+`detail` answers "why this status" -- not "what this check asserts", which the name already says. On a pass it reports the evidence; on a skip, why the check did not apply; on a failure, what went wrong. It opens in lower case, continuing the claim it hangs from rather than standing as a sentence of its own.
 
 | Status  | Where `detail` renders                                  |
 | ------- | ------------------------------------------------------- |
@@ -258,26 +260,26 @@ export default defineRdyKit({
       name: 'release',
       checks: [
         {
-          name: 'working tree is clean',
+          name: 'Working tree is clean',
           check: () => ({ ok: true, detail: 'no uncommitted changes' }),
         },
         {
-          name: 'dependencies are installed',
+          name: 'Dependencies are installed',
           check: () => true,
           checks: [
             {
-              name: 'lockfile is current',
+              name: 'Lockfile is current',
               check: () => ({ ok: true, progress: { type: 'fraction', passedCount: 4, count: 4 } }),
               checks: [
                 {
-                  name: 'no duplicated majors',
+                  name: 'No dependency has duplicated majors',
                   check: () => ({ ok: false, detail: 'react resolves to both 18.3.1 and 19.0.0' }),
                   fix: 'Run `pnpm dedupe`, then commit the lockfile',
                 },
               ],
             },
             {
-              name: 'native modules are rebuilt',
+              name: 'Native modules are rebuilt',
               check: () => true,
               skip: () => 'no native dependencies in this workspace',
             },
@@ -292,18 +294,18 @@ export default defineRdyKit({
 It produces:
 
 ```
-🟢 working tree is clean · no uncommitted changes
-🟢 dependencies are installed
-   🟢 lockfile is current [4 of 4]
-      🔴 no duplicated majors
+🟢 Working tree is clean · no uncommitted changes
+🟢 Dependencies are installed
+   🟢 Lockfile is current [4 of 4]
+      🔴 No dependency has duplicated majors
          react resolves to both 18.3.1 and 19.0.0
-   ⚪ native modules are rebuilt · no native dependencies in this workspace
+   ⚪ Native modules are rebuilt · no native dependencies in this workspace
 
 🔴 3 passed | 1 error | 1 skipped (0ms)
 
 ── Fixes
 
-💊 no duplicated majors
+💊 No dependency has duplicated majors
    Run `pnpm dedupe`, then commit the lockfile
 ```
 
@@ -318,7 +320,7 @@ import { defineRdyStagedChecklist } from 'readyup';
 
 export default defineRdyStagedChecklist({
   name: 'release',
-  groups: [[{ name: 'working tree is clean', check: () => true }], [{ name: 'tests pass', check: () => true }]],
+  groups: [[{ name: 'Working tree is clean', check: () => true }], [{ name: 'Tests pass', check: () => true }]],
 });
 ```
 
@@ -455,23 +457,23 @@ Headings encode level by rule weight: `━━` for a kit, `──` for a checkli
 ```
 ── build
 
-🟢 types check cleanly (343ms)
-🟢 bundle is within budget · 42kB of a 50kB budget [84%]
+🟢 Types check cleanly (343ms)
+🟢 Bundle is within budget · 42kB of a 50kB budget [84%]
 
 🟢 2 passed (343ms)
 
 ── integration
 
-🟢 database is reachable
-🔴 migrations are applied (151ms)
+🟢 Database is reachable
+🔴 Migrations are applied (151ms)
    2 migrations pending: add_users, add_index
-⚪ seed data is loaded · seeding is disabled outside CI
+⚪ Seed data is loaded · seeding is disabled outside CI
 
 🔴 1 passed | 1 error | 1 skipped (151ms)
 
 ── Fixes
 
-💊 migrations are applied
+💊 Migrations are applied
    Run `pnpm migrate` against the target database
 
 ── Summary
@@ -500,10 +502,10 @@ In `plain`, every character is printable ASCII, heading rules and separators inc
 ```
 -- integration
 
-PASS  database is reachable
-FAIL  migrations are applied (151ms)
+PASS  Database is reachable
+FAIL  Migrations are applied (151ms)
       2 migrations pending: add_users, add_index
-SKIP  seed data is loaded - seeding is disabled outside CI
+SKIP  Seed data is loaded - seeding is disabled outside CI
 
 FAIL  1 passed | 1 error | 1 skipped (151ms)
 ```

--- a/packages/readyup/__tests__/check-utils/filesystem.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/filesystem.unit.test.ts
@@ -88,7 +88,7 @@ describe(filesExist, () => {
 
     expect(result).toStrictEqual({
       ok: false,
-      detail: 'Missing files: b.txt, c.txt',
+      detail: 'missing files: b.txt, c.txt',
       progress: { type: 'fraction', passedCount: 1, count: 3 },
     });
   });
@@ -100,7 +100,7 @@ describe(filesExist, () => {
 
     expect(result).toStrictEqual({
       ok: false,
-      detail: 'Missing files: missing.txt',
+      detail: 'missing files: missing.txt',
       progress: { type: 'fraction', passedCount: 1, count: 2 },
     });
   });

--- a/packages/readyup/__tests__/check-utils/git/factories.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/factories.unit.test.ts
@@ -58,7 +58,7 @@ describe(makeLocalRefSyncCheck, () => {
     const outcome = await check.check();
 
     expect(outcome).toMatchObject({ ok: false, detail: expect.stringContaining('behind') });
-    expect(outcome).toMatchObject({ detail: expect.stringContaining('git merge') });
+    expect(outcome).toMatchObject({ detail: expect.not.stringContaining('git merge') });
   });
 
   it('reports diverged detail when both sides have commits', async () => {
@@ -102,10 +102,10 @@ describe(makeLocalRefSyncCheck, () => {
     expect(check.fix).toBe('custom fix');
   });
 
-  it('has no fix when not provided', () => {
+  it('falls back to a default fix naming the refs to reconcile', () => {
     const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'a', refB: 'b' });
 
-    expect(check.fix).toBeUndefined();
+    expect(check.fix).toBe('Reconcile a with b in /repo');
   });
 
   it('forwards severity to the check', () => {
@@ -165,7 +165,7 @@ describe(makeRemoteRefSyncCheck, () => {
     const outcome = await check.check();
 
     expect(outcome).toMatchObject({ ok: false, detail: expect.stringContaining('behind') });
-    expect(outcome).toMatchObject({ detail: expect.stringContaining('git pull') });
+    expect(outcome).toMatchObject({ detail: expect.not.stringContaining('git pull') });
   });
 
   it('reports diverged detail when both sides have commits', async () => {
@@ -200,8 +200,7 @@ describe(makeRemoteRefSyncCheck, () => {
     const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'main' });
     const skipResult = await check.skip?.();
 
-    expect(skipResult).toBeTypeOf('string');
-    expect(skipResult).toContain('unreachable');
+    expect(skipResult).toBe("remote 'origin' is unreachable");
   });
 
   it('returns pass from check() when remote is unreachable', async () => {
@@ -230,10 +229,10 @@ describe(makeRemoteRefSyncCheck, () => {
     expect(check.fix).toBe('run git pull');
   });
 
-  it('has no fix when not provided', () => {
+  it('falls back to a default fix naming the local and remote refs', () => {
     const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/repo', ref: 'main' });
 
-    expect(check.fix).toBeUndefined();
+    expect(check.fix).toBe('Reconcile main with origin/main in /repo');
   });
 
   it('forwards severity to the check', () => {

--- a/packages/readyup/__tests__/check-utils/git/factories.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/factories.unit.test.ts
@@ -102,10 +102,10 @@ describe(makeLocalRefSyncCheck, () => {
     expect(check.fix).toBe('custom fix');
   });
 
-  it('falls back to a default fix naming the refs to reconcile', () => {
+  it('falls back to a default fix naming the refs to bring into sync', () => {
     const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'a', refB: 'b' });
 
-    expect(check.fix).toBe('Reconcile a with b in /repo');
+    expect(check.fix).toBe('Make a and b point at the same commit in /repo');
   });
 
   it('forwards severity to the check', () => {
@@ -229,10 +229,10 @@ describe(makeRemoteRefSyncCheck, () => {
     expect(check.fix).toBe('run git pull');
   });
 
-  it('falls back to a default fix naming the local and remote refs', () => {
+  it('falls back to a default fix naming the local and remote refs to bring into sync', () => {
     const check = makeRemoteRefSyncCheck({ name: 'sync', path: '/repo', ref: 'main' });
 
-    expect(check.fix).toBe('Reconcile main with origin/main in /repo');
+    expect(check.fix).toBe('Make main and origin/main point at the same commit in /repo');
   });
 
   it('forwards severity to the check', () => {

--- a/packages/readyup/__tests__/check-utils/git/factories.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/factories.unit.test.ts
@@ -96,6 +96,20 @@ describe(makeLocalRefSyncCheck, () => {
     expect(outcome).toMatchObject({ ok: false, detail: expect.stringContaining('nonexistent') });
   });
 
+  // A caller runs these checks over more than one repository, which is what `path` is for, so a detail
+  // that reports a count has to say which repository it counted in.
+  it.each([
+    { ahead: 3, behind: 0 },
+    { ahead: 0, behind: 2 },
+    { ahead: 2, behind: 3 },
+  ])('names the repository in the detail reporting $ahead ahead and $behind behind', async (aheadBehind) => {
+    mockCompareLocalRefs.mockResolvedValue({ status: 'mismatch', shaA: 'aaa', shaB: 'bbb', aheadBehind });
+
+    const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'main', refB: 'feature' });
+
+    await expect(check.check()).resolves.toMatchObject({ detail: expect.stringContaining('in /repo') });
+  });
+
   it('uses custom fix when provided', () => {
     const check = makeLocalRefSyncCheck({ name: 'sync', path: '/repo', refA: 'a', refB: 'b', fix: 'custom fix' });
 
@@ -190,7 +204,24 @@ describe(makeRemoteRefSyncCheck, () => {
     const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'feature' });
     const outcome = await check.check();
 
-    expect(outcome).toMatchObject({ ok: false, detail: expect.stringContaining('origin/feature') });
+    expect(outcome).toMatchObject({ ok: false, detail: "ref 'origin/feature' does not exist in /repo" });
+  });
+
+  it.each([
+    { ahead: 1, behind: 0 },
+    { ahead: 0, behind: 3 },
+    { ahead: 2, behind: 5 },
+  ])('names the repository in the detail reporting $ahead ahead and $behind behind', async (aheadBehind) => {
+    mockCompareRefToRemote.mockResolvedValue({
+      status: 'out-of-sync',
+      localSha: 'aaa',
+      remoteSha: 'bbb',
+      aheadBehind,
+    });
+
+    const check = makeRemoteRefSyncCheck({ name: 'remote-sync', path: '/repo', ref: 'main' });
+
+    await expect(check.check()).resolves.toMatchObject({ detail: expect.stringContaining('in /repo') });
   });
 
   it('returns skip reason when remote is unreachable', async () => {

--- a/packages/readyup/__tests__/check-utils/json.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/json.unit.test.ts
@@ -108,7 +108,7 @@ describe(hasJsonFields, () => {
 
     expect(result).toStrictEqual({
       ok: false,
-      detail: 'Missing fields: version, type',
+      detail: 'missing fields: version, type',
       progress: { type: 'fraction', passedCount: 1, count: 3 },
     });
   });
@@ -129,7 +129,7 @@ describe(hasJsonFields, () => {
 
     expect(result).toStrictEqual({
       ok: false,
-      detail: 'Missing fields: name, version',
+      detail: 'missing fields: name, version',
       progress: { type: 'fraction', passedCount: 0, count: 2 },
     });
   });

--- a/packages/readyup/__tests__/check-utils/missingFrom.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/missingFrom.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { missingFrom as missingFromBarrel } from '../../src/check-utils/index.ts';
 import { missingFrom } from '../../src/check-utils/missingFrom.ts';
 
 describe(missingFrom, () => {
@@ -17,7 +18,7 @@ describe(missingFrom, () => {
 
     expect(result).toStrictEqual({
       ok: false,
-      detail: 'Missing fields: a, c',
+      detail: 'missing fields: a, c',
       progress: { type: 'fraction', passedCount: 1, count: 3 },
     });
   });
@@ -27,7 +28,7 @@ describe(missingFrom, () => {
 
     expect(result).toStrictEqual({
       ok: false,
-      detail: 'Missing deps: x, y',
+      detail: 'missing deps: x, y',
       progress: { type: 'fraction', passedCount: 0, count: 2 },
     });
   });
@@ -39,5 +40,9 @@ describe(missingFrom, () => {
       ok: true,
       progress: { type: 'fraction', passedCount: 0, count: 0 },
     });
+  });
+
+  it('is reachable from the check-utils barrel', () => {
+    expect(missingFromBarrel).toBe(missingFrom);
   });
 });

--- a/packages/readyup/__tests__/initCommand.scaffold.unit.test.ts
+++ b/packages/readyup/__tests__/initCommand.scaffold.unit.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { loadRdyKit } from '../src/config.ts';
+import { initCommand } from '../src/init/initCommand.ts';
+import { runRdy } from '../src/runRdy.ts';
+import type { RdyResult } from '../src/types.ts';
+
+const TEST_DIR = join(import.meta.dirname, '../.test-tmp-scaffold');
+const KIT_PATH = '.readyup/kits/default.ts';
+
+/**
+ * Covers the kit `rdy init` writes by running it, rather than comparing it to the template it came from.
+ *
+ * The template is a string, so no typecheck or lint reaches it. Loading it through the same path
+ * `rdy run --jit` takes is what proves a scaffolded project works before its author has written anything.
+ */
+describe('scaffolded kit', () => {
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    mkdirSync(TEST_DIR, { recursive: true });
+    process.chdir(TEST_DIR);
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('passes with NODE_ENV set, reporting the value it found', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    initCommand({ dryRun: false, force: false });
+
+    const results = await runScaffoldedKit();
+
+    expect(results).toMatchObject([{ name: 'NODE_ENV is set', status: 'passed', detail: 'production' }]);
+  });
+
+  it('fails with NODE_ENV unset, reporting that the environment carries no value', async () => {
+    vi.stubEnv('NODE_ENV', undefined);
+    initCommand({ dryRun: false, force: false });
+
+    const results = await runScaffoldedKit();
+
+    expect(results).toMatchObject([
+      {
+        name: 'NODE_ENV is set',
+        status: 'failed',
+        detail: 'no value in the environment',
+        fix: 'Set NODE_ENV before deploying',
+      },
+    ]);
+  });
+});
+
+/** Loads the scaffolded kit from source and runs the one checklist it declares. */
+async function runScaffoldedKit(): Promise<RdyResult[]> {
+  const { kit } = await loadRdyKit(KIT_PATH);
+  const [checklist] = kit.checklists;
+  if (checklist === undefined) throw new Error('The scaffolded kit declares no checklist');
+
+  const report = await runRdy(checklist);
+  return report.results;
+}

--- a/packages/readyup/src/assertIsRdyKit.ts
+++ b/packages/readyup/src/assertIsRdyKit.ts
@@ -24,7 +24,7 @@ const FunctionSchema = z.custom<(...args: never[]) => unknown>((value) => typeof
   error: (issue) => `expected a function, got ${describeType(issue.input)}`,
 });
 
-/** Schema for a display name, which every check and checklist must carry. */
+/** Schema for the name every check and checklist must carry. */
 const NameSchema = z.string('expected a non-empty string').min(1, 'expected a non-empty string');
 
 /**

--- a/packages/readyup/src/check-utils/git/factories.ts
+++ b/packages/readyup/src/check-utils/git/factories.ts
@@ -11,7 +11,7 @@ interface LocalRefSyncCheckOptions {
   refA: string;
   /** Second local ref to compare against. */
   refB: string;
-  /** Remediation message. Overrides the default, which names the refs to reconcile. */
+  /** Remediation message. Overrides the default, which names the refs to bring into sync. */
   fix?: string;
   /** Severity of the check. When omitted, the kit's default severity applies. */
   severity?: Severity;
@@ -26,7 +26,7 @@ interface RemoteRefSyncCheckOptions {
   ref: string;
   /** Remote name. Default: `origin`. */
   remote?: string;
-  /** Remediation message. Overrides the default, which names the refs to reconcile. */
+  /** Remediation message. Overrides the default, which names the refs to bring into sync. */
   fix?: string;
   /** Severity of the check. When omitted, the kit's default severity applies. */
   severity?: Severity;
@@ -43,7 +43,7 @@ export function makeLocalRefSyncCheck(options: LocalRefSyncCheckOptions): RdyChe
       if (result.status === 'match') return true;
       return { ok: false, detail: formatLocalResult(result, refA, refB, path) };
     },
-    fix: customFix ?? `Reconcile ${refA} with ${refB} in ${path}`,
+    fix: customFix ?? `Make ${refA} and ${refB} point at the same commit in ${path}`,
   };
   if (severity !== undefined) check.severity = severity;
   return check;
@@ -80,7 +80,7 @@ export function makeRemoteRefSyncCheck(options: RemoteRefSyncCheckOptions): RdyC
       if (result.status === 'unreachable') return true;
       return { ok: false, detail: formatRemoteResult(result, ref, remote, path) };
     },
-    fix: customFix ?? `Reconcile ${ref} with ${remote}/${ref} in ${path}`,
+    fix: customFix ?? `Make ${ref} and ${remote}/${ref} point at the same commit in ${path}`,
   };
   if (severity !== undefined) rdyCheck.severity = severity;
   return rdyCheck;

--- a/packages/readyup/src/check-utils/git/factories.ts
+++ b/packages/readyup/src/check-utils/git/factories.ts
@@ -104,12 +104,12 @@ function formatLocalResult(
 
   const { ahead, behind } = aheadBehind;
   if (ahead > 0 && behind > 0) {
-    return `${refA} and ${refB} have diverged, with ${ahead} and ${behind} different commits each`;
+    return `${refA} and ${refB} have diverged in ${path}, with ${ahead} and ${behind} different commits each`;
   }
   if (behind > 0) {
-    return `${refA} is behind ${refB} by ${behind} commit${behind === 1 ? '' : 's'}`;
+    return `${refA} is behind ${refB} by ${behind} commit${behind === 1 ? '' : 's'} in ${path}`;
   }
-  return `${refA} is ahead of ${refB} by ${ahead} commit${ahead === 1 ? '' : 's'}`;
+  return `${refA} is ahead of ${refB} by ${ahead} commit${ahead === 1 ? '' : 's'} in ${path}`;
 }
 
 /** Format a human-readable detail message for a remote ref comparison failure. */
@@ -120,7 +120,7 @@ function formatRemoteResult(
   path: string,
 ): string {
   if (result.status === 'ref-missing') {
-    return `ref '${result.ref}' does not exist`;
+    return `ref '${result.ref}' does not exist in ${path}`;
   }
   if (result.status === 'unreachable') {
     return `remote '${remote}' is unreachable`;
@@ -133,10 +133,10 @@ function formatRemoteResult(
 
   const { ahead, behind } = aheadBehind;
   if (ahead > 0 && behind > 0) {
-    return `${ref} and ${remote}/${ref} have diverged, with ${ahead} and ${behind} different commits each`;
+    return `${ref} and ${remote}/${ref} have diverged in ${path}, with ${ahead} and ${behind} different commits each`;
   }
   if (behind > 0) {
-    return `${ref} is behind ${remote}/${ref} by ${behind} commit${behind === 1 ? '' : 's'}`;
+    return `${ref} is behind ${remote}/${ref} by ${behind} commit${behind === 1 ? '' : 's'} in ${path}`;
   }
-  return `${ref} is ahead of ${remote}/${ref} by ${ahead} commit${ahead === 1 ? '' : 's'}`;
+  return `${ref} is ahead of ${remote}/${ref} by ${ahead} commit${ahead === 1 ? '' : 's'} in ${path}`;
 }

--- a/packages/readyup/src/check-utils/git/factories.ts
+++ b/packages/readyup/src/check-utils/git/factories.ts
@@ -11,7 +11,7 @@ interface LocalRefSyncCheckOptions {
   refA: string;
   /** Second local ref to compare against. */
   refB: string;
-  /** Custom remediation message. Overrides the default. */
+  /** Remediation message. Overrides the default, which names the refs to reconcile. */
   fix?: string;
   /** Severity of the check. When omitted, the kit's default severity applies. */
   severity?: Severity;
@@ -26,7 +26,7 @@ interface RemoteRefSyncCheckOptions {
   ref: string;
   /** Remote name. Default: `origin`. */
   remote?: string;
-  /** Custom remediation message. Overrides the default. */
+  /** Remediation message. Overrides the default, which names the refs to reconcile. */
   fix?: string;
   /** Severity of the check. When omitted, the kit's default severity applies. */
   severity?: Severity;
@@ -43,8 +43,8 @@ export function makeLocalRefSyncCheck(options: LocalRefSyncCheckOptions): RdyChe
       if (result.status === 'match') return true;
       return { ok: false, detail: formatLocalResult(result, refA, refB, path) };
     },
+    fix: customFix ?? `Reconcile ${refA} with ${refB} in ${path}`,
   };
-  if (customFix !== undefined) check.fix = customFix;
   if (severity !== undefined) check.severity = severity;
   return check;
 }
@@ -67,7 +67,7 @@ export function makeRemoteRefSyncCheck(options: RemoteRefSyncCheckOptions): RdyC
     async skip() {
       const result = await getProbe();
       if (result.status === 'unreachable') {
-        return `remote '${remote}' is unreachable; skipping network check`;
+        return `remote '${remote}' is unreachable`;
       }
       return false;
     },
@@ -80,8 +80,8 @@ export function makeRemoteRefSyncCheck(options: RemoteRefSyncCheckOptions): RdyC
       if (result.status === 'unreachable') return true;
       return { ok: false, detail: formatRemoteResult(result, ref, remote, path) };
     },
+    fix: customFix ?? `Reconcile ${ref} with ${remote}/${ref} in ${path}`,
   };
-  if (customFix !== undefined) rdyCheck.fix = customFix;
   if (severity !== undefined) rdyCheck.severity = severity;
   return rdyCheck;
 }
@@ -107,7 +107,7 @@ function formatLocalResult(
     return `${refA} and ${refB} have diverged, with ${ahead} and ${behind} different commits each`;
   }
   if (behind > 0) {
-    return `${refA} is behind ${refB} by ${behind} commit${behind === 1 ? '' : 's'}; run 'git merge ${refB}' in ${path}`;
+    return `${refA} is behind ${refB} by ${behind} commit${behind === 1 ? '' : 's'}`;
   }
   return `${refA} is ahead of ${refB} by ${ahead} commit${ahead === 1 ? '' : 's'}`;
 }
@@ -136,7 +136,7 @@ function formatRemoteResult(
     return `${ref} and ${remote}/${ref} have diverged, with ${ahead} and ${behind} different commits each`;
   }
   if (behind > 0) {
-    return `${ref} is behind ${remote}/${ref} by ${behind} commit${behind === 1 ? '' : 's'}; run 'git pull' in ${path}`;
+    return `${ref} is behind ${remote}/${ref} by ${behind} commit${behind === 1 ? '' : 's'}`;
   }
   return `${ref} is ahead of ${remote}/${ref} by ${ahead} commit${ahead === 1 ? '' : 's'}`;
 }

--- a/packages/readyup/src/check-utils/git/factories.ts
+++ b/packages/readyup/src/check-utils/git/factories.ts
@@ -3,7 +3,7 @@ import { compareLocalRefs } from './compare-local-refs.ts';
 import { compareRefToRemote } from './compare-ref-to-remote.ts';
 
 interface LocalRefSyncCheckOptions {
-  /** Display name for the check. */
+  /** The claim the check asserts. */
   name: string;
   /** Path to the git repository. */
   path: string;
@@ -18,7 +18,7 @@ interface LocalRefSyncCheckOptions {
 }
 
 interface RemoteRefSyncCheckOptions {
-  /** Display name for the check. */
+  /** The claim the check asserts. */
   name: string;
   /** Path to the git repository. */
   path: string;

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -17,6 +17,7 @@ export {
 export { computeHash, fileMatchesHash } from './hashing.ts';
 export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json.ts';
 export { getJsonValue, hasJsonValue } from './json-value.ts';
+export { missingFrom } from './missingFrom.ts';
 export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
 export { compareVersions } from './semver.ts';
 export { readToolVersionsNode } from './tool-versions.ts';

--- a/packages/readyup/src/check-utils/missingFrom.ts
+++ b/packages/readyup/src/check-utils/missingFrom.ts
@@ -18,7 +18,7 @@ export function missingFrom(category: string, expected: string[], actual: string
 
   return {
     ok: false,
-    detail: `Missing ${category}: ${missing.join(', ')}`,
+    detail: `missing ${category}: ${missing.join(', ')}`,
     progress,
   };
 }

--- a/packages/readyup/src/init/templates.ts
+++ b/packages/readyup/src/init/templates.ts
@@ -17,7 +17,10 @@ export const rdyKitTemplate = `import { defineRdyKit } from 'readyup';
  * Default rdy kit.
  *
  * Each checklist contains checks that run before a deployment or other operation.
- * Checks run concurrently within a checklist. Use \`fix\` to provide remediation hints.
+ * Checks run concurrently within a checklist.
+ *
+ * Three fields, three questions: \`name\` states what must be true, phrased so it reads
+ * true on a pass; \`detail\` answers why this status; \`fix\` says what to do about it.
  */
 export default defineRdyKit({
   checklists: [
@@ -25,8 +28,11 @@ export default defineRdyKit({
       name: 'deploy',
       checks: [
         {
-          name: 'environment variables set',
-          check: () => Boolean(process.env['NODE_ENV']),
+          name: 'NODE_ENV is set',
+          check: () => {
+            const value = process.env['NODE_ENV'];
+            return { ok: Boolean(value), detail: value ?? 'no value in the environment' };
+          },
           fix: 'Set NODE_ENV before deploying',
         },
       ],

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -105,8 +105,19 @@ export function isPercentProgress(progress: Progress): progress is PercentProgre
 
 /** Structured outcome from a check, carrying diagnostic data alongside the pass/fail status. */
 export interface CheckOutcome {
+  /** Whether the check's claim holds. */
   ok: boolean;
+
+  /**
+   * Why this status: the evidence on a pass, what went wrong on a failure. Not what the check
+   * asserts, which the name already states, and not how to fix it, which belongs in `fix`.
+   */
   detail?: string | undefined;
+
+  /**
+   * Quantitative progress toward the claim, rendered alongside the name. Needs no `detail`:
+   * the fraction is already the evidence.
+   */
   progress?: Progress | undefined;
 }
 
@@ -117,10 +128,13 @@ export type CheckReturnValue = boolean | CheckOutcome;
 
 /** A single readyup check. */
 export interface RdyCheck {
-  /** Display name shown in output. */
+  /**
+   * The claim being asserted, phrased to read true on a pass and false on a failure:
+   * `Node 24 or later`, not `Node >= 24`.
+   */
   name: string;
 
-  /** Assert a condition. Return true/false or a CheckOutcome. */
+  /** Assert the claim. Return true/false or a CheckOutcome. */
   check: () => CheckReturnValue | Promise<CheckReturnValue>;
 
   /**
@@ -135,7 +149,7 @@ export interface RdyCheck {
    */
   skip?: (() => SkipResult | Promise<SkipResult>) | undefined;
 
-  /** Remediation message shown when the check fails. */
+  /** What to do about a failure. Remediation belongs here rather than in a `CheckOutcome`'s `detail`. */
   fix?: string | undefined;
 
   /** Dependent checks that run only if this check passes. */

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -129,8 +129,9 @@ export type CheckReturnValue = boolean | CheckOutcome;
 /** A single readyup check. */
 export interface RdyCheck {
   /**
-   * The claim being asserted, phrased to read true on a pass and false on a failure:
-   * `Node 24 or later`, not `Node >= 24`.
+   * The claim being asserted, in the third person indicative and capitalized like a sentence,
+   * phrased to read true on a pass and false on a failure: `Node.js runtime is v24 or later`,
+   * not `Node >= 24`.
    */
   name: string;
 

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -115,8 +115,8 @@ export interface CheckOutcome {
   detail?: string | undefined;
 
   /**
-   * Quantitative progress toward the claim, rendered alongside the name. Needs no `detail`:
-   * the fraction is already the evidence.
+   * Quantitative progress toward the claim, rendered alongside the name. On a pass it stands as
+   * the evidence in place of a `detail`; a failing count still needs one, to name what is missing.
    */
   progress?: Progress | undefined;
 }


### PR DESCRIPTION
## What

Revises ReadyUp's starter template, demo, editor tooltips, and documentation so that they all align with ReadyUp's own check-authoring contract. 

New features:

- Checks can now report progress as a fraction over any collection, not just files and JSON fields.
- A failing git ref-sync check now reports the difference between the two refs, and its remediation hint is now shown in the list of fixes, superseded by a hint provided by the kit itself.

## Why

An author writing their first kit meets the contract in three places before they ever open the README: the kit `rdy init` scaffolds, the demo kit, and their editor's tooltips. Each of those taught something the README forbids, so the guidance that shipped in #123 had no working demonstration anywhere in the package.

## Details

### 🎉 Features

- `missingFrom` is exported from `readyup/check-utils` and documented there. It builds the fraction `CheckOutcome` that `filesExist` returns, and was previously unreachable for any collection other than files and JSON fields.

### 🐛 Bug fixes

- `makeLocalRefSyncCheck` and `makeRemoteRefSyncCheck` carry remediation in `fix` rather than appending it to `detail`, where readyup renders diagnosis. Both now supply a default fix naming the state the refs should reach, which a caller-supplied `fix` replaces; previously no default existed, so a caller who supplied one saw the remediation twice.
- Every ref-sync failure reason names the repository it describes, so a kit checking several repositories can tell them apart. A remote ref that does not exist is reported like a missing local ref.
- A remote check skipped because the remote is unreachable gives that as its reason without also restating that it was skipped.
- A failing fraction detail opens in lower case, matching every other reason readyup renders beneath a claim.
- The kit `rdy init` writes names its check as a claim that reads true when it passes, and reports what it found alongside the result.

### 🧪 Tests

- The scaffolded kit is loaded and run, with and without the environment variable it checks. Its source is a template string that no typecheck or lint reaches.

### 📚 Documentation

- The README's naming guidance states the form a claim takes, its poor/better table gains a bare-noun gate check and a verb-first fragment, and its version-floor example names the runtime it claims about. The detail contract records the lower-case opening that pairs with a capitalized name.
- Editor tooltips carry the contract: `RdyCheck.name` is the claim being asserted, all three `CheckOutcome` fields are documented, and no surface describes a check name as a display string.
- The demo kit exercises `detail` and `progress` alongside the features its header advertises, and reaches for shipped `check-utils` rather than composing or reimplementing them locally.

Closes #143
