### PR TITLE
#263 Migrate to the shared tsconfig

### DIFF
--- a/.agents/PROJECT.md
+++ b/.agents/PROJECT.md
@@ -18,6 +18,7 @@ Key files:
 - `.config/readyup.config.ts` — Readyup compile settings
 - `.readyup/kits/` — Kit files (TypeScript sources compiled to self-contained ESM bundles)
 - `packages/readyup/vitest.config.ts` — Retained per-package config; pins `RDY_STYLE=rich` so rendering assertions never depend on TTY detection
+- `tsconfig.json` — Extends `@williamthorsen/tsconfig`; declares only the `paths`, `types`, and `include` the shared base leaves to the consumer
 - `vitest.config.ts` — Vitest projects for packages, built on `@williamthorsen/nmr/vitest`
 - `vitest.root.config.ts` — Vitest projects for root-level tests, which exclude every workspace package
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@williamthorsen/nmr": "0.27.0",
     "@williamthorsen/release-kit": "10.2.2",
     "@williamthorsen/strict-lint": "9.4.0",
+    "@williamthorsen/tsconfig": "0.3.0",
     "codeassembly": "0.6.0",
     "esbuild": "0.28.1",
     "eslint": "10.8.0",

--- a/packages/readyup/.readyup/kits/checks/describeFilesCoverage.ts
+++ b/packages/readyup/.readyup/kits/checks/describeFilesCoverage.ts
@@ -16,7 +16,7 @@ export function describeFilesCoverage(): CheckOutcome {
   const packageJson = readPackageJson();
   if (packageJson === undefined) return { ok: false, detail: 'package.json is missing or unreadable' };
 
-  const files = packageJson.files;
+  const files = packageJson['files'];
   if (files === undefined) return { ok: true, detail: 'no "files" allowlist, so everything ships' };
   if (!Array.isArray(files)) return { ok: false, detail: '"files" is not an array' };
 

--- a/packages/readyup/.readyup/kits/checks/kit-layout.ts
+++ b/packages/readyup/.readyup/kits/checks/kit-layout.ts
@@ -52,7 +52,7 @@ export function readManifestEntries(): ManifestEntry[] {
   const manifest = readJsonFile(DEFAULT_MANIFEST_PATH);
   if (manifest === undefined) return [];
 
-  const kits = manifest.kits;
+  const kits = manifest['kits'];
   if (!Array.isArray(kits)) return [];
 
   return kits.filter(isRecord).map(toManifestEntry);
@@ -73,11 +73,11 @@ function asString(value: unknown): string | undefined {
 /** Projects a raw manifest kit record onto the fields these kits read. */
 function toManifestEntry(kit: Record<string, unknown>): ManifestEntry {
   return {
-    name: asString(kit.name) ?? '(unnamed)',
-    path: asString(kit.path),
-    source: asString(kit.source),
-    sourceHash: asString(kit.sourceHash),
-    targetHash: asString(kit.targetHash),
+    name: asString(kit['name']) ?? '(unnamed)',
+    path: asString(kit['path']),
+    source: asString(kit['source']),
+    sourceHash: asString(kit['sourceHash']),
+    targetHash: asString(kit['targetHash']),
   };
 }
 

--- a/packages/readyup/__tests__/cli.unit.test.ts
+++ b/packages/readyup/__tests__/cli.unit.test.ts
@@ -855,7 +855,7 @@ describe(resolveKitSources, () => {
   // -- --from global --
 
   it('resolves --from global to home directory', () => {
-    const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? '~';
+    const homeDir = process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
 
     expect(resolve({ fromValue: 'global' })).toStrictEqual([
       {

--- a/packages/readyup/__tests__/compile/pickJsonPlugin.tool.test.ts
+++ b/packages/readyup/__tests__/compile/pickJsonPlugin.tool.test.ts
@@ -39,6 +39,6 @@ describe('pickJsonPlugin compile pipeline', () => {
   it('produces valid ESM that exports the expected values', async () => {
     const mod: unknown = await import(outputPath);
     assert.ok(isRecord(mod));
-    expect(mod.metadata).toStrictEqual({ name: 'test-kit', version: '1.0.0' });
+    expect(mod['metadata']).toStrictEqual({ name: 'test-kit', version: '1.0.0' });
   });
 });

--- a/packages/readyup/__tests__/layout/layoutEngine.unit.test.ts
+++ b/packages/readyup/__tests__/layout/layoutEngine.unit.test.ts
@@ -441,11 +441,12 @@ function measureNameColumn(line: string): number {
   const match = /^(?<indent> *)(?<glyph>\P{White_Space})(?<pad> +)/u.exec(line);
   const groups = match?.groups;
   if (groups === undefined) throw new Error(`Not a token-led line: ${JSON.stringify(line)}`);
+  const { glyph, indent, pad } = groups;
 
-  const token = Object.values(richFormatter.tokens).find((entry) => entry.glyph === groups.glyph);
-  if (token === undefined) throw new Error(`Unknown glyph: ${JSON.stringify(groups.glyph)}`);
+  const token = Object.values(richFormatter.tokens).find((entry) => entry.glyph === glyph);
+  if (token === undefined) throw new Error(`Unknown glyph: ${JSON.stringify(glyph)}`);
 
-  return (groups.indent?.length ?? 0) + token.width + (groups.pad?.length ?? 0);
+  return (indent?.length ?? 0) + token.width + (pad?.length ?? 0);
 }
 
 /** Returns a line's count of leading spaces, one per column. */

--- a/packages/readyup/__tests__/layout/plainFormatter.unit.test.ts
+++ b/packages/readyup/__tests__/layout/plainFormatter.unit.test.ts
@@ -137,8 +137,9 @@ function measureNameColumn(line: string): number {
   const match = /^(?<indent> *)(?<word>[A-Z]*)(?<pad> +)/u.exec(line);
   const groups = match?.groups;
   if (groups === undefined) throw new Error(`Not a token-led line: ${JSON.stringify(line)}`);
+  const { indent, pad, word } = groups;
 
-  return (groups.indent?.length ?? 0) + (groups.word?.length ?? 0) + (groups.pad?.length ?? 0);
+  return (indent?.length ?? 0) + (word?.length ?? 0) + (pad?.length ?? 0);
 }
 
 /** Returns a line's count of leading spaces, one per column. */

--- a/packages/readyup/__tests__/schemas/generateSchemas.unit.test.ts
+++ b/packages/readyup/__tests__/schemas/generateSchemas.unit.test.ts
@@ -20,29 +20,6 @@ import {
 
 const documents = new Map(buildSchemaDocuments().map(({ fileName, document }) => [fileName, document]));
 
-/** Look up a generated document by file name, failing loudly rather than returning undefined. */
-function documentFor(fileName: string): Record<string, unknown> {
-  const document = documents.get(fileName);
-  if (document === undefined) throw new Error(`No generated schema named ${fileName}`);
-  return document;
-}
-
-/** Read a nested object property, failing when the path does not lead to an object. */
-function objectAt(root: Record<string, unknown>, ...keys: string[]): Record<string, unknown> {
-  let current: unknown = root;
-  for (const key of keys) {
-    if (!isRecord(current)) throw new TypeError(`Expected an object at ${keys.join('.')}`);
-    current = current[key];
-  }
-  if (!isRecord(current)) throw new TypeError(`Expected an object at ${keys.join('.')}`);
-  return current;
-}
-
-/** Compile a generated document into a validator. */
-function validatorFor(fileName: string): ValidateFunction {
-  return new Ajv2020({ strict: true }).compile(documentFor(fileName));
-}
-
 describe('generated JSON Schemas', () => {
   it('emits one document per published payload', () => {
     expect(documents.keys().toArray()).toStrictEqual([
@@ -56,13 +33,13 @@ describe('generated JSON Schemas', () => {
 
   it('gives each document an $id matching its published location', () => {
     for (const [fileName, document] of documents) {
-      expect(document.$id).toBe(`${SCHEMA_BASE_URL}/${fileName}`);
+      expect(document).toMatchObject({ $id: `${SCHEMA_BASE_URL}/${fileName}` });
     }
   });
 
   it('declares the draft each document is written against', () => {
     for (const document of documents.values()) {
-      expect(document.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+      expect(document).toMatchObject({ $schema: 'https://json-schema.org/draft/2020-12/schema' });
     }
   });
 
@@ -70,7 +47,7 @@ describe('generated JSON Schemas', () => {
     const report = documentFor('report.v1.json');
 
     it('requires exactly the fields every report carries', () => {
-      expect(report.required).toStrictEqual([
+      expect(valueAt(report, 'required')).toStrictEqual([
         'schemaVersion',
         'readyupVersion',
         'passed',
@@ -82,21 +59,19 @@ describe('generated JSON Schemas', () => {
     });
 
     it('requires the effective thresholds on a kit that ran, where the top level leaves them optional', () => {
-      expect(objectAt(report, '$defs', 'KitResultEntry').required).toContain('failOn');
-      expect(objectAt(report, '$defs', 'KitResultEntry').required).toContain('reportOn');
+      expect(valueAt(report, '$defs', 'KitResultEntry', 'required')).toContain('failOn');
+      expect(valueAt(report, '$defs', 'KitResultEntry', 'required')).toContain('reportOn');
     });
 
     it('publishes the warning vocabulary as an open set that still names its known codes', () => {
-      const warningCode = objectAt(report, '$defs', 'WarningCode');
-
-      expect(warningCode.anyOf).toStrictEqual([
+      expect(valueAt(report, '$defs', 'WarningCode', 'anyOf')).toStrictEqual([
         { type: 'string', enum: ['source-stale', 'target-drift', 'version-skew'] },
         { type: 'string' },
       ]);
     });
 
     it('requires all six buckets of the counts object', () => {
-      expect(objectAt(report, '$defs', 'Counts').required).toStrictEqual([
+      expect(valueAt(report, '$defs', 'Counts', 'required')).toStrictEqual([
         'passed',
         'errors',
         'warnings',
@@ -107,11 +82,13 @@ describe('generated JSON Schemas', () => {
     });
 
     it('expresses the check tree as a self-reference rather than a fixed depth', () => {
-      expect(objectAt(report, '$defs', 'CheckEntry', 'properties', 'checks', 'items').$ref).toBe('#/$defs/CheckEntry');
+      expect(valueAt(report, '$defs', 'CheckEntry', 'properties', 'checks', 'items', '$ref')).toBe(
+        '#/$defs/CheckEntry',
+      );
     });
 
     it('offers both kit-entry shapes as alternatives', () => {
-      expect(objectAt(report, '$defs', 'KitEntry').anyOf).toStrictEqual([
+      expect(valueAt(report, '$defs', 'KitEntry', 'anyOf')).toStrictEqual([
         { $ref: '#/$defs/KitErrorEntry' },
         { $ref: '#/$defs/KitResultEntry' },
       ]);
@@ -128,7 +105,7 @@ describe('generated JSON Schemas', () => {
 
     it('publishes the hint as an optional field, which is what keeps the version at 1', () => {
       expect(objectAt(envelope, '$defs', 'ErrorBody', 'properties', 'hint')).toStrictEqual({ type: 'string' });
-      expect(objectAt(envelope, '$defs', 'ErrorBody').required).toStrictEqual(['code', 'message']);
+      expect(valueAt(envelope, '$defs', 'ErrorBody', 'required')).toStrictEqual(['code', 'message']);
     });
   });
 
@@ -185,3 +162,36 @@ describe('generated JSON Schemas', () => {
     });
   });
 });
+
+// region | Helpers
+
+/** Looks up a generated document by file name, failing loudly rather than returning undefined. */
+function documentFor(fileName: string): Record<string, unknown> {
+  const document = documents.get(fileName);
+  if (document === undefined) throw new Error(`No generated schema named ${fileName}`);
+  return document;
+}
+
+/** Reads a nested object property, failing when the path does not lead to an object. */
+function objectAt(root: Record<string, unknown>, ...keys: string[]): Record<string, unknown> {
+  const value = valueAt(root, ...keys);
+  if (!isRecord(value)) throw new TypeError(`Expected an object at ${keys.join('.')}`);
+  return value;
+}
+
+/** Compiles a generated document into a validator. */
+function validatorFor(fileName: string): ValidateFunction {
+  return new Ajv2020({ strict: true }).compile(documentFor(fileName));
+}
+
+/** Reads a nested value, failing when the path runs through anything but an object. */
+function valueAt(root: Record<string, unknown>, ...keys: string[]): unknown {
+  let current: unknown = root;
+  for (const key of keys) {
+    if (!isRecord(current)) throw new TypeError(`Expected an object at ${keys.join('.')}`);
+    current = current[key];
+  }
+  return current;
+}
+
+// endregion | Helpers

--- a/packages/readyup/__tests__/sideEffectFreeSrc.unit.test.ts
+++ b/packages/readyup/__tests__/sideEffectFreeSrc.unit.test.ts
@@ -106,7 +106,7 @@ function findTopLevelSideEffects(absolutePath: string): Offender[] {
 
 function extractSideEffectsArray(parsed: unknown): Set<string> {
   if (!isRecord(parsed)) return new Set();
-  const value = parsed.sideEffects;
+  const value = parsed['sideEffects'];
   if (!Array.isArray(value)) return new Set();
   return new Set(value.filter((entry): entry is string => typeof entry === 'string'));
 }

--- a/packages/readyup/__tests__/utils/describe-value.unit.test.ts
+++ b/packages/readyup/__tests__/utils/describe-value.unit.test.ts
@@ -59,7 +59,7 @@ describe(previewValue, () => {
 
   it('falls back to the type name for a value with no JSON rendering', () => {
     const circular: Record<string, unknown> = {};
-    circular.self = circular;
+    circular['self'] = circular;
 
     expect(previewValue(circular)).toBe('object');
   });

--- a/packages/readyup/src/check-utils/engines.ts
+++ b/packages/readyup/src/check-utils/engines.ts
@@ -21,9 +21,9 @@ const COMPARABLE_VERSION = /^\d+(?:\.\d+)*$/;
  * Ranges outside the simple floor forms are reported as unparseable rather than guessed at.
  */
 export function readEnginesNodeFloor(manifest: Record<string, unknown>): EnginesNodeFloor {
-  const engines = manifest.engines;
+  const engines = manifest['engines'];
   if (!isRecord(engines)) return { kind: 'absent' };
-  const raw = engines.node;
+  const raw = engines['node'];
   if (typeof raw !== 'string') return { kind: 'absent' };
 
   const floor = SIMPLE_FLOOR.exec(raw.trim())?.[1];

--- a/packages/readyup/src/check-utils/package-json.ts
+++ b/packages/readyup/src/check-utils/package-json.ts
@@ -16,7 +16,7 @@ export function hasPackageJsonField(field: string, expectedValue?: string): bool
 export function hasDevDependency(name: string): boolean {
   const pkg = readJsonFile('package.json');
   if (pkg === undefined) return false;
-  const devDeps = pkg.devDependencies;
+  const devDeps = pkg['devDependencies'];
   return isRecord(devDeps) && Object.hasOwn(devDeps, name);
 }
 
@@ -28,7 +28,7 @@ export function hasMinDevDependencyVersion(
 ): boolean {
   const pkg = readJsonFile('package.json');
   if (pkg === undefined) return false;
-  const devDeps = pkg.devDependencies;
+  const devDeps = pkg['devDependencies'];
   if (!isRecord(devDeps) || !Object.hasOwn(devDeps, name)) return false;
   const range = devDeps[name];
   if (typeof range !== 'string') return false;

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -62,15 +62,16 @@ export function readTsconfigLanguageLevel(relativePath: string): TsconfigLanguag
  * `extends` entry overrides an earlier one.
  */
 function applyConfig(config: Record<string, unknown>, configPath: string, resolution: Resolution): void {
-  const compilerOptions = isRecord(config.compilerOptions) ? config.compilerOptions : {};
+  const compilerOptions = isRecord(config['compilerOptions']) ? config['compilerOptions'] : {};
   if (resolution.lib === undefined) {
-    resolution.lib = readLib(compilerOptions.lib);
+    resolution.lib = readLib(compilerOptions['lib']);
   }
   if (resolution.target === undefined) {
-    resolution.target = readTarget(compilerOptions.target);
+    resolution.target = readTarget(compilerOptions['target']);
   }
 
-  for (const specifier of readExtends(config.extends).toReversed()) {
+  const parentSpecifiers = readExtends(config['extends']).toReversed();
+  for (const specifier of parentSpecifiers) {
     visitParent(specifier, configPath, resolution);
   }
 }
@@ -163,11 +164,11 @@ function resolvePackageDefaultConfig(packageName: string, configDir: string): st
   if (manifest === undefined) return undefined;
   // An `exports` map is exhaustive, so it answers for the package or nothing does. A null map has no
   // entries to answer with, and TypeScript reads it as no map at all.
-  if ('exports' in manifest && manifest.exports !== null) {
+  if ('exports' in manifest && manifest['exports'] !== null) {
     return resolveThroughNodeResolver(packageName, configDir);
   }
 
-  const declared = manifest.tsconfig;
+  const declared = manifest['tsconfig'];
   return resolvePathSpecifier(typeof declared === 'string' ? declared : './tsconfig.json', packageRoot);
 }
 

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -105,7 +105,7 @@ function resolveWorkspacePatterns(cwd: string): { patterns: string[]; source: Wo
 
   const rootPackageJson = readJsonFile('package.json');
   if (rootPackageJson !== undefined) {
-    const workspaces = rootPackageJson.workspaces;
+    const workspaces = rootPackageJson['workspaces'];
     const npmPatterns = extractNpmWorkspacePatterns(workspaces);
     if (npmPatterns !== null) {
       return { patterns: npmPatterns, source: 'package.json' };
@@ -123,7 +123,7 @@ function extractNpmWorkspacePatterns(workspaces: unknown): string[] | null {
     return strings;
   }
   if (isRecord(workspaces)) {
-    const nested = workspaces.packages;
+    const nested = workspaces['packages'];
     if (Array.isArray(nested)) {
       const strings = nested.filter((entry): entry is string => typeof entry === 'string');
       if (strings.length !== nested.length) return null;
@@ -186,7 +186,7 @@ function walk(cwd: string, relDir: string, depth: number, visit: (relDir: string
   } catch (error) {
     // Skip directories we can't read for benign reasons (missing, permission-denied).
     // Rethrow systemic failures (e.g. EMFILE, EIO) so an incomplete walk isn't masked.
-    const code = isRecord(error) && typeof error.code === 'string' ? error.code : undefined;
+    const code = isRecord(error) && typeof error['code'] === 'string' ? error['code'] : undefined;
     if (code !== undefined && SKIPPABLE_READ_CODES.has(code)) return;
     throw error;
   }
@@ -216,9 +216,9 @@ function buildWorkspaceFromPackageJson(
   absolutePath: string,
   packageJson: Record<string, unknown>,
 ): Workspace {
-  const nameValue = packageJson.name;
+  const nameValue = packageJson['name'];
   const name = typeof nameValue === 'string' ? nameValue : undefined;
-  const isPackage = packageJson.private !== true;
+  const isPackage = packageJson['private'] !== true;
   return { dir: relDir, absolutePath, name, isPackage, packageJson };
 }
 

--- a/packages/readyup/src/compile/pickJsonPlugin.ts
+++ b/packages/readyup/src/compile/pickJsonPlugin.ts
@@ -43,8 +43,7 @@ function parsePickJsonArgs(argsText: string): { relativePath: string; paths: Arr
   }
 
   assert.ok(match.groups);
-  const relativePath = match.groups.relPath;
-  const rest = match.groups.rest;
+  const { relPath: relativePath, rest } = match.groups;
   assert.ok(relativePath !== undefined);
   assert.ok(rest !== undefined);
 

--- a/packages/readyup/src/config.ts
+++ b/packages/readyup/src/config.ts
@@ -94,6 +94,6 @@ function listAvailableKits(dir: string, extension: string): string[] {
 
 /** Narrow `__readyupVersion` from an imported module namespace to a string, or undefined. */
 function readCompileTimeVersion(moduleRecord: Record<string, unknown>): string | undefined {
-  const value = moduleRecord.__readyupVersion;
+  const value = moduleRecord['__readyupVersion'];
   return typeof value === 'string' ? value : undefined;
 }

--- a/packages/readyup/src/kitsDir.ts
+++ b/packages/readyup/src/kitsDir.ts
@@ -13,5 +13,5 @@ export const KITS_DIR = `${READYUP_DIR}/kits`;
 
 /** Resolve the home directory the `global` kit source is rooted at, across platforms. */
 export function resolveHomeDir(): string {
-  return process.env.HOME ?? process.env.USERPROFILE ?? '~';
+  return process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
 }

--- a/packages/readyup/src/layout/resolveStyle.ts
+++ b/packages/readyup/src/layout/resolveStyle.ts
@@ -103,7 +103,7 @@ function readStyleFlag(argv: string[]): string | undefined {
  * it. An explicit `CI=false` is honored as a denial, which is how the wider ecosystem reads it.
  */
 function detectStyle(env: Environment, isTty: boolean): Style {
-  const ci = env.CI;
+  const ci = env['CI'];
   if (ci !== undefined && ci !== '' && ci !== 'false') return 'plain';
   return isTty ? 'rich' : 'plain';
 }

--- a/packages/readyup/src/loadConfig.ts
+++ b/packages/readyup/src/loadConfig.ts
@@ -76,7 +76,7 @@ export async function loadConfig(options: LoadConfigOptions = {}): Promise<Resol
   );
 
   // Support both default export and named exports
-  const raw = imported.default !== undefined && isRecord(imported.default) ? imported.default : imported;
+  const raw = imported['default'] !== undefined && isRecord(imported['default']) ? imported['default'] : imported;
 
   assertIsRdyConfig(raw);
 

--- a/packages/readyup/src/remote/__tests__/resolveBitbucketToken.unit.test.ts
+++ b/packages/readyup/src/remote/__tests__/resolveBitbucketToken.unit.test.ts
@@ -6,31 +6,31 @@ describe(resolveBitbucketToken, () => {
   let originalToken: string | undefined;
 
   beforeEach(() => {
-    originalToken = process.env.BITBUCKET_TOKEN;
+    originalToken = process.env['BITBUCKET_TOKEN'];
   });
 
   afterEach(() => {
     if (originalToken === undefined) {
-      delete process.env.BITBUCKET_TOKEN;
+      delete process.env['BITBUCKET_TOKEN'];
     } else {
-      process.env.BITBUCKET_TOKEN = originalToken;
+      process.env['BITBUCKET_TOKEN'] = originalToken;
     }
   });
 
   it('returns the env value when BITBUCKET_TOKEN is set and non-empty', () => {
-    process.env.BITBUCKET_TOKEN = 'bb-secret-123';
+    process.env['BITBUCKET_TOKEN'] = 'bb-secret-123';
 
     expect(resolveBitbucketToken()).toBe('bb-secret-123');
   });
 
   it('returns undefined when BITBUCKET_TOKEN is unset', () => {
-    delete process.env.BITBUCKET_TOKEN;
+    delete process.env['BITBUCKET_TOKEN'];
 
     expect(resolveBitbucketToken()).toBeUndefined();
   });
 
   it('returns undefined when BITBUCKET_TOKEN is the empty string', () => {
-    process.env.BITBUCKET_TOKEN = '';
+    process.env['BITBUCKET_TOKEN'] = '';
 
     expect(resolveBitbucketToken()).toBeUndefined();
   });

--- a/packages/readyup/src/remote/__tests__/resolveGitHubToken.unit.test.ts
+++ b/packages/readyup/src/remote/__tests__/resolveGitHubToken.unit.test.ts
@@ -9,33 +9,33 @@ vi.mock(import('node:child_process'), () => ({
 import { resolveGitHubToken } from '../resolveGitHubToken.ts';
 
 describe(resolveGitHubToken, () => {
-  const originalEnv = process.env.GITHUB_TOKEN;
+  const originalEnv = process.env['GITHUB_TOKEN'];
 
   afterEach(() => {
     if (originalEnv === undefined) {
-      delete process.env.GITHUB_TOKEN;
+      delete process.env['GITHUB_TOKEN'];
     } else {
-      process.env.GITHUB_TOKEN = originalEnv;
+      process.env['GITHUB_TOKEN'] = originalEnv;
     }
     mockExecFileSync.mockReset();
   });
 
   it('returns GITHUB_TOKEN env var when set', () => {
-    process.env.GITHUB_TOKEN = 'env-token-123';
+    process.env['GITHUB_TOKEN'] = 'env-token-123';
 
     expect(resolveGitHubToken()).toBe('env-token-123');
     expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 
   it('falls back to gh auth token output', () => {
-    delete process.env.GITHUB_TOKEN;
+    delete process.env['GITHUB_TOKEN'];
     mockExecFileSync.mockReturnValue('  gh-token-456\n');
 
     expect(resolveGitHubToken()).toBe('gh-token-456');
   });
 
   it('returns undefined when both sources fail', () => {
-    delete process.env.GITHUB_TOKEN;
+    delete process.env['GITHUB_TOKEN'];
     mockExecFileSync.mockImplementation(() => {
       throw new Error('gh not found');
     });
@@ -44,14 +44,14 @@ describe(resolveGitHubToken, () => {
   });
 
   it('returns undefined when gh returns empty output', () => {
-    delete process.env.GITHUB_TOKEN;
+    delete process.env['GITHUB_TOKEN'];
     mockExecFileSync.mockReturnValue('  \n');
 
     expect(resolveGitHubToken()).toBeUndefined();
   });
 
   it('skips empty GITHUB_TOKEN env var', () => {
-    process.env.GITHUB_TOKEN = '';
+    process.env['GITHUB_TOKEN'] = '';
     mockExecFileSync.mockReturnValue('gh-token-789\n');
 
     expect(resolveGitHubToken()).toBe('gh-token-789');

--- a/packages/readyup/src/remote/loadRemoteKit.ts
+++ b/packages/readyup/src/remote/loadRemoteKit.ts
@@ -55,7 +55,7 @@ export async function loadRemoteKit({ url, headers = {} }: LoadRemoteKitOptions)
     // but TypeScript types it as `any`; narrowing avoids unsafe-member-access lint errors.
     const moduleRecord = isRecord(imported) ? imported : {};
     // Read __readyupVersion from the raw namespace before resolveKitExports drops unknown fields.
-    const versionValue = moduleRecord.__readyupVersion;
+    const versionValue = moduleRecord['__readyupVersion'];
     const compileTimeVersion = typeof versionValue === 'string' ? versionValue : undefined;
     const resolved = resolveKitExports(moduleRecord);
     assertIsRdyKit(resolved, url);

--- a/packages/readyup/src/remote/resolveBitbucketToken.ts
+++ b/packages/readyup/src/remote/resolveBitbucketToken.ts
@@ -6,7 +6,7 @@
  * Returns `undefined` when the env var is unset or empty.
  */
 export function resolveBitbucketToken(): string | undefined {
-  const envToken = process.env.BITBUCKET_TOKEN;
+  const envToken = process.env['BITBUCKET_TOKEN'];
   if (envToken !== undefined && envToken !== '') {
     return envToken;
   }

--- a/packages/readyup/src/remote/resolveGitHubToken.ts
+++ b/packages/readyup/src/remote/resolveGitHubToken.ts
@@ -7,7 +7,7 @@ import { execFileSync } from 'node:child_process';
  * Returns `undefined` when neither source produces a token.
  */
 export function resolveGitHubToken(): string | undefined {
-  const envToken = process.env.GITHUB_TOKEN;
+  const envToken = process.env['GITHUB_TOKEN'];
   if (envToken !== undefined && envToken !== '') {
     return envToken;
   }

--- a/packages/readyup/src/resolveKitExports.ts
+++ b/packages/readyup/src/resolveKitExports.ts
@@ -10,21 +10,21 @@ import { isRecord } from './isRecord.ts';
  */
 export function resolveKitExports(moduleRecord: Record<string, unknown>): Record<string, unknown> {
   // Unwrap default export when present (e.g., `export default defineRdyKit({...})`)
-  const source = isRecord(moduleRecord.default) ? moduleRecord.default : moduleRecord;
+  const source = isRecord(moduleRecord['default']) ? moduleRecord['default'] : moduleRecord;
 
-  if (source.checklists === undefined) {
+  if (source['checklists'] === undefined) {
     throw new Error(
       'Kit file must export checklists (e.g., `export default defineRdyKit({ checklists: [...] })` or `export const checklists = [...]`)',
     );
   }
 
   return {
-    checklists: source.checklists,
-    ...(source.defaultSeverity !== undefined && { defaultSeverity: source.defaultSeverity }),
-    ...(source.description !== undefined && { description: source.description }),
-    ...(source.failOn !== undefined && { failOn: source.failOn }),
-    ...(source.fixLocation !== undefined && { fixLocation: source.fixLocation }),
-    ...(source.reportOn !== undefined && { reportOn: source.reportOn }),
-    ...(source.suites !== undefined && { suites: source.suites }),
+    checklists: source['checklists'],
+    ...(source['defaultSeverity'] !== undefined && { defaultSeverity: source['defaultSeverity'] }),
+    ...(source['description'] !== undefined && { description: source['description'] }),
+    ...(source['failOn'] !== undefined && { failOn: source['failOn'] }),
+    ...(source['fixLocation'] !== undefined && { fixLocation: source['fixLocation'] }),
+    ...(source['reportOn'] !== undefined && { reportOn: source['reportOn'] }),
+    ...(source['suites'] !== undefined && { suites: source['suites'] }),
   };
 }

--- a/packages/readyup/src/resolvePackageRoot.ts
+++ b/packages/readyup/src/resolvePackageRoot.ts
@@ -41,7 +41,7 @@ export function resolvePackageRoot(packageName: string, fromDir: string = proces
 export function readPackageVersion(packageRoot: string): string | undefined {
   try {
     const parsed: unknown = JSON.parse(readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
-    if (isRecord(parsed) && typeof parsed.version === 'string') return parsed.version;
+    if (isRecord(parsed) && typeof parsed['version'] === 'string') return parsed['version'];
   } catch {
     // A package whose manifest is unreadable is still a package; it simply goes unlabelled.
   }

--- a/packages/readyup/src/runRdy.ts
+++ b/packages/readyup/src/runRdy.ts
@@ -366,5 +366,5 @@ function assertRankedSeverity(severity: Severity, role: string): void {
  * treating it as one is how a broken check reports success.
  */
 function isCheckOutcome(raw: unknown): raw is CheckOutcome {
-  return isRecord(raw) && typeof raw.ok === 'boolean';
+  return isRecord(raw) && typeof raw['ok'] === 'boolean';
 }

--- a/packages/readyup/src/utils/install-command.ts
+++ b/packages/readyup/src/utils/install-command.ts
@@ -78,7 +78,7 @@ function readDeclaredManager(packageJsonPath: string): string | undefined {
     return undefined;
   }
 
-  const declared = isRecord(parsed) ? parsed.packageManager : undefined;
+  const declared = isRecord(parsed) ? parsed['packageManager'] : undefined;
   return typeof declared === 'string' ? /^[a-z]+/.exec(declared)?.[0] : undefined;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@williamthorsen/strict-lint':
         specifier: 9.4.0
         version: 9.4.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
+      '@williamthorsen/tsconfig':
+        specifier: 0.3.0
+        version: 0.3.0
       codeassembly:
         specifier: 0.6.0
         version: 0.6.0
@@ -791,6 +794,10 @@ packages:
   '@williamthorsen/toolbelt.filesystem@0.2.1':
     resolution: {integrity: sha512-vC+LkLEVBKaTcOsR6G8R0cGPnseX3IC3ZiWeYGuPcwOwypmWb8+CgG/a8P6fhaSU/aqXpszUFB41nTLsEeTyWw==}
     engines: {node: '>=24.0.0'}
+
+  '@williamthorsen/tsconfig@0.3.0':
+    resolution: {integrity: sha512-rajRi79is5CAvStqS9hXsq94RiCqwtBWZno35ZjqCIbIvGOhzIOcGmxI1n5yCJzP1wAETRoQnXtQQ2fdNbJ0UA==}
+    engines: {node: '>=24'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3195,6 +3202,8 @@ snapshots:
       eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
 
   '@williamthorsen/toolbelt.filesystem@0.2.1': {}
+
+  '@williamthorsen/tsconfig@0.3.0': {}
 
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,47 +1,17 @@
-// TSConfig for monorepo root
-// Adapted from https://blog.logrocket.com/setting-up-monorepo-with-lerna-typescript/
+// TSConfig for the monorepo root. Packages have their own tsconfig.json files that extend this one.
+// Every setting not declared here comes from the shared base.
 {
   "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@williamthorsen/tsconfig/tsconfig.base.json",
   "compilerOptions": {
-    "allowImportingTsExtensions": true,
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "declaration": true,
-    // Support importation of CJS modules in ESM.
-    "esModuleInterop": true,
-    // Report an error when the value `undefined` is given to an optional property that doesn't specify `undefined` as a valid value.
-    "exactOptionalPropertyTypes": true,
-    // Each file must transpile standalone.
-    "isolatedModules": true,
-    "lib": ["ES2025"], // Keep aligned with the `engines` floor: Node 24 → ES2025.
-    // Omitting this would default to `ES2022` with `Bundler` resolution, which is wrong for published Node packages.
-    "module": "NodeNext",
-    // Treat every file as a module, including those with no import or export.
-    "moduleDetection": "force",
-    "noEmit": true,
-    "noFallthroughCasesInSwitch": true,
-    // Force functions designed to override their parent class to be specified as `override`.
-    "noImplicitOverride": true,
-    // Force functions to specify that they can return `undefined` if a possible code path does not return a value.
-    "noImplicitReturns": true,
-    // Consider enabling this; see https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature
-    // "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    // TypeScript resolves `baseUrl`-less `paths` relative to the file that declares them, so the shared
+    // base cannot carry this: it would resolve inside node_modules.
     "paths": {
       "~/*": ["./*"],
     },
-    "removeComments": true,
-    // Don't typecheck libraries and declaration (.d.ts) files
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "target": "ES2025", // Keep aligned with the `engines` floor: Node 24 → ES2025.
     "types": ["node"],
   },
-  "exclude": ["node_modules"],
   "include": [
-    // This file covers only the monorepo root. Packages have their own tsconfig.json files that extend this one.
     ".config/**/*.ts",
     "__tests__/",
     "config/",


### PR DESCRIPTION
## What

Adopts `@williamthorsen/tsconfig` as the standard TypeScript configuration for this repo, replacing the previous hand-maintained copy. Reading a property through an index signature now requires bracket notation or a type that declares the property. Explicit resource management (`using` and `await using`) can now be used.

## Why

The root TypeScript config was a hand-copied baseline that had fallen behind the one it was copied
from, so this repo was quietly running a weaker standard than the repos it was meant to match, and
nobody would notice until someone compared the two by hand. Keeping a baseline in one published place
means the next tightening arrives here as a version bump instead of a manual reconciliation.

## Details

### ♻️ Refactoring

- Reads of index-signature properties -- parsed JSON, module namespaces, environment variables -- now
  use bracket notation across `readyup`. Only the access syntax changes; behavior is identical.
- Regex named groups are destructured at the match site rather than read by property. The new rule is
  a constraint on property-access syntax and does not reach destructuring patterns, so the reads stay
  direct instead of becoming bracket lookups.
- One `for...of` header moved to a named binding, which the added brackets had made too complex for
  the readability rule to accept.

### 🧪 Tests

- Assertions on generated JSON Schema documents read nested values through a helper rather than by
  property access. Assertions covering a whole value keep their exact-equality matcher; the two
  single-property checks use a partial-object matcher.
- Module-level test helpers moved below the test blocks into a helpers region.

### ⚙️ Tooling

- The root `tsconfig.json` extends `@williamthorsen/tsconfig`, which becomes a root devDependency.
  Only `paths`, `types`, and `include` stay declared locally, because a shared base cannot supply
  them: `baseUrl`-less `paths` resolve relative to the file that declares them, which for a published
  base is inside `node_modules`.
- `declaration` and `sourceMap` are dropped. Both were inert under the base's `noEmit`, since
  `nmr-compile` sets emit options programmatically.
- `exclude` is dropped. A declared `exclude` replaces TypeScript's default rather than extending it,
  and because `exclude` paths resolve relative to the config that declares them, the root's entry was
  only ever excluding the root's own `node_modules` on behalf of every package. The default is
  anchored per project.
- Inheriting the base activates `noPropertyAccessFromIndexSignature` and adds `ESNext.Disposable` to
  `lib`. The rule was satisfied rather than switched off, since switching it off would opt out of the
  base's only behavioral contribution to this repo.

### 🤖 Agentic support

- Project guidance lists the root TypeScript config among the repo's key files, naming the base it
  extends and the settings it still owns, so a reader does not mistake the short config for an
  incomplete one.


Closes #263
