### PR TITLE
#254 Name the flag at fault when arguments are rejected

### DIFF
--- a/packages/overlay/src/bin/__tests__/parseArgs.unit.test.ts
+++ b/packages/overlay/src/bin/__tests__/parseArgs.unit.test.ts
@@ -48,6 +48,35 @@ describe(parseArgs, () => {
   });
 
   it('throws on an unknown option', () => {
-    expect(() => parseArgs(['./source', '--nope'])).toThrow();
+    expect(() => parseArgs(['./source', '--nope'])).toThrow(/unknown option: --nope/);
+  });
+
+  it('throws when a boolean option is given a value', () => {
+    expect(() => parseArgs(['./source', '--json=x'])).toThrow(/option takes no value: --json/);
+  });
+
+  it('keeps the underlying parse error as the cause', () => {
+    expect(catchError(() => parseArgs(['./source', '--nope']))).toHaveProperty(
+      'cause.code',
+      'ERR_PARSE_ARGS_UNKNOWN_OPTION',
+    );
+    expect(catchError(() => parseArgs(['./source', '--json=x']))).toHaveProperty(
+      'cause.code',
+      'ERR_PARSE_ARGS_INVALID_OPTION_VALUE',
+    );
   });
 });
+
+// region | Helpers
+
+/** Returns the value `act` throws, or `undefined` when it returns normally. */
+function catchError(act: () => unknown): unknown {
+  try {
+    act();
+  } catch (error: unknown) {
+    return error;
+  }
+  return undefined;
+}
+
+// endregion | Helpers

--- a/packages/overlay/src/bin/__tests__/parseArgs.unit.test.ts
+++ b/packages/overlay/src/bin/__tests__/parseArgs.unit.test.ts
@@ -55,6 +55,10 @@ describe(parseArgs, () => {
     expect(() => parseArgs(['./source', '--json=x'])).toThrow(/option takes no value: --json/);
   });
 
