### PR TITLE
#264 Follow package-specifier extends when reading a tsconfig's language level

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1030,7 +1030,7 @@ import { fileExists, hasPackageJsonField } from 'readyup/check-utils';
 | `esYearForNodeMajor(major)`          | ECMAScript year a Node major supports (`24` → `es2025`)                                  |
 | `readTsconfigLanguageLevel(path)`    | Effective `lib` and `target`, resolved through `extends`                                 |
 
-Each reader answers only what it can see, so a check composing them decides for itself what each unknown means. `readEnginesNodeFloor` recognizes only forms from which a single floor follows (`>=24`, `^22.1`, `24.1.0`); a union or wildcard comes back `unparseable` rather than an invented floor. `readTsconfigLanguageLevel` also returns `chain` (the configs it read) and `unresolvedExtends` (references it could not follow), so a check can tell an incomplete answer from an undeclared setting.
+Each reader answers only what it can see, so a check composing them decides for itself what each unknown means. `readEnginesNodeFloor` recognizes only forms from which a single floor follows (`>=24`, `^22.1`, `24.1.0`); a union or wildcard comes back `unparseable` rather than an invented floor. `readTsconfigLanguageLevel` resolves `extends` as TypeScript does, following relative paths and published base configs alike; it also returns `chain` (the configs it read) and `unresolvedExtends` (references it could not follow), so a check can tell an incomplete answer from an undeclared setting.
 
 ```ts
 import {

--- a/packages/readyup/__tests__/check-utils/tsconfig.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/tsconfig.unit.test.ts
@@ -117,7 +117,102 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
-  it('reports a bare package specifier as unresolved without following it', () => {
+  it('resolves a package subpath through the exports map that names it', () => {
+    installPackage('@scoped/base', {
+      'package.json': { name: '@scoped/base', exports: { './tsconfig.base.json': './tsconfig.base.json' } },
+      'tsconfig.base.json': { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: '@scoped/base/tsconfig.base.json' });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
+      lib: ['es2025'],
+      target: 'es2025',
+      chain: ['tsconfig.json', 'node_modules/@scoped/base/tsconfig.base.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('resolves a package subpath when the package declares no exports map', () => {
+    installPackage('plain-base', {
+      'package.json': { name: 'plain-base' },
+      'tsconfig.json': { compilerOptions: { target: 'ES2024' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: 'plain-base/tsconfig.json' });
+
+    const result = readTsconfigLanguageLevel('tsconfig.json');
+
+    expect(result?.target).toBe('es2024');
+    expect(result?.chain).toStrictEqual(['tsconfig.json', 'node_modules/plain-base/tsconfig.json']);
+  });
+
+  it('appends .json to a package subpath written without an extension', () => {
+    installPackage('plain-base', {
+      'package.json': { name: 'plain-base' },
+      'tsconfig.json': { compilerOptions: { target: 'ES2024' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: 'plain-base/tsconfig' });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')?.target).toBe('es2024');
+  });
+
+  it('resolves a bare package name to the config in the package root', () => {
+    installPackage('plain-base', {
+      'package.json': { name: 'plain-base' },
+      'tsconfig.json': { compilerOptions: { lib: ['ES2024'], target: 'ES2024' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: 'plain-base' });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
+      lib: ['es2024'],
+      target: 'es2024',
+      chain: ['tsconfig.json', 'node_modules/plain-base/tsconfig.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('resolves a bare package name through the tsconfig field of its manifest', () => {
+    installPackage('field-base', {
+      'package.json': { name: 'field-base', tsconfig: './configs/base.json' },
+      'configs/base.json': { compilerOptions: { target: 'ES2019' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: 'field-base' });
+
+    const result = readTsconfigLanguageLevel('tsconfig.json');
+
+    expect(result?.target).toBe('es2019');
+    expect(result?.chain).toStrictEqual(['tsconfig.json', 'node_modules/field-base/configs/base.json']);
+  });
+
+  it('reports a bare package name as unresolved when the package declares an exports map', () => {
+    installPackage('@scoped/base', {
+      'package.json': { name: '@scoped/base', exports: { './tsconfig.base.json': './tsconfig.base.json' } },
+      // Present so the refusal is attributable to the exports map rather than to a missing file.
+      'tsconfig.json': { compilerOptions: { target: 'ES2020' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: '@scoped/base', compilerOptions: { target: 'ES2025' } });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
+      lib: undefined,
+      target: 'es2025',
+      chain: ['tsconfig.json'],
+      unresolvedExtends: ['@scoped/base'],
+    });
+  });
+
+  it('reports a package subpath as unresolved when the exports map does not name it', () => {
+    installPackage('@scoped/base', {
+      'package.json': { name: '@scoped/base', exports: { './tsconfig.base.json': './tsconfig.base.json' } },
+      'other.json': { compilerOptions: { target: 'ES2020' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: '@scoped/base/other.json', compilerOptions: { lib: ['ES2025'] } });
+
+    const result = readTsconfigLanguageLevel('tsconfig.json');
+
+    expect(result?.lib).toStrictEqual(['es2025']);
+    expect(result?.unresolvedExtends).toStrictEqual(['@scoped/base/other.json']);
+  });
+
+  it('reports a package specifier as unresolved when the package is not installed', () => {
     temp.writeJson('tsconfig.json', {
       extends: '@tsconfig/node24/tsconfig.json',
       compilerOptions: { target: 'ES2025' },
@@ -128,6 +223,62 @@ describe(readTsconfigLanguageLevel, () => {
       target: 'es2025',
       chain: ['tsconfig.json'],
       unresolvedExtends: ['@tsconfig/node24/tsconfig.json'],
+    });
+  });
+
+  it('reports a Node core module as unresolved', () => {
+    temp.writeJson('tsconfig.json', { extends: 'path', compilerOptions: { target: 'ES2025' } });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
+      lib: undefined,
+      target: 'es2025',
+      chain: ['tsconfig.json'],
+      unresolvedExtends: ['path'],
+    });
+  });
+
+  it('reports a Node core module subpath as unresolved', () => {
+    temp.writeJson('tsconfig.json', { extends: 'fs/promises', compilerOptions: { target: 'ES2025' } });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
+      lib: undefined,
+      target: 'es2025',
+      chain: ['tsconfig.json'],
+      unresolvedExtends: ['fs/promises'],
+    });
+  });
+
+  it('names the directory a symlinked package occupies rather than the link', () => {
+    linkPackage('@scoped/base', {
+      'package.json': { name: '@scoped/base', exports: { './tsconfig.base.json': './tsconfig.base.json' } },
+      'tsconfig.base.json': { compilerOptions: { lib: ['ES2025'], target: 'ES2025' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: '@scoped/base/tsconfig.base.json' });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
+      lib: ['es2025'],
+      target: 'es2025',
+      chain: ['tsconfig.json', 'store/@scoped/base/tsconfig.base.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('follows a symlinked package whose config extends a second symlinked package', () => {
+    linkPackage('inner-base', {
+      'package.json': { name: 'inner-base' },
+      'tsconfig.json': { compilerOptions: { lib: ['ES2023'], target: 'ES2023' } },
+    });
+    linkPackage('outer-base', {
+      'package.json': { name: 'outer-base' },
+      'tsconfig.json': { extends: 'inner-base' },
+    });
+    temp.writeJson('tsconfig.json', { extends: 'outer-base' });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
+      lib: ['es2023'],
+      target: 'es2023',
+      chain: ['tsconfig.json', 'store/outer-base/tsconfig.json', 'store/inner-base/tsconfig.json'],
+      unresolvedExtends: [],
     });
   });
 
@@ -181,3 +332,25 @@ describe(readTsconfigLanguageLevel, () => {
     expect(readTsconfigLanguageLevel('tsconfig.json')).toBeUndefined();
   });
 });
+
+// region | Helpers
+
+/** Writes a package into the temporary directory's `node_modules`, one JSON file per entry of `files`. */
+function installPackage(name: string, files: Record<string, unknown>): void {
+  writePackageFiles(`node_modules/${name}`, files);
+}
+
+/** Writes a package outside `node_modules` and links it in, as a pnpm install does. */
+function linkPackage(name: string, files: Record<string, unknown>): void {
+  writePackageFiles(`store/${name}`, files);
+  temp.symlinkDir(`node_modules/${name}`, `store/${name}`);
+}
+
+/** Writes each entry of `files` as JSON under `packageDir`. */
+function writePackageFiles(packageDir: string, files: Record<string, unknown>): void {
+  for (const [fileName, contents] of Object.entries(files)) {
+    temp.writeJson(`${packageDir}/${fileName}`, contents);
+  }
+}
+
+// endregion | Helpers

--- a/packages/readyup/__tests__/check-utils/tsconfig.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/tsconfig.unit.test.ts
@@ -183,7 +183,22 @@ describe(readTsconfigLanguageLevel, () => {
     expect(result?.chain).toStrictEqual(['tsconfig.json', 'node_modules/field-base/configs/base.json']);
   });
 
-  it('reports a bare package name as unresolved when the package declares an exports map', () => {
+  it('resolves a bare package name through the "." entry of an exports map', () => {
+    installPackage('@scoped/base', {
+      'package.json': { name: '@scoped/base', exports: { '.': './tsconfig.json' } },
+      'tsconfig.json': { compilerOptions: { lib: ['ES2018'], target: 'ES2018' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: '@scoped/base' });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
+      lib: ['es2018'],
+      target: 'es2018',
+      chain: ['tsconfig.json', 'node_modules/@scoped/base/tsconfig.json'],
+      unresolvedExtends: [],
+    });
+  });
+
+  it('reports a bare package name as unresolved when the exports map has no "." entry', () => {
     installPackage('@scoped/base', {
       'package.json': { name: '@scoped/base', exports: { './tsconfig.base.json': './tsconfig.base.json' } },
       // Present so the refusal is attributable to the exports map rather than to a missing file.

--- a/packages/readyup/__tests__/check-utils/tsconfig.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/tsconfig.unit.test.ts
@@ -212,6 +212,21 @@ describe(readTsconfigLanguageLevel, () => {
     expect(result?.chain).toStrictEqual(['tsconfig.json', 'node_modules/both-base/declared.json']);
   });
 
+  it('reads past a null exports map to the config in the package root', () => {
+    installPackage('null-base', {
+      'package.json': { name: 'null-base', exports: null, main: './index.js' },
+      'tsconfig.json': { compilerOptions: { target: 'ES2016' } },
+    });
+    // A resolvable `main` stands in the way, so reaching the root config is what proves the map is read past.
+    temp.write('node_modules/null-base/index.js', 'module.exports = {};\n');
+    temp.writeJson('tsconfig.json', { extends: 'null-base' });
+
+    const result = readTsconfigLanguageLevel('tsconfig.json');
+
+    expect(result?.target).toBe('es2016');
+    expect(result?.chain).toStrictEqual(['tsconfig.json', 'node_modules/null-base/tsconfig.json']);
+  });
+
   it('reports a package whose entry point is not a config as unresolved', () => {
     installPackage('js-base', { 'package.json': { name: 'js-base', exports: { '.': './index.js' } } });
     // The parser recovers an empty record from JavaScript source, so only the resolver can reject this.

--- a/packages/readyup/__tests__/check-utils/tsconfig.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/tsconfig.unit.test.ts
@@ -198,6 +198,34 @@ describe(readTsconfigLanguageLevel, () => {
     });
   });
 
+  it('lets the "." entry of an exports map outrank the manifest tsconfig field', () => {
+    installPackage('both-base', {
+      'package.json': { name: 'both-base', exports: { '.': './declared.json' }, tsconfig: './field.json' },
+      'declared.json': { compilerOptions: { target: 'ES2015' } },
+      'field.json': { compilerOptions: { target: 'ES2014' } },
+    });
+    temp.writeJson('tsconfig.json', { extends: 'both-base' });
+
+    const result = readTsconfigLanguageLevel('tsconfig.json');
+
+    expect(result?.target).toBe('es2015');
+    expect(result?.chain).toStrictEqual(['tsconfig.json', 'node_modules/both-base/declared.json']);
+  });
+
+  it('reports a package whose entry point is not a config as unresolved', () => {
+    installPackage('js-base', { 'package.json': { name: 'js-base', exports: { '.': './index.js' } } });
+    // The parser recovers an empty record from JavaScript source, so only the resolver can reject this.
+    temp.write('node_modules/js-base/index.js', 'module.exports = {};\n');
+    temp.writeJson('tsconfig.json', { extends: 'js-base', compilerOptions: { target: 'ES2025' } });
+
+    expect(readTsconfigLanguageLevel('tsconfig.json')).toStrictEqual({
+      lib: undefined,
+      target: 'es2025',
+      chain: ['tsconfig.json'],
+      unresolvedExtends: ['js-base'],
+    });
+  });
+
   it('reports a bare package name as unresolved when the exports map has no "." entry', () => {
     installPackage('@scoped/base', {
       'package.json': { name: '@scoped/base', exports: { './tsconfig.base.json': './tsconfig.base.json' } },

--- a/packages/readyup/__tests__/helpers/tempDir.ts
+++ b/packages/readyup/__tests__/helpers/tempDir.ts
@@ -104,7 +104,7 @@ function createTempDir(prefix: string): TempDir {
   function symlinkDir(relativePath: string, relativeTarget: string): string {
     const absolutePath = path.join(dir, relativePath);
     mkdirSync(path.dirname(absolutePath), { recursive: true });
-    // `junction` is ignored off Windows, where it links a directory without the elevation a symlink needs.
+    // On Windows a junction links a directory without the elevation a symlink needs; other platforms ignore the type.
     symlinkSync(path.join(dir, relativeTarget), absolutePath, 'junction');
     return absolutePath;
   }

--- a/packages/readyup/__tests__/helpers/tempDir.ts
+++ b/packages/readyup/__tests__/helpers/tempDir.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -10,6 +10,8 @@ export interface TempDir {
   readonly dir: string;
   /** Creates a directory-relative directory and its parents, and returns the absolute path. */
   mkdir(relativePath: string): string;
+  /** Links a directory-relative path to a directory-relative target, creating parents, and returns the link path. */
+  symlinkDir(relativePath: string, relativeTarget: string): string;
   /** Writes `contents` at a directory-relative path, creating parents, and returns the absolute path. */
   write(relativePath: string, contents: string | Uint8Array): string;
   /** Writes `value` as JSON at a directory-relative path, creating parents, and returns the absolute path. */
@@ -76,6 +78,7 @@ export function useTempDir(options: TempDirOptions): TempDir {
       return requireCurrent().dir;
     },
     mkdir: (relativePath) => requireCurrent().mkdir(relativePath),
+    symlinkDir: (relativePath, relativeTarget) => requireCurrent().symlinkDir(relativePath, relativeTarget),
     write: (relativePath, contents) => requireCurrent().write(relativePath, contents),
     writeJson: (relativePath, value) => requireCurrent().writeJson(relativePath, value),
   };
@@ -98,6 +101,14 @@ function createTempDir(prefix: string): TempDir {
     return absolutePath;
   }
 
+  function symlinkDir(relativePath: string, relativeTarget: string): string {
+    const absolutePath = path.join(dir, relativePath);
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    // `junction` is ignored off Windows, where it links a directory without the elevation a symlink needs.
+    symlinkSync(path.join(dir, relativeTarget), absolutePath, 'junction');
+    return absolutePath;
+  }
+
   function write(relativePath: string, contents: string | Uint8Array): string {
     const absolutePath = path.join(dir, relativePath);
     mkdirSync(path.dirname(absolutePath), { recursive: true });
@@ -109,7 +120,7 @@ function createTempDir(prefix: string): TempDir {
     return write(relativePath, JSON.stringify(value));
   }
 
-  return { dir, mkdir, write, writeJson };
+  return { dir, mkdir, symlinkDir, write, writeJson };
 }
 
 /** Points the code under test at `dir`, returning the undo. */

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -150,8 +150,8 @@ function resolveThroughNodeResolver(specifier: string, configDir: string): strin
 }
 
 /**
- * Resolves a bare package name to the config the package declares, as TypeScript does: the `"."` entry of an
- * `exports` map, else the manifest's `tsconfig` field, else `tsconfig.json` in the package root.
+ * Resolves a bare package name to the config the package declares, as TypeScript does: the `"."` entry of a
+ * non-null `exports` map, else the manifest's `tsconfig` field, else `tsconfig.json` in the package root.
  *
  * Reaching the last two takes readyup's own walk, because `exports` exists to hide the directory they address.
  */
@@ -161,8 +161,11 @@ function resolvePackageDefaultConfig(packageName: string, configDir: string): st
 
   const manifest = readJsonFile(resolve(packageRoot, 'package.json'));
   if (manifest === undefined) return undefined;
-  // An `exports` map is exhaustive, so it answers for the package or nothing does.
-  if ('exports' in manifest) return resolveThroughNodeResolver(packageName, configDir);
+  // An `exports` map is exhaustive, so it answers for the package or nothing does. A null map has no
+  // entries to answer with, and TypeScript reads it as no map at all.
+  if ('exports' in manifest && manifest.exports !== null) {
+    return resolveThroughNodeResolver(packageName, configDir);
+  }
 
   const declared = manifest.tsconfig;
   return resolvePathSpecifier(typeof declared === 'string' ? declared : './tsconfig.json', packageRoot);

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -15,7 +15,7 @@ export interface TsconfigLanguageLevel {
   target: string | undefined;
   /** Config paths visited, entry file first, cwd-relative. */
   chain: string[];
-  /** `extends` references resolution could not follow: uninstalled packages, missing files, malformed configs. */
+  /** `extends` references resolution could not follow: specifiers that do not resolve, configs that do not parse. */
   unresolvedExtends: string[];
 }
 
@@ -116,14 +116,9 @@ function resolvePathSpecifier(specifier: string, baseDir: string): string | unde
   return undefined;
 }
 
-/**
- * Resolves a package specifier, which names either a subpath into a package or the package alone.
- *
- * The two forms take different instruments because `exports` governs a subpath but hides the package
- * directory a bare name has to reach.
- */
+/** Resolves a package specifier, which names either a subpath into a package or the package alone. */
 function resolvePackageSpecifier(specifier: string, configDir: string): string | undefined {
-  if (hasSubpath(specifier)) return resolvePackageSubpath(specifier, configDir);
+  if (hasSubpath(specifier)) return resolveThroughNodeResolver(specifier, configDir);
   return resolvePackageDefaultConfig(specifier, configDir);
 }
 
@@ -134,13 +129,13 @@ function hasSubpath(specifier: string): boolean {
 }
 
 /**
- * Resolves a package subpath through Node's resolver anchored at the extending config, so `exports`
- * governs which subpaths are reachable and a pnpm symlink answers with the directory the package occupies.
+ * Resolves a package specifier through Node's resolver anchored at the extending config, so `exports`
+ * governs what is reachable and a pnpm symlink answers with the directory the package occupies.
  *
  * Resolution runs under the `require` condition, which is the condition TypeScript resolves `extends`
- * under, so a subpath this reaches is a subpath `tsc` reaches.
+ * under, so a specifier this reaches is a specifier `tsc` reaches.
  */
-function resolvePackageSubpath(specifier: string, configDir: string): string | undefined {
+function resolveThroughNodeResolver(specifier: string, configDir: string): string | undefined {
   let resolved: string;
   try {
     // The anchor names a file that need not exist; only its directory takes part in resolution.
@@ -153,17 +148,19 @@ function resolvePackageSubpath(specifier: string, configDir: string): string | u
 }
 
 /**
- * Resolves a bare package name to the config the package declares, as TypeScript does: its `tsconfig`
- * field, else `tsconfig.json` in its root.
+ * Resolves a bare package name to the config the package declares, as TypeScript does: the `"."` entry of an
+ * `exports` map, else the manifest's `tsconfig` field, else `tsconfig.json` in the package root.
  *
- * A package declaring `exports` declines the form, because the map is exhaustive and names no default config.
+ * Reaching the last two takes readyup's own walk, because `exports` exists to hide the directory they address.
  */
 function resolvePackageDefaultConfig(packageName: string, configDir: string): string | undefined {
   const packageRoot = resolvePackageRoot(packageName, configDir);
   if (packageRoot === undefined) return undefined;
 
   const manifest = readJsonFile(resolve(packageRoot, 'package.json'));
-  if (manifest === undefined || 'exports' in manifest) return undefined;
+  if (manifest === undefined) return undefined;
+  // An `exports` map is exhaustive, so it answers for the package or nothing does.
+  if ('exports' in manifest) return resolveThroughNodeResolver(packageName, configDir);
 
   const declared = manifest.tsconfig;
   return resolvePathSpecifier(typeof declared === 'string' ? declared : './tsconfig.json', packageRoot);

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -144,7 +144,9 @@ function resolveThroughNodeResolver(specifier: string, configDir: string): strin
     return undefined;
   }
   // A core module such as `"fs/promises"` answers with its own name rather than with a path.
-  return isAbsolute(resolved) ? resolved : undefined;
+  if (!isAbsolute(resolved)) return undefined;
+  // TypeScript resolves `extends` under a JSON-only extension set, so a package's entry point is not a config.
+  return resolved.endsWith('.json') ? resolved : undefined;
 }
 
 /**

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -1,9 +1,11 @@
 import { readFileSync, statSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
 
 import { parse as parseJsonc } from 'jsonc-parser';
 
 import { isRecord } from '../isRecord.ts';
+import { resolvePackageRoot } from '../resolvePackageRoot.ts';
 
 /** Effective language-level settings of a tsconfig, resolved through its `extends` chain. */
 export interface TsconfigLanguageLevel {
@@ -13,7 +15,7 @@ export interface TsconfigLanguageLevel {
   target: string | undefined;
   /** Config paths visited, entry file first, cwd-relative. */
   chain: string[];
-  /** `extends` references resolution could not follow: bare specifiers, missing files, malformed configs. */
+  /** `extends` references resolution could not follow: uninstalled packages, missing files, malformed configs. */
   unresolvedExtends: string[];
 }
 
@@ -28,14 +30,14 @@ interface Resolution {
 }
 
 /**
- * Reads a tsconfig's effective `lib` and `target`, resolving relative and array-form `extends`.
+ * Reads a tsconfig's effective `lib` and `target`, resolving `extends` as TypeScript does.
  * Returns undefined if the entry file is missing or unparseable; unresolvable parents are reported
  * in `unresolvedExtends` rather than treated as failures.
  */
 export function readTsconfigLanguageLevel(relativePath: string): TsconfigLanguageLevel | undefined {
   const cwd = process.cwd();
   const entryPath = resolve(cwd, relativePath);
-  const entryConfig = readTsconfigFile(entryPath);
+  const entryConfig = readJsonFile(entryPath);
   if (entryConfig === undefined) return undefined;
 
   const resolution: Resolution = {
@@ -84,7 +86,7 @@ function visitParent(specifier: string, configPath: string, resolution: Resoluti
   if (resolution.visited.has(parentPath)) return;
   resolution.visited.add(parentPath);
 
-  const parentConfig = readTsconfigFile(parentPath);
+  const parentConfig = readJsonFile(parentPath);
   if (parentConfig === undefined) {
     resolution.unresolvedExtends.push(specifier);
     return;
@@ -94,20 +96,81 @@ function visitParent(specifier: string, configPath: string, resolution: Resoluti
 }
 
 /**
- * Resolves a relative `extends` specifier against the extending config's directory, retrying with a
- * `.json` suffix as TypeScript does for `"./base"`. Bare package specifiers are not followed.
+ * Resolves an `extends` specifier as TypeScript does: a path specifier against the extending config's
+ * directory, and a package specifier through Node's resolver anchored there.
  */
 function resolveExtendsPath(specifier: string, configDir: string): string | undefined {
-  if (!specifier.startsWith('.') && !isAbsolute(specifier)) return undefined;
-  const candidate = resolve(configDir, specifier);
+  if (specifier.startsWith('.') || isAbsolute(specifier)) return resolvePathSpecifier(specifier, configDir);
+  return resolvePackageSpecifier(specifier, configDir);
+}
+
+/**
+ * Resolves a relative or absolute specifier against `baseDir`, retrying with a `.json` suffix as
+ * TypeScript does for `"./base"`.
+ */
+function resolvePathSpecifier(specifier: string, baseDir: string): string | undefined {
+  const candidate = resolve(baseDir, specifier);
   if (isFile(candidate)) return candidate;
   const withJsonSuffix = `${candidate}.json`;
   if (isFile(withJsonSuffix)) return withJsonSuffix;
   return undefined;
 }
 
-/** Reads and JSONC-parses a tsconfig. Returns undefined when the file is unreadable or is not an object. */
-function readTsconfigFile(absolutePath: string): Record<string, unknown> | undefined {
+/**
+ * Resolves a package specifier, which names either a subpath into a package or the package alone.
+ *
+ * The two forms take different instruments because `exports` governs a subpath but hides the package
+ * directory a bare name has to reach.
+ */
+function resolvePackageSpecifier(specifier: string, configDir: string): string | undefined {
+  if (hasSubpath(specifier)) return resolvePackageSubpath(specifier, configDir);
+  return resolvePackageDefaultConfig(specifier, configDir);
+}
+
+/** Reports whether a package specifier names a subpath, which a scoped name reaches only at its third segment. */
+function hasSubpath(specifier: string): boolean {
+  const segmentCount = specifier.split('/').length;
+  return segmentCount > (specifier.startsWith('@') ? 2 : 1);
+}
+
+/**
+ * Resolves a package subpath through Node's resolver anchored at the extending config, so `exports`
+ * governs which subpaths are reachable and a pnpm symlink answers with the directory the package occupies.
+ *
+ * Resolution runs under the `require` condition, which is the condition TypeScript resolves `extends`
+ * under, so a subpath this reaches is a subpath `tsc` reaches.
+ */
+function resolvePackageSubpath(specifier: string, configDir: string): string | undefined {
+  let resolved: string;
+  try {
+    // The anchor names a file that need not exist; only its directory takes part in resolution.
+    resolved = createRequire(resolve(configDir, 'tsconfig.json')).resolve(specifier);
+  } catch {
+    return undefined;
+  }
+  // A core module such as `"fs/promises"` answers with its own name rather than with a path.
+  return isAbsolute(resolved) ? resolved : undefined;
+}
+
+/**
+ * Resolves a bare package name to the config the package declares, as TypeScript does: its `tsconfig`
+ * field, else `tsconfig.json` in its root.
+ *
+ * A package declaring `exports` declines the form, because the map is exhaustive and names no default config.
+ */
+function resolvePackageDefaultConfig(packageName: string, configDir: string): string | undefined {
+  const packageRoot = resolvePackageRoot(packageName, configDir);
+  if (packageRoot === undefined) return undefined;
+
+  const manifest = readJsonFile(resolve(packageRoot, 'package.json'));
+  if (manifest === undefined || 'exports' in manifest) return undefined;
+
+  const declared = manifest.tsconfig;
+  return resolvePathSpecifier(typeof declared === 'string' ? declared : './tsconfig.json', packageRoot);
+}
+
+/** Reads and JSONC-parses a JSON file. Returns undefined when the file is unreadable or is not an object. */
+function readJsonFile(absolutePath: string): Record<string, unknown> | undefined {
   if (!isFile(absolutePath)) return undefined;
   let content: string;
   try {


### PR DESCRIPTION
## What

A check that asserts a project's effective TypeScript language level now gets an answer when the project inherits that level from a base config installed as a package, not only from a config file within the project itself. Such a project previously reported no language level at all, indistinguishable from one that declares none. A base config that still cannot be reached is reported as unresolved rather than as an absent setting.

## Why

Sharing a base config across repositories is the point of publishing one, and until now it cost every consuming project its readable language level. A kit could assert a target for a project holding its own tsconfig, and got nothing for the same project once that tsconfig inherited from a package -- the shape the shared base config exists to encourage, and the shape every repository migrating to it takes. The gap widened with each migration.

## Details

### 🎉 Features

- `readTsconfigLanguageLevel` resolves `extends` the way TypeScript does, so its specification is TypeScript's rules rather than a documented subset. A specifier naming a subpath resolves through the package's `exports` map; a bare package name resolves to the config the package declares, through the map's `"."` entry, else the manifest's `tsconfig` field, else `tsconfig.json` in the package root.
- Resolution holds under pnpm's symlinked `node_modules`, including a base config that itself inherits from a second installed package. A resolved config contributes the directory it occupies to `chain`, not the link that reached it.
- A specifier that resolves to something other than a JSON config -- a package's JavaScript entry point, a Node core module, an uninstalled package -- is reported in `unresolvedExtends` rather than contributing an empty config, so an incomplete answer stays distinguishable from an undeclared setting.

### 🧪 Tests

- Fifteen cases across the package-specifier branches, covering each way a specifier resolves and each way it declines, built from hand-written `node_modules` fixtures so the suite needs no install step and stays in the `unit` tier.
- `TempDir` gains `symlinkDir`, letting a suite build the pnpm-style layout the symlink cases need.
- Resolution was compared against `tsc@6.0.3` across eleven `extends` shapes, including a `"."` entry outranking the manifest's `tsconfig` field, a null `exports` map, a package entry point that is not a config, and an extensionless subpath. It agrees on all eleven.


Closes #264
