### PR TITLE
#228 Add rdy verify --rebuild to check a kit by recompiling it

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -526,11 +526,11 @@ They are silent when the manifest is absent, when no entry describes the kit, wh
 
 ### Exit codes
 
-| Code | Meaning                                                                                             |
-| ---- | --------------------------------------------------------------------------------------------------- |
-| `0`  | Ran and found no problems                                                                           |
-| `1`  | Ran and found problems: failed checks, a `verify` drift or missing kit, a kit that fails to compile |
-| `2`  | Could not complete the invocation: a usage, config, kit-load, or internal error                     |
+| Code | Meaning                                                                                       |
+| ---- | --------------------------------------------------------------------------------------------- |
+| `0`  | Ran and found no problems                                                                     |
+| `1`  | Ran and found problems: failed checks, a kit that fails `verify`, a kit that fails to compile |
+| `2`  | Could not complete the invocation: a usage, config, kit-load, or internal error               |
 
 The distinction is "fix the repo" (`1`) versus "fix the invocation" (`2`). `rdy list` and `rdy init` produce only `0` and `2`. A run that loses a kit part-way exits `2` even when the kits that ran found problems, and still reports what it collected.
 
@@ -702,7 +702,7 @@ The path from source to a consumer:
 2. Run `rdy compile` to bundle it to `<name>.js` and record its hashes in `.readyup/manifest.json`.
 3. Commit both the compiled `.js` and the manifest.
 4. Consumers run `rdy run --from github:org/repo`, which fetches the bundle the manifest describes.
-5. Run `rdy verify` in CI to catch a bundle edited by hand or a source left uncompiled.
+5. Run `rdy verify` in CI to catch a bundle edited by hand or a source left uncompiled, or `rdy verify --rebuild` to catch a bundle stale in anything the hashes do not record.
 
 A published package can carry its kits instead, so consumers reach them through the dependency they already have rather than through a repository URL. See [package-hosted kits](#package-hosted-kits).
 
@@ -839,6 +839,7 @@ export default defineRdyConfig({
 ```
 rdy verify                     Check compiled kits against the manifest's hashes
 rdy verify --manifest <path>   Use a manifest other than .readyup/manifest.json
+rdy verify --rebuild           Also recompile each kit and compare it to the committed bundle
 ```
 
 ```
@@ -864,6 +865,38 @@ In CI:
 ```
 
 `rdy verify` enforces where `rdy run` advises: a stale source fails verification and exits 1, while a run emits a warning and proceeds. A verification tool that refused to run because its own bookkeeping was out of date would be worse than one that ran and said so.
+
+#### Verifying by recompiling
+
+The two hashes record two of a bundle's inputs. A bundle is a function of many more: every module it inlines past the entry, every JSON file `pickJson` inlines at compile time, the bundler's version, and the compile options. None of those is recorded, so a bundle stale in any of them still hashes as `ok`.
+
+`--rebuild` answers the question exactly. It recompiles each kit in memory and compares the result to the committed bundle byte for byte:
+
+```
+── Verifying kits against .readyup/manifest.json
+
+🔴 deploy
+   rebuild mismatch (rebuilt 8c31f0a2, on disk 6f58905a)
+🟢 smoke
+```
+
+The comparison is against the bundle on disk, never the recorded hash, so the verdict is independent of the manifest's bookkeeping and can contradict it. A bundle that reproduces exactly while its recorded hash does not match says the record is what went wrong, not the kit:
+
+```
+🔴 deploy
+   drift (expected 6f58905a, got eb104f57)
+   rebuild ok
+```
+
+The verdict is `ok`, `mismatch`, `failed` (the source no longer compiles), or `missing` (nothing to recompile, or nothing to compare against). Only `ok` passes. There is no `unverified` here: an exactness check that waived the kits it could not reach would establish less than it appears to.
+
+Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
+
+Two things to know before wiring it into CI. It requires esbuild, and says so rather than passing when esbuild is absent. And the readyup version is part of a bundle's bytes, so upgrading readyup makes every kit mismatch until `rdy compile` runs -- a mismatch that spans versions names both of them, so the cause is legible.
+
+```yaml
+- run: npx rdy verify --rebuild
+```
 
 ## Check utilities
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -915,7 +915,7 @@ The comparison is against the bundle on disk, never the recorded hash, so the ve
 
 The verdict is `ok`, `mismatch`, `failed` (the source no longer compiles), or `missing` (nothing to recompile, or nothing to compare against). Only `ok` passes. There is no `unverified` here: an exactness check that waived the kits it could not reach would establish less than it appears to.
 
-Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
+Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`, plus `rebuildCompiledWith` when the bundle was built by a different readyup; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
 
 Two things to know before wiring it into CI. It requires esbuild, and says so rather than passing when esbuild is absent. And the readyup version is part of a bundle's bytes, so upgrading readyup makes every kit mismatch until `rdy compile` runs -- a mismatch that spans versions names both of them, so the cause is legible.
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -364,6 +364,31 @@ Invalid kit at .readyup/kits/default.js:
 
 A typo'd `severity` is the mistake this matters most for: an unrecognized value would otherwise exclude the check from both thresholds, and the run would pass.
 
+### Inlining JSON at compile time
+
+A compiled kit is self-contained, so it cannot read a JSON file that sits next to its source. `pickJson` closes that gap by copying selected fields into the bundle while it is being built:
+
+```ts
+import { pickJson } from 'readyup';
+
+const pkg = pickJson('../../package.json', ['name', 'version', ['engines', 'node']]);
+```
+
+`rdy compile` replaces the call with the literal it resolves to. Nothing of `pickJson` survives, not even the import:
+
+```js
+var pkg = { "name": "my-app", "version": "3.1.0", "engines": { "node": ">=24" } };
+```
+
+The path resolves relative to the source file. Each entry in the second argument names a field to keep: a string for a top-level key, an array of strings for a nested one, whose nesting the result preserves. Naming a path the file does not have fails the compile rather than inlining `undefined`.
+
+Both arguments must be literals written in place. They are read out of the source text before it is parsed, so a variable, a template literal, or a concatenation is a compile error -- and a call inside a comment or a string is still processed, since that reader cannot tell the difference.
+
+Two consequences follow from the value being resolved at compile time:
+
+- `pickJson` throws if it is ever reached at runtime. A kit that hits it was not compiled.
+- Editing the JSON afterward leaves the bundle stale, and neither recorded hash changes -- the source did not move, and neither did the bundle. [`rdy verify --rebuild`](#verifying-by-recompiling) is what catches it.
+
 ## Running checks
 
 ```
@@ -868,7 +893,7 @@ In CI:
 
 #### Verifying by recompiling
 
-The two hashes record two of a bundle's inputs. A bundle is a function of many more: every module it inlines past the entry, every JSON file `pickJson` inlines at compile time, the bundler's version, and the compile options. None of those is recorded, so a bundle stale in any of them still hashes as `ok`.
+The two hashes record two of a bundle's inputs. A bundle is a function of many more: every module it inlines past the entry, every JSON file [`pickJson`](#inlining-json-at-compile-time) inlines at compile time, the bundler's version, and the compile options. None of those is recorded, so a bundle stale in any of them still hashes as `ok`.
 
 `--rebuild` answers the question exactly. It recompiles each kit in memory and compares the result to the committed bundle byte for byte:
 

--- a/packages/readyup/__tests__/compileConfig.unit.test.ts
+++ b/packages/readyup/__tests__/compileConfig.unit.test.ts
@@ -2,7 +2,8 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { compileConfig, KIT_COMPILE_TARGET } from '../src/compile/compileConfig.ts';
+import { KIT_COMPILE_TARGET } from '../src/compile/buildBundle.ts';
+import { compileConfig } from '../src/compile/compileConfig.ts';
 import { VERSION } from '../src/version.ts';
 
 const mockBuild = vi.hoisted(() => vi.fn());

--- a/packages/readyup/__tests__/schemas/schemas.unit.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.unit.test.ts
@@ -155,6 +155,33 @@ describe('JSON payload schemas', () => {
 
       expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow();
     });
+
+    it('accepts a payload from a readyup that predates the rebuild verdict', () => {
+      const kits = [{ name: 'deploy', status: 'ok', sourceStatus: 'ok' }];
+
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).not.toThrow();
+    });
+
+    it('accepts a rebuild mismatch carrying both hashes', () => {
+      const kits = [
+        {
+          name: 'deploy',
+          status: 'ok',
+          sourceStatus: 'ok',
+          rebuildStatus: 'mismatch',
+          rebuildExpected: '1111aaaa',
+          rebuildActual: '2222bbbb',
+        },
+      ];
+
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: false, kits })).not.toThrow();
+    });
+
+    it('rejects a rebuild verdict outside the vocabulary', () => {
+      const kits = [{ name: 'deploy', status: 'ok', rebuildStatus: 'unverified' }];
+
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow();
+    });
   });
 
   describe('kit entries', () => {

--- a/packages/readyup/__tests__/verify/checkRebuild.unit.test.ts
+++ b/packages/readyup/__tests__/verify/checkRebuild.unit.test.ts
@@ -1,0 +1,134 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockBuildBundle = vi.hoisted(() => vi.fn());
+
+vi.mock(import('../../src/compile/buildBundle.ts'), () => ({
+  buildBundle: mockBuildBundle,
+}));
+
+import { checkRebuild } from '../../src/verify/checkRebuild.ts';
+import { hashBytes } from '../../src/verify/targetHash.ts';
+import { VERSION } from '../../src/version.ts';
+
+describe(checkRebuild, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'rebuild-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    mockBuildBundle.mockReset();
+  });
+
+  it('returns ok when the recompiled bytes match the bundle on disk', async () => {
+    const bundle = Buffer.from('compiled output');
+    writeKitFiles(tempDir, bundle);
+    mockBuildBundle.mockResolvedValue(bundle);
+
+    const status = await checkRebuild(kit(), tempDir);
+
+    expect(status.kind).toBe('ok');
+  });
+
+  it('returns mismatch carrying the recompiled and on-disk hashes when the bytes differ', async () => {
+    const onDisk = Buffer.from('stale output');
+    const rebuilt = Buffer.from('fresh output');
+    writeKitFiles(tempDir, onDisk);
+    mockBuildBundle.mockResolvedValue(rebuilt);
+
+    const status = await checkRebuild(kit(), tempDir);
+
+    expect(status).toStrictEqual({
+      kind: 'mismatch',
+      expected: hashBytes(rebuilt),
+      actual: hashBytes(onDisk),
+    });
+  });
+
+  it('compares against the on-disk bytes rather than the recorded targetHash', async () => {
+    const bundle = Buffer.from('compiled output');
+    writeKitFiles(tempDir, bundle);
+    mockBuildBundle.mockResolvedValue(bundle);
+
+    const status = await checkRebuild({ ...kit(), targetHash: 'deadbeef' }, tempDir);
+
+    expect(status.kind).toBe('ok');
+  });
+
+  it('names the compiling version on a mismatch when it differs from the runner', async () => {
+    writeKitFiles(tempDir, Buffer.from('stale output'));
+    mockBuildBundle.mockResolvedValue(Buffer.from('fresh output'));
+
+    const status = await checkRebuild({ ...kit(), readyupVersion: '0.0.1-old' }, tempDir);
+
+    expect(status).toMatchObject({ kind: 'mismatch', compiledWith: '0.0.1-old' });
+  });
+
+  it('omits the compiling version on a mismatch when it matches the runner', async () => {
+    writeKitFiles(tempDir, Buffer.from('stale output'));
+    mockBuildBundle.mockResolvedValue(Buffer.from('fresh output'));
+
+    const status = await checkRebuild({ ...kit(), readyupVersion: VERSION }, tempDir);
+
+    expect(status).not.toHaveProperty('compiledWith');
+  });
+
+  it('returns failed carrying the compile error when the source no longer compiles', async () => {
+    writeKitFiles(tempDir, Buffer.from('compiled output'));
+    mockBuildBundle.mockRejectedValue(new Error('Unexpected token'));
+
+    const status = await checkRebuild(kit(), tempDir);
+
+    expect(status).toStrictEqual({ kind: 'failed', message: 'Unexpected token' });
+  });
+
+  it('returns missing when the manifest entry records no source', async () => {
+    writeKitFiles(tempDir, Buffer.from('compiled output'));
+
+    const status = await checkRebuild({ name: 'demo', path: 'demo.js' }, tempDir);
+
+    expect(status).toMatchObject({ kind: 'missing', reason: expect.stringContaining('no source recorded') });
+    expect(mockBuildBundle).not.toHaveBeenCalled();
+  });
+
+  it('returns missing when the manifest entry records no compiled path', async () => {
+    writeKitFiles(tempDir, Buffer.from('compiled output'));
+
+    const status = await checkRebuild({ name: 'demo', source: 'demo.ts' }, tempDir);
+
+    expect(status).toMatchObject({ kind: 'missing', reason: expect.stringContaining('no compiled path recorded') });
+  });
+
+  it('returns missing when the recorded source file is gone', async () => {
+    writeFileSync(path.join(tempDir, 'demo.js'), Buffer.from('compiled output'));
+
+    const status = await checkRebuild(kit(), tempDir);
+
+    expect(status).toMatchObject({ kind: 'missing', reason: expect.stringContaining('source file missing') });
+  });
+
+  it('returns missing when the compiled file is gone', async () => {
+    writeFileSync(path.join(tempDir, 'demo.ts'), 'export default {};\n');
+
+    const status = await checkRebuild(kit(), tempDir);
+
+    expect(status).toMatchObject({ kind: 'missing', reason: expect.stringContaining('compiled file missing') });
+  });
+});
+
+/** Returns a manifest entry naming the source and bundle that `writeKitFiles` lays down. */
+function kit() {
+  return { name: 'demo', path: 'demo.js', source: 'demo.ts' };
+}
+
+/** Writes a kit's source and its compiled bundle into `dir`. */
+function writeKitFiles(dir: string, bundle: Buffer): void {
+  writeFileSync(path.join(dir, 'demo.ts'), 'export default {};\n');
+  writeFileSync(path.join(dir, 'demo.js'), bundle);
+}