+  it.each([['--h'], ['--h=1']])('reports %s as an unknown option, not the -h short flag', (flag) => {
+    expect(() => parseArgs(['./source', flag])).toThrow(/unknown option: --h/);
+  });
+
   it('keeps the underlying parse error as the cause', () => {
     expect(catchError(() => parseArgs(['./source', '--nope']))).toHaveProperty(
       'cause.code',

--- a/packages/overlay/src/bin/__tests__/run.unit.test.ts
+++ b/packages/overlay/src/bin/__tests__/run.unit.test.ts
@@ -15,11 +15,11 @@ const stubResult: OverlayResult = {
   exitCode: 0,
 };
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
 describe(run, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('writes JSON to stdout and returns the result exit code under --json', async () => {
     vi.spyOn(overlayModule, 'overlay').mockResolvedValue(stubResult);
     const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);

--- a/packages/overlay/src/bin/parseArgs.ts
+++ b/packages/overlay/src/bin/parseArgs.ts
@@ -1,32 +1,35 @@
 import { parseArgs as nodeParseArgs } from 'node:util';
 
 import type { OverlayMode } from '../types.ts';
+import { extractMessage } from '../utils/error-handling.ts';
 
 /** The CLI invocation parsed from argv: either a request to show help or a resolved overlay command. */
 export type ParsedCommand =
   { kind: 'help' } | { kind: 'run'; source: string; target: string | undefined; mode: OverlayMode; json: boolean };
 
+const OPTIONS = {
+  verify: { type: 'boolean' },
+  create: { type: 'boolean' },
+  force: { type: 'boolean' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+/** Every option name `node:util.parseArgs` accepts, in the undashed form its tokens carry. */
+const ACCEPTED_NAMES = new Set<string>(
+  Object.entries(OPTIONS).flatMap(([name, option]) => ('short' in option ? [name, option.short] : [name])),
+);
+
 /**
- * Parse overlay's CLI arguments via `node:util.parseArgs`.
+ * Parses overlay's CLI arguments via `node:util.parseArgs`.
  *
  * Accepts `--verify`/`--create`/`--force` (mutually exclusive; default `verify`), `--json`, and `--help`/`-h`. The
  * first positional is the required source directory; the second is the optional target. Throws an `Error` with a
- * user-facing message on unknown options, multiple mode flags, or a missing source. Never calls `console` or
- * `process.exit`.
+ * user-facing message on an unknown option, a value passed to one of these boolean options, multiple mode flags, or
+ * a missing source. Never calls `console` or `process.exit`.
  */
 export function parseArgs(argv: string[]): ParsedCommand {
-  const { values, positionals } = nodeParseArgs({
-    args: argv,
-    allowPositionals: true,
-    strict: true,
-    options: {
-      verify: { type: 'boolean' },
-      create: { type: 'boolean' },
-      force: { type: 'boolean' },
-      json: { type: 'boolean' },
-      help: { type: 'boolean', short: 'h' },
-    },
-  });
+  const { values, positionals } = parseStrictArgv(argv);
 
   if (values.help === true) {
     return { kind: 'help' };
@@ -42,7 +45,43 @@ export function parseArgs(argv: string[]): ParsedCommand {
   return { kind: 'run', source, target, mode, json: values.json === true };
 }
 
-/** Resolve the single active mode flag, rejecting more than one. Defaults to `verify`. */
+// region | Helpers
+
+/** Builds overlay's message for a `node:util.parseArgs` rejection, naming the flag at fault. */
+function describeParseFailure(argv: string[], error: unknown): string {
+  // The rejection carries only a code, so a permissive second pass supplies the token that names the flag.
+  const { tokens } = nodeParseArgs({
+    args: argv,
+    allowPositionals: true,
+    strict: false,
+    tokens: true,
+    options: OPTIONS,
+  });
+  const options = tokens.filter((token) => token.kind === 'option');
+
+  const unknown = options.find((token) => !ACCEPTED_NAMES.has(token.name));
+  if (unknown !== undefined) {
+    return `unknown option: ${unknown.rawName}`;
+  }
+
+  const valued = options.find((token) => token.inlineValue === true);
+  if (valued !== undefined) {
+    return `option takes no value: ${valued.rawName}`;
+  }
+
+  return extractMessage(error);
+}
+
+/** Parses argv in strict mode, restating any rejection as an overlay message that keeps the original as `cause`. */
+function parseStrictArgv(argv: string[]) {
+  try {
+    return nodeParseArgs({ args: argv, allowPositionals: true, strict: true, options: OPTIONS });
+  } catch (error: unknown) {
+    throw new Error(describeParseFailure(argv, error), { cause: error });
+  }
+}
+
+/** Resolves the single active mode flag, rejecting more than one. Defaults to `verify`. */
 function resolveMode(verify: boolean, create: boolean, force: boolean): OverlayMode {
   const selected = [verify ? 'verify' : undefined, create ? 'create' : undefined, force ? 'force' : undefined].filter(
     (value): value is OverlayMode => value !== undefined,
@@ -52,3 +91,5 @@ function resolveMode(verify: boolean, create: boolean, force: boolean): OverlayM
   }
   return selected[0] ?? 'verify';
 }
+
+// endregion | Helpers

--- a/packages/overlay/src/bin/parseArgs.ts
+++ b/packages/overlay/src/bin/parseArgs.ts
@@ -15,10 +15,8 @@ const OPTIONS = {
   help: { type: 'boolean', short: 'h' },
 } as const;
 
-/** Every option name `node:util.parseArgs` accepts, in the undashed form its tokens carry. */
-const ACCEPTED_NAMES = new Set<string>(
-  Object.entries(OPTIONS).flatMap(([name, option]) => ('short' in option ? [name, option.short] : [name])),
-);
+/** Every option name a token can carry: `node:util.parseArgs` reports a short flag under its long name. */
+const ACCEPTED_NAMES = new Set<string>(Object.keys(OPTIONS));
 
 /**
  * Parses overlay's CLI arguments via `node:util.parseArgs`.
@@ -49,7 +47,7 @@ export function parseArgs(argv: string[]): ParsedCommand {
 
 /** Builds overlay's message for a `node:util.parseArgs` rejection, naming the flag at fault. */
 function describeParseFailure(argv: string[], error: unknown): string {
-  // The rejection carries only a code, so a permissive second pass supplies the token that names the flag.
+  // Node exposes the offending flag only inside its message prose, so a permissive second pass supplies it as a token.
   const { tokens } = nodeParseArgs({
     args: argv,
     allowPositionals: true,

--- a/packages/overlay/src/chezmoi/__tests__/readStatus.unit.test.ts
+++ b/packages/overlay/src/chezmoi/__tests__/readStatus.unit.test.ts
@@ -6,11 +6,11 @@ import * as runChezmoiModule from '../runChezmoi.ts';
 
 const context: ChezmoiContext = { source: '/src', target: '/dst' };
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
 describe(readStatus, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('returns stdout when chezmoi status exits 0', async () => {
     vi.spyOn(runChezmoiModule, 'runChezmoiCaptured').mockResolvedValue({ stdout: 'A  .newfile', stderr: '', code: 0 });
 

--- a/packages/overlay/src/chezmoi/__tests__/runChezmoi.unit.test.ts
+++ b/packages/overlay/src/chezmoi/__tests__/runChezmoi.unit.test.ts
@@ -23,11 +23,11 @@ interface ChildStub {
   on: (event: string, handler: (value: unknown) => void) => ChildStub;
 }
 
-afterEach(() => {
-  vi.clearAllMocks();
-});
-
 describe(runChezmoiCaptured, () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('injects source, destination, throwaway persistent-state and config, and --no-tty', async () => {
     resolveExecFile('output');
 
@@ -71,6 +71,10 @@ describe(runChezmoiCaptured, () => {
 });
 
 describe(runChezmoiStreamed, () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('inherits child stdout and stderr to process.stderr, never stdout', async () => {
     arrangeSpawn('close', 0);
 

--- a/packages/overlay/src/modes/__tests__/create.unit.test.ts
+++ b/packages/overlay/src/modes/__tests__/create.unit.test.ts
@@ -5,11 +5,11 @@ import { runCreate } from '../create.ts';
 
 const context = { source: '/src', target: '/target' };
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
 describe(runCreate, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('applies A and D entries by absolute target path', async () => {
     mockStatus(' A .new\n D .gone\n');
     const streamed = mockStreamed(0);

--- a/packages/overlay/src/modes/__tests__/force.unit.test.ts
+++ b/packages/overlay/src/modes/__tests__/force.unit.test.ts
@@ -5,11 +5,11 @@ import { runForce } from '../force.ts';
 
 const context = { source: '/src', target: '/target' };
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
 describe(runForce, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('runs a full apply and reports M rows as forced, exiting 0 on success', async () => {
     mockStatus(' A .new\n M .diff\n D .gone\n R normalize.sh\n');
     const apply = mockApply(0);


### PR DESCRIPTION
## What

Fixes an issue where overlay rejected a command line without naming the flag at fault, whether the flag was unrecognized or was given a value it does not take, and offered advice about passing positional arguments that does not apply to overlay. A single letter written in long form, such as `--h`, is now reported as unrecognized rather than read as the short flag `-h`.

## Why

Two of overlay's four argument errors reached the user in `node:util.parseArgs`' own wording, which appends advice about placing positional arguments after a `--` terminator. overlay's positionals are directory paths, so that advice sends the reader nowhere.

Separately, six violations of the deferred Vitest rules remained in overlay's test files. Those rules stay at `warn` until `.config/eslint/deferred-lint-rules.ts` is deleted, and this package's share is one of that deletion's two blockers (#153).

## Details

### 🐛 Bug fixes

- `parseArgs` now owns the message for both of `node:util.parseArgs`' strict-mode failures: `unknown option: --nope` for a flag overlay does not accept, and `option takes no value: --json` for a value passed to a boolean flag. The original `TypeError` is retained as `cause`.
- A long-form single letter is treated as an unknown option. `--h` and `--h=1` both report `unknown option: --h`; previously the first leaked Node's wording and the second named `--h` as a flag that exists but takes no value.

### ♻️ Refactoring

- The `parseArgs` options object moved to a module-level `OPTIONS` const, and the set of accepted names is derived from it rather than maintained separately.

### 🧪 Tests

- Mock-cleanup hooks in five test files moved inside the `describe` blocks they serve, clearing the five `vitest/require-top-level-describe` violations. `runChezmoi.unit.test.ts` has two `describe`s and both read `mock.calls[0]`, so each received its own hook rather than an outer wrapper.
- New coverage for both message branches, the preserved `cause` chain, and the `--h` / `--h=1` boundary. 79 tests pass, up from 75.

Closes #254
