### PR TITLE
#243 Keep the kit heading from reading as a failure

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -135,7 +135,7 @@ Role glyphs are nouns rather than statuses. They name what something is, in a he
 | Rich | Names                                                  |
 | ---- | ------------------------------------------------------ |
 | 📄   | a kit's TypeScript source                              |
-| 🧰   | a kit                                                  |
+| 📓   | a kit                                                  |
 | 📋   | a checklist                                            |
 | 📦   | the npm package a kit was published in                 |
 | 🌐   | a kit fetched from `github:`, `bitbucket:`, or `--url` |
@@ -525,9 +525,9 @@ Blank lines part blocks rather than decorate headings: none opens a command's ou
 A kit from an installed package, a repository, or a URL names where it came from, so a long run says which checks belong to which kit without the reader scrolling for it:
 
 ```
-━━ 📦 @acme/release-kit@2.1.0 / 🧰 npm-auto-publish / 📋 repo
-━━ 🌐 github:acme/checks@main / 🧰 default
-━━ 📁 ../shared-kits / 🧰 default
+━━ 📦 @acme/release-kit@2.1.0 / 📓 npm-auto-publish / 📋 repo
+━━ 🌐 github:acme/checks@main / 📓 default
+━━ 📁 ../shared-kits / 📓 default
 ```
 
 ### Output styles
@@ -600,8 +600,8 @@ Each section names the command that runs the kits beneath it:
 
 ── Compiled
    rdy run <name>
-🧰 deploy
-🧰 smoke
+📓 deploy
+📓 smoke
 ```
 
 Kits from configured packages get their own section, each named package-first so a kit reads the same here as in the heading `rdy run` gives it, and any installed dependency publishing kits the config omits is named as a candidate:
@@ -609,7 +609,7 @@ Kits from configured packages get their own section, each named package-first so
 ```
 ── Packages
    rdy run --packages
-📦 @acme/eslint-config@2.1.0 / 🧰 drift
+📦 @acme/eslint-config@2.1.0 / 📓 drift
 
 ── Available
    Add to "packages" in the readyup config
@@ -620,8 +620,8 @@ Kits from configured packages get their own section, each named package-first so
 
 ```
 ── Manifest: .readyup/manifest.json
-🧰 deploy (readyup v0.22.0) · Pre-deployment checks
-🧰 smoke (readyup v0.22.0)
+📓 deploy (readyup v0.22.0) · Pre-deployment checks
+📓 smoke (readyup v0.22.0)
 ```
 
 A local `--from` source with no manifest falls back to listing the compiled kits on disk; those rows carry a name and path only. A remote source still requires a manifest.
@@ -766,7 +766,7 @@ rdy compile <file>             Compile a single file
 
 ```
 ── Compiling kits in packages/api/.readyup/kits
-🟢 deploy.ts -> 🧰 deploy.js
+🟢 deploy.ts -> 📓 deploy.js
 ⚪ smoke.ts · no changes
 ```
 

--- a/packages/readyup/__tests__/cli.unit.test.ts
+++ b/packages/readyup/__tests__/cli.unit.test.ts
@@ -1133,8 +1133,8 @@ describe(runCommand, () => {
     });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(allOutput).toContain('\u{2501}\u{2501} \u{1F9F0} kit1');
-    expect(allOutput).toContain('\u{2501}\u{2501} \u{1F9F0} kit2');
+    expect(allOutput).toContain('\u{2501}\u{2501} \u{1F4D3} kit1');
+    expect(allOutput).toContain('\u{2501}\u{2501} \u{1F4D3} kit2');
   });
 
   // Two blanks at a kit boundary, none before the first block. Once headings stopped nesting, the wider
@@ -1155,8 +1155,8 @@ describe(runCommand, () => {
     });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(allOutput.startsWith('\u{2501}\u{2501} \u{1F9F0} kit1')).toBe(true);
-    expect(allOutput).toContain(`${KIT_BOUNDARY_GAP}\u{2501}\u{2501} \u{1F9F0} kit2`);
+    expect(allOutput.startsWith('\u{2501}\u{2501} \u{1F4D3} kit1')).toBe(true);
+    expect(allOutput).toContain(`${KIT_BOUNDARY_GAP}\u{2501}\u{2501} \u{1F4D3} kit2`);
     expect(allOutput).not.toContain(`${KIT_BOUNDARY_GAP}\n`);
   });
 

