### PR TITLE
#255 Clear readyup's Vitest lint violations and enforce the rules

### DIFF
--- a/.config/eslint/deferred-lint-rules.ts
+++ b/.config/eslint/deferred-lint-rules.ts
@@ -10,10 +10,3 @@ export const deferredLintRules = {
   'unicorn/prefer-includes-over-repeated-comparisons': 'warn',
   'preserve-caught-error': 'warn',
 } as const;
-
-export const deferredTestRules = {
-  'vitest/no-conditional-expect': 'warn',
-  'vitest/no-conditional-in-test': 'warn',
-  'vitest/require-to-throw-message': 'warn',
-  'vitest/require-top-level-describe': 'warn',
-} as const;

--- a/.config/strict-lint.config.ts
+++ b/.config/strict-lint.config.ts
@@ -1,14 +1,13 @@
 import { advisoryRuleSeverities } from '@williamthorsen/eslint-config-typescript';
 import { defineConfig } from '@williamthorsen/strict-lint/config';
 
-import { deferredLintRules, deferredTestRules } from './eslint/deferred-lint-rules.ts';
+import { deferredLintRules } from './eslint/deferred-lint-rules.ts';
 
 const config = defineConfig({
   // Keep the deferred rules as warnings; strict-lint otherwise promotes every warning to an error.
   maxSeverity: {
     ...advisoryRuleSeverities,
     ...deferredLintRules,
-    ...deferredTestRules,
   },
 });
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,7 +1,7 @@
 import baseConfig, { createConfig } from '@williamthorsen/eslint-config-typescript';
 import { defineConfig } from 'eslint/config';
 
