### PR TITLE
#259 Enforce kit-bundle freshness in the quality gate

### DIFF
--- a/.agents/PROJECT.md
+++ b/.agents/PROJECT.md
@@ -29,7 +29,7 @@ Use `nmr {command}` for monorepo scripts. Use `pnpm run {script}` only for scrip
 **Root-level (from repo root):**
 
 - `pnpm install` — Install all dependencies
-- `nmr ci` — The code-quality gate CI runs (build + strict checks)
+- `nmr ci` — The code-quality gate CI runs (kit-freshness check + build + strict checks)
 - `nmr prepush` — Everything the remote runs (`nmr ci` plus the dependency audit)
 - `nmr check` — Typecheck, format check, lint check, and tests
 - `nmr build` — Build all packages
@@ -67,3 +67,4 @@ Use `nmr {command}` for monorepo scripts. Use `pnpm run {script}` only for scrip
 
 - **Build caching**: `nmr-compile`'s content-hash cache (`dist/esm/.cache`) means a rebuild won't run if only non-source files change. Delete the cache file to force a rebuild.
 - **Check caching**: a check that already passed on the current working tree reports a pass without running again. Use `nmr --no-cache {command}` when the run has to produce an artifact rather than an exit status (a fresh `coverage/`), and `nmr clean` to forget every recorded pass.
+- **Kit freshness**: the tracked kit bundles embed the readyup version that compiled them, so a readyup version bump leaves them stale until `rdy compile` runs. `nmr ci` verifies them by recompiling, and does so before its build step, which would otherwise regenerate a stale bundle in place.

