### PR TITLE
#233 Stop creating a manifest in projects that have no kits

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -774,6 +774,8 @@ The directory is named against the enclosing workspace root, so `pnpm -r exec rd
 
 A sweep runs to completion: a kit that fails is reported, the next is tried, and the run exits 1. A failed kit is never recorded as though it had compiled, and one compiled previously keeps its existing manifest entry.
 
+A sweep that finds no kits writes a manifest only where one already exists, emptying it so that kits since deleted stop being advertised. A project with neither kits nor a manifest is left alone, so sweeping a monorepo does not seed `.readyup/` in workspaces that hold no kits.
+
 `rdy compile` refuses to overwrite a compiled kit whose on-disk hash differs from the manifest's recorded `targetHash` -- someone edited the bundle directly:
 
 ```

--- a/packages/readyup/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/__tests__/compileCommand.unit.test.ts
@@ -325,59 +325,98 @@ describe(compileCommand, () => {
     expect(mockCompileConfig).toHaveBeenCalledTimes(2);
   });
 
-  it('writes empty manifest and emits info message when srcDir does not exist', async () => {
-    mockLoadConfig.mockResolvedValue({
-      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+  describe('sweep that finds no kits', () => {
+    it('writes no manifest when the source directory is absent and no manifest exists', async () => {
+      arrangeEmptySweep({ srcDirExists: false, manifestExists: false });
+
+      const exitCode = await compileCommand([]);
+
+      expect(exitCode).toBe(0);
+      expect(mockReaddirSync).not.toHaveBeenCalled();
+      expect(mockWriteManifest).not.toHaveBeenCalled();
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Source directory not found: .readyup/kits; manifest not written'),
+      );
     });
-    mockExistsSync.mockReturnValue(false);
 
-    const exitCode = await compileCommand([]);
+    it('writes no manifest when the source directory holds no .ts files and no manifest exists', async () => {
+      arrangeEmptySweep({ srcDirExists: true, manifestExists: false });
+      mockReaddirSync.mockReturnValue(['readme.md']);
 
-    expect(exitCode).toBe(0);
-    expect(mockReaddirSync).not.toHaveBeenCalled();
-    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('treating as empty'));
-  });
+      const exitCode = await compileCommand([]);
 
-  it('returns 0 and skips manifest when --skip-manifest is set and srcDir does not exist', async () => {
-    mockLoadConfig.mockResolvedValue({
-      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+      expect(exitCode).toBe(0);
+      expect(mockWriteManifest).not.toHaveBeenCalled();
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No .ts files found in .readyup/kits; manifest not written'),
+      );
     });
-    mockExistsSync.mockReturnValue(false);
 
-    const exitCode = await compileCommand(['--skip-manifest']);
+    it('empties an existing manifest when the source directory is absent', async () => {
+      arrangeEmptySweep({ srcDirExists: false, manifestExists: true });
 
-    expect(exitCode).toBe(0);
-    expect(mockWriteManifest).not.toHaveBeenCalled();
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('treating as empty'));
-  });
+      const exitCode = await compileCommand([]);
 
-  it('writes empty manifest and emits info message when srcDir has no .ts files', async () => {
-    mockLoadConfig.mockResolvedValue({
-      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+      expect(exitCode).toBe(0);
+      expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('manifest now lists no kits'));
     });
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValue(['readme.md']);
 
-    const exitCode = await compileCommand([]);
+    it('empties an existing manifest when the source directory holds no .ts files', async () => {
+      arrangeEmptySweep({ srcDirExists: true, manifestExists: true });
+      mockReaddirSync.mockReturnValue(['readme.md']);
 
-    expect(exitCode).toBe(0);
-    expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));
-  });
+      const exitCode = await compileCommand([]);
 
-  it('returns 0 and skips manifest when --skip-manifest is set and srcDir has no .ts files', async () => {
-    mockLoadConfig.mockResolvedValue({
-      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+      expect(exitCode).toBe(0);
+      expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('manifest now lists no kits'));
     });
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValue(['readme.md']);
 
-    const exitCode = await compileCommand(['--skip-manifest']);
+    it('gates on the path --manifest names rather than the default', async () => {
+      arrangeEmptySweep({ srcDirExists: false, manifestExists: false });
 
-    expect(exitCode).toBe(0);
-    expect(mockWriteManifest).not.toHaveBeenCalled();
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('No .ts files found'));
+      await compileCommand(['--manifest', 'custom/manifest.json']);
+
+      expect(mockExistsSync).toHaveBeenCalledWith(path.resolve(process.cwd(), 'custom/manifest.json'));
+      expect(mockWriteManifest).not.toHaveBeenCalled();
+    });
+
+    it('reports no manifest outcome under --skip-manifest when the source directory is absent', async () => {
+      arrangeEmptySweep({ srcDirExists: false, manifestExists: true });
+
+      const exitCode = await compileCommand(['--skip-manifest']);
+
+      expect(exitCode).toBe(0);
+      expect(mockWriteManifest).not.toHaveBeenCalled();
+      expect(stdoutSpy).toHaveBeenCalledWith('Source directory not found: .readyup/kits\n');
+    });
+
+    it('reports no manifest outcome under --skip-manifest when the directory holds no .ts files', async () => {
+      arrangeEmptySweep({ srcDirExists: true, manifestExists: true });
+      mockReaddirSync.mockReturnValue(['readme.md']);
+
+      const exitCode = await compileCommand(['--skip-manifest']);
+
+      expect(exitCode).toBe(0);
+      expect(mockWriteManifest).not.toHaveBeenCalled();
+      expect(stdoutSpy).toHaveBeenCalledWith('No .ts files found in .readyup/kits\n');
+    });
+
+    // region | Helpers
+
+    /** Arranges a config-driven sweep with no sources, answering `existsSync` per path. */
+    function arrangeEmptySweep(existence: { srcDirExists: boolean; manifestExists: boolean }): void {
+      const { srcDirExists, manifestExists } = existence;
+      mockLoadConfig.mockResolvedValue({
+        compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+      });
+      mockExistsSync.mockImplementation((target: unknown) =>
+        String(target).endsWith('manifest.json') ? manifestExists : srcDirExists,
+      );
+    }
+
+    // endregion | Helpers
   });
 
   // Post-compile validation tests

--- a/packages/readyup/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/__tests__/compileCommand.unit.test.ts
@@ -382,7 +382,7 @@ describe(compileCommand, () => {
       expect(mockWriteManifest).not.toHaveBeenCalled();
     });
 
-    it('reports no manifest outcome under --skip-manifest when the source directory is absent', async () => {
+    it('omits the manifest clause under --skip-manifest when the source directory is absent', async () => {
       arrangeEmptySweep({ srcDirExists: false, manifestExists: true });
 
       const exitCode = await compileCommand(['--skip-manifest']);
@@ -392,7 +392,7 @@ describe(compileCommand, () => {
       expect(stdoutSpy).toHaveBeenCalledWith('Source directory not found: .readyup/kits\n');
     });
 
-    it('reports no manifest outcome under --skip-manifest when the directory holds no .ts files', async () => {
+    it('omits the manifest clause under --skip-manifest when the directory holds no .ts files', async () => {
       arrangeEmptySweep({ srcDirExists: true, manifestExists: true });
       mockReaddirSync.mockReturnValue(['readme.md']);
 
@@ -405,15 +405,12 @@ describe(compileCommand, () => {
 
     // region | Helpers
 
-    /** Arranges a config-driven sweep with no sources, answering `existsSync` per path. */
-    function arrangeEmptySweep(existence: { srcDirExists: boolean; manifestExists: boolean }): void {
-      const { srcDirExists, manifestExists } = existence;
+    /** Arranges a config-driven sweep that finds no kits. */
+    function arrangeEmptySweep(existence: ArrangeExistenceArgs): void {
       mockLoadConfig.mockResolvedValue({
         compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
       });
-      mockExistsSync.mockImplementation((target: unknown) =>
-        String(target).endsWith('manifest.json') ? manifestExists : srcDirExists,
-      );
+      arrangeExistence(existence);
     }
 
     // endregion | Helpers
@@ -475,6 +472,20 @@ describe(compileCommand, () => {
       await compileCommand([]);
 
       expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2 kits failed to compile.'));
+    });
+
+    it('writes a manifest when sources are found but every one fails to compile', async () => {
+      mockLoadConfig.mockResolvedValue({
+        compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+      });
+      arrangeExistence({ srcDirExists: true, manifestExists: false });
+      mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
+      mockCompileConfig.mockRejectedValue(new Error('not valid TypeScript'));
+
+      const exitCode = await compileCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
     });
 
     it('leaves a failed kit out of the manifest rather than recording it as compiled', async () => {
@@ -639,11 +650,11 @@ describe(compileCommand, () => {
     expect(error.message).toContain('EACCES');
   });
 
-  it('writes empty manifest when glob matches only non-.ts files during batch compile', async () => {
+  it('treats an include glob matching only non-.ts files as a sweep that finds no kits', async () => {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: 'data/*' },
     });
-    mockExistsSync.mockReturnValue(true);
+    arrangeExistence({ srcDirExists: true, manifestExists: true });
     mockReaddirSync.mockReturnValue(['data/readme.md', 'data/config.json']);
     mockPicomatch.mockReturnValue(() => true);
 
@@ -1128,4 +1139,21 @@ describe(compileCommand, () => {
 
     expect(stderrSpy).not.toHaveBeenCalledWith(expect.stringContaining('drift gate skipped'));
   });
+
+  // region | Helpers
+
+  interface ArrangeExistenceArgs {
+    srcDirExists: boolean;
+    manifestExists: boolean;
+  }
+
+  /** Answers `existsSync` per path, so the source directory and the manifest are arranged independently. */
+  function arrangeExistence(existence: ArrangeExistenceArgs): void {
+    const { srcDirExists, manifestExists } = existence;
+    mockExistsSync.mockImplementation((target: unknown) =>
+      String(target).endsWith('manifest.json') ? manifestExists : srcDirExists,
+    );
+  }
+
+  // endregion | Helpers
 });

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -217,8 +217,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
   const srcDir = path.resolve(process.cwd(), config.compile.srcDir);
   const outDir = path.resolve(process.cwd(), config.compile.outDir);
 
-  // A missing source directory is treated as an empty one: fall through to the empty-kit-list
-  // manifest write below rather than erroring.
+  // A missing source directory is treated as an empty one rather than as an error.
   const srcDirExists = existsSync(srcDir);
 
   let tsFiles: string[] = [];

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -231,19 +231,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
   }
 
   if (tsFiles.length === 0) {
-    const relSrc = path.relative(process.cwd(), srcDir);
-    const reason = srcDirExists
-      ? `No .ts files found in ${relSrc}`
-      : `Source directory not found: ${relSrc}; treating as empty`;
-    writeHuman(`${reason}\n`, json);
-    if (!skipManifest) {
-      try {
-        writeManifest(manifestPath, { version: 1, kits: [] });
-      } catch (error: unknown) {
-        throw configError(`Error writing manifest: ${extractMessage(error)}`, { cause: error });
-      }
-    }
-    return finishCompile([], json);
+    return finishEmptySweep({ srcDir, srcDirExists, skipManifest, manifestPath, json });
   }
 
   const anchor = resolveWorkspaceAnchor(srcDir);
@@ -330,6 +318,42 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
   }
 
   return finishCompile(kitResults, json);
+}
+
+/** Arguments for the no-kits early return of a batch compile. */
+interface FinishEmptySweepArgs {
+  srcDir: string;
+  srcDirExists: boolean;
+  skipManifest: boolean;
+  manifestPath: string;
+  json: boolean;
+}
+
+/**
+ * Reports a sweep that found no kits, and settles what becomes of the manifest.
+ *
+ * An existing manifest may still list kits that have since been deleted, so it is emptied rather than
+ * left stale. A project holding neither kits nor a manifest is not one this sweep describes, and gets
+ * none seeded for it.
+ */
+function finishEmptySweep(args: FinishEmptySweepArgs): number {
+  const { srcDir, srcDirExists, skipManifest, manifestPath, json } = args;
+
+  const relSrc = path.relative(process.cwd(), srcDir);
+  const reason = srcDirExists ? `No .ts files found in ${relSrc}` : `Source directory not found: ${relSrc}`;
+  const writesManifest = !skipManifest && existsSync(manifestPath);
+
+  writeHuman(`${reason}${formatManifestOutcome(skipManifest, writesManifest)}\n`, json);
+
+  if (writesManifest) {
+    try {
+      writeManifest(manifestPath, { version: 1, kits: [] });
+    } catch (error: unknown) {
+      throw configError(`Error writing manifest: ${extractMessage(error)}`, { cause: error });
+    }
+  }
+
+  return finishCompile([], json);
 }
 
 /** Location fields for a manifest kit entry. */
@@ -451,6 +475,16 @@ function formatDriftLine(srcName: string, status: Extract<DriftStatus, { kind: '
 /** Returns a section heading as a single writable string, newline-terminated. */
 function formatSectionHeading(label: string): string {
   return `${getLayout().formatHeading(label, 'section')}\n`;
+}
+
+/**
+ * Returns the clause naming what a sweep that found no kits did with the manifest.
+ *
+ * Empty under `--skip-manifest`, where the manifest was never consulted and so has nothing to report.
+ */
+function formatManifestOutcome(skipManifest: boolean, writesManifest: boolean): string {
+  if (skipManifest) return '';
+  return writesManifest ? '; manifest now lists no kits' : '; manifest not written';
 }
 
 /**


### PR DESCRIPTION
## What

Changes the behavior of `rdy compile` so that it no longer creates a manifest if no kits are found to compile. This allows `rdy compile` to be run recursively in a monorepo that has kits in only some workspaces; previously, that operation would have created an empty manifest in workspaces that didn't need one.

A run that finds no kits now reports whether a manifest was written. In a project with no kits, `rdy verify` now reports a missing manifest.

## Why

`pnpm -r exec rdy compile` across a monorepo left a `.readyup/` directory in every workspace, including the ones that hold no kits and never will. The unconditional write it came from was there for a reason -- a project that deletes its last kit needs its manifest emptied so the departed kits stop being advertised -- so the fix had to keep that case working rather than simply drop the write.

## Details

### 🎉 Features

- The batch manifest write, when a sweep finds no kits, is gated on a manifest already existing at the resolved path. A project with neither kits nor a manifest is left alone; one whose kits were all deleted still has its manifest emptied.
- The gate keys on sources found, not on kits compiled: a sweep whose sources all fail to compile still writes a manifest, because the question it answers is whether this is a readyup project, not whether the run succeeded.
- `--manifest <path>` does not bypass the gate. That flag says where the manifest goes; `--skip-manifest` says whether one is written at all, and the resolved path is what the existence check tests.
- Single-file compile (`rdy compile <file>`) is unchanged, and still upserts. Exit codes and the `--json` payload are unchanged.
- The reported line names the outcome (`manifest not written` / `manifest now lists no kits`), replacing `treating as empty`, which described a write that no longer always happens. Under `--skip-manifest` the line carries no clause, since the manifest is never consulted.

### 🧪 Tests

- Empty-sweep coverage is arranged through a path-aware `existsSync` helper, so the source directory and the manifest are stated independently. The prior blanket mock could not express "source directory absent, manifest present" -- the case the fix has to preserve.
- All four quadrants of (sources found × manifest exists) are covered, plus `--manifest` path resolution and both `--skip-manifest` messages.
- The sources-found boundary is pinned by its own case: two sources, both failing to compile, no manifest on disk, manifest still written.

### 📚 Documentation

- The README's compiling section states when a sweep writes a manifest and when it leaves the project alone.

## Known consequence

A kit-free project now has no manifest, so `rdy verify` there reports a missing manifest, and `pnpm -r exec rdy verify` fails where an empty manifest had been quietly satisfying it. The answer is `rdy verify --recursive` over the discovery in #245, not blunting verify's missing-manifest error, which is a real "you forgot to compile" signal.

Closes #233