--- a/packages/readyup/__tests__/verify/checkRebuild.unit.test.ts
+++ b/packages/readyup/__tests__/verify/checkRebuild.unit.test.ts
@@ -110,7 +110,7 @@ describe(checkRebuild, () => {
 
     const status = await checkRebuild(kit(), tempDir);
 
-    expect(status).toMatchObject({ kind: 'missing', reason: expect.stringContaining('source file missing') });
+    expect(status).toMatchObject({ kind: 'missing', reason: expect.stringContaining('source file demo.ts is gone') });
   });
 
   it('returns missing when the compiled file is gone', async () => {
@@ -118,7 +118,7 @@ describe(checkRebuild, () => {
 
     const status = await checkRebuild(kit(), tempDir);
 
-    expect(status).toMatchObject({ kind: 'missing', reason: expect.stringContaining('compiled file missing') });
+    expect(status).toMatchObject({ kind: 'missing', reason: expect.stringContaining('compiled file demo.js is gone') });
   });
 });
 

--- a/packages/readyup/__tests__/verify/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.rebuild.tool.test.ts
@@ -5,7 +5,9 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 import { compileConfig } from '../../src/compile/compileConfig.ts';
+import { ManifestSchema } from '../../src/manifest/manifestSchema.ts';
 import type { JsonVerifyOutput } from '../../src/schemas/index.ts';
+import { VerifyOutputSchema } from '../../src/schemas/index.ts';
 import { hashFile } from '../../src/verify/targetHash.ts';
 import { verifyCommand } from '../../src/verify/verifyCommand.ts';
 import { VERSION } from '../../src/version.ts';
@@ -109,9 +111,7 @@ describe('verifyCommand --rebuild', () => {
   });
 
   it('reports a passing rebuild beside a recorded hash that has gone wrong', async () => {
-    const manifestPath = path.join(tempDir, 'manifest.json');
-    const manifest: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
-    writeFileSync(manifestPath, JSON.stringify(overrideTargetHash(manifest, 'deadbeef')));
+    overrideTargetHash(path.join(tempDir, 'manifest.json'), 'deadbeef');
 
     const exitCode = await runVerify();
 
@@ -147,13 +147,21 @@ async function runVerify(): Promise<number> {
   return verifyCommand(['--manifest', 'manifest.json', '--rebuild', '--json']);
 }
 
-/** Reads the single JSON document the run wrote to stdout. */
+/**
+ * Reads the single JSON document the run wrote to stdout.
+ *
+ * Parsed through the published schema rather than cast, so a payload that does not satisfy the
+ * contract fails here rather than reaching an assertion that happens not to look at the bad field.
+ */
 function readPayload(stdoutSpy: MockInstance): JsonVerifyOutput {
-  return JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0])) as JsonVerifyOutput;
+  const emitted: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+  return VerifyOutputSchema.parse(emitted);
 }
 
-/** Returns the manifest with its one kit's `targetHash` replaced, standing in for a record gone wrong. */
-function overrideTargetHash(manifest: unknown, targetHash: string): unknown {
-  const { kits, ...rest } = manifest as { kits: Array<Record<string, unknown>> };
-  return { ...rest, kits: kits.map((kit) => ({ ...kit, targetHash })) };
+/** Rewrites every kit's recorded `targetHash`, standing in for a record that has gone wrong. */
+function overrideTargetHash(manifestPath: string, targetHash: string): void {
+  const stored: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const manifest = ManifestSchema.parse(stored);
+  const kits = manifest.kits.map((kit) => ({ ...kit, targetHash }));
+  writeFileSync(manifestPath, JSON.stringify({ ...manifest, kits }));
 }

--- a/packages/readyup/__tests__/verify/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.rebuild.tool.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+
+import { compileConfig } from '../../src/compile/compileConfig.ts';
+import type { JsonVerifyOutput } from '../../src/schemas/index.ts';
+import { hashFile } from '../../src/verify/targetHash.ts';
+import { verifyCommand } from '../../src/verify/verifyCommand.ts';
+import { VERSION } from '../../src/version.ts';
+
+/** Absolute specifier for the `pickJson` marker, so a kit written into a tempdir can import it. */
+const PICK_JSON_MODULE = path.resolve(import.meta.dirname, '../../src/compile/pickJson.ts');
+
+const KIT_SOURCE = `import { pickJson } from ${JSON.stringify(PICK_JSON_MODULE)};
+
+export const metadata = pickJson('./data.json', ['name', 'version']);
+
+export default { checklists: [] };
+`;
+
+/**
+ * Exercises `--rebuild` against real esbuild, which is what the check is for: the inputs it catches
+ * and the recorded hashes miss are the ones a mocked bundler stands in for.
+ */
+describe('verifyCommand --rebuild', () => {
+  let tempDir: string;
+  let stdoutSpy: MockInstance;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'verify-rebuild-'));
+    writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '1.0.0' }));
+    writeFileSync(path.join(tempDir, 'kit.ts'), KIT_SOURCE);
+
+    // Record the manifest from a real compile, so its hashes are the ones the pipeline produces.
+    const result = await compileConfig(path.join(tempDir, 'kit.ts'), path.join(tempDir, 'kit.js'));
+    writeFileSync(
+      path.join(tempDir, 'manifest.json'),
+      JSON.stringify({
+        version: 1,
+        kits: [
+          {
+            name: 'demo',
+            path: 'kit.js',
+            readyupVersion: VERSION,
+            source: 'kit.ts',
+            sourceHash: hashFile(path.join(tempDir, 'kit.ts')),
+            targetHash: result.targetHash,
+          },
+        ],
+      }),
+    );
+
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('passes an untouched tree', async () => {
+    const exitCode = await runVerify();
+
+    expect(exitCode).toBe(0);
+    expect(readPayload(stdoutSpy)).toMatchObject({
+      passed: true,
+      kits: [{ name: 'demo', status: 'ok', sourceStatus: 'ok', rebuildStatus: 'ok' }],
+    });
+  });
+
+  it('fails a bundle stale only in an inlined JSON file, which both recorded hashes still pass', async () => {
+    writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
+
+    const exitCode = await runVerify();
+
+    expect(exitCode).toBe(1);
+    expect(readPayload(stdoutSpy)).toMatchObject({
+      passed: false,
+      // The `.ts` and the `.js` are both untouched, so the hash verdicts see nothing wrong. Only the
+      // rebuild reads the JSON the bundle inlined, which is the gap the flag exists to close.
+      kits: [{ status: 'ok', sourceStatus: 'ok', rebuildStatus: 'mismatch' }],
+    });
+  });
+
+  it('inlines the edited value into the recompiled bundle rather than the committed one', async () => {
+    writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
+
+    await runVerify();
+
+    expect(readFileSync(path.join(tempDir, 'kit.js'), 'utf8')).toContain('1.0.0');
+  });
+
+  it('fails a hand-edited bundle', async () => {
+    writeFileSync(path.join(tempDir, 'kit.js'), 'export default { checklists: [] };\n');
+
+    const exitCode = await runVerify();
+
+    expect(exitCode).toBe(1);
+    expect(readPayload(stdoutSpy)).toMatchObject({
+      kits: [{ status: 'drift', rebuildStatus: 'mismatch' }],
+    });
+  });
+
+  it('reports a passing rebuild beside a recorded hash that has gone wrong', async () => {
+    const manifestPath = path.join(tempDir, 'manifest.json');
+    const manifest: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    writeFileSync(manifestPath, JSON.stringify(overrideTargetHash(manifest, 'deadbeef')));
+
+    const exitCode = await runVerify();
+
+    expect(exitCode).toBe(1);
+    expect(readPayload(stdoutSpy)).toMatchObject({
+      kits: [{ status: 'drift', rebuildStatus: 'ok' }],
+    });
+  });
+
+  it('fails a kit whose source no longer compiles', async () => {
+    writeFileSync(path.join(tempDir, 'kit.ts'), 'export default { checklists: [ ;\n');
+
+    const exitCode = await runVerify();
+
+    expect(exitCode).toBe(1);
+    expect(readPayload(stdoutSpy)).toMatchObject({
+      kits: [{ rebuildStatus: 'failed' }],
+    });
+  });
+
+  it('leaves every rebuild field out of the payload without the flag', async () => {
+    writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
+
+    const exitCode = await verifyCommand(['--manifest', 'manifest.json', '--json']);
+
+    expect(exitCode).toBe(0);
+    expect(readPayload(stdoutSpy).kits[0]).not.toHaveProperty('rebuildStatus');
+  });
+});
+
+/** Runs `verify` over the tempdir's manifest with the rebuild check and JSON output on. */
+async function runVerify(): Promise<number> {
+  return verifyCommand(['--manifest', 'manifest.json', '--rebuild', '--json']);
+}
+
+/** Reads the single JSON document the run wrote to stdout. */
+function readPayload(stdoutSpy: MockInstance): JsonVerifyOutput {
+  return JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0])) as JsonVerifyOutput;
+}
+
+/** Returns the manifest with its one kit's `targetHash` replaced, standing in for a record gone wrong. */
+function overrideTargetHash(manifest: unknown, targetHash: string): unknown {
+  const { kits, ...rest } = manifest as { kits: Array<Record<string, unknown>> };
+  return { ...rest, kits: kits.map((kit) => ({ ...kit, targetHash })) };
+}