--- a/packages/readyup/__tests__/layout/layoutEngine.unit.test.ts
+++ b/packages/readyup/__tests__/layout/layoutEngine.unit.test.ts
@@ -180,7 +180,7 @@ describe('formatBreadcrumb', () => {
       'kit',
     );
 
-    expect(rendered).toBe('\u{2501}\u{2501} 📦 @acme/release-kit@2.1.0 / 🧰 npm-auto-publish / 📋 repo');
+    expect(rendered).toBe('\u{2501}\u{2501} 📦 @acme/release-kit@2.1.0 / 📓 npm-auto-publish / 📋 repo');
   });
 
   it('renders a lone segment without a separator', () => {

--- a/packages/readyup/__tests__/layout/richFormatter.unit.test.ts
+++ b/packages/readyup/__tests__/layout/richFormatter.unit.test.ts
@@ -6,7 +6,7 @@ import { richFormatter } from '../../src/layout/richFormatter.ts';
 const VARIATION_SELECTOR_16 = '\u{FE0F}';
 
 /** Glyphs no token may use, each stripped of any variation selector. */
-const RETIRED_GLYPHS = ['\u{23ED}', '\u{2705}', '\u{26A0}', '\u{274C}', '\u{2753}', '\u{2796}'];
+const RETIRED_GLYPHS = ['\u{1F9F0}', '\u{23ED}', '\u{2705}', '\u{26A0}', '\u{274C}', '\u{2753}', '\u{2796}'];
 
 const entries = TOKEN_NAMES.map((name) => ({ name, ...richFormatter.tokens[name] }));
 
@@ -15,7 +15,7 @@ describe('richFormatter', () => {
     expect(new Set(Object.keys(richFormatter.tokens))).toStrictEqual(new Set<string>(TOKEN_NAMES));
   });
 
-  it('retires the glyphs the unified vocabulary replaced', () => {
+  it('retires every glyph withdrawn from use', () => {
     const glyphs = entries.map((entry) => entry.glyph);
 
     for (const retired of RETIRED_GLYPHS) {

--- a/packages/readyup/__tests__/listCommand.unit.test.ts
+++ b/packages/readyup/__tests__/listCommand.unit.test.ts
@@ -91,7 +91,7 @@ describe(listCommand, () => {
       const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
       expect(exitCode).toBe(0);
       expect(output).toContain('Packages');
-      expect(output).toContain('@acme/kits@2.1.0 / \u{1F9F0} drift');
+      expect(output).toContain('@acme/kits@2.1.0 / \u{1F4D3} drift');
       expect(output).not.toContain('No kits found');
     });
 

--- a/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
@@ -99,7 +99,7 @@ describe('--packages run path wiring', () => {
 
     await runCommand({ kitEntries: entries, json: false });
 
-    expect(stdout.join('')).toContain('\u{1F4E6} @acme/kits@2.1.0 / \u{1F9F0} drift');
+    expect(stdout.join('')).toContain('\u{1F4E6} @acme/kits@2.1.0 / \u{1F4D3} drift');
   });
 });
 

--- a/packages/readyup/__tests__/partialResults.unit.test.ts
+++ b/packages/readyup/__tests__/partialResults.unit.test.ts
@@ -78,8 +78,8 @@ describe('partial results when a kit fails after dispatch', () => {
     it('heads every requested kit on stdout, including one that never ran', async () => {
       await routeCommand(['passing', 'absent']);
 
-      expect(io.stdout).toContain('\u{2501}\u{2501} \u{1F9F0} passing');
-      expect(io.stdout).toContain('\u{2501}\u{2501} \u{1F9F0} absent');
+      expect(io.stdout).toContain('\u{2501}\u{2501} \u{1F4D3} passing');
+      expect(io.stdout).toContain('\u{2501}\u{2501} \u{1F4D3} absent');
     });
 
     it('keeps the failure off stdout, where a failed check would appear', async () => {

--- a/packages/readyup/src/layout/richFormatter.ts
+++ b/packages/readyup/src/layout/richFormatter.ts
@@ -22,7 +22,7 @@ export const richFormatter: Formatter = {
     failedRecommend: { glyph: '\u{1F7E1}', width: 2 },
     failedWarn: { glyph: '\u{1F7E0}', width: 2 },
     fix: { glyph: '\u{1F48A}', width: 2 },
-    kit: { glyph: '\u{1F9F0}', width: 2 },
+    kit: { glyph: '\u{1F4D3}', width: 2 },
     kitSource: { glyph: '\u{1F4C4}', width: 2 },
     passed: { glyph: '\u{1F7E2}', width: 2 },
     skippedOptional: { glyph: '\u{26AA}', width: 2 },


### PR DESCRIPTION
## What

Replaces the 🧰 Toolbox emoji representing kits in `rdy` output with 📓 Notebook emoji. At a glance, the Toolbox's emoji's bright red color gave the false impression that a failure had occurred.

## Why

The heading that names a kit sat directly above the check results it introduced, in a colour the reader had just been taught means failure. That put the two hardest-working signals in the output in conflict, and the conflict fell on the reader in the moment they were scanning for whether anything had gone wrong.

## Details

### 🐛 Bug fixes

The `kit` role token now uses a glyph outside the palette the failure severities occupy. Role glyphs name what something is rather than how it fared, so none of them should carry a status hue.

The replacement also stays distinct from the kit-source glyph. Under the default configuration `rdy list` reports a kit twice — once under **Internal** and once under **Compiled** — with the same name in both rows, so the glyph is the only per-row signal separating source from bundle.

Two candidates considered for the replacement are unusable here: both are text-presentation code points requiring a variation selector, which the two-cell width contract rejects.

### 🧪 Tests

The retired-glyph guard now covers the withdrawn glyph, so it cannot return for any token, and its name generalizes from the vocabulary unification that motivated the original list to withdrawal from use.

Nine assertions across five suites were realigned. Each preserves its file's existing convention for escaping, which varies by file.

### 📚 Documentation

The role-glyph legend and all nine sample-output blocks in readyup's README show the new glyph.

Closes #243
