### PR TITLE
#262 Report each kit's compile-time readyup version in JSON output

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -739,6 +739,7 @@ An error body may also carry `hint`, one action that would clear the failure:
   "kits": [
     {
       "name": "deploy",
+      "compiledWith": "0.21.0",
       "passed": false,
       "counts": {},
       "worstSeverity": "error",
@@ -755,6 +756,7 @@ An error body may also carry `hint`, one action that would clear the failure:
 - **`counts`** holds the six tallies at report, kit, and checklist level, nested so count names and verdict names share no namespace.
 - **`worstSeverity`** is derived verdict data, omitted when nothing failed.
 - **`failOn`** and **`reportOn`** appear at the top level only when the corresponding flag was passed, and on every kit that ran as the value that governed it. See [thresholds](#thresholds) for how each resolves.
+- **`compiledWith`** names the readyup that built a kit's bundle. It appears on every kit that ran whose bundle carries a compile-time stamp, including where that stamp matches the report's own `readyupVersion`, and is absent for a bundle compiled before the stamp existed or for a kit run from source under `--jit`. `rdy verify`'s [`rebuildCompiledWith`](#verifying-by-recompiling) reports the same value under a narrower rule, appearing only where it disagrees with the running readyup: that field explains a mismatch, this one records what ran.
 - **`warnings`** carries any advisory as `{ code, message, remedy? }`, absent when none was raised.
 
 Payloads are slim by construction: a field carrying nothing is omitted rather than emitted as `null`, empty `checks` arrays are dropped, and `fix` appears only on failed checks.

--- a/packages/readyup/__tests__/compiledWithReporting.unit.test.ts
+++ b/packages/readyup/__tests__/compiledWithReporting.unit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { routeCommand } from '../src/bin/route.ts';
+import { VERSION } from '../src/version.ts';
+import { useCapturedStdio } from './helpers/capturedStdio.ts';
+import { useTempDir } from './helpers/tempDir.ts';
+
+/** A kit whose single check passes, shared by every fixture here so only the stamp varies. */
+const KIT_BODY = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
+
+const temp = useTempDir({
+  prefix: 'readyup-compiled-with-',
+  cwd: 'chdir',
+  scope: 'file',
+  setup: () => {
+    temp.write('.readyup/kits/stamped.js', buildStampedKit('0.19.2'));
+    temp.write('.readyup/kits/current.js', buildStampedKit(VERSION));
+    temp.write('.readyup/kits/unstamped.js', KIT_BODY);
+  },
+});
+
+const io = useCapturedStdio();
+
+describe('compile-time readyup version in the run report', () => {
+  it('names the readyup a stamped bundle was built by', async () => {
+    await routeCommand(['stamped', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(parsed).toHaveProperty('kits.0.compiledWith', '0.19.2');
+  });
+
+  it('names it for a locally compiled kit, which no package published', async () => {
+    await routeCommand(['stamped', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(parsed).toHaveProperty('kits.0.compiledWith', '0.19.2');
+    expect(parsed).not.toHaveProperty('kits.0.origin');
+  });
+
+  it('names it even where it matches the runner', async () => {
+    await routeCommand(['current', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(parsed).toHaveProperty('kits.0.compiledWith', VERSION);
+  });
+
+  it('omits the key for a bundle carrying no stamp', async () => {
+    await routeCommand(['unstamped', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(parsed).toHaveProperty('kits.0.name', 'unstamped');
+    expect(parsed).not.toHaveProperty('kits.0.compiledWith');
+  });
+
+  it('withholds it from a kit that loaded and then failed', async () => {
+    const exitCode = await routeCommand(['stamped:absent', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(exitCode).toBe(2);
+    expect(parsed).toHaveProperty('kits.0.error.code', 'usage');
+    expect(parsed).not.toHaveProperty('kits.0.compiledWith');
+  });
+});
+
+// region | Helpers
+
+/** Builds a kit source carrying the version stamp `rdy compile` embeds in a bundle. */
+function buildStampedKit(version: string): string {
+  return `export const __readyupVersion = '${version}';\n${KIT_BODY}`;
+}
+
+// endregion | Helpers

--- a/packages/readyup/__tests__/compiledWithReporting.unit.test.ts
+++ b/packages/readyup/__tests__/compiledWithReporting.unit.test.ts
@@ -22,14 +22,7 @@ const temp = useTempDir({
 const io = useCapturedStdio();
 
 describe('compile-time readyup version in the run report', () => {
-  it('names the readyup a stamped bundle was built by', async () => {
-    await routeCommand(['stamped', '--json']);
-    const parsed: unknown = JSON.parse(io.stdout);
-
-    expect(parsed).toHaveProperty('kits.0.compiledWith', '0.19.2');
-  });
-
-  it('names it for a locally compiled kit, which no package published', async () => {
+  it('names the readyup a local bundle was built by, with no origin to nest it under', async () => {
     await routeCommand(['stamped', '--json']);
     const parsed: unknown = JSON.parse(io.stdout);
 

--- a/packages/readyup/__tests__/formatJsonReport.unit.test.ts
+++ b/packages/readyup/__tests__/formatJsonReport.unit.test.ts
@@ -193,6 +193,28 @@ describe(formatJsonReport, () => {
       expect(parsed).not.toHaveProperty('warnings');
       expect(parsed).toHaveProperty('counts.warnings', 0);
     });
+
+    it('names the readyup that compiled a kit on that kit\u{2019}s entry', () => {
+      const kits = [{ name: 'deploy', compiledWith: '0.19.2', entries: [{ name: 'preflight', report: makeReport() }] }];
+
+      const parsed: unknown = JSON.parse(formatReport(kits));
+
+      expect(parsed).toHaveProperty('kits.0.compiledWith', '0.19.2');
+    });
+
+    it('names the compiling readyup even where it matches the runner', () => {
+      const kits = [{ name: 'deploy', compiledWith: VERSION, entries: [{ name: 'preflight', report: makeReport() }] }];
+
+      const parsed: unknown = JSON.parse(formatReport(kits));
+
+      expect(parsed).toHaveProperty('kits.0.compiledWith', VERSION);
+    });
+
+    it('omits the compiling readyup for a kit that carries no stamp', () => {
+      const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', makeReport())));
+
+      expect(parsed).not.toHaveProperty('kits.0.compiledWith');
+    });
   });
 
   describe('per-kit thresholds', () => {

--- a/packages/readyup/__tests__/helpers/payloadFixtures.ts
+++ b/packages/readyup/__tests__/helpers/payloadFixtures.ts
@@ -26,6 +26,7 @@ export const reportPayload = {
   kits: [
     {
       name: 'deploy',
+      compiledWith: '0.19.2',
       passed: false,
       counts: { passed: 2, errors: 1, warnings: 0, recommendations: 0, blocked: 1, optional: 0 },
       worstSeverity: 'error',

--- a/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
@@ -39,7 +39,7 @@ describe('--packages run path wiring', () => {
   });
 
   it('expands a configured package into entries carrying its name and version', () => {
-    installPackage('@acme/kits', ['drift', 'preflight'], '2.1.0');
+    installPackage('@acme/kits', ['drift', 'preflight'], { version: '2.1.0' });
 
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
@@ -71,7 +71,7 @@ describe('--packages run path wiring', () => {
   });
 
   it('carries the package and version into the JSON report', async () => {
-    installPackage('@acme/kits', ['drift'], '2.1.0');
+    installPackage('@acme/kits', ['drift'], { version: '2.1.0' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
     const exitCode = await runCommand({ kitEntries: entries, json: true });
@@ -82,7 +82,7 @@ describe('--packages run path wiring', () => {
   });
 
   it('omits the version from the report when the package declares none', async () => {
-    installPackage('@acme/kits', ['drift'], undefined);
+    installPackage('@acme/kits', ['drift']);
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
     await runCommand({ kitEntries: entries, json: true });
@@ -93,7 +93,7 @@ describe('--packages run path wiring', () => {
   });
 
   it('names the readyup that compiled a package kit beside the package, not inside it', async () => {
-    installPackage('@acme/kits', ['drift'], '2.1.0', '0.19.2');
+    installPackage('@acme/kits', ['drift'], { version: '2.1.0', readyupVersion: '0.19.2' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
     await runCommand({ kitEntries: entries, json: true });
@@ -105,7 +105,7 @@ describe('--packages run path wiring', () => {
 
   // A lone dependency-provided kit is the common shape, and its package appears nowhere else on screen.
   it('heads a single package kit with the package and version in human output', async () => {
-    installPackage('@acme/kits', ['drift'], '2.1.0');
+    installPackage('@acme/kits', ['drift'], { version: '2.1.0' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
     await runCommand({ kitEntries: entries, json: false });
@@ -127,21 +127,27 @@ const baseArgs = {
   internal: false,
 };
 
-/** Installs a package publishing the named kits, each holding one passing check and an optional version stamp. */
-function installPackage(name: string, kits: string[], version: string | undefined, stamp?: string): void {
+/** Installs a package publishing the named kits, each holding one passing check. */
+function installPackage(name: string, kits: string[], options: InstallPackageOptions = {}): void {
+  const { readyupVersion, version } = options;
   const root = path.join(process.cwd(), 'node_modules', name);
   mkdirSync(path.join(root, '.readyup', 'kits'), { recursive: true });
   writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name, ...(version !== undefined && { version }) }));
 
   for (const kit of kits) {
     const body = `export default { checklists: [{ name: '${kit}', checks: [{ name: 'ok', check: () => true }] }] };\n`;
-    const source = stamp === undefined ? body : `export const __readyupVersion = '${stamp}';\n${body}`;
-    writeFileSync(path.join(root, '.readyup', 'kits', `${kit}.js`), source);
+    const stamp = readyupVersion === undefined ? '' : `export const __readyupVersion = '${readyupVersion}';\n`;
+    writeFileSync(path.join(root, '.readyup', 'kits', `${kit}.js`), `${stamp}${body}`);
   }
   writeFileSync(
     path.join(root, '.readyup', 'manifest.json'),
     JSON.stringify({ version: 1, kits: kits.map((kit) => ({ name: kit })) }),
   );
+}
+
+interface InstallPackageOptions {
+  version?: string;
+  readyupVersion?: string;
 }
 
 // endregion | Helpers

--- a/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
@@ -92,6 +92,17 @@ describe('--packages run path wiring', () => {
     expect(report.kits[0]?.origin).not.toHaveProperty('version');
   });
 
+  it('names the readyup that compiled a package kit beside the package, not inside it', async () => {
+    installPackage('@acme/kits', ['drift'], '2.1.0', '0.19.2');
+    const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
+
+    await runCommand({ kitEntries: entries, json: true });
+
+    const report = ReportSchema.parse(JSON.parse(stdout.join('')));
+    expect(report.kits[0]).toMatchObject({ compiledWith: '0.19.2', origin: { package: '@acme/kits' } });
+    expect(report.kits[0]?.origin).not.toHaveProperty('compiledWith');
+  });
+
   // A lone dependency-provided kit is the common shape, and its package appears nowhere else on screen.
   it('heads a single package kit with the package and version in human output', async () => {
     installPackage('@acme/kits', ['drift'], '2.1.0');
@@ -116,15 +127,16 @@ const baseArgs = {
   internal: false,
 };
 
-/** Installs a package publishing the named kits, each holding one passing check. */
-function installPackage(name: string, kits: string[], version: string | undefined): void {
+/** Installs a package publishing the named kits, each holding one passing check and an optional version stamp. */
+function installPackage(name: string, kits: string[], version: string | undefined, stamp?: string): void {
   const root = path.join(process.cwd(), 'node_modules', name);
   mkdirSync(path.join(root, '.readyup', 'kits'), { recursive: true });
   writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name, ...(version !== undefined && { version }) }));
 
   for (const kit of kits) {
     const body = `export default { checklists: [{ name: '${kit}', checks: [{ name: 'ok', check: () => true }] }] };\n`;
-    writeFileSync(path.join(root, '.readyup', 'kits', `${kit}.js`), body);
+    const source = stamp === undefined ? body : `export const __readyupVersion = '${stamp}';\n${body}`;
+    writeFileSync(path.join(root, '.readyup', 'kits', `${kit}.js`), source);
   }
   writeFileSync(
     path.join(root, '.readyup', 'manifest.json'),

--- a/packages/readyup/__tests__/schemas/schemas.unit.test.ts
+++ b/packages/readyup/__tests__/schemas/schemas.unit.test.ts
@@ -59,6 +59,15 @@ describe('JSON payload schemas', () => {
       expect(parsed.kits[1]?.project).toBe('packages/ui');
       expect(parsed.kits[1]?.origin).toBeUndefined();
     });
+
+    it('accepts a kit that names no compile-time readyup, at the same schema version', () => {
+      const kit = reportPayload.kits[0];
+      const stripped = Object.fromEntries(Object.entries(kit ?? {}).filter(([key]) => key !== 'compiledWith'));
+
+      expect(kit).toHaveProperty('compiledWith');
+      expect(ReportSchema.parse(reportPayload).schemaVersion).toBe(1);
+      expect(ReportSchema.parse({ ...reportPayload, kits: [stripped] }).schemaVersion).toBe(1);
+    });
   });
 
   describe('required fields', () => {

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -774,11 +774,14 @@ async function runMultiKitJsonMode(
       kitInputs.push({
         name: entry.name,
         ...toJsonOriginField(entry.provenance),
+        ...(compileTimeVersion !== undefined && { compiledWith: compileTimeVersion }),
         entries,
         failOn: thresholds.failOn,
         reportOn: thresholds.reportOn,
       });
     } catch (error: unknown) {
+      // An entry built here carries no `compiledWith`: a kit that produced no results has nothing
+      // for a compile-time version to explain.
       const { code, hint, message } = toRdyError(error);
       kitInputs.push({
         name: entry.name,

--- a/packages/readyup/src/formatJsonReport.ts
+++ b/packages/readyup/src/formatJsonReport.ts
@@ -30,6 +30,7 @@ interface ChecklistEntry {
 export interface KitResultInput {
   name: string;
   origin?: JsonKitOrigin;
+  compiledWith?: string;
   entries: ChecklistEntry[];
   failOn: Severity;
   reportOn: Severity;
@@ -135,6 +136,7 @@ function aggregateKit(input: KitResultInput, detail: JsonDetail): AggregatedKit 
   const entry: JsonKitResultEntry = {
     name: input.name,
     ...(input.origin !== undefined && { origin: input.origin }),
+    ...(input.compiledWith !== undefined && { compiledWith: input.compiledWith }),
     passed: checklists.every((checklist) => checklist.passed),
     ...splitCounts(counts),
     failOn: input.failOn,

--- a/packages/readyup/src/schemas/reportSchema.ts
+++ b/packages/readyup/src/schemas/reportSchema.ts
@@ -87,11 +87,19 @@ export const KitOriginSchema = z
  * differ from the run level: `passed` is meaningless without the threshold it was decided against,
  * and an absent-means-inherit rule would send a consumer elsewhere in the document to read a
  * six-byte enum.
+ *
+ * `compiledWith` is the readyup that built this kit's bundle, read from the stamp the bundle
+ * exports. It is present whenever that stamp is, including when it equals the report's own
+ * `readyupVersion`, so its absence means the kit carries no stamp: a bundle compiled before the
+ * stamp existed, or a `--jit` run that loaded TypeScript source. `rdy verify` reports the same
+ * value as `rebuildCompiledWith` under a narrower rule, appearing only where it differs from the
+ * running readyup.
  */
 export const KitResultEntrySchema = z
   .object({
     name: z.string(),
     origin: KitOriginSchema.optional(),
+    compiledWith: z.string().optional(),
     passed: z.boolean(),
     counts: CountsSchema,
     worstSeverity: SeveritySchema.optional(),


### PR DESCRIPTION
## What

`rdy run --json` now reports which version of `readyup` compiled each kit. No version appears for kits built by older `readyup` versions that did not record it, or for kits run from TypeScript source under `--jit`.

## Why

A kit can misbehave for a reason no automatic check catches: a helper whose semantics shift without its signature moving, as five check helpers did when `in` gave way to `Object.hasOwn` in 0.23.0. Diagnosing that starts from knowing which readyup built the bundle, and the run report did not say -- it named the package a kit came from, but nothing about the toolchain that produced it. The value was already in hand at load time and discarded.

## Details

### 🎉 Features

- `rdy run --json` adds an optional `compiledWith` to each kit's result entry, carrying the compile-time stamp the bundle exports.
- The field sits **beside** `origin` rather than inside it. `origin` is present only for package-sourced kits, so nesting would have hidden the stamp from every locally compiled kit.
- Presence is unconditional on the stamp existing, including where it equals the running readyup's version. The field records what built the kit rather than signalling a discrepancy, so absence has one meaning: no stamp.
- Result entries only. A kit that failed before producing results carries identity, not provenance.
- Human-readable `rdy run` output is unchanged.
- No `schemaVersion` bump. The published schema's evolution policy exempts added optional fields, so a consumer pinned to `report.v1.json` keeps validating.

### 🧪 Tests

- A new end-to-end suite drives real kit fixtures through the CLI, covering a stamped bundle, an unstamped one, a stamp equal to the runner's version, and a kit that loads and then fails.
- The `--packages` wiring suite covers a package-published kit, pinning the field beside the publishing package rather than inside it.
- A schema round-trip confirms both the presence and absence shapes validate at the unchanged payload version.
- The `--packages` fixture installer now takes the package version and the compile-time readyup version as named options rather than adjacent positional strings, so a call site says which version is which.

### 📚 Documentation

- The README's run-report section documents `compiledWith`: when it appears, when it is absent, and how its presence rule differs from `rdy verify`'s pre-existing `rebuildCompiledWith`, which reports the same underlying value only where it disagrees with the running readyup.

Closes #262