--- a/packages/readyup/__tests__/verify/verifyCommand.unit.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.unit.test.ts
@@ -359,6 +359,60 @@ describe(verifyCommand, () => {
       });
     });
 
+    it('speaks over an unverified target, where it supplies the answer the absent hash could not', async () => {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'alpha', path: 'alpha.js', source: 'alpha.ts' }],
+      });
+      mockCheckDrift.mockReturnValue({ kind: 'unverified' });
+      mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
+      mockCheckRebuild.mockResolvedValue({ kind: 'ok' });
+
+      const exitCode = await verifyCommand(['--rebuild']);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha`));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('rebuild ok'));
+    });
+
+    it('keeps the skip token on an unverified target the rebuild did not answer for', async () => {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'alpha', path: 'alpha.js' }],
+      });
+      mockCheckDrift.mockReturnValue({ kind: 'unverified' });
+
+      const exitCode = await verifyCommand([]);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${UNVERIFIED} alpha`));
+    });
+
+    it('carries the compiling version in the JSON payload when it differs from the runner', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({
+        kind: 'mismatch',
+        expected: '1111aaaa',
+        actual: '2222bbbb',
+        compiledWith: '0.0.1-old',
+      });
+
+      await verifyCommand(['--rebuild', '--json']);
+
+      const payload: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({ kits: [{ rebuildCompiledWith: '0.0.1-old' }] });
+    });
+
+    it('omits the compiling version from the JSON payload when it matches the runner', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({ kind: 'mismatch', expected: '1111aaaa', actual: '2222bbbb' });
+
+      await verifyCommand(['--rebuild', '--json']);
+
+      const payload = String(stdoutSpy.mock.calls.at(-1)?.[0]);
+      expect(payload).not.toContain('rebuildCompiledWith');
+    });
+
     it('carries the compile error in the JSON payload for a kit that failed to build', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'failed', message: 'Unexpected token' });

--- a/packages/readyup/__tests__/verify/verifyCommand.unit.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.unit.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 const mockReadManifest = vi.hoisted(() => vi.fn());
 const mockCheckDrift = vi.hoisted(() => vi.fn());
 const mockCheckSourceDrift = vi.hoisted(() => vi.fn());