-import { deferredLintRules, deferredTestRules } from './.config/eslint/deferred-lint-rules.ts';
+import { deferredLintRules } from './.config/eslint/deferred-lint-rules.ts';
 
 const config = defineConfig([
   ...baseConfig,
@@ -57,9 +57,6 @@ const config = defineConfig([
   defineConfig({
     files: ['**/*.test.ts', '**/*.test.tsx'],
     extends: [await createConfig.vitest()],
-    rules: {
-      ...deferredTestRules,
-    },
   }),
   {
     // Config files legitimately mutate and compose configuration objects at module top level.

--- a/packages/readyup/__tests__/check-utils/git/compare-local-refs.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/compare-local-refs.unit.test.ts
@@ -15,32 +15,11 @@ vi.mock(import('../../../src/check-utils/git/run-git.ts'), async (importOriginal
 
 const runGit = vi.mocked(runGitModule.runGit);
 
-beforeEach(() => {
-  vi.restoreAllMocks();
-});
-
-/** Stub `runGit` to route calls by git subcommand and arguments. */
-function stubRunGit(routes: Record<string, string | Error>): void {
-  runGit.mockImplementation((_path: string, ...args: string[]) => {
-    const key = args.join(' ');
-    for (const [pattern, value] of Object.entries(routes)) {
-      if (key.includes(pattern)) {
-        if (value instanceof Error) return Promise.reject(value);
-        return Promise.resolve(value);
-      }
-    }
-    return Promise.reject(new Error(`Unexpected runGit call: git ${args.join(' ')}`));
-  });
-}
-
-function makeRefMissingError(ref: string): Error {
-  return Object.assign(new Error(`unknown revision: ${ref}`), {
-    code: 128,
-    stderr: `fatal: ambiguous argument '${ref}': unknown revision or path not in the working tree.`,
-  });
-}
-
 describe(compareLocalRefs, () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('returns match when both refs resolve to the same SHA', async () => {
     const sha = 'abc123def456abc123def456abc123def456abc1';
     stubRunGit({
@@ -174,3 +153,25 @@ describe(compareLocalRefs, () => {
     expect(result.aheadBehind).toBeUndefined();
   });
 });
+
+/** Builds the error shape git produces for a ref that does not resolve. */
+function makeRefMissingError(ref: string): Error {
+  return Object.assign(new Error(`unknown revision: ${ref}`), {
+    code: 128,
+    stderr: `fatal: ambiguous argument '${ref}': unknown revision or path not in the working tree.`,
+  });
+}
+
+/** Stubs `runGit` to route calls by git subcommand and arguments. */
+function stubRunGit(routes: Record<string, string | Error>): void {
+  runGit.mockImplementation((_path: string, ...args: string[]) => {
+    const key = args.join(' ');
+    for (const [pattern, value] of Object.entries(routes)) {
+      if (key.includes(pattern)) {
+        if (value instanceof Error) return Promise.reject(value);
+        return Promise.resolve(value);
+      }
+    }
+    return Promise.reject(new Error(`Unexpected runGit call: git ${args.join(' ')}`));
+  });
+}

--- a/packages/readyup/__tests__/check-utils/git/repo-predicates.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/repo-predicates.unit.test.ts
@@ -19,12 +19,12 @@ vi.mock(import('node:fs'), () => ({
 
 import { isAtRepoRoot, isGitRepo } from '../../../src/check-utils/git/repo-predicates.ts';
 
-beforeEach(() => {
-  vi.clearAllMocks();
-  existsSyncMock.mockReturnValue(true);
-});
-
 describe(isGitRepo, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    existsSyncMock.mockReturnValue(true);
+  });
+
   it('returns false when the path does not exist', async () => {
     existsSyncMock.mockReturnValue(false);
 
@@ -69,6 +69,11 @@ describe(isGitRepo, () => {
 });
 
 describe(isAtRepoRoot, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    existsSyncMock.mockReturnValue(true);
+  });
+
   it('returns false when the path does not exist', async () => {
     existsSyncMock.mockReturnValue(false);
 

--- a/packages/readyup/__tests__/check-utils/git/run-git.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/git/run-git.unit.test.ts
@@ -14,11 +14,11 @@ vi.mock('node:child_process', () => {
   return { execFile: stub };
 });
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe(runGit, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('returns trimmed stdout for a successful git command', async () => {
     execFileAsync.mockResolvedValue({ stdout: '  abc123\n', stderr: '' });
 

--- a/packages/readyup/__tests__/compile/validateCompiledOutput.unit.test.ts
+++ b/packages/readyup/__tests__/compile/validateCompiledOutput.unit.test.ts
@@ -69,7 +69,7 @@ describe(validateCompiledOutput, () => {
       notAKit: true,
     });
 
-    await expect(validateCompiledOutput(outputPath)).rejects.toThrow();
+    await expect(validateCompiledOutput(outputPath)).rejects.toThrow('Kit file must export checklists');
     expect(existsSync(outputPath)).toBe(false);
   });
 

--- a/packages/readyup/__tests__/compileConfig.unit.test.ts
+++ b/packages/readyup/__tests__/compileConfig.unit.test.ts
@@ -154,11 +154,7 @@ describe(compileConfig, () => {
     const importError = new Error('Cannot find module esbuild');
     mockLoadEsbuild.mockRejectedValue(importError);
 
-    const thrownError = await compileConfig('input.ts').catch((error: unknown) => error);
-    expect(thrownError).toBeInstanceOf(Error);
-    if (thrownError instanceof Error) {
-      expect(thrownError.cause).toBe(importError);
-    }
+    await expect(compileConfig('input.ts')).rejects.toThrow(expect.objectContaining({ cause: importError }));
   });
 });
 

--- a/packages/readyup/__tests__/exitCodes.tool.test.ts
+++ b/packages/readyup/__tests__/exitCodes.tool.test.ts
@@ -171,11 +171,9 @@ describe('flag surface', () => {
     { long: '--report-on', args: ['passing', '--report-on', 'error'] },
   ])('leaves $long accepted after its short is retired', async ({ args }) => {
     // The flag may still fail for want of a kit; what matters is that it is not a usage error.
-    const exitCode = await routeCommand([...args, '--json']);
+    await routeCommand([...args, '--json']);
 
-    if (exitCode === 2) {
-      expect(JSON.parse(io.stdout)).not.toMatchObject({ error: { code: 'usage' } });
-    }
+    expect(JSON.parse(io.stdout)).not.toMatchObject({ error: { code: 'usage' } });
   });
 
   it('runs the named checklists from a single positional kit', async () => {

--- a/packages/readyup/__tests__/initCommand.scaffold.unit.test.ts
+++ b/packages/readyup/__tests__/initCommand.scaffold.unit.test.ts
@@ -30,7 +30,6 @@ describe('scaffolded kit', () => {
   afterEach(() => {
     process.chdir(originalCwd);
     rmSync(TEST_DIR, { recursive: true, force: true });
-    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 

--- a/packages/readyup/__tests__/list/enumerateKits.unit.test.ts
+++ b/packages/readyup/__tests__/list/enumerateKits.unit.test.ts
@@ -72,7 +72,9 @@ describe(enumerateKits, () => {
     fs.mkdirSync(path.join(tempDir, 'restricted'));
     fs.chmodSync(path.join(tempDir, 'restricted'), 0o000);
 
-    expect(() => enumerateKits({ dir: path.join(tempDir, 'restricted'), extension: '.ts' })).toThrow();
+    expect(() => enumerateKits({ dir: path.join(tempDir, 'restricted'), extension: '.ts' })).toThrow(
+      expect.objectContaining({ code: 'EACCES' }),
+    );
 
     // Restore permissions for cleanup
     fs.chmodSync(path.join(tempDir, 'restricted'), 0o755);

--- a/packages/readyup/__tests__/schemas/schemas.unit.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
+import { ZodError } from 'zod';
 
 import type { RdyErrorCode } from '../../src/errors.ts';
 import type {
@@ -64,7 +65,7 @@ describe('JSON payload schemas', () => {
       (field) => {
         const incomplete = Object.fromEntries(Object.entries(minimalReportPayload).filter(([key]) => key !== field));
 
-        expect(() => ReportSchema.parse(incomplete)).toThrow();
+        expect(() => ReportSchema.parse(incomplete)).toThrow(ZodError);
       },
     );
 
@@ -77,13 +78,13 @@ describe('JSON payload schemas', () => {
       const kit = reportPayload.kits[0];
       const stripped = Object.fromEntries(Object.entries(kit ?? {}).filter(([key]) => key !== field));
 
-      expect(() => ReportSchema.parse({ ...reportPayload, kits: [stripped] })).toThrow();
+      expect(() => ReportSchema.parse({ ...reportPayload, kits: [stripped] })).toThrow(ZodError);
     });
 
     it('rejects a counts object missing one of its six buckets', () => {
       const counts = { passed: 0, errors: 0, warnings: 0, recommendations: 0, blocked: 0 };
 
-      expect(() => ReportSchema.parse({ ...minimalReportPayload, counts })).toThrow();
+      expect(() => ReportSchema.parse({ ...minimalReportPayload, counts })).toThrow(ZodError);
     });
   });
 
@@ -101,7 +102,7 @@ describe('JSON payload schemas', () => {
     it('rejects a non-string hint', () => {
       const error = { code: 'config', message: 'boom', hint: 42 };
 
-      expect(() => ErrorEnvelopeSchema.parse({ schemaVersion: 1, error })).toThrow();
+      expect(() => ErrorEnvelopeSchema.parse({ schemaVersion: 1, error })).toThrow(ZodError);
     });
   });
 
@@ -127,7 +128,7 @@ describe('JSON payload schemas', () => {
     });
 
     it('rejects a numeric `warnings` at the top level, where the old flat shape put the count', () => {
-      expect(() => ReportSchema.parse({ ...minimalReportPayload, warnings: 3 })).toThrow();
+      expect(() => ReportSchema.parse({ ...minimalReportPayload, warnings: 3 })).toThrow(ZodError);
     });
   });
 
@@ -150,7 +151,7 @@ describe('JSON payload schemas', () => {
     it('rejects an error code this version does not know, which selects a consumer branch', () => {
       const kits = [{ name: 'release', error: { code: 'kit-retired', message: 'boom' } }];
 
-      expect(() => ReportSchema.parse({ ...minimalReportPayload, kits })).toThrow();
+      expect(() => ReportSchema.parse({ ...minimalReportPayload, kits })).toThrow(ZodError);
     });
   });
 
@@ -162,13 +163,13 @@ describe('JSON payload schemas', () => {
     it('rejects a source verdict outside the vocabulary', () => {
       const kits = [{ name: 'deploy', status: 'ok', sourceStatus: 'drift' }];
 
-      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow();
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow(ZodError);
     });
 
     it('keeps the source vocabulary distinct from the target vocabulary', () => {
       const kits = [{ name: 'deploy', status: 'stale', sourceStatus: 'ok' }];
 
-      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow();
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow(ZodError);
     });
 
     it('accepts a payload from a readyup that predates the rebuild verdict', () => {
@@ -195,7 +196,7 @@ describe('JSON payload schemas', () => {
     it('rejects a rebuild verdict outside the vocabulary', () => {
       const kits = [{ name: 'deploy', status: 'ok', rebuildStatus: 'unverified' }];
 
-      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow();
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow(ZodError);
     });
   });
 
@@ -207,7 +208,7 @@ describe('JSON payload schemas', () => {
     });
 
     it('rejects a kit that carries neither results nor an error', () => {
-      expect(() => ReportSchema.parse({ ...minimalReportPayload, kits: [{ name: 'orphan' }] })).toThrow();
+      expect(() => ReportSchema.parse({ ...minimalReportPayload, kits: [{ name: 'orphan' }] })).toThrow(ZodError);
     });
   });
 

--- a/packages/readyup/__tests__/schemas/schemas.unit.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.unit.test.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert';
+
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { ZodError } from 'zod';
 
@@ -110,7 +112,7 @@ describe('JSON payload schemas', () => {
     it('reads `passed` as a verdict at every level and as a count only under `counts`', () => {
       const parsed = ReportSchema.parse(reportPayload);
       const kit = parsed.kits[0];
-      if (kit === undefined || 'error' in kit) throw new Error('expected a kit that ran');
+      assert.ok(kit !== undefined && !('error' in kit), 'expected a kit that ran');
 
       expect(parsed.passed).toBe(false);
       expect(parsed.counts.passed).toBe(2);
@@ -136,7 +138,7 @@ describe('JSON payload schemas', () => {
     it('carries the kit-declared threshold that governed a kit, not the one the run requested', () => {
       const parsed = ReportSchema.parse(reportPayload);
       const kit = parsed.kits[0];
-      if (kit === undefined || 'error' in kit) throw new Error('expected a kit that ran');
+      assert.ok(kit !== undefined && !('error' in kit), 'expected a kit that ran');
 
       expect(parsed.failOn).toBe('error');
       expect(kit.failOn).toBe('warn');

--- a/packages/readyup/__tests__/styleSelection.unit.test.ts
+++ b/packages/readyup/__tests__/styleSelection.unit.test.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { routeCommand } from '../src/bin/route.ts';
 import { plainFormatter } from '../src/layout/plainFormatter.ts';
@@ -51,10 +51,6 @@ const temp = useTempDir({
 
 // `init` reports through the console rather than the streams directly, so both channels are captured.
 const io = useCapturedStdio({ console: true });
-
-afterEach(() => {
-  vi.unstubAllEnvs();
-});
 
 describe('--style plain', () => {
   it.for(RENDERING_COMMANDS)('renders $name without leaving the ASCII range', async ({ args }) => {

--- a/packages/readyup/__tests__/verify/targetHash.unit.test.ts
+++ b/packages/readyup/__tests__/verify/targetHash.unit.test.ts
@@ -57,6 +57,6 @@ describe(hashFile, () => {
   });
 
   it('throws when the file does not exist', () => {
-    expect(() => hashFile(path.join(tempDir, 'missing.js'))).toThrow();
+    expect(() => hashFile(path.join(tempDir, 'missing.js'))).toThrow(expect.objectContaining({ code: 'ENOENT' }));
   });
 });

--- a/packages/readyup/vitest.config.ts
+++ b/packages/readyup/vitest.config.ts
@@ -10,6 +10,9 @@ import { defineVitestConfig } from '@williamthorsen/nmr/vitest';
 // a terminal and whether CI was set, so the same assertion would pass locally and fail on the runner. A test wanting
 // plain output passes `--style plain`, which outranks this.
 //
+// Restoring a stubbed environment variable is the runner's job rather than a suite's. `unstubEnvs` clears every stub
+// before each test, so a suite that stubs one carries no hook to undo it.
+//
 // The aliases let a test import this package's own kits, which reach readyup by package name the way a consumer's kit
 // does, without a prior build standing between the test and the source. Longest specifier first: an alias on `readyup`
 // also matches `readyup/check-utils`, and the first match wins.
@@ -20,7 +23,7 @@ import { defineVitestConfig } from '@williamthorsen/nmr/vitest';
 // drops the `__tests__/` directories the same glob would otherwise sweep in. The text reporter shows no `test-utils`
 // group; those files are in the coverage data regardless.
 export default defineVitestConfig({
-  project: { env: { RDY_STYLE: 'rich' } },
+  project: { env: { RDY_STYLE: 'rich' }, unstubEnvs: true },
   root: {
     resolve: {
       alias: [


### PR DESCRIPTION
## What

Fixes deferred violations of Vitest lint rules in the readyup package and restores the severity of the associated rules to "error" when a strict-lint check is run.

## Why

A warning nobody reads protects nothing. Held at that severity, the four rules let 23 violations accumulate in readyup alone, and one of them had already produced a test that asserted nothing across most of its inputs. Clearing the violations without promoting the rules would have left the next one to land just as silently.

## Details

### 🧪 Tests

- 13 `.toThrow()` assertions name the layer that raises the failure: `ZodError` for the ten schema rejections, readyup's own message for the compiled-kit validation, and Node's errno (`EACCES`, `ENOENT`) for the two filesystem failures. Matching a third party's wording would have satisfied the rule while coupling readyup's tests to phrasing it does not control.
- Four conditionals dissolved rather than relocated. Two type-narrowing `if`/`throw` pairs became `assert.ok`; `compileConfig`'s `catch`/`instanceof`/`if` trio collapsed into a single `rejects.toThrow(expect.objectContaining({ cause }))`; and `exitCodes`' `if (exitCode === 2)` guard dropped, so five parameterized flags now assert on every path instead of only on usage errors.
- Three module-level mock hooks moved into the suites they serve. In `run-git.unit.test.ts` the hook went into `describe(runGit)` alone, since the other two suites exercise pure functions and touch no mock.
- Both `vi.unstubAllEnvs()` hooks gave way to `unstubEnvs: true` in `packages/readyup/vitest.config.ts`. Restoring a stubbed environment variable is the runner's job rather than a hook each suite has to carry.
- `compare-local-refs.unit.test.ts`'s two helpers moved below the suite they support and gained descriptions.

### ⚙️ Tooling

- `deferredTestRules` is gone from `.config/eslint/deferred-lint-rules.ts`, `eslint.config.ts`, and `.config/strict-lint.config.ts`. Only the `strict-lint` `maxSeverity` entry was load-bearing: `createConfig.vitest()` already sets all four rules to `warn`, so the `eslint.config.ts` spread restated a severity that was already in force.
- The eight `deferredLintRules` entries are untouched. #153 owns those.

Closes #255
