### PR TITLE
#181 Conform property names to the naming conventions

### DIFF
--- a/packages/compositor/src/closure/readFrontmatterEdges.ts
+++ b/packages/compositor/src/closure/readFrontmatterEdges.ts
@@ -52,7 +52,7 @@ export function readFrontmatterEdges(input: FrontmatterEdgesInput): FrontmatterE
 
   const block = parseFrontmatter(content);
   if (block.frontmatter === undefined) {
-    if (block.unterminated) {
+    if (block.isUnterminated) {
       fault('invalid-declaration', undefined, 'opens a frontmatter block that no delimiter closes');
     }
     return { edges, diagnostics };

--- a/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/loadConfig.unit.test.ts
@@ -35,7 +35,7 @@ describe(loadConfig, () => {
     const config = await loadConfig([buildTierFile(dir, 'global'), buildTierFile(dir, 'project')]);
 
     expect(config.tiers).toStrictEqual([
-      { id: 'global', label: 'global', baseDir: dir, reset: false, sources: { use: [], drop: [] }, select: [] },
+      { id: 'global', label: 'global', baseDir: dir, shouldReset: false, sources: { use: [], drop: [] }, select: [] },
     ]);
   });
 

--- a/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
+++ b/packages/compositor/src/config/__tests__/resolveSources.unit.test.ts
@@ -76,10 +76,10 @@ describe(resolveSources, () => {
     await expect(collectNames(config)).resolves.toStrictEqual(['vendor']);
   });
 
-  it('discards every lower tier’s sources and declines at a tier declaring reset', async () => {
+  it('discards every lower tier’s sources and declines at a tier declaring shouldReset', async () => {
     const config = buildConfig([
       { sources: { use: [{ name: 'shared', path: './shared' }], drop: ['vendor'] } },
-      { reset: true, sources: { use: [{ name: 'local', path: './local' }] } },
+      { shouldReset: true, sources: { use: [{ name: 'local', path: './local' }] } },
     ]);
 
     await expect(resolveSources(config, options)).resolves.toMatchObject({ declined: [] });

--- a/packages/compositor/src/config/resolveSources.ts
+++ b/packages/compositor/src/config/resolveSources.ts
@@ -31,9 +31,9 @@ export interface SourceResolution {
  * Resolves the sources `config` declares, locating each on disk, in precedence order.
  *
  * The fold runs lowest tier first, keyed by name: a `use` adds the source or remaps an inherited one, a `drop` removes
- * it and records the decline, and a tier declaring `reset` discards every lower tier's contributions before it applies.
- * Precedence then runs higher tier first, and author order within a tier, so a config reads with precedence descending
- * down the page and a consumer's own content outranks a package it listed below.
+ * it and records the decline, and a tier declaring `shouldReset` discards every lower tier's contributions before it
+ * applies. Precedence then runs higher tier first, and author order within a tier, so a config reads with precedence
+ * descending down the page and a consumer's own content outranks a package it listed below.
  *
  * A package name is located here; a path is resolved against the tier that declared it. The location a consumer wrote
  * stays on the origin either way, so a plan reports the declaration rather than where it landed. Whether a resolved
@@ -47,7 +47,7 @@ export async function resolveSources(
   const declined = new Set<string>();
 
   for (const [tierIndex, tier] of config.tiers.entries()) {
-    if (tier.reset) {
+    if (tier.shouldReset) {
       adopted.clear();
       declined.clear();
     }

--- a/packages/compositor/src/deployment/resolveDeployedPath.ts
+++ b/packages/compositor/src/deployment/resolveDeployedPath.ts
@@ -3,24 +3,26 @@ import type { KindDeployment } from '../schemas/render-target-schemas.ts';
 /**
  * Resolves where one of an artifact's files lands, relative to the target's root and with POSIX separators.
  *
- * `relPath` is the file's path within the artifact's own directory, which only a directory layout has: it defaults to
- * the entry file, and naming one under a file layout throws, since a file layout holds exactly one file and a caller
- * asking for a second has a fault no path could express.
+ * `relativePath` is the file's path within the artifact's own directory, which only a directory layout has: it
+ * defaults to the entry file, and naming one under a file layout throws, since a file layout holds exactly one file
+ * and a caller asking for a second has a fault no path could express.
  *
  * A layout rooted at the empty string puts the kind at the target's root, which is how a destination that keeps one
  * guidance file beside its directories is expressed.
  */
-export function resolveDeployedPath(deployment: KindDeployment, deployedName: string, relPath?: string): string {
+export function resolveDeployedPath(deployment: KindDeployment, deployedName: string, relativePath?: string): string {
   const { layout } = deployment;
 
   if (layout.form === 'file') {
-    if (relPath !== undefined) {
-      throw new Error(`Cannot resolve "${relPath}" within "${deployedName}": kind "${deployment.kindId}" is one file.`);
+    if (relativePath !== undefined) {
+      throw new Error(
+        `Cannot resolve "${relativePath}" within "${deployedName}": kind "${deployment.kindId}" is one file.`,
+      );
     }
     return joinPosix(layout.root, `${deployedName}${layout.extension}`);
   }
 
-  return joinPosix(layout.root, deployedName, relPath ?? layout.entryFile);
+  return joinPosix(layout.root, deployedName, relativePath ?? layout.entryFile);
 }
 
 // region | Helpers

--- a/packages/compositor/src/frontmatter/__tests__/parseFrontmatter.unit.test.ts
+++ b/packages/compositor/src/frontmatter/__tests__/parseFrontmatter.unit.test.ts
@@ -7,7 +7,7 @@ describe(parseFrontmatter, () => {
     expect(parseFrontmatter('---\nname: reviewer\n---\nRead the diff.\n')).toStrictEqual({
       frontmatter: 'name: reviewer',
       body: 'Read the diff.\n',
-      unterminated: false,
+      isUnterminated: false,
     });
   });
 
@@ -15,26 +15,26 @@ describe(parseFrontmatter, () => {
     expect(parseFrontmatter('---\n---\nBody\n')).toStrictEqual({
       frontmatter: '',
       body: 'Body\n',
-      unterminated: false,
+      isUnterminated: false,
     });
   });
 
   it('if the content opens with something other than a delimiter, reports no block and keeps the whole content', () => {
     const content = '# Reviewer\n\nRead the diff.\n';
 
-    expect(parseFrontmatter(content)).toStrictEqual({ frontmatter: undefined, body: content, unterminated: false });
+    expect(parseFrontmatter(content)).toStrictEqual({ frontmatter: undefined, body: content, isUnterminated: false });
   });
 
   it('does not read a horizontal rule below the first line as a block, which the ported original did', () => {
     const content = 'Some prose.\n\n---\n\nMore prose.\n\n---\n\nAnd more.\n';
 
-    expect(parseFrontmatter(content)).toStrictEqual({ frontmatter: undefined, body: content, unterminated: false });
+    expect(parseFrontmatter(content)).toStrictEqual({ frontmatter: undefined, body: content, isUnterminated: false });
   });
 
   it('if the opening delimiter is never closed, reports the block unterminated rather than absent', () => {
     const content = '---\nname: reviewer\n';
 
-    expect(parseFrontmatter(content)).toStrictEqual({ frontmatter: undefined, body: content, unterminated: true });
+    expect(parseFrontmatter(content)).toStrictEqual({ frontmatter: undefined, body: content, isUnterminated: true });
   });
 
   it('keeps a delimiter line inside the body, which belongs to the body and not to the block', () => {

--- a/packages/compositor/src/frontmatter/mergeFrontmatter.ts
+++ b/packages/compositor/src/frontmatter/mergeFrontmatter.ts
@@ -26,8 +26,8 @@ export function mergeFrontmatter(content: string, overlay: FrontmatterOverlay, s
     return content;
   }
 
-  const { frontmatter, body, unterminated } = parseFrontmatter(content);
-  if (unterminated) {
+  const { frontmatter, body, isUnterminated } = parseFrontmatter(content);
+  if (isUnterminated) {
     throw new Error(`Cannot overlay metadata onto "${slug}": its frontmatter block is never closed.`);
   }
 

--- a/packages/compositor/src/frontmatter/parseFrontmatter.ts
+++ b/packages/compositor/src/frontmatter/parseFrontmatter.ts
@@ -11,7 +11,7 @@ export interface ParsedFrontmatter {
    * tells them apart. An artifact that opened a block declared metadata, and reading that as body would let a caller
    * write a second block above a declaration it could not see.
    */
-  readonly unterminated: boolean;
+  readonly isUnterminated: boolean;
 }
 
 /**
@@ -28,17 +28,17 @@ export interface ParsedFrontmatter {
 export function parseFrontmatter(content: string): ParsedFrontmatter {
   const lines = content.split('\n');
   if (lines[0] !== '---') {
-    return { frontmatter: undefined, body: content, unterminated: false };
+    return { frontmatter: undefined, body: content, isUnterminated: false };
   }
 
   const closingIndex = lines.indexOf('---', 1);
   if (closingIndex === -1) {
-    return { frontmatter: undefined, body: content, unterminated: true };
+    return { frontmatter: undefined, body: content, isUnterminated: true };
   }
 
   return {
     frontmatter: lines.slice(1, closingIndex).join('\n'),
     body: lines.slice(closingIndex + 1).join('\n'),
-    unterminated: false,
+    isUnterminated: false,
   };
 }

--- a/packages/compositor/src/ownership/structured/document-access.ts
+++ b/packages/compositor/src/ownership/structured/document-access.ts
@@ -54,7 +54,7 @@ export function openDocument(
  */
 interface JsonFormat {
   readonly indent: string | number;
-  readonly trailingNewline: boolean;
+  readonly hasTrailingNewline: boolean;
 }
 
 /**
@@ -66,12 +66,12 @@ interface JsonFormat {
 function detectJsonFormat(content: string): JsonFormat {
   const body = content.trim();
   const isEmptyDocument = ['', '{}', '[]'].includes(body);
-  const trailingNewline = content.endsWith('\n') || body === '';
+  const hasTrailingNewline = content.endsWith('\n') || body === '';
   const indented = /\n([ \t]+)\S/.exec(content);
   if (indented?.[1] !== undefined) {
-    return { indent: indented[1], trailingNewline };
+    return { indent: indented[1], hasTrailingNewline };
   }
-  return { indent: !isEmptyDocument && !body.includes('\n') ? 0 : 2, trailingNewline };
+  return { indent: !isEmptyDocument && !body.includes('\n') ? 0 : 2, hasTrailingNewline };
 }
 
 /**
@@ -154,7 +154,7 @@ function openJsonDocument(content: string): { readonly document: DocumentAccess 
         }
       },
       serialize() {
-        return JSON.stringify(root, undefined, format.indent) + (format.trailingNewline ? '\n' : '');
+        return JSON.stringify(root, undefined, format.indent) + (format.hasTrailingNewline ? '\n' : '');
       },
       toHandle: (value) => value,
       toPlain: (item) => item,

--- a/packages/compositor/src/render/renderArtifact.ts
+++ b/packages/compositor/src/render/renderArtifact.ts
@@ -23,7 +23,7 @@ export interface RenderArtifactInput {
   /** The file to render, relative to `source.dir`. */
   readonly entryPath: string;
   /** The file's path within the artifact's own directory, for a kind deploying as one. */
-  readonly relPath?: string;
+  readonly relativePath?: string;
   readonly resolveDeployedName: DeployedNameLookup;
   readonly source: TransclusionSource;
   readonly target: RenderTarget;
@@ -85,7 +85,7 @@ export async function renderArtifact(input: RenderArtifactInput): Promise<Artifa
       segments,
       pattern: links.pattern,
       tokenKinds: input.tokenKinds,
-      filePath: resolveDeployedPath(deployment, deployedName, input.relPath),
+      filePath: resolveDeployedPath(deployment, deployedName, input.relativePath),
       targetRoot: input.target.root,
       host: input.artifact.id,
     });

--- a/packages/compositor/src/schemas/__tests__/config-schemas.unit.test.ts
+++ b/packages/compositor/src/schemas/__tests__/config-schemas.unit.test.ts
@@ -22,12 +22,12 @@ const authoredTier = {
 
 describe('TierBodySchema', () => {
   it('reads an empty body as a tier declaring nothing', () => {
-    expect(TierBodySchema.parse({})).toStrictEqual({ reset: false, sources: { use: [], drop: [] }, select: [] });
+    expect(TierBodySchema.parse({})).toStrictEqual({ shouldReset: false, sources: { use: [], drop: [] }, select: [] });
   });
 
   it.each(['sources', 'select'] as const)('reads a null %s block as declaring nothing', (block) => {
     expect(TierBodySchema.parse({ [block]: null })).toStrictEqual({
-      reset: false,
+      shouldReset: false,
       sources: { use: [], drop: [] },
       select: [],
     });
@@ -46,7 +46,7 @@ describe('ConfigTierSchema', () => {
       id: 'project',
       label: 'Project',
       baseDir: '/srv/app/.agents',
-      reset: false,
+      shouldReset: false,
       sources: {
         use: [
           { name: 'local', origin: { kind: 'directory', location: './content' } },

--- a/packages/compositor/src/schemas/config-schemas.ts
+++ b/packages/compositor/src/schemas/config-schemas.ts
@@ -22,7 +22,7 @@ import { SourceDeclarationSchema } from './source-declaration-schemas.ts';
  * because every entry under it is commented out, reads as the empty declaration it means.
  */
 export const TierBodySchema = z.strictObject({
-  reset: z.boolean().default(false),
+  shouldReset: z.boolean().default(false),
   sources: z.preprocess((value) => value ?? undefined, SourceDeclarationSchema.default({ use: [], drop: [] })),
   select: z.preprocess((value) => value ?? undefined, SelectSchema.default([])),
 });

--- a/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/selectArtifacts.unit.test.ts
@@ -109,10 +109,10 @@ describe(selectArtifacts, () => {
     expect(selection.declined.map(({ artifactId }) => artifactId)).toStrictEqual(['skill:lint', 'skill:review']);
   });
 
-  it('discards every lower tier’s seeds and declines at a tier declaring reset', () => {
+  it('discards every lower tier’s seeds and declines at a tier declaring shouldReset', () => {
     const selection = select([
       { id: 'global', select: { skill: { use: ['lint'], drop: ['format'] } } },
-      { id: 'project', reset: true, select: { skill: { use: ['format'] } } },
+      { id: 'project', shouldReset: true, select: { skill: { use: ['format'] } } },
     ]);
 
     expect(collectIds(selection)).toStrictEqual(['skill:format']);

--- a/packages/compositor/src/selection/selectArtifacts.ts
+++ b/packages/compositor/src/selection/selectArtifacts.ts
@@ -39,10 +39,11 @@ export interface Selection {
  * Pure and free of I/O: the catalog is the only view of the filesystem, so re-running this over a changed config reads
  * nothing, which is what makes a shadow evaluation of an edited config free.
  *
- * The fold runs lowest tier first. Within a tier every `use` applies before every `drop`, and a tier declaring `reset`
- * discards every lower tier's decisions first. Seeds and declines stay disjoint per artifact: a `drop` clears the seeds
- * beneath it and records the decline, and a later `use` clears the decline and seeds afresh. What survives to the end
- * is therefore what decided the final state, which is what tells a project-level opt-in from an inherited one.
+ * The fold runs lowest tier first. Within a tier every `use` applies before every `drop`, and a tier declaring
+ * `shouldReset` discards every lower tier's decisions first. Seeds and declines stay disjoint per artifact: a `drop`
+ * clears the seeds beneath it and records the decline, and a later `use` clears the decline and seeds afresh. What
+ * survives to the end is therefore what decided the final state, which is what tells a project-level opt-in from an
+ * inherited one.
  *
  * A selector matching nothing is a diagnostic rather than a failure, so validation reports every mistake in a config at
  * once.
@@ -54,7 +55,7 @@ export function selectArtifacts(config: CompositorConfig, catalog: Catalog): Sel
   const diagnostics: Array<SelectionDiagnostic> = [];
 
   for (const tier of config.tiers) {
-    if (tier.reset) {
+    if (tier.shouldReset) {
       seeds.clear();
       declines.clear();
     }

--- a/packages/compositor/src/test-utils/buildConfig.ts
+++ b/packages/compositor/src/test-utils/buildConfig.ts
@@ -10,7 +10,7 @@ import { CompositorConfigSchema } from '../schemas/config-schemas.ts';
 export interface TierInput {
   readonly id?: string;
   readonly baseDir?: string;
-  readonly reset?: boolean;
+  readonly shouldReset?: boolean;
   readonly sources?: unknown;
   readonly select?: unknown;
 }
@@ -22,7 +22,7 @@ export function buildConfig(tiers: ReadonlyArray<TierInput>): CompositorConfig {
       id: tier.id ?? `tier-${index}`,
       label: tier.id ?? `tier-${index}`,
       baseDir: tier.baseDir ?? '/srv/app',
-      reset: tier.reset,
+      shouldReset: tier.shouldReset,
       sources: tier.sources,
       select: tier.select,
     })),


### PR DESCRIPTION
## What

Aligns property names with in-house naming conventions. 

## Why

A boolean whose name reads as a noun or a command costs the reader a trip to the type before they can read the code, and an abbreviation that expands four ways costs them a guess. Compositor carried four such names, and no record existed of whether the rest of its properties had ever been checked against the conventions at all.

## Details

### ♻️ Refactoring

- `TierBodySchema.reset` is now `shouldReset`. The schema is strict, so a tier file still spelling `reset` fails the parse and names the unrecognized key.
- `ParsedFrontmatter.unterminated` is now `isUnterminated` and `RenderArtifactInput.relPath` is now `relativePath`, both on barrel-exported types.
- The module-private `JsonFormat.trailingNewline` is now `hasTrailingNewline`.
- The sweep behind the four renames enumerated every field of the 17 schema modules and every property of the interfaces and object types under `src`. It cleared `emitsFiles`, `dir`/`baseDir`/`fileDir`, `config`, and the `Spec`/`Ref` type-name suffixes as already conforming; those verdicts are recorded on the ticket rather than in source comments.
- No schema version constant moved, and `samples/minimal.json` and `samples/representative.json` are byte-identical.

Closes #181