+const mockCheckRebuild = vi.hoisted(() => vi.fn());
+const mockLoadEsbuild = vi.hoisted(() => vi.fn());
 
 vi.mock(import('../../src/manifest/readManifest.ts'), async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/manifest/readManifest.ts')>();
@@ -20,9 +22,18 @@ vi.mock(import('../../src/verify/checkSourceDrift.ts'), () => ({
   checkSourceDrift: mockCheckSourceDrift,
 }));
 
+vi.mock(import('../../src/verify/checkRebuild.ts'), () => ({
+  checkRebuild: mockCheckRebuild,
+}));
+
+vi.mock(import('../../src/compile/loadEsbuild.ts'), () => ({
+  loadEsbuild: mockLoadEsbuild,
+}));
+
 import { richFormatter } from '../../src/layout/richFormatter.ts';
 import { captureRdyError } from '../../src/test-utils/captureRdyError.ts';
 import { verifyCommand } from '../../src/verify/verifyCommand.ts';
+import { VERSION } from '../../src/version.ts';
 
 const OK = richFormatter.tokens.passed.glyph;
 const FAILED = richFormatter.tokens.failedError.glyph;
@@ -35,6 +46,7 @@ describe(verifyCommand, () => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockCheckSourceDrift.mockReturnValue({ kind: 'unverified' });
+    mockLoadEsbuild.mockResolvedValue({ build: vi.fn() });
   });
 
   afterEach(() => {
@@ -42,9 +54,11 @@ describe(verifyCommand, () => {
     mockReadManifest.mockReset();
     mockCheckDrift.mockReset();
     mockCheckSourceDrift.mockReset();
+    mockCheckRebuild.mockReset();
+    mockLoadEsbuild.mockReset();
   });
 
-  it('returns 0 when every kit is ok', () => {
+  it('returns 0 when every kit is ok', async () => {
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [
@@ -54,7 +68,7 @@ describe(verifyCommand, () => {
     });
     mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
 
-    const exitCode = verifyCommand([]);
+    const exitCode = await verifyCommand([]);
 
     expect(exitCode).toBe(0);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha`));
@@ -62,7 +76,7 @@ describe(verifyCommand, () => {
     expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('failed verification'));
   });
 
-  it('returns 1 when any kit has drift', () => {
+  it('returns 1 when any kit has drift', async () => {
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [
@@ -79,7 +93,7 @@ describe(verifyCommand, () => {
       })
       .mockReturnValueOnce({ kind: 'ok', targetHash: 'bbbb2222' });
 
-    const exitCode = verifyCommand([]);
+    const exitCode = await verifyCommand([]);
 
     expect(exitCode).toBe(1);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} alpha\n   drift`));
@@ -87,36 +101,36 @@ describe(verifyCommand, () => {
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2 kits failed verification'));
   });
 
-  it('returns 1 when any kit is missing', () => {
+  it('returns 1 when any kit is missing', async () => {
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [{ name: 'alpha', path: 'alpha.js', targetHash: 'aaaa1111' }],
     });
     mockCheckDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/alpha.js' });
 
-    const exitCode = verifyCommand([]);
+    const exitCode = await verifyCommand([]);
 
     expect(exitCode).toBe(1);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} alpha\n   compiled file missing`));
   });
 
-  it('returns 0 when a kit is unverified (no targetHash)', () => {
+  it('returns 0 when a kit is unverified (no targetHash)', async () => {
     mockReadManifest.mockReturnValue({
       version: 1,
       kits: [{ name: 'alpha', path: 'alpha.js' }],
     });
     mockCheckDrift.mockReturnValue({ kind: 'unverified' });
 
-    const exitCode = verifyCommand([]);
+    const exitCode = await verifyCommand([]);
 
     expect(exitCode).toBe(0);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${UNVERIFIED} alpha \u{00B7} unverified`));
   });
 
-  it('returns 0 and reports no-kits message when the manifest is empty', () => {
+  it('returns 0 and reports no-kits message when the manifest is empty', async () => {
     mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-    const exitCode = verifyCommand([]);
+    const exitCode = await verifyCommand([]);
 
     expect(exitCode).toBe(0);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('(no kits in manifest)'));
@@ -133,7 +147,7 @@ describe(verifyCommand, () => {
       mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
     }
 
-    it('fails a kit whose source changed without a recompile', () => {
+    it('fails a kit whose source changed without a recompile', async () => {
       arrangeSingleKit();
       mockCheckSourceDrift.mockReturnValue({
         kind: 'stale',
@@ -142,7 +156,7 @@ describe(verifyCommand, () => {
         resolvedPath: '/abs/alpha.ts',
       });
 
-      const exitCode = verifyCommand([]);
+      const exitCode = await verifyCommand([]);
 
       expect(exitCode).toBe(1);
       expect(stdoutSpy).toHaveBeenCalledWith(
@@ -150,11 +164,11 @@ describe(verifyCommand, () => {
       );
     });
 
-    it('fails a kit whose recorded source file is gone', () => {
+    it('fails a kit whose recorded source file is gone', async () => {
       arrangeSingleKit();
       mockCheckSourceDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/alpha.ts' });
 
-      const exitCode = verifyCommand([]);
+      const exitCode = await verifyCommand([]);
 
       expect(exitCode).toBe(1);
       expect(stdoutSpy).toHaveBeenCalledWith(
@@ -162,26 +176,26 @@ describe(verifyCommand, () => {
       );
     });
 
-    it('passes a kit whose source matches, leaving the line unchanged', () => {
+    it('passes a kit whose source matches, leaving the line unchanged', async () => {
       arrangeSingleKit();
       mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
 
-      const exitCode = verifyCommand([]);
+      const exitCode = await verifyCommand([]);
 
       expect(exitCode).toBe(0);
       expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha\n`));
     });
 
-    it('passes a manifest that records no source hash, leaving the line unchanged', () => {
+    it('passes a manifest that records no source hash, leaving the line unchanged', async () => {
       arrangeSingleKit();
 
-      const exitCode = verifyCommand([]);
+      const exitCode = await verifyCommand([]);
 
       expect(exitCode).toBe(0);
       expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha\n`));
     });
 
-    it('reports both verdicts when the source is stale and the target has drifted', () => {
+    it('reports both verdicts when the source is stale and the target has drifted', async () => {
       arrangeSingleKit();
       mockCheckDrift.mockReturnValue({
         kind: 'drift',
@@ -196,7 +210,7 @@ describe(verifyCommand, () => {
         resolvedPath: '/abs/alpha.ts',
       });
 
-      const exitCode = verifyCommand([]);
+      const exitCode = await verifyCommand([]);
 
       expect(exitCode).toBe(1);
       expect(stdoutSpy).toHaveBeenCalledWith(
@@ -218,10 +232,10 @@ describe(verifyCommand, () => {
     expect(error.message).toContain('Manifest file not found');
   });
 
-  it('honors --manifest flag to resolve a custom path', () => {
+  it('honors --manifest flag to resolve a custom path', async () => {
     mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-    verifyCommand(['--manifest', 'custom/manifest.json']);
+    await verifyCommand(['--manifest', 'custom/manifest.json']);
 
     expect(mockReadManifest).toHaveBeenCalledWith(expect.stringContaining('custom/manifest.json'));
   });
@@ -231,6 +245,167 @@ describe(verifyCommand, () => {
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain('does not accept positional arguments');
+  });
+
+  describe('rebuild verdict', () => {
+    /** A manifest naming one fully recorded kit whose two hash verdicts both pass. */
+    function arrangeSingleKit(): void {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'alpha', path: 'alpha.js', source: 'alpha.ts', targetHash: 'aaaa1111' }],
+      });
+      mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
+      mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
+    }
+
+    it('leaves the run untouched without the flag, never reaching for esbuild', async () => {
+      arrangeSingleKit();
+
+      const exitCode = await verifyCommand([]);
+
+      expect(exitCode).toBe(0);
+      expect(mockCheckRebuild).not.toHaveBeenCalled();
+      expect(mockLoadEsbuild).not.toHaveBeenCalled();
+      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+    });
+
+    it('passes a kit that reproduces, leaving its line unchanged', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({ kind: 'ok' });
+
+      const exitCode = await verifyCommand(['--rebuild']);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+    });
+
+    it('fails a kit whose bundle differs from what its source rebuilds to', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({ kind: 'mismatch', expected: '1111aaaa', actual: '2222bbbb' });
+
+      const exitCode = await verifyCommand(['--rebuild']);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`${FAILED} alpha\n   rebuild mismatch (rebuilt 1111aaaa, on disk 2222bbbb)`),
+      );
+    });
+
+    it('names both versions on a mismatch spanning a readyup move', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({
+        kind: 'mismatch',
+        expected: '1111aaaa',
+        actual: '2222bbbb',
+        compiledWith: '0.0.1-old',
+      });
+
+      await verifyCommand(['--rebuild']);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`compiled by readyup 0.0.1-old, rebuilt by ${VERSION}`),
+      );
+    });
+
+    it('fails a kit whose source no longer compiles, carrying the compile error', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({ kind: 'failed', message: 'Unexpected token' });
+
+      const exitCode = await verifyCommand(['--rebuild']);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('rebuild failed (Unexpected token)'));
+    });
+
+    it('fails a kit that cannot be rebuilt rather than waiving it', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({ kind: 'missing', reason: 'no source recorded in manifest' });
+
+      const exitCode = await verifyCommand(['--rebuild']);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining('cannot rebuild (no source recorded in manifest)'),
+      );
+    });
+
+    it('states a passing rebuild beside a failing hash verdict, where it changes the reading', async () => {
+      arrangeSingleKit();
+      mockCheckDrift.mockReturnValue({
+        kind: 'drift',
+        expected: 'aaaa1111',
+        actual: 'aaaa9999',
+        resolvedPath: '/abs/alpha.js',
+      });
+      mockCheckRebuild.mockResolvedValue({ kind: 'ok' });
+
+      const exitCode = await verifyCommand(['--rebuild']);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('drift (expected aaaa1111, got aaaa9999)'));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('rebuild ok'));
+    });
+
+    it('carries the rebuild verdict and its hashes in the JSON payload', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({ kind: 'mismatch', expected: '1111aaaa', actual: '2222bbbb' });
+
+      await verifyCommand(['--rebuild', '--json']);
+
+      const payload: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({
+        passed: false,
+        kits: [{ name: 'alpha', rebuildStatus: 'mismatch', rebuildExpected: '1111aaaa', rebuildActual: '2222bbbb' }],
+      });
+    });
+
+    it('carries the compile error in the JSON payload for a kit that failed to build', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({ kind: 'failed', message: 'Unexpected token' });
+
+      await verifyCommand(['--rebuild', '--json']);
+
+      const payload: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({ kits: [{ rebuildStatus: 'failed', rebuildError: 'Unexpected token' }] });
+    });
+
+    it('omits every rebuild field from the JSON payload without the flag', async () => {
+      arrangeSingleKit();
+
+      await verifyCommand(['--json']);
+
+      const payload = String(stdoutSpy.mock.calls.at(-1)?.[0]);
+      expect(payload).not.toContain('rebuild');
+    });
+
+    it('reports a config error naming the install command when esbuild is absent', async () => {
+      arrangeSingleKit();
+      mockLoadEsbuild.mockRejectedValue(new Error('Cannot find module esbuild'));
+
+      const error = await captureRdyError(() => verifyCommand(['--rebuild']));
+
+      expect(error.code).toBe('config');
+      expect(error.message).toContain('pnpm add --save-dev esbuild');
+    });
+
+    it('raises the absent-esbuild error before any kit is reported', async () => {
+      arrangeSingleKit();
+      mockLoadEsbuild.mockRejectedValue(new Error('Cannot find module esbuild'));
+
+      await captureRdyError(() => verifyCommand(['--rebuild']));
+
+      expect(mockReadManifest).not.toHaveBeenCalled();
+      expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it('verifies without esbuild when the flag is absent', async () => {
+      arrangeSingleKit();
+      mockLoadEsbuild.mockRejectedValue(new Error('Cannot find module esbuild'));
+
+      const exitCode = await verifyCommand([]);
+
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe('unified vocabulary', () => {
@@ -244,14 +419,14 @@ describe(verifyCommand, () => {
 
     it.each(['\u{2705}', '\u{26A0}', '\u{2753}', '\u{2796}', '\u{FE0F}', '\u{2014}'])(
       'renders no %s for any verdict',
-      (retired) => {
+      async (retired) => {
         for (const verdict of verdicts) {
           mockReadManifest.mockReturnValue({
             version: 1,
             kits: [{ name: 'alpha', path: 'alpha.js', targetHash: 'aaaa1111', source: 'alpha.ts' }],
           });
           mockCheckDrift.mockReturnValue(verdict);
-          verifyCommand([]);
+          await verifyCommand([]);
         }
 
         const written = stdoutSpy.mock.calls.flat().join('\n');
@@ -259,15 +434,15 @@ describe(verifyCommand, () => {
       },
     );
 
-    it('renders a section heading rather than a colon-terminated header', () => {
+    it('renders a section heading rather than a colon-terminated header', async () => {
       mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-      verifyCommand([]);
+      await verifyCommand([]);
 
       expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('\u{2500}\u{2500} Verifying kits against '));
     });
 
-    it('leaves a wholly verified kit carrying nothing beyond its token', () => {
+    it('leaves a wholly verified kit carrying nothing beyond its token', async () => {
       mockReadManifest.mockReturnValue({
         version: 1,
         kits: [{ name: 'alpha', path: 'alpha.js', targetHash: 'aaaa1111', source: 'alpha.ts', sourceHash: '5555aaaa' }],
@@ -275,7 +450,7 @@ describe(verifyCommand, () => {
       mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
       mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
 
-      verifyCommand([]);
+      await verifyCommand([]);
 
       expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
     });

--- a/packages/readyup/__tests__/verify/verifyCommand.wiring.unit.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.wiring.unit.test.ts
@@ -41,7 +41,7 @@ describe('verifyCommand wiring', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('returns 0 and reports ok when on-disk compiled kit matches manifest targetHash', () => {
+  it('returns 0 and reports ok when on-disk compiled kit matches manifest targetHash', async () => {
     const compiled = Buffer.from('export default { checks: [] };\n');
     writeFileSync(path.join(tempDir, 'demo.js'), compiled);
     const manifestPath = path.join(tempDir, 'manifest.json');
@@ -53,14 +53,14 @@ describe('verifyCommand wiring', () => {
       }),
     );
 
-    const exitCode = verifyCommand(['--manifest', 'manifest.json']);
+    const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
 
     expect(exitCode).toBe(0);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
     expect(stderrSpy).not.toHaveBeenCalled();
   });
 
-  it('returns 1 and reports drift when on-disk compiled kit differs from manifest targetHash', () => {
+  it('returns 1 and reports drift when on-disk compiled kit differs from manifest targetHash', async () => {
     writeFileSync(path.join(tempDir, 'demo.js'), 'export default { edited: true };\n');
     const manifestPath = path.join(tempDir, 'manifest.json');
     writeFileSync(
@@ -71,7 +71,7 @@ describe('verifyCommand wiring', () => {
       }),
     );
 
-    const exitCode = verifyCommand(['--manifest', 'manifest.json']);
+    const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
 
     expect(exitCode).toBe(1);
     expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} demo\n   drift`));
@@ -109,41 +109,41 @@ describe('verifyCommand wiring', () => {
       return sourcePath;
     }
 
-    it('returns 0 when both the source and the compiled kit match the manifest', () => {
+    it('returns 0 when both the source and the compiled kit match the manifest', async () => {
       writeCompiledPair();
 
-      const exitCode = verifyCommand(['--manifest', 'manifest.json']);
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(0);
       expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
     });
 
-    it('returns 1 when the source was edited without a recompile', () => {
+    it('returns 1 when the source was edited without a recompile', async () => {
       const sourcePath = writeCompiledPair();
       writeFileSync(sourcePath, 'export default defineRdyKit({ checklists: [], failOn: "warn" });\n');
 
-      const exitCode = verifyCommand(['--manifest', 'manifest.json']);
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(1);
       expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} demo\n   source stale`));
     });
 
-    it('returns 1 when the recorded source was deleted', () => {
+    it('returns 1 when the recorded source was deleted', async () => {
       const sourcePath = writeCompiledPair();
       rmSync(sourcePath);
 
-      const exitCode = verifyCommand(['--manifest', 'manifest.json']);
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(1);
       expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} demo\n   source file missing`));
     });
 
-    it('carries both source hashes in the JSON entry for a stale kit', () => {
+    it('carries both source hashes in the JSON entry for a stale kit', async () => {
       const sourcePath = writeCompiledPair();
       const edited = Buffer.from('export default defineRdyKit({ checklists: [], failOn: "warn" });\n');
       writeFileSync(sourcePath, edited);
 
-      verifyCommand(['--manifest', 'manifest.json', '--json']);
+      await verifyCommand(['--manifest', 'manifest.json', '--json']);
 
       expect(JSON.parse(stdout.join(''))).toMatchObject({
         passed: false,
@@ -179,10 +179,10 @@ describe('verifyCommand wiring', () => {
       );
     }
 
-    it('reports every kit status with the hashes only a drift verdict compared', () => {
+    it('reports every kit status with the hashes only a drift verdict compared', async () => {
       writeMixedManifest();
 
-      const exitCode = verifyCommand(['--manifest', 'manifest.json', '--json']);
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json', '--json']);
 
       expect(exitCode).toBe(1);
       expect(JSON.parse(stdout.join(''))).toStrictEqual({
@@ -203,16 +203,16 @@ describe('verifyCommand wiring', () => {
       });
     });
 
-    it('emits exactly one JSON document and sends the per-kit prose to stderr', () => {
+    it('emits exactly one JSON document and sends the per-kit prose to stderr', async () => {
       writeMixedManifest();
 
-      verifyCommand(['--manifest', 'manifest.json', '--json']);
+      await verifyCommand(['--manifest', 'manifest.json', '--json']);
 
       expect(stdoutSpy).toHaveBeenCalledTimes(1);
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} clean`));
     });
 
-    it('passes when every kit is ok or unverified', () => {
+    it('passes when every kit is ok or unverified', async () => {
       const compiled = Buffer.from('export default { checks: [] };\n');
       writeFileSync(path.join(tempDir, 'demo.js'), compiled);
       writeFileSync(
@@ -226,16 +226,16 @@ describe('verifyCommand wiring', () => {
         }),
       );
 
-      const exitCode = verifyCommand(['--manifest', 'manifest.json', '--json']);
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json', '--json']);
 
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout.join(''))).toMatchObject({ passed: true });
     });
 
-    it('reports an empty manifest as a passing run with no kits', () => {
+    it('reports an empty manifest as a passing run with no kits', async () => {
       writeFileSync(path.join(tempDir, 'manifest.json'), JSON.stringify({ version: 1, kits: [] }));
 
-      const exitCode = verifyCommand(['--manifest', 'manifest.json', '--json']);
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json', '--json']);
 
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout.join(''))).toStrictEqual({ schemaVersion: 1, passed: true, kits: [] });

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -165,6 +165,8 @@ Check compiled kits against the hashes recorded in the manifest.
 Options:
   --manifest <path>          Manifest file path (default: .readyup/manifest.json)
   --json                     Report each kit's verification status as JSON
+  --rebuild                  Also recompile each kit and compare it to the committed bundle;
+                             requires esbuild
   --style <auto|plain|rich>  Output style (default: auto)
   --help, -h                 Show this help message
 

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -1,0 +1,74 @@
+import path from 'node:path';
+
+import { VERSION } from '../version.ts';
+import { loadEsbuild } from './loadEsbuild.ts';
+import { pickJsonPlugin } from './pickJsonPlugin.ts';
+
+/** esbuild target for compiled kits. Matches the Node floor of the `rdy` runner that executes them. */
+export const KIT_COMPILE_TARGET = 'es2025';
+
+/** How to obtain esbuild, named wherever its absence is reported so every path prescribes one remedy. */
+export const ESBUILD_INSTALL_HINT = 'Install it with: pnpm add --save-dev esbuild';
+
+/**
+ * Generated-file header prepended to compiled output.
+ *
+ * Includes an exported `__readyupVersion` constant so the runner can detect skew between the
+ * readyup version a kit was compiled against and the runner's own version at execution time. The
+ * constant is part of the bundle's bytes, so a kit rebuilt under a different readyup differs from
+ * the one on disk even when its source has not moved.
+ */
+const GENERATED_HEADER = [
+  '/** @noformat — @generated. Do not edit. Compiled by rdy. */',
+  '/* eslint-disable */',
+  `export const __readyupVersion = ${JSON.stringify(VERSION)};`,
+  '',
+].join('\n');
+
+/**
+ * Bundles a TypeScript checklist file into a self-contained ESM bundle and returns its bytes.
+ *
+ * Node built-in modules and the `readyup` package (including `readyup/*` subpaths) are kept
+ * external; all other imports are inlined. The externalized `readyup` specifiers are resolved at
+ * runtime by the `rdy` runner's module-resolution hook (`readyupResolverHook.ts`), which routes
+ * them to the runner's own readyup installation.
+ *
+ * The single place the bundler is configured. `compileConfig` writes what this returns and
+ * `checkRebuild` compares against it, so the bundle a verification recompiles is the bundle a
+ * compile would have produced -- a property that holds by construction rather than by two option
+ * objects being kept in agreement.
+ *
+ * Takes no output path, because none can reach the result: esbuild is invoked without `outfile`, so
+ * the bytes are a function of the entry point and the plugin alone.
+ */
+export async function buildBundle(inputPath: string): Promise<Buffer> {
+  const resolvedInput = path.resolve(inputPath);
+
+  let esbuild: typeof import('esbuild');
+  try {
+    esbuild = await loadEsbuild();
+  } catch (error: unknown) {
+    throw new Error(`esbuild is required to compile kits but is not installed. ${ESBUILD_INSTALL_HINT}`, {
+      cause: error,
+    });
+  }
+
+  const result = await esbuild.build({
+    entryPoints: [resolvedInput],
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: KIT_COMPILE_TARGET,
+    external: ['node:*', 'readyup', 'readyup/*'],
+    plugins: [pickJsonPlugin()],
+    banner: { js: GENERATED_HEADER },
+    write: false,
+  });
+
+  const outputFile = result.outputFiles[0];
+  if (outputFile === undefined) {
+    throw new Error(`esbuild produced no output for ${resolvedInput}`);
+  }
+
+  return Buffer.from(outputFile.contents);
+}

--- a/packages/readyup/src/compile/compileConfig.ts
+++ b/packages/readyup/src/compile/compileConfig.ts
@@ -2,9 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { hashBytes } from '../verify/targetHash.ts';
-import { VERSION } from '../version.ts';
-import { loadEsbuild } from './loadEsbuild.ts';
-import { pickJsonPlugin } from './pickJsonPlugin.ts';
+import { buildBundle } from './buildBundle.ts';
 
 /** Result of a successful compilation. */
 export interface CompileResult {
@@ -13,63 +11,17 @@ export interface CompileResult {
   targetHash: string;
 }
 
-/** esbuild target for compiled kits. Matches the Node floor of the `rdy` runner that executes them. */
-export const KIT_COMPILE_TARGET = 'es2025';
-
 /**
- * Generated-file header prepended to compiled output.
+ * Bundles a TypeScript checklist file and writes the result to disk.
  *
- * Includes an exported `__readyupVersion` constant so the runner can detect skew between the
- * readyup version a kit was compiled against and the runner's own version at execution time.
- */
-const GENERATED_HEADER = [
-  '/** @noformat — @generated. Do not edit. Compiled by rdy. */',
-  '/* eslint-disable */',
-  `export const __readyupVersion = ${JSON.stringify(VERSION)};`,
-  '',
-].join('\n');
-
-/**
- * Bundles a TypeScript checklist file into a self-contained ESM bundle using esbuild.
- *
- * Node built-in modules and the `readyup` package (including `readyup/*` subpaths) are
- * kept external; all other imports are inlined. The externalized `readyup` specifiers
- * are resolved at runtime by the `rdy` runner's module-resolution hook
- * (`readyupResolverHook.ts`), which routes them to the runner's own readyup
- * installation. Prepends a generated-file header comment to the output.
+ * The bundle itself is `buildBundle`'s; this adds the destination. Writing is skipped when the
+ * bytes already on disk are identical, so a compile that changes nothing leaves the file's mtime
+ * alone.
  */
 export async function compileConfig(inputPath: string, outputPath?: string): Promise<CompileResult> {
-  const resolvedInput = path.resolve(inputPath);
   const resolvedOutput = path.resolve(outputPath ?? deriveOutputPath(inputPath));
 
-  let esbuild: typeof import('esbuild');
-  try {
-    esbuild = await loadEsbuild();
-  } catch (error: unknown) {
-    throw new Error(
-      'esbuild is required for the compile command but is not installed. Install it with: pnpm add --save-dev esbuild',
-      { cause: error },
-    );
-  }
-
-  const result = await esbuild.build({
-    entryPoints: [resolvedInput],
-    bundle: true,
-    format: 'esm',
-    platform: 'node',
-    target: KIT_COMPILE_TARGET,
-    external: ['node:*', 'readyup', 'readyup/*'],
-    plugins: [pickJsonPlugin()],
-    banner: { js: GENERATED_HEADER },
-    write: false,
-  });
-
-  const outputFile = result.outputFiles[0];
-  if (outputFile === undefined) {
-    throw new Error(`esbuild produced no output for ${resolvedInput}`);
-  }
-
-  const compiled = Buffer.from(outputFile.contents);
+  const compiled = await buildBundle(inputPath);
   const existing = existsSync(resolvedOutput) ? readFileSync(resolvedOutput) : undefined;
   const changed = existing === undefined || !compiled.equals(existing);
 

--- a/packages/readyup/src/schemas/index.ts
+++ b/packages/readyup/src/schemas/index.ts
@@ -50,9 +50,16 @@ export type { JsonKitKind, JsonListKitEntry, JsonListOutput } from './listOutput
 export { KitKindSchema, ListKitEntrySchema, ListOutputSchema } from './listOutputSchema.ts';
 
 // verify
-export type { JsonDriftStatus, JsonSourceStatus, JsonVerifyKitEntry, JsonVerifyOutput } from './verifyOutputSchema.ts';
+export type {
+  JsonDriftStatus,
+  JsonRebuildStatus,
+  JsonSourceStatus,
+  JsonVerifyKitEntry,
+  JsonVerifyOutput,
+} from './verifyOutputSchema.ts';
 export {
   DriftStatusSchema,
+  RebuildStatusSchema,
   SourceStatusSchema,
   VerifyKitEntrySchema,
   VerifyOutputSchema,

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -21,6 +21,20 @@ export const DriftStatusSchema = z.enum(['drift', 'missing', 'ok', 'unverified']
 export const SourceStatusSchema = z.enum(['missing', 'ok', 'stale', 'unverified']).meta({ id: 'SourceStatus' });
 
 /**
+ * Outcome of recompiling one kit and comparing the result to the bundle on disk.
+ *
+ * A third vocabulary rather than a widening of either enum above, for the reason `SourceStatus`
+ * already records: the verdicts answer different questions, and widening a closed enum breaks a
+ * consumer that switches exhaustively over it.
+ *
+ * It has no `unverified`. The other two axes admit one because a manifest with no recorded hash
+ * says nothing about whether the kit changed; here there is no bookkeeping to be absent, only
+ * inputs the check needs, and a kit exempted from an exactness check would make a passing run mean
+ * less than it says. `missing` covers every such absence and fails.
+ */
+export const RebuildStatusSchema = z.enum(['failed', 'missing', 'mismatch', 'ok']).meta({ id: 'RebuildStatus' });
+
+/**
  * One kit's verdicts.
  *
  * `expected` and `actual` are the manifest's hash and the on-disk hash of the compiled bundle; both
@@ -28,6 +42,11 @@ export const SourceStatusSchema = z.enum(['missing', 'ok', 'stale', 'unverified'
  * `sourceExpected` and `sourceActual` are their counterparts for the source, present only on
  * `stale`. `sourceStatus` is optional so a consumer pinned to this schema still validates a payload
  * from the readyup that predates the source verdict.
+ *
+ * `rebuildStatus` and its fields appear only under `--rebuild`, so a run without the flag emits the
+ * payload it always did. `rebuildExpected` is the hash of the recompiled bytes and `rebuildActual`
+ * the hash of the bundle on disk, both present only on `mismatch`; `rebuildError` carries the
+ * compile failure on `failed`.
  */
 export const VerifyKitEntrySchema = z
   .object({
@@ -38,6 +57,10 @@ export const VerifyKitEntrySchema = z
     sourceStatus: SourceStatusSchema.optional(),
     sourceExpected: z.string().optional(),
     sourceActual: z.string().optional(),
+    rebuildStatus: RebuildStatusSchema.optional(),
+    rebuildExpected: z.string().optional(),
+    rebuildActual: z.string().optional(),
+    rebuildError: z.string().optional(),
   })
   .meta({ id: 'VerifyKitEntry' });
 
@@ -56,6 +79,7 @@ export const VerifyOutputSchema = z
   .meta({ id: 'VerifyOutput' });
 
 export type JsonDriftStatus = z.infer<typeof DriftStatusSchema>;
+export type JsonRebuildStatus = z.infer<typeof RebuildStatusSchema>;
 export type JsonSourceStatus = z.infer<typeof SourceStatusSchema>;
 export type JsonVerifyKitEntry = z.infer<typeof VerifyKitEntrySchema>;
 export type JsonVerifyOutput = z.infer<typeof VerifyOutputSchema>;

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -32,7 +32,7 @@ export const SourceStatusSchema = z.enum(['missing', 'ok', 'stale', 'unverified'
  * inputs the check needs, and a kit exempted from an exactness check would make a passing run mean
  * less than it says. `missing` covers every such absence and fails.
  */
-export const RebuildStatusSchema = z.enum(['failed', 'missing', 'mismatch', 'ok']).meta({ id: 'RebuildStatus' });
+export const RebuildStatusSchema = z.enum(['failed', 'mismatch', 'missing', 'ok']).meta({ id: 'RebuildStatus' });
 
 /**
  * One kit's verdicts.
@@ -46,7 +46,9 @@ export const RebuildStatusSchema = z.enum(['failed', 'missing', 'mismatch', 'ok'
  * `rebuildStatus` and its fields appear only under `--rebuild`, so a run without the flag emits the
  * payload it always did. `rebuildExpected` is the hash of the recompiled bytes and `rebuildActual`
  * the hash of the bundle on disk, both present only on `mismatch`; `rebuildError` carries the
- * compile failure on `failed`.
+ * compile failure on `failed`. `rebuildCompiledWith` names the readyup a mismatched bundle was
+ * built by, present only when it differs from the running one, which is what separates a mismatch
+ * caused by a readyup upgrade from one caused by an edited bundle.
  */
 export const VerifyKitEntrySchema = z
   .object({
@@ -60,6 +62,7 @@ export const VerifyKitEntrySchema = z
     rebuildStatus: RebuildStatusSchema.optional(),
     rebuildExpected: z.string().optional(),
     rebuildActual: z.string().optional(),
+    rebuildCompiledWith: z.string().optional(),
     rebuildError: z.string().optional(),
   })
   .meta({ id: 'VerifyKitEntry' });

--- a/packages/readyup/src/verify/checkRebuild.ts
+++ b/packages/readyup/src/verify/checkRebuild.ts
@@ -42,12 +42,12 @@ export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Pr
 
   const sourcePath = path.resolve(manifestDir, kit.source);
   if (!existsSync(sourcePath)) {
-    return { kind: 'missing', reason: `source file missing (expected ${kit.source})` };
+    return { kind: 'missing', reason: `source file ${kit.source} is gone` };
   }
 
   const targetPath = path.resolve(manifestDir, kit.path);
   if (!existsSync(targetPath)) {
-    return { kind: 'missing', reason: `compiled file missing (expected ${kit.path})` };
+    return { kind: 'missing', reason: `compiled file ${kit.path} is gone` };
   }
 
   let rebuilt: Buffer;
@@ -67,12 +67,12 @@ export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Pr
   // The generated banner embeds the compiling readyup's version, so a version move alone makes an
   // untouched source rebuild to different bytes. Carry the recorded version to keep that cause
   // distinguishable from a hand edit.
-  const movedVersion = kit.readyupVersion !== undefined && kit.readyupVersion !== VERSION;
+  const compiledWith = kit.readyupVersion !== VERSION ? kit.readyupVersion : undefined;
 
   return {
     kind: 'mismatch',
     expected: hashBytes(rebuilt),
     actual: hashBytes(onDisk),
-    ...(movedVersion && { compiledWith: kit.readyupVersion }),
+    ...(compiledWith !== undefined && { compiledWith }),
   };
 }

--- a/packages/readyup/src/verify/checkRebuild.ts
+++ b/packages/readyup/src/verify/checkRebuild.ts
@@ -1,0 +1,78 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { buildBundle } from '../compile/buildBundle.ts';
+import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
+import { extractMessage } from '../utils/error-handling.ts';
+import { VERSION } from '../version.ts';
+import { hashBytes } from './targetHash.ts';
+
+/** Outcome of a per-kit rebuild check. */
+export type RebuildStatus =
+  | { kind: 'ok' }
+  | { kind: 'mismatch'; expected: string; actual: string; compiledWith?: string }
+  | { kind: 'failed'; message: string }
+  | { kind: 'missing'; reason: string };
+
+/**
+ * Determines whether recompiling a kit's source reproduces the compiled bundle on disk.
+ *
+ * Answers exactly the question the two hash verdicts approximate. `targetHash` and `sourceHash`
+ * record two of the bundle's inputs, but a bundle is a function of every module it inlines, every
+ * JSON file `pickJson` reads, the esbuild version, and the compile options -- none of which the
+ * manifest records. Recompiling reads all of them.
+ *
+ * Compares against the on-disk bytes and never against `targetHash`, so the verdict is independent
+ * of the manifest's bookkeeping and can contradict it. A kit whose recorded hash has gone wrong
+ * reports drift and a passing rebuild together, which is how the two verdicts distinguish a corrupt
+ * bundle from corrupt bookkeeping.
+ *
+ * Every way the check can fail to reach an answer is reported rather than waved through: `missing`
+ * when an input is absent, `failed` when the source no longer compiles. `failed` is distinct from
+ * `mismatch` because the remedy differs -- fix the kit, versus recompile it.
+ */
+export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Promise<RebuildStatus> {
+  if (kit.source === undefined) {
+    return { kind: 'missing', reason: 'no source recorded in manifest' };
+  }
+
+  if (kit.path === undefined) {
+    return { kind: 'missing', reason: 'no compiled path recorded in manifest' };
+  }
+
+  const sourcePath = path.resolve(manifestDir, kit.source);
+  if (!existsSync(sourcePath)) {
+    return { kind: 'missing', reason: `source file missing (expected ${kit.source})` };
+  }
+
+  const targetPath = path.resolve(manifestDir, kit.path);
+  if (!existsSync(targetPath)) {
+    return { kind: 'missing', reason: `compiled file missing (expected ${kit.path})` };
+  }
+
+  let rebuilt: Buffer;
+  try {
+    rebuilt = await buildBundle(sourcePath);
+  } catch (error: unknown) {
+    // A source that no longer compiles is a finding about the kit, not a failure of the invocation,
+    // so the sweep carries on to the kits after it.
+    return { kind: 'failed', message: extractMessage(error) };
+  }
+
+  const onDisk = readFileSync(targetPath);
+  if (rebuilt.equals(onDisk)) {
+    return { kind: 'ok' };
+  }
+
+  // The generated banner embeds the compiling readyup's version, so a version move alone makes an
+  // untouched source rebuild to different bytes. Carry the recorded version to keep that cause
+  // distinguishable from a hand edit.
+  const movedVersion = kit.readyupVersion !== undefined && kit.readyupVersion !== VERSION;
+
+  return {
+    kind: 'mismatch',
+    expected: hashBytes(rebuilt),
+    actual: hashBytes(onDisk),
+    ...(movedVersion && { compiledWith: kit.readyupVersion }),
+  };
+}

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -106,7 +106,7 @@ export async function verifyCommand(args: string[]): Promise<number> {
 }
 
 /**
- * Confirm esbuild is installed, raising a config error naming the install command when it is not.
+ * Confirms esbuild is installed, raising a config error naming the install command when it is not.
  *
  * Refuses rather than degrading. `--rebuild` asks whether each bundle is reproducible, and a run
  * that answered "no esbuild, so nothing to report" would pass while establishing nothing -- the

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -33,8 +33,8 @@ const verifyOptions = {
 } as const;
 
 /**
- * Handle the `verify` subcommand: read the manifest, hash each kit's source and compiled output,
- * and report what no longer matches.
+ * Handles the `verify` subcommand: reads the manifest, hashes each kit's source and compiled
+ * output, and reports what no longer matches.
  *
  * Each kit carries two independent verdicts, and a third under `--rebuild`. Returns 0 when every
  * verdict is `ok` or `unverified`; 1 when any kit has drifted, gone stale, lost a file, or failed
@@ -122,7 +122,7 @@ async function requireEsbuild(): Promise<void> {
   }
 }
 
-/** Emit the verify payload under `--json` and turn the run's verdict into an exit code. */
+/** Emits the verify payload under `--json` and turns the run's verdict into an exit code. */
 function finishVerify(kits: JsonVerifyKitEntry[], passed: boolean, json: boolean): number {
   if (json) {
     const output: JsonVerifyOutput = { schemaVersion: SCHEMA_VERSION, passed, kits };
@@ -133,7 +133,7 @@ function finishVerify(kits: JsonVerifyKitEntry[], passed: boolean, json: boolean
 }
 
 /**
- * Return true when none of a kit's verdicts reports a mismatch or a missing file.
+ * Returns true when none of a kit's verdicts reports a mismatch or a missing file.
  *
  * Reads the verdicts themselves rather than the entry serialized from them. Each is a total union,
  * so every case is accounted for; the wire shape leaves `sourceStatus` optional for consumers that
@@ -155,7 +155,7 @@ function isPassingVerdict(
   return targetPasses && sourcePasses && rebuildPasses;
 }
 
-/** Build a kit's JSON entry, carrying a pair of hashes only on a verdict that compared them. */
+/** Builds a kit's JSON entry, carrying a pair of hashes only on a verdict that compared them. */
 function buildVerifyEntry(
   name: string,
   status: DriftStatus,
@@ -175,6 +175,7 @@ function buildVerifyEntry(
     ...(rebuildStatus?.kind === 'mismatch' && {
       rebuildExpected: rebuildStatus.expected,
       rebuildActual: rebuildStatus.actual,
+      ...(rebuildStatus.compiledWith !== undefined && { rebuildCompiledWith: rebuildStatus.compiledWith }),
     }),
     ...(rebuildStatus?.kind === 'failed' && { rebuildError: rebuildStatus.message }),
   };
@@ -193,11 +194,11 @@ function formatStatusLine(
   rebuildStatus: RebuildStatus | undefined,
 ): string {
   const token = resolveToken(status, sourceStatus, rebuildStatus);
-  const hashesFailed = hasTargetFailed(status) || hasSourceFailed(sourceStatus);
+  const hashesConfirmed = status.kind === 'ok' && sourceStatus.kind === 'ok';
   const clauses = [
     describeDriftStatus(kit, status),
     describeSourceStatus(kit, sourceStatus),
-    describeRebuildStatus(rebuildStatus, hashesFailed),
+    describeRebuildStatus(rebuildStatus, hashesConfirmed),
   ].filter((clause): clause is string => clause !== undefined);
 
   if (token === 'failedError') {
@@ -212,8 +213,9 @@ function formatStatusLine(
 /**
  * Returns the token for the worst of a kit's verdicts.
  *
- * A mismatch or a missing file on any axis yields a failure. `unverified` yields the skip token only
- * when the target itself is unverified.
+ * A mismatch or a missing file on any axis yields a failure. The skip token needs an unverified
+ * target and no answer from the rebuild: a rebuild that reproduced the bundle has checked the kit
+ * more exactly than the absent hash would have, so the kit passed rather than went unchecked.
  */
 function resolveToken(
   status: DriftStatus,
@@ -222,7 +224,7 @@ function resolveToken(
 ): TokenName {
   const rebuildFailed = rebuildStatus !== undefined && rebuildStatus.kind !== 'ok';
   if (hasTargetFailed(status) || hasSourceFailed(sourceStatus) || rebuildFailed) return 'failedError';
-  if (status.kind === 'unverified') return 'skippedOptional';
+  if (status.kind === 'unverified' && rebuildStatus?.kind !== 'ok') return 'skippedOptional';
   return 'passed';
 }
 
@@ -266,16 +268,17 @@ function describeSourceStatus(kit: RdyManifestKit, status: SourceStatus): string
 /**
  * Returns a clause describing the rebuild verdict, or nothing when there is nothing to add.
  *
- * A passing rebuild is normally silent, but is stated when a hash verdict is failing: that pairing
- * says the bundle reproduces exactly and the manifest's record of it is what has gone wrong, which
- * is the opposite conclusion from the one the failing verdict invites on its own.
+ * A passing rebuild is silent only where both hash verdicts already reached `ok` and it would
+ * restate them. Anywhere else it speaks, because it then carries the line's strongest answer: over
+ * a failing verdict it says the bundle reproduces and the manifest's record of it is what went
+ * wrong, and over an unverified one it supplies the answer the absent hash could not.
  */
-function describeRebuildStatus(status: RebuildStatus | undefined, hashesFailed: boolean): string | undefined {
+function describeRebuildStatus(status: RebuildStatus | undefined, hashesConfirmed: boolean): string | undefined {
   if (status === undefined) return undefined;
 
   switch (status.kind) {
     case 'ok':
-      return hashesFailed ? 'rebuild ok' : undefined;
+      return hashesConfirmed ? undefined : 'rebuild ok';
     case 'mismatch': {
       const versions =
         status.compiledWith === undefined ? '' : `; compiled by readyup ${status.compiledWith}, rebuilt by ${VERSION}`;

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -2,6 +2,8 @@ import path from 'node:path';
 import process from 'node:process';
 import { parseArgs as nodeParseArgs } from 'node:util';
 
+import { ESBUILD_INSTALL_HINT } from '../compile/buildBundle.ts';
+import { loadEsbuild } from '../compile/loadEsbuild.ts';
 import { configError, usageError } from '../errors.ts';
 import { EXIT_OK, EXIT_PROBLEMS_FOUND } from '../exitCodes.ts';
 import { getLayout } from '../layout/engine.ts';
@@ -13,15 +15,19 @@ import type { JsonVerifyKitEntry, JsonVerifyOutput } from '../schemas/index.ts';
 import { SCHEMA_VERSION } from '../schemas/verifyOutputSchema.ts';
 import { extractMessage } from '../utils/error-handling.ts';
 import { translateParseArgsError } from '../utils/parse-args-error.ts';
+import { VERSION } from '../version.ts';
 import { writeHuman } from '../writeHuman.ts';
 import type { DriftStatus } from './checkDrift.ts';
 import { checkDrift } from './checkDrift.ts';
+import type { RebuildStatus } from './checkRebuild.ts';
+import { checkRebuild } from './checkRebuild.ts';
 import type { SourceStatus } from './checkSourceDrift.ts';
 import { checkSourceDrift } from './checkSourceDrift.ts';
 
 const verifyOptions = {
   json: { type: 'boolean' },
   manifest: { type: 'string' },
+  rebuild: { type: 'boolean' },
   // Declared so strict parsing accepts it; `routeCommand` consumed its value before dispatch.
   style: { type: 'string' },
 } as const;
@@ -30,11 +36,12 @@ const verifyOptions = {
  * Handle the `verify` subcommand: read the manifest, hash each kit's source and compiled output,
  * and report what no longer matches.
  *
- * Each kit carries two independent verdicts. Returns 0 when both are `ok` or `unverified` for every
- * kit; 1 when any kit has drifted, gone stale, or lost a file. An unreadable manifest is a config
- * failure and is thrown rather than reported as drift.
+ * Each kit carries two independent verdicts, and a third under `--rebuild`. Returns 0 when every
+ * verdict is `ok` or `unverified`; 1 when any kit has drifted, gone stale, lost a file, or failed
+ * to reproduce. An unreadable manifest is a config failure and is thrown rather than reported as
+ * drift, as is a `--rebuild` run with no esbuild to rebuild with.
  */
-export function verifyCommand(args: string[]): number {
+export async function verifyCommand(args: string[]): Promise<number> {
   let parsed;
   try {
     parsed = nodeParseArgs({ args, options: verifyOptions, strict: true, allowPositionals: true });
@@ -54,8 +61,14 @@ export function verifyCommand(args: string[]): number {
   }
 
   const json = values.json === true;
+  const rebuild = values.rebuild === true;
   const manifestPath = path.resolve(process.cwd(), values.manifest ?? DEFAULT_MANIFEST_PATH);
   const manifestDir = path.dirname(manifestPath);
+
+  // Settle the bundler's availability before the run says anything. An exactness check that reports
+  // kit after kit and then discovers it could never have run reads as a partial result; raised here,
+  // an absent esbuild is what it is -- a problem with the environment, not with any kit.
+  if (rebuild) await requireEsbuild();
 
   let manifest;
   try {
@@ -77,9 +90,10 @@ export function verifyCommand(args: string[]): number {
   for (const kit of manifest.kits) {
     const status = checkDrift(kit, manifestDir);
     const sourceStatus = checkSourceDrift(kit, manifestDir);
-    writeHuman(formatStatusLine(kit, status, sourceStatus), json);
-    entries.push(buildVerifyEntry(kit.name, status, sourceStatus));
-    if (!isPassingVerdict(status, sourceStatus)) {
+    const rebuildStatus = rebuild ? await checkRebuild(kit, manifestDir) : undefined;
+    writeHuman(formatStatusLine(kit, status, sourceStatus, rebuildStatus), json);
+    entries.push(buildVerifyEntry(kit.name, status, sourceStatus, rebuildStatus));
+    if (!isPassingVerdict(status, sourceStatus, rebuildStatus)) {
       failed += 1;
     }
   }
@@ -89,6 +103,23 @@ export function verifyCommand(args: string[]): number {
   }
 
   return finishVerify(entries, failed === 0, json);
+}
+
+/**
+ * Confirm esbuild is installed, raising a config error naming the install command when it is not.
+ *
+ * Refuses rather than degrading. `--rebuild` asks whether each bundle is reproducible, and a run
+ * that answered "no esbuild, so nothing to report" would pass while establishing nothing -- the
+ * failure mode the flag exists to remove.
+ */
+async function requireEsbuild(): Promise<void> {
+  try {
+    await loadEsbuild();
+  } catch (error: unknown) {
+    throw configError(`rdy verify --rebuild requires esbuild, which is not installed. ${ESBUILD_INSTALL_HINT}`, {
+      cause: error,
+    });
+  }
 }
 
 /** Emit the verify payload under `--json` and turn the run's verdict into an exit code. */
@@ -102,23 +133,35 @@ function finishVerify(kits: JsonVerifyKitEntry[], passed: boolean, json: boolean
 }
 
 /**
- * Return true when neither of a kit's verdicts reports a mismatch or a missing file.
+ * Return true when none of a kit's verdicts reports a mismatch or a missing file.
  *
- * Reads the verdicts themselves rather than the entry serialized from them. Both are total unions,
+ * Reads the verdicts themselves rather than the entry serialized from them. Each is a total union,
  * so every case is accounted for; the wire shape leaves `sourceStatus` optional for consumers that
  * predate it, and a verdict derived from an optional field has an absent case to get wrong.
  *
- * `unverified` passes on either axis: a manifest entry with no recorded hash predates the feature
- * or was written with `--skip-manifest`, which says nothing about whether the kit has changed.
+ * `unverified` passes on either hash axis: a manifest entry with no recorded hash predates the
+ * feature or was written with `--skip-manifest`, which says nothing about whether the kit has
+ * changed. The rebuild axis has no such case -- only `ok` passes there, and a kit the rebuild could
+ * not reach an answer for fails rather than being waived.
  */
-function isPassingVerdict(status: DriftStatus, sourceStatus: SourceStatus): boolean {
+function isPassingVerdict(
+  status: DriftStatus,
+  sourceStatus: SourceStatus,
+  rebuildStatus: RebuildStatus | undefined,
+): boolean {
   const targetPasses = status.kind === 'ok' || status.kind === 'unverified';
   const sourcePasses = sourceStatus.kind === 'ok' || sourceStatus.kind === 'unverified';
-  return targetPasses && sourcePasses;
+  const rebuildPasses = rebuildStatus === undefined || rebuildStatus.kind === 'ok';
+  return targetPasses && sourcePasses && rebuildPasses;
 }
 
 /** Build a kit's JSON entry, carrying a pair of hashes only on a verdict that compared them. */
-function buildVerifyEntry(name: string, status: DriftStatus, sourceStatus: SourceStatus): JsonVerifyKitEntry {
+function buildVerifyEntry(
+  name: string,
+  status: DriftStatus,
+  sourceStatus: SourceStatus,
+  rebuildStatus: RebuildStatus | undefined,
+): JsonVerifyKitEntry {
   return {
     name,
     status: status.kind,
@@ -128,20 +171,34 @@ function buildVerifyEntry(name: string, status: DriftStatus, sourceStatus: Sourc
       sourceExpected: sourceStatus.expected,
       sourceActual: sourceStatus.actual,
     }),
+    ...(rebuildStatus !== undefined && { rebuildStatus: rebuildStatus.kind }),
+    ...(rebuildStatus?.kind === 'mismatch' && {
+      rebuildExpected: rebuildStatus.expected,
+      rebuildActual: rebuildStatus.actual,
+    }),
+    ...(rebuildStatus?.kind === 'failed' && { rebuildError: rebuildStatus.message }),
   };
 }
 
 /**
- * Returns a kit's line, carrying whichever of its two verdicts has something to report.
+ * Returns a kit's line, carrying whichever of its verdicts has something to report.
  *
  * A failing kit carries each verdict on its own line beneath its name; any other kit carries them
- * inline. A kit that passes both verdicts carries none, leaving its token to report the outcome.
+ * inline. A kit that passes every verdict carries none, leaving its token to report the outcome.
  */
-function formatStatusLine(kit: RdyManifestKit, status: DriftStatus, sourceStatus: SourceStatus): string {
-  const token = resolveToken(status, sourceStatus);
-  const clauses = [describeDriftStatus(kit, status), describeSourceStatus(kit, sourceStatus)].filter(
-    (clause): clause is string => clause !== undefined,
-  );
+function formatStatusLine(
+  kit: RdyManifestKit,
+  status: DriftStatus,
+  sourceStatus: SourceStatus,
+  rebuildStatus: RebuildStatus | undefined,
+): string {
+  const token = resolveToken(status, sourceStatus, rebuildStatus);
+  const hashesFailed = hasTargetFailed(status) || hasSourceFailed(sourceStatus);
+  const clauses = [
+    describeDriftStatus(kit, status),
+    describeSourceStatus(kit, sourceStatus),
+    describeRebuildStatus(rebuildStatus, hashesFailed),
+  ].filter((clause): clause is string => clause !== undefined);
 
   if (token === 'failedError') {
     const claim = getLayout().formatCheckLine({ token, name: kit.name });
@@ -153,17 +210,30 @@ function formatStatusLine(kit: RdyManifestKit, status: DriftStatus, sourceStatus
 }
 
 /**
- * Returns the token for the worse of a kit's two verdicts.
+ * Returns the token for the worst of a kit's verdicts.
  *
- * A mismatch or a missing file on either axis yields a failure. `unverified` yields the skip token only
+ * A mismatch or a missing file on any axis yields a failure. `unverified` yields the skip token only
  * when the target itself is unverified.
  */
-function resolveToken(status: DriftStatus, sourceStatus: SourceStatus): TokenName {
-  const targetFailed = status.kind === 'missing' || status.kind === 'drift';
-  const sourceFailed = sourceStatus.kind === 'missing' || sourceStatus.kind === 'stale';
-  if (targetFailed || sourceFailed) return 'failedError';
+function resolveToken(
+  status: DriftStatus,
+  sourceStatus: SourceStatus,
+  rebuildStatus: RebuildStatus | undefined,
+): TokenName {
+  const rebuildFailed = rebuildStatus !== undefined && rebuildStatus.kind !== 'ok';
+  if (hasTargetFailed(status) || hasSourceFailed(sourceStatus) || rebuildFailed) return 'failedError';
   if (status.kind === 'unverified') return 'skippedOptional';
   return 'passed';
+}
+
+/** Returns true when the compiled-output verdict reports a mismatch or a missing file. */
+function hasTargetFailed(status: DriftStatus): boolean {
+  return status.kind === 'missing' || status.kind === 'drift';
+}
+
+/** Returns true when the source verdict reports a mismatch or a missing file. */
+function hasSourceFailed(status: SourceStatus): boolean {
+  return status.kind === 'missing' || status.kind === 'stale';
 }
 
 /** Returns a clause describing the compiled-output verdict, or nothing when the verdict is `ok`. */
@@ -190,5 +260,30 @@ function describeSourceStatus(kit: RdyManifestKit, status: SourceStatus): string
     case 'ok':
     case 'unverified':
       return undefined;
+  }
+}
+
+/**
+ * Returns a clause describing the rebuild verdict, or nothing when there is nothing to add.
+ *
+ * A passing rebuild is normally silent, but is stated when a hash verdict is failing: that pairing
+ * says the bundle reproduces exactly and the manifest's record of it is what has gone wrong, which
+ * is the opposite conclusion from the one the failing verdict invites on its own.
+ */
+function describeRebuildStatus(status: RebuildStatus | undefined, hashesFailed: boolean): string | undefined {
+  if (status === undefined) return undefined;
+
+  switch (status.kind) {
+    case 'ok':
+      return hashesFailed ? 'rebuild ok' : undefined;
+    case 'mismatch': {
+      const versions =
+        status.compiledWith === undefined ? '' : `; compiled by readyup ${status.compiledWith}, rebuilt by ${VERSION}`;
+      return `rebuild mismatch (rebuilt ${status.expected}, on disk ${status.actual}${versions})`;
+    }
+    case 'failed':
+      return `rebuild failed (${status.message})`;
+    case 'missing':
+      return `cannot rebuild (${status.reason})`;
   }
 }


### PR DESCRIPTION
## What

Adds a `--rebuild` flag to `rdy verify`, which causes the verification to check whether an existing compiled kit bundle exactly matches what its source produces. Previously, a kit was checked only against recorded hashes of its source and its compiled bundle, so a kit could be reported current even if an imported module or inlined data had changed.

The `--rebuild` flag requires `esbuild`. Because a bundle carries the version of `readyup` that compiled it, upgrading `readyup` makes untouched kits fail until they are recompiled.

## Why

A publisher runs `rdy verify` in CI to be sure the bundle consumers fetch is the one its source produces, and the check was reporting `ok` for bundles where that was no longer true. The manifest records a hash for the entry source and one for the emitted bundle, but a bundle also depends on every module it inlines, every JSON file `pickJson` copies in, the bundler's version, and the compile options. Recording more hashes is bookkeeping that can never be complete; recompiling answers the question exactly.

## Details

### 🎉 Features

- `rdy verify --rebuild` recompiles each kit in memory and compares the result to the committed bundle byte for byte. Each kit reports one of `ok`, `mismatch`, `failed` (the source no longer compiles), or `missing` (nothing to recompile, or nothing to compare against). Only `ok` passes.
- The comparison is against the bundle on disk, never the recorded `targetHash`, so the rebuild verdict is independent of the manifest's bookkeeping and can contradict it. A kit that reproduces exactly while its recorded hash does not match reports drift and a passing rebuild together, which is what separates a corrupt bundle from a corrupt record.
- Everything that stops the check from reaching an answer fails the run rather than being waived. `RebuildStatus` has no `unverified` case, unlike the two verdict vocabularies beside it: the other axes admit one because an absent hash says nothing about whether a kit changed, whereas a kit exempted from an exactness check would make a passing run mean less than it says.
- An absent esbuild is raised as a config error naming the install command, before any kit is reported, rather than reported per kit or waved through as a pass. Without `--rebuild`, `rdy verify` behaves as it did and needs no bundler.
- A mismatch spanning readyup versions names both of them, so an upgrade is not mistaken for a hand edit.
- Under `--json`, each kit carries `rebuildStatus`, plus `rebuildExpected` and `rebuildActual` on a mismatch, `rebuildCompiledWith` when the bundle was compiled by a different readyup, and `rebuildError` on a compile failure. A run without the flag emits the payload it always did.

### 🏗️ Internal features

- `checkRebuild` supplies the per-kit rebuild verdict, reached by rebuilding rather than by trusting the manifest's pair of hashes.

### ♻️ Refactoring

- `buildBundle` separates producing a kit's compiled bytes from writing them, so the bundler is configured in one place. The bundle a verification recompiles is the bundle a compile would have produced by construction, rather than by two option objects being kept in agreement.

### 🧪 Tests

- The rebuild check is covered end to end against the real bundler, including the case it exists for: a bundle left stale by an edit to a JSON file it inlined, which every recorded hash still reports as current.
- The rebuild payload is read through the published verify schema rather than asserted against a hand-written shape, so a payload that breaks the contract fails there.

### 📚 Documentation

- The README's verify section documents `--rebuild`: what recompiling establishes that the recorded hashes cannot, the four verdicts, the fields added under `--json`, and the two things to know before wiring it into CI (it requires esbuild, and upgrading readyup requires a recompile before it passes again).
- `pickJson` gains a section of its own, covering what it copies into the bundle, how a nested field is named, that both arguments must be literals written in place, and the two consequences of resolving at compile time: the call throws if a kit reaches it at runtime, and editing the JSON afterward leaves a stale bundle that both recorded hashes still pass.
- `rdy verify --help` documents the flag and its esbuild requirement.

Closes #228