--- a/.config/nmr.config.ts
+++ b/.config/nmr.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@williamthorsen/nmr/config';
 /** nmr configuration for this repo. */
 export default defineConfig({
   devBin: {
-    // Run the readyup bin from TypeScript source so `build:post` needs no prior build.
+    // Run the readyup bin from TypeScript source so the root's `rdy` hooks need no prior build.
     rdy: 'node packages/readyup/src/bin/rdy.ts',
   },
   rootScripts: {
@@ -11,5 +11,7 @@ export default defineConfig({
     // Checks are cwd-relative, so the kit has to run from the package it audits. A root
     // `rdy run --from npm:readyup publishing` would audit the repo root instead.
     'ci:post': 'pnpm --filter readyup run verify:kits',
+    // `build:post` recompiles every kit, so a committed bundle's freshness is observable only before the build.
+    'ci:pre': 'rdy verify --rebuild',
   },
 });

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -982,7 +982,7 @@ The verdict is `ok`, `mismatch`, `failed` (the source no longer compiles), or `m
 
 Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`, plus `rebuildCompiledWith` when the bundle was built by a different readyup; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
 
-Three things to know before wiring it into CI. It requires esbuild, and says so rather than passing when esbuild is absent. The readyup version is part of a bundle's bytes, so upgrading readyup makes every kit mismatch until `rdy compile` runs -- a mismatch that spans versions names both of them, so the cause is legible.
+Three things to know before wiring it into CI: It requires esbuild. The readyup version forms part of a bundle's hash, so a readyup upgrade makes every kit mismatch until recompiled. And it must not run after a step that recompiles kits, because recompilation would defeat the comparison.
 
 ```yaml
 - run: npx rdy verify --rebuild

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -982,7 +982,7 @@ The verdict is `ok`, `mismatch`, `failed` (the source no longer compiles), or `m
 
 Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`, plus `rebuildCompiledWith` when the bundle was built by a different readyup; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
 
-Two things to know before wiring it into CI. It requires esbuild, and says so rather than passing when esbuild is absent. And the readyup version is part of a bundle's bytes, so upgrading readyup makes every kit mismatch until `rdy compile` runs -- a mismatch that spans versions names both of them, so the cause is legible.
+Three things to know before wiring it into CI. It requires esbuild, and says so rather than passing when esbuild is absent. The readyup version is part of a bundle's bytes, so upgrading readyup makes every kit mismatch until `rdy compile` runs -- a mismatch that spans versions names both of them, so the cause is legible.
 
 ```yaml
 - run: npx rdy verify --rebuild

--- a/packages/readyup/__tests__/verify/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.rebuild.tool.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 import { compileConfig } from '../../src/compile/compileConfig.ts';
+import type { RdyManifestKit } from '../../src/manifest/manifestSchema.ts';
 import { ManifestSchema } from '../../src/manifest/manifestSchema.ts';
 import type { JsonVerifyOutput } from '../../src/schemas/index.ts';
 import { VerifyOutputSchema } from '../../src/schemas/index.ts';
@@ -21,6 +22,9 @@ export const metadata = pickJson('./data.json', ['name', 'version']);
 
 export default { checklists: [] };
 `;
+
+/** A readyup old enough that no fixture here could have been compiled by it. */
+const PRIOR_VERSION = '0.19.2';
 
 /**
  * Exercises `--rebuild` against real esbuild, which is what the check is for: the inputs it catches
@@ -99,6 +103,20 @@ describe('verifyCommand --rebuild', () => {
     expect(readFileSync(path.join(tempDir, 'kit.js'), 'utf8')).toContain('1.0.0');
   });
 
+  it('fails a bundle stale only in its version stamp, which both recorded hashes still pass', async () => {
+    // A version bump moves neither the source nor the bundle, so the stamp and the hashes recorded for
+    // it go stale in agreement and keep matching. Only a recompile reads the version.
+    restampBundle(tempDir, PRIOR_VERSION);
+
+    const exitCode = await runVerify();
+
+    expect(exitCode).toBe(1);
+    expect(readPayload(stdoutSpy)).toMatchObject({
+      passed: false,
+      kits: [{ status: 'ok', sourceStatus: 'ok', rebuildStatus: 'mismatch', rebuildCompiledWith: PRIOR_VERSION }],
+    });
+  });
+
   it('fails a hand-edited bundle', async () => {
     writeFileSync(path.join(tempDir, 'kit.js'), 'export default { checklists: [] };\n');
 
@@ -111,7 +129,7 @@ describe('verifyCommand --rebuild', () => {
   });
 
   it('reports a passing rebuild beside a recorded hash that has gone wrong', async () => {
-    overrideTargetHash(path.join(tempDir, 'manifest.json'), 'deadbeef');
+    patchKits(path.join(tempDir, 'manifest.json'), { targetHash: 'deadbeef' });
 
     const exitCode = await runVerify();
 
@@ -142,9 +160,14 @@ describe('verifyCommand --rebuild', () => {
   });
 });
 
-/** Runs `verify` over the tempdir's manifest with the rebuild check and JSON output on. */
-async function runVerify(): Promise<number> {
-  return verifyCommand(['--manifest', 'manifest.json', '--rebuild', '--json']);
+// region | Helpers
+
+/** Applies a patch to every kit the manifest records. */
+function patchKits(manifestPath: string, patch: Partial<RdyManifestKit>): void {
+  const stored: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const manifest = ManifestSchema.parse(stored);
+  const kits = manifest.kits.map((kit) => ({ ...kit, ...patch }));
+  writeFileSync(manifestPath, JSON.stringify({ ...manifest, kits }));
 }
 
 /**
@@ -158,10 +181,26 @@ function readPayload(stdoutSpy: MockInstance): JsonVerifyOutput {
   return VerifyOutputSchema.parse(emitted);
 }
 
-/** Rewrites every kit's recorded `targetHash`, standing in for a record that has gone wrong. */
-function overrideTargetHash(manifestPath: string, targetHash: string): void {
-  const stored: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  const manifest = ManifestSchema.parse(stored);
-  const kits = manifest.kits.map((kit) => ({ ...kit, targetHash }));
-  writeFileSync(manifestPath, JSON.stringify({ ...manifest, kits }));
+/**
+ * Rewrites the bundle's version stamp and re-records the manifest against the restamped bytes.
+ *
+ * The stamp, the recorded `targetHash`, and the recorded `readyupVersion` all name the earlier
+ * readyup, which is the state a version bump leaves behind.
+ */
+function restampBundle(tempDir: string, version: string): void {
+  const bundlePath = path.join(tempDir, 'kit.js');
+  const restamped = readFileSync(bundlePath, 'utf8').replace(
+    /__readyupVersion = "[^"]*"/,
+    `__readyupVersion = ${JSON.stringify(version)}`,
+  );
+  writeFileSync(bundlePath, restamped);
+
+  patchKits(path.join(tempDir, 'manifest.json'), { readyupVersion: version, targetHash: hashFile(bundlePath) });
 }
+
+/** Runs `verify` over the tempdir's manifest with the rebuild check and JSON output on. */
+async function runVerify(): Promise<number> {
+  return verifyCommand(['--manifest', 'manifest.json', '--rebuild', '--json']);
+}
+
+// endregion | Helpers

--- a/packages/readyup/__tests__/verify/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/__tests__/verify/verifyCommand.rebuild.tool.test.ts
@@ -191,7 +191,7 @@ function restampBundle(tempDir: string, version: string): void {
   const bundlePath = path.join(tempDir, 'kit.js');
   const restamped = readFileSync(bundlePath, 'utf8').replace(
     /__readyupVersion = "[^"]*"/,
-    `__readyupVersion = ${JSON.stringify(version)}`,
+    () => `__readyupVersion = ${JSON.stringify(version)}`,
   );
   writeFileSync(bundlePath, restamped);
 


### PR DESCRIPTION
## What

Adds `rdy verify --rebuild` to the repo's quality gate, which now fails when a committed kit bundle has fallen out of date with the installed `readyup`; `rdy compile` clears the failure.

## Why

The release job bumps versions after installing dependencies and runs no build before it commits, so a release run in CI would land a bumped `package.json` beside bundles stamped with the version before it, and nothing would notice. Every release so far was run locally, where an install happens to fall between the bump and the next recompile, so the gap has not yet produced a bad commit -- it has simply not been exercised. The cost when it is exercised is a default branch that disagrees with itself.

## Details

### 🧪 Tests

- Covers the one rebuild-failure shape the suite left uncovered: a bundle stale only in its version stamp, with both recorded hashes still agreeing with it. That is the defect exactly, and it is what separates it from the already-covered hand-edit case, which the cheap hash verdict catches on its own and reports as `status: 'drift'`.
- Generalizes the `overrideTargetHash` fixture helper into `patchKits`, taking a `Partial<RdyManifestKit>`, so the new case can rewrite `readyupVersion` and `targetHash` in one pass.
- Restamps the bundle through a replacer function rather than a template literal, which would be scanned for `$&` and `$1` patterns.

### 👷 CI

- `.config/nmr.config.ts` gains `'ci:pre': 'rdy verify --rebuild'`, expanding `nmr ci` to `nmr ci:pre && nmr build && nmr check:strict && nmr ci:post`.
- The hook has to precede the build. `build:post` is `rdy compile`, so a freshness check placed after it reads bundles that were regenerated moments earlier and can only ever pass.
- The `devBin` comment now names the root's `rdy` hooks rather than `build:post` alone, which was the only one when it was written.

### 📚 Documentation

- `.agents/PROJECT.md`: the `nmr ci` entry names the freshness check, and a new Gotcha records that a readyup version bump leaves the tracked bundles stale until `rdy compile` runs.
- `packages/readyup/README.md`: the caveats to know before wiring `rdy verify --rebuild` into CI go from two to three, the new one being the ordering constraint. It is framed as a property of any build step that compiles kits, so a consumer whose CI is a bare `npx rdy verify --rebuild` step correctly reads it as not applying to them.

Closes #259
