### PR TITLE
#215 Run only the default kit under `--packages` unless a kit is named

### DIFF
--- a/.config/readyup.config.ts
+++ b/.config/readyup.config.ts
@@ -7,6 +7,6 @@ export default defineRdyConfig({
   internal: {
     dir: 'internal',
   },
-  // The checks in these packages will be run by `rdy run --packages`.
+  // `rdy run --packages` runs the `default` kit of each of these packages.
   packages: ['@williamthorsen/nmr', '@williamthorsen/release-kit', 'v11y-check'],
 });

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -871,9 +871,9 @@ rdy run --packages drift # the kit named `drift`, from every listed package publ
 
 The kit name is the selector, exactly as it is for every other source, and each result carries the package and version it came from. A checklist filter is rejected in both spellings -- `--checklists` and inline `kit:checklist` -- because several listed packages may publish the named kit, leaving the checklists no single one to select within.
 
-The two forms differ in strictness. A listed package publishing no `default` fails the run and names the kits it does publish: the list is hand-maintained, and a package in it that does not follow the convention is drift. A name other than `default` is a selection, so a listed package not publishing it is skipped, and only a name no listed package publishes fails, as a bad invocation.
+A listed package that does not publish the requested kit is skipped. `rdy run --packages` asks whether this project satisfies what its listed packages require of it, and a package publishing no `default` requires nothing of it: that package contributes no kit, and a run that selects nothing reports as much and passes. The named form differs in one respect, because naming a kit asks for something specific: a name no listed package publishes is a usage error rather than an empty run.
 
-That split is how an author holds a kit back from a routine `--packages` run: publish it under a name other than `default`. It stays listed by `rdy list` and reachable by name, both here and through `--from npm:<package>`. Nothing is needed from the consumer's config, and nothing needs republishing.
+That rule is how an author holds a kit back from a routine `--packages` run: publish it under a name other than `default`. It stays listed by `rdy list` and reachable by name, both here and through `--from npm:<package>`. Nothing is needed from the consumer's config, and nothing needs republishing.
 
 A listed package that is absent, or that publishes no kits at all, fails the run and names itself; `rdy list` warns instead and reports the rest, then names any installed dependency publishing kits the list omits.
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -177,7 +177,7 @@ Repo-level settings live in `.config/readyup.config.ts`.
 | `compile.include` | all `.ts` files | Glob limiting which sources a sweep compiles                  |
 | `internal.dir`    | `.`             | Directory holding internal sources, relative to the kits root |
 | `internal.infix`  | none            | Filename segment marking a file as internal                   |
-| `packages`        | none            | Packages whose published kits `rdy run --packages` runs       |
+| `packages`        | none            | Packages `rdy run --packages` runs a published kit from       |
 
 See [internal kits](#internal-kits) for what the `internal` keys select, and [package-hosted kits](#package-hosted-kits) for `packages`.
 
@@ -439,20 +439,20 @@ rdy run -- "--odd-kit-name"
 
 ### Run options
 
-| Option                        | Description                                           |
-| ----------------------------- | ----------------------------------------------------- |
-| `--from <source>`             | Kit source (see [kit sources](#kit-sources))          |
-| `--file, -f <path>`           | Path to a local kit file                              |
-| `--url <url>`                 | Fetch kit from a URL                                  |
-| `--packages`                  | Run every kit the config's `packages` list publishes  |
-| `--jit`                       | Run from TypeScript source instead of compiled JS     |
-| `--internal`                  | Use the internal kit directory and infix from config  |
-| `--checklists, -c <name,...>` | Filter checklists within the selected kit             |
-| `--json`                      | Output results as JSON                                |
-| `--detail <summary\|full>`    | How much of the JSON report to emit (default: `full`) |
-| `--fail-on <severity>`        | Fail on this severity or above                        |
-| `--report-on <severity>`      | Show this severity or above                           |
-| `--quiet`                     | Hide passed checks; incompatible with `--json`        |
+| Option                        | Description                                                           |
+| ----------------------------- | --------------------------------------------------------------------- |
+| `--from <source>`             | Kit source (see [kit sources](#kit-sources))                          |
+| `--file, -f <path>`           | Path to a local kit file                                              |
+| `--url <url>`                 | Fetch kit from a URL                                                  |
+| `--packages [<name>]`         | Run a kit the config's `packages` list publishes (default: `default`) |
+| `--jit`                       | Run from TypeScript source instead of compiled JS                     |
+| `--internal`                  | Use the internal kit directory and infix from config                  |
+| `--checklists, -c <name,...>` | Filter checklists within the selected kit                             |
+| `--json`                      | Output results as JSON                                                |
+| `--detail <summary\|full>`    | How much of the JSON report to emit (default: `full`)                 |
+| `--fail-on <severity>`        | Fail on this severity or above                                        |
+| `--report-on <severity>`      | Show this severity or above                                           |
+| `--quiet`                     | Hide passed checks; incompatible with `--json`                        |
 
 `--quiet` filters by status where `--report-on` filters by severity, so the two compose rather than override. Both keep the parent checks of anything they show, so a failure nested under passing parents stays reachable.
 
@@ -624,7 +624,7 @@ Kits from configured packages get their own section, each named package-first so
 
 ```
 ── Packages
-   rdy run --packages
+   rdy run --packages [<name>]
 📦 @acme/eslint-config@2.1.0 / 📓 drift
 
 ── Available
@@ -854,7 +854,7 @@ rdy run --from npm:@acme/eslint-config drift # a kit it publishes, by name
 rdy list --from npm:@acme/eslint-config      # what it publishes
 ```
 
-Like every other `--from` source, a bare invocation runs the kit named `default`; a package publishing under other names needs one of them named. `--packages` below is what runs every kit a package publishes.
+Like every other `--from` source, a bare invocation runs the kit named `default`; a package publishing under other names needs one of them named. `--packages` below is the same selection, made across several packages at once.
 
 Naming several packages once is a config list, because running code a dependency ships is an opt-in worth writing down:
 
@@ -865,10 +865,17 @@ export default defineRdyConfig({
 ```
 
 ```bash
-rdy run --packages
+rdy run --packages       # the kit named `default`, from every listed package
+rdy run --packages drift # the kit named `drift`, from every listed package publishing it
 ```
 
-`rdy run --packages` runs every kit each listed package publishes and reports each with the package and version it came from. A listed package that is absent, or that publishes no kits, fails the run and names itself; `rdy list` warns instead and reports the rest, then names any installed dependency publishing kits the list omits.
+The kit name is the selector, exactly as it is for every other source, and each result carries the package and version it came from. A checklist filter is rejected in both spellings -- `--checklists` and inline `kit:checklist` -- because several listed packages may publish the named kit, leaving the checklists no single one to select within.
+
+The two forms differ in strictness. A listed package publishing no `default` fails the run and names the kits it does publish: the list is hand-maintained, and a package in it that does not follow the convention is drift. A name other than `default` is a selection, so a listed package not publishing it is skipped, and only a name no listed package publishes fails, as a bad invocation.
+
+That split is how an author holds a kit back from a routine `--packages` run: publish it under a name other than `default`. It stays listed by `rdy list` and reachable by name, both here and through `--from npm:<package>`. Nothing is needed from the consumer's config, and nothing needs republishing.
+
+A listed package that is absent, or that publishes no kits at all, fails the run and names itself; `rdy list` warns instead and reports the rest, then names any installed dependency publishing kits the list omits.
 
 Two limitations follow from resolving through `node_modules`. A package must be a **direct** dependency: a strict pnpm layout links nothing else into the project, so a transitive package is genuinely unreachable. And Yarn Plug'n'Play keeps no `node_modules` on disk, so package sources do not resolve under it.
 
@@ -909,7 +916,7 @@ A package declaring no `files` field passes the first check, because everything 
 
 Both kits read the convention layout: `.readyup/manifest.json` and bundles directly under `.readyup/kits`. A project that compiles to a different `outDir` still gets its recorded kits checked for freshness, since those paths come from the manifest, but the checks that count compiled bundles report nothing to do. For a published package the layout is not a convention but a contract, which is what the last `packaging` check enforces: `--from npm:` composes a kit's path from its name, so a bundle recorded anywhere else is listed and then fails to load.
 
-Adding readyup to `packages` in the config is what makes `rdy run --packages` include the `default` kit. Until it is listed there, `rdy list` names readyup among the dependencies that publish kits.
+Adding readyup to `packages` in the config is what makes `rdy run --packages` include readyup's `default` kit. `publishing` is not part of that run, by the rule that holds back every kit not named `default`; reach it with `rdy run --packages publishing`, which runs it from each listed package publishing a kit by that name. Until readyup is listed, `rdy list` names it among the dependencies that publish kits.
 
 ### Internal kits
 

--- a/packages/readyup/__tests__/cli.unit.test.ts
+++ b/packages/readyup/__tests__/cli.unit.test.ts
@@ -321,15 +321,22 @@ describe(parseRunArgs, () => {
     expect(() => parseRunArgs(['--packages', '--from', '/path'])).toThrow('Cannot combine --from, --packages flags');
   });
 
-  it('throws when --packages is combined with positional kit arguments', () => {
-    expect(() => parseRunArgs(['--packages', 'deploy'])).toThrow(
-      '--packages cannot be combined with positional kit arguments',
-    );
+  // The positional selects which kit runs in every configured package, so it narrows rather than competes.
+  it('accepts a positional kit name alongside --packages', () => {
+    expect(parseRunArgs(['--packages', 'deploy']).kitSpecifiers).toStrictEqual([{ kitName: 'deploy', checklists: [] }]);
   });
 
   it('throws when --packages is combined with --checklists', () => {
     expect(() => parseRunArgs(['--packages', '--checklists', 'build'])).toThrow(
-      '--packages cannot be combined with --checklists',
+      '--packages cannot be combined with --checklists; several configured packages may publish the named kit',
+    );
+  });
+
+  // Unreachable while positionals were banned outright, and silently dropped if left unrejected.
+  it('throws when --packages is combined with an inline checklist filter', () => {
+    expect(() => parseRunArgs(['--packages', 'deploy:build'])).toThrow(
+      '--packages cannot be combined with the ":" checklist filter on "deploy"; ' +
+        'several configured packages may publish the named kit',
     );
   });
 

--- a/packages/readyup/__tests__/list/formatList.unit.test.ts
+++ b/packages/readyup/__tests__/list/formatList.unit.test.ts
@@ -146,6 +146,20 @@ describe(formatOwnerView, () => {
     expect(findSectionCommand(result, 'Compiled')).not.toContain('--jit');
   });
 
+  // Discovery is not run selection, so the rows list every published kit and the optional name reaches each.
+  it('heads the Packages section with the optional-name form of the run command', () => {
+    const result = formatOwnerView({
+      internalKits: [],
+      compiledKits: [],
+      compiledStyle: { kind: 'local-convention' },
+      packageKits: ['default', 'npm-auto-publish'],
+    });
+
+    expect(findSectionCommand(result, 'Packages')).toBe('   rdy run --packages [<name>]');
+    expect(result).toContain('default');
+    expect(result).toContain('npm-auto-publish');
+  });
+
   it('renders custom outDir style with file paths', () => {
     const result = formatOwnerView({
       internalKits: [],

--- a/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
@@ -126,19 +126,37 @@ describe('--packages run path wiring', () => {
     expect(entries.map((entry) => entry.name)).toStrictEqual(['default']);
   });
 
-  // Drift between a hand-maintained list and a convention readyup's own `publishing` kit enforces.
-  it('fails a configured package publishing no default, naming what it does publish', async () => {
+  // A package publishing no `default` requires nothing of this project, so there is nothing to fail.
+  it('skips a configured package publishing no default', () => {
+    installPackage('plain-kit', ['default']);
     installPackage('@acme/kits', ['drift', 'preflight']);
 
-    const error = await captureRdyError(() => {
-      resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
-      return 0;
+    const entries = resolveKitSources({
+      ...baseArgs,
+      packages: true,
+      configuredPackages: ['plain-kit', '@acme/kits'],
     });
 
-    expect(error.code).toBe('config');
-    expect(error.message).toBe(
-      'Configured package "@acme/kits" publishes no kit named "default"; it publishes: drift, preflight.',
-    );
+    expect(entries.map(describeEntry)).toStrictEqual(['plain-kit:default']);
+  });
+
+  // Nothing published to align with is alignment, not a failure to check.
+  it('selects nothing when no configured package publishes a default', () => {
+    installPackage('@acme/kits', ['drift', 'preflight']);
+
+    const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
+
+    expect(entries).toStrictEqual([]);
+  });
+
+  it('passes without running a kit when the selection is empty', async () => {
+    installPackage('@acme/kits', ['drift']);
+    const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
+
+    const exitCode = await runCommand({ kitEntries: entries, json: false });
+
+    expect(exitCode).toBe(0);
+    expect(stdout.join('')).toBe('No kits to run.\n');
   });
 
   // Answering with an empty pass would be the clean report of nothing checked.

--- a/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/__tests__/packages/packagesRun.wiring.unit.test.ts
@@ -5,7 +5,7 @@ import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveKitSources, runCommand } from '../../src/cli.ts';
+import { type ResolvedKitEntry, resolveKitSources, runCommand } from '../../src/cli.ts';
 import { ReportSchema } from '../../src/schemas/index.ts';
 import { captureRdyError } from '../../src/test-utils/captureRdyError.ts';
 
@@ -13,7 +13,7 @@ import { captureRdyError } from '../../src/test-utils/captureRdyError.ts';
  * Joins `--packages` to the kits an installed package publishes, against a real fixture project. The
  * unit tests cover the expansion and the resolver separately; this locks in the seam between them —
  * that a configured package becomes a run entry carrying the provenance the report and the headings
- * render.
+ * render, and that the kit name selects which of its kits run.
  */
 describe('--packages run path wiring', () => {
   let projectRoot: string;
@@ -39,24 +39,126 @@ describe('--packages run path wiring', () => {
   });
 
   it('expands a configured package into entries carrying its name and version', () => {
-    installPackage('@acme/kits', ['drift', 'preflight'], { version: '2.1.0' });
+    installPackage('@acme/kits', ['default'], { version: '2.1.0' });
 
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
     expect(entries).toStrictEqual([
       {
-        name: 'drift',
-        source: { path: path.join(projectRoot, 'node_modules', '@acme/kits', '.readyup', 'kits', 'drift.js') },
-        checklists: [],
-        provenance: { kind: 'package', packageName: '@acme/kits', version: '2.1.0' },
-      },
-      {
-        name: 'preflight',
-        source: { path: path.join(projectRoot, 'node_modules', '@acme/kits', '.readyup', 'kits', 'preflight.js') },
+        name: 'default',
+        source: { path: path.join(projectRoot, 'node_modules', '@acme/kits', '.readyup', 'kits', 'default.js') },
         checklists: [],
         provenance: { kind: 'package', packageName: '@acme/kits', version: '2.1.0' },
       },
     ]);
+  });
+
+  // The defect #215 reports: a kit needing credentials failed a run that never asked for it.
+  it('runs only the default kit when the invocation names none', () => {
+    installPackage('@acme/kits', ['default', 'preflight'], { version: '2.1.0' });
+
+    const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
+
+    expect(entries.map((entry) => entry.name)).toStrictEqual(['default']);
+  });
+
+  it('runs a named kit from every configured package publishing it, in configured order', () => {
+    installPackage('plain-kit', ['default', 'preflight']);
+    installPackage('@acme/kits', ['default', 'preflight']);
+
+    const entries = resolveKitSources({
+      ...baseArgs,
+      packages: true,
+      configuredPackages: ['plain-kit', '@acme/kits'],
+      kitSpecifiers: [{ kitName: 'preflight', checklists: [] }],
+    });
+
+    expect(entries.map((entry) => entry.provenance)).toStrictEqual([
+      { kind: 'package', packageName: 'plain-kit', version: undefined },
+      { kind: 'package', packageName: '@acme/kits', version: undefined },
+    ]);
+  });
+
+  // A package that does not publish the named kit is not participating in the selection, not drifting.
+  it('skips a configured package that does not publish the named kit', () => {
+    installPackage('plain-kit', ['default']);
+    installPackage('@acme/kits', ['default', 'preflight']);
+
+    const entries = resolveKitSources({
+      ...baseArgs,
+      packages: true,
+      configuredPackages: ['plain-kit', '@acme/kits'],
+      kitSpecifiers: [{ kitName: 'preflight', checklists: [] }],
+    });
+
+    expect(entries.map((entry) => entry.name)).toStrictEqual(['preflight']);
+  });
+
+  // The order `rdy run a b` runs them in against a single source.
+  it('orders several named kits name-major across the configured packages', () => {
+    installPackage('plain-kit', ['drift', 'preflight']);
+    installPackage('@acme/kits', ['drift', 'preflight']);
+
+    const entries = resolveKitSources({
+      ...baseArgs,
+      packages: true,
+      configuredPackages: ['plain-kit', '@acme/kits'],
+      kitSpecifiers: [
+        { kitName: 'drift', checklists: [] },
+        { kitName: 'preflight', checklists: [] },
+      ],
+    });
+
+    expect(entries.map(describeEntry)).toStrictEqual([
+      'plain-kit:drift',
+      '@acme/kits:drift',
+      'plain-kit:preflight',
+      '@acme/kits:preflight',
+    ]);
+  });
+
+  // Selection reads names, so the manifest-less path needs no handling of its own — but it has to answer alike.
+  it('selects by name when a package ships no manifest', () => {
+    installPackage('plain-kit', ['default', 'preflight'], { hasManifest: false });
+
+    const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['plain-kit'] });
+
+    expect(entries.map((entry) => entry.name)).toStrictEqual(['default']);
+  });
+
+  // Drift between a hand-maintained list and a convention readyup's own `publishing` kit enforces.
+  it('fails a configured package publishing no default, naming what it does publish', async () => {
+    installPackage('@acme/kits', ['drift', 'preflight']);
+
+    const error = await captureRdyError(() => {
+      resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
+      return 0;
+    });
+
+    expect(error.code).toBe('config');
+    expect(error.message).toBe(
+      'Configured package "@acme/kits" publishes no kit named "default"; it publishes: drift, preflight.',
+    );
+  });
+
+  // Answering with an empty pass would be the clean report of nothing checked.
+  it('rejects a named kit no configured package publishes', async () => {
+    installPackage('@acme/kits', ['default', 'preflight']);
+
+    const error = await captureRdyError(() => {
+      resolveKitSources({
+        ...baseArgs,
+        packages: true,
+        configuredPackages: ['@acme/kits'],
+        kitSpecifiers: [{ kitName: 'absent', checklists: [] }],
+      });
+      return 0;
+    });
+
+    expect(error.code).toBe('usage');
+    expect(error.message).toBe(
+      'No configured package publishes a kit named "absent"; available kits: default, preflight.',
+    );
   });
 
   // Reporting a clean pass having checked nothing is the one outcome a verification tool must not invent.
@@ -71,18 +173,18 @@ describe('--packages run path wiring', () => {
   });
 
   it('carries the package and version into the JSON report', async () => {
-    installPackage('@acme/kits', ['drift'], { version: '2.1.0' });
+    installPackage('@acme/kits', ['default'], { version: '2.1.0' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
     const exitCode = await runCommand({ kitEntries: entries, json: true });
 
     expect(exitCode).toBe(0);
     const report = ReportSchema.parse(JSON.parse(stdout.join('')));
-    expect(report.kits[0]).toMatchObject({ name: 'drift', origin: { package: '@acme/kits', version: '2.1.0' } });
+    expect(report.kits[0]).toMatchObject({ name: 'default', origin: { package: '@acme/kits', version: '2.1.0' } });
   });
 
   it('omits the version from the report when the package declares none', async () => {
-    installPackage('@acme/kits', ['drift']);
+    installPackage('@acme/kits', ['default']);
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
     await runCommand({ kitEntries: entries, json: true });
@@ -93,7 +195,7 @@ describe('--packages run path wiring', () => {
   });
 
   it('names the readyup that compiled a package kit beside the package, not inside it', async () => {
-    installPackage('@acme/kits', ['drift'], { version: '2.1.0', readyupVersion: '0.19.2' });
+    installPackage('@acme/kits', ['default'], { version: '2.1.0', readyupVersion: '0.19.2' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
     await runCommand({ kitEntries: entries, json: true });
@@ -105,12 +207,12 @@ describe('--packages run path wiring', () => {
 
   // A lone dependency-provided kit is the common shape, and its package appears nowhere else on screen.
   it('heads a single package kit with the package and version in human output', async () => {
-    installPackage('@acme/kits', ['drift'], { version: '2.1.0' });
+    installPackage('@acme/kits', ['default'], { version: '2.1.0' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
     await runCommand({ kitEntries: entries, json: false });
 
-    expect(stdout.join('')).toContain('\u{1F4E6} @acme/kits@2.1.0 / \u{1F4D3} drift');
+    expect(stdout.join('')).toContain('\u{1F4E6} @acme/kits@2.1.0 / \u{1F4D3} default');
   });
 });
 
@@ -127,9 +229,15 @@ const baseArgs = {
   internal: false,
 };
 
+/** Names a run entry as the package it came from and the kit it runs, which is what an order assertion reads. */
+function describeEntry(entry: ResolvedKitEntry): string {
+  const origin = entry.provenance?.kind === 'package' ? entry.provenance.packageName : entry.provenance?.kind;
+  return `${origin}:${entry.name}`;
+}
+
 /** Installs a package publishing the named kits, each holding one passing check. */
 function installPackage(name: string, kits: string[], options: InstallPackageOptions = {}): void {
-  const { readyupVersion, version } = options;
+  const { hasManifest = true, readyupVersion, version } = options;
   const root = path.join(process.cwd(), 'node_modules', name);
   mkdirSync(path.join(root, '.readyup', 'kits'), { recursive: true });
   writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name, ...(version !== undefined && { version }) }));
@@ -139,15 +247,18 @@ function installPackage(name: string, kits: string[], options: InstallPackageOpt
     const stamp = readyupVersion === undefined ? '' : `export const __readyupVersion = '${readyupVersion}';\n`;
     writeFileSync(path.join(root, '.readyup', 'kits', `${kit}.js`), `${stamp}${body}`);
   }
-  writeFileSync(
-    path.join(root, '.readyup', 'manifest.json'),
-    JSON.stringify({ version: 1, kits: kits.map((kit) => ({ name: kit })) }),
-  );
+  if (hasManifest) {
+    writeFileSync(
+      path.join(root, '.readyup', 'manifest.json'),
+      JSON.stringify({ version: 1, kits: kits.map((kit) => ({ name: kit })) }),
+    );
+  }
 }
 
 interface InstallPackageOptions {
-  version?: string;
+  hasManifest?: boolean;
   readyupVersion?: string;
+  version?: string;
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -60,7 +60,7 @@ Run options:
   --from <source>                    Kit source (github:org/repo, bitbucket:ws/repo, npm:package, global, dir:path, or local path)
   --file, -f <path>                  Path to a local kit file
   --url <url>                        Fetch kit from a URL
-  --packages                         Run every kit the config's "packages" list publishes
+  --packages [<name>]                Run a kit the config's "packages" list publishes (default: "default")
   --jit                              Run from TypeScript source instead of compiled JS
   --internal                         Use internal kit directory and infix from config
   --checklists, -c <name,...>        Filter checklists within the selected kit
@@ -101,8 +101,9 @@ Kit source (mutually exclusive):
                                      npm:package, global, dir:path, or local repo path)
   --file, -f <path>                  Path to a local kit file
   --url <url>                        Fetch kit from a URL
-  --packages                         Run every kit published by the packages the config's
-                                     "packages" list names
+  --packages [<name>]                Run a kit from every package the config's "packages"
+                                     list names that publishes it; without a name, the kit
+                                     named "default", which every listed package must publish
 
 Mode flags (incompatible with --from, --file, --url, --packages):
   --jit                              Run from TypeScript source instead of compiled JS

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -102,8 +102,8 @@ Kit source (mutually exclusive):
   --file, -f <path>                  Path to a local kit file
   --url <url>                        Fetch kit from a URL
   --packages [<name>]                Run a kit from every package the config's "packages"
-                                     list names that publishes it; without a name, the kit
-                                     named "default", which every listed package must publish
+                                     list names that publishes it, skipping those that do
+                                     not; without a name, the kit named "default"
 
 Mode flags (incompatible with --from, --file, --url, --packages):
   --jit                              Run from TypeScript source instead of compiled JS

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -129,6 +129,10 @@ function buildBitbucketKitUrl(workspace: string, repo: string, ref: string, kit:
 /** Guidance shown for every spelling of `--checklists` that names no checklist. */
 const CHECKLISTS_HINT = '--checklists requires a comma-separated list of checklist names';
 
+/** Why checklist selection is rejected under `--packages`, whichever spelling expressed it. */
+const PACKAGES_CHECKLISTS_REASON =
+  'several configured packages may publish the named kit, so the checklists select within no single one';
+
 /** Map generic "requires a value" errors to domain-specific hints for run-subcommand flags. */
 const flagErrorHints: Record<string, string> = {
   '--checklists': CHECKLISTS_HINT,
@@ -164,13 +168,18 @@ function validateFlagConstraints(parsed: RunFlagConstraints, kitSpecifiers: KitS
     throw usageError(`Cannot combine ${sourceFlags.join(', ')} flags`);
   }
 
-  // `--packages` runs every kit its configured packages publish, so nothing it could be paired with
-  // narrows that set: a positional or a `--checklists` filter names kits in this project instead.
-  if (parsed.packages && kitSpecifiers.length > 0) {
-    throw usageError('--packages cannot be combined with positional kit arguments');
-  }
+  // A positional names the kit to select in every configured package, so it narrows the run. Checklist
+  // selection cannot: it names checklists within one kit, and `--packages` may reach several packages'
+  // copies of the name. Both spellings of that selection are rejected for the same reason.
   if (parsed.packages && parsed.checklists !== undefined) {
-    throw usageError('--packages cannot be combined with --checklists; it runs every kit each package publishes');
+    throw usageError(`--packages cannot be combined with --checklists; ${PACKAGES_CHECKLISTS_REASON}`);
+  }
+  const filteredSpec = kitSpecifiers.find((spec) => spec.checklists.length > 0);
+  if (parsed.packages && filteredSpec !== undefined) {
+    throw usageError(
+      `--packages cannot be combined with the ":" checklist filter on "${filteredSpec.kitName}"; ` +
+        PACKAGES_CHECKLISTS_REASON,
+    );
   }
 
   const sourceType = sourceFlags[0];

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -4,7 +4,7 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 
 import { buildKitFilename } from './buildKitFilename.ts';
 import { type LoadedRdyKit, loadRdyKit } from './config.ts';
-import { kitLoadError, type RdyError, toRdyError, usageError } from './errors.ts';
+import { configError, kitLoadError, type RdyError, toRdyError, usageError } from './errors.ts';
 import { EXIT_OK, EXIT_PROBLEMS_FOUND, EXIT_TOOL_FAILURE } from './exitCodes.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonReport, type KitInput } from './formatJsonReport.ts';
@@ -17,7 +17,7 @@ import { type BreadcrumbSegment, SEGMENT_SEPARATOR } from './layout/layoutEngine
 import { DEFAULT_MANIFEST_PATH } from './manifest/manifestPath.ts';
 import type { RdyManifest } from './manifest/manifestSchema.ts';
 import { readManifest } from './manifest/readManifest.ts';
-import { expandConfiguredPackages } from './packages/expandConfiguredPackages.ts';
+import { expandConfiguredPackages, type PackageKit } from './packages/expandConfiguredPackages.ts';
 import { type FromSource, type NpmSource, parseFromValue } from './parseFromValue.ts';
 import { type KitSpecifier, parseKitSpecifiers } from './parseKitSpecifiers.ts';
 import { loadRemoteKit, type LoadRemoteKitOptions } from './remote/loadRemoteKit.ts';
@@ -41,6 +41,9 @@ import { extractHint, extractMessage } from './utils/error-handling.ts';
 import { translateParseArgsError } from './utils/parse-args-error.ts';
 import { checkDrift } from './verify/checkDrift.ts';
 import { checkSourceDrift } from './verify/checkSourceDrift.ts';
+
+/** The kit every source runs when the invocation names none. */
+const DEFAULT_KIT_NAME = 'default';
 
 /** Valid severity values for CLI flag validation. */
 const VALID_SEVERITIES = new Set<string>(['error', 'warn', 'recommend']);
@@ -362,10 +365,15 @@ export function resolveKitSources({
   // Assume `jit` is always false when `fromValue` is present; `parseRunArgs` enforces this constraint.
   const extension = jit ? '.ts' : '.js';
 
+  // Fill the default before the `--packages` branch reads it, so a bare invocation is structurally
+  // `--packages default` and the two forms cannot select different kits.
+  const declaredSpecs = kitSpecifiers.length > 0 ? kitSpecifiers : [{ kitName: DEFAULT_KIT_NAME, checklists: [] }];
+
   if (packages === true) {
-    return resolveConfiguredPackages(configuredPackages ?? [], extension);
+    const requestedNames = declaredSpecs.map((spec) => spec.kitName);
+    return resolveConfiguredPackages(configuredPackages ?? [], requestedNames, extension);
   }
-  const declaredSpecs = kitSpecifiers.length > 0 ? kitSpecifiers : [{ kitName: 'default', checklists: [] }];
+
   // `--checklists` names checklists within one kit, and `parseRunArgs` has already rejected every
   // invocation where "one kit" is ambiguous, so this map never covers more than a single spec.
   const specs = checklists === undefined ? declaredSpecs : declaredSpecs.map((spec) => ({ ...spec, checklists }));
@@ -472,23 +480,80 @@ function resolveFromSource(source: FromSource, specs: KitSpecifier[], extension:
 }
 
 /**
- * Resolves every kit the configured packages publish into run entries.
+ * Resolves the requested kits, drawn from what the configured packages publish, into run entries.
  *
  * An empty list is a usage error rather than an empty run: `--packages` with nothing configured would
  * otherwise report a clean pass having checked nothing, which is the one outcome a verification tool
  * must never invent.
  */
-function resolveConfiguredPackages(configuredPackages: string[], extension: string): ResolvedKitEntry[] {
+function resolveConfiguredPackages(
+  configuredPackages: string[],
+  requestedNames: string[],
+  extension: string,
+): ResolvedKitEntry[] {
   if (configuredPackages.length === 0) {
     throw usageError('--packages requires a "packages" list in the readyup config; none is configured.');
   }
 
-  return expandConfiguredPackages(configuredPackages, extension).map((kit) => ({
+  const published = expandConfiguredPackages(configuredPackages, extension);
+
+  return selectRequestedKits(published, requestedNames).map((kit) => ({
     name: kit.kitName,
     source: { path: kit.path },
     checklists: [],
     provenance: { kind: 'package', packageName: kit.packageName, version: kit.version },
   }));
+}
+
+/**
+ * Narrows what the configured packages publish to the requested kits, name-major.
+ *
+ * Name-major so `--packages a b` runs every package's `a` before any package's `b`, matching the
+ * order `rdy run a b` runs them in against a single source.
+ */
+function selectRequestedKits(published: PackageKit[], requestedNames: string[]): PackageKit[] {
+  return requestedNames.flatMap((kitName) =>
+    kitName === DEFAULT_KIT_NAME ? selectDefaultKits(published) : selectNamedKits(published, kitName),
+  );
+}
+
+/**
+ * Selects `default` from every configured package, failing on one that publishes none.
+ *
+ * A package missing `default` is drift between a hand-maintained list and a convention readyup's own
+ * `publishing` kit enforces, so it fails the run the way an absent package already does. The kits it
+ * does publish are named because the reader's next move is to run one of them by name.
+ */
+function selectDefaultKits(published: PackageKit[]): PackageKit[] {
+  const packageNames = new Set(published.map((kit) => kit.packageName));
+
+  return [...packageNames].map((packageName) => {
+    const kits = published.filter((kit) => kit.packageName === packageName);
+    const defaultKit = kits.find((kit) => kit.kitName === DEFAULT_KIT_NAME);
+    if (defaultKit === undefined) {
+      const names = kits.map((kit) => kit.kitName).join(', ');
+      throw configError(
+        `Configured package "${packageName}" publishes no kit named "${DEFAULT_KIT_NAME}"; it publishes: ${names}.`,
+      );
+    }
+    return defaultKit;
+  });
+}
+
+/**
+ * Selects a named kit from every configured package publishing it, rejecting a name none publishes.
+ *
+ * A package without the kit is skipped rather than reported: naming a kit is a selection across the
+ * configured set, and a package that does not participate is not drift. A name nothing publishes is a
+ * bad invocation, and answering it with an empty pass would be the clean report of nothing checked.
+ */
+function selectNamedKits(published: PackageKit[], kitName: string): PackageKit[] {
+  const selected = published.filter((kit) => kit.kitName === kitName);
+  if (selected.length === 0) {
+    const available = [...new Set(published.map((kit) => kit.kitName))].join(', ');
+    throw usageError(`No configured package publishes a kit named "${kitName}"; available kits: ${available}.`);
+  }
+  return selected;
 }
 
 /**

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -4,7 +4,7 @@ import { parseArgs as nodeParseArgs } from 'node:util';
 
 import { buildKitFilename } from './buildKitFilename.ts';
 import { type LoadedRdyKit, loadRdyKit } from './config.ts';
-import { configError, kitLoadError, type RdyError, toRdyError, usageError } from './errors.ts';
+import { kitLoadError, type RdyError, toRdyError, usageError } from './errors.ts';
 import { EXIT_OK, EXIT_PROBLEMS_FOUND, EXIT_TOOL_FAILURE } from './exitCodes.ts';
 import { formatCombinedSummary } from './formatCombinedSummary.ts';
 import { formatJsonReport, type KitInput } from './formatJsonReport.ts';
@@ -491,9 +491,10 @@ function resolveFromSource(source: FromSource, specs: KitSpecifier[], extension:
 /**
  * Resolves the requested kits, drawn from what the configured packages publish, into run entries.
  *
- * An empty list is a usage error rather than an empty run: `--packages` with nothing configured would
- * otherwise report a clean pass having checked nothing, which is the one outcome a verification tool
- * must never invent.
+ * An empty `packages` list is a usage error: the flag names a config key the config does not have, so
+ * the invocation asks for something that cannot be answered. Configured packages that publish no
+ * requested kit are a different case and run nothing, which is the honest answer to "does this project
+ * satisfy what these packages require of it" when they require nothing.
  */
 function resolveConfiguredPackages(
   configuredPackages: string[],
@@ -517,52 +518,22 @@ function resolveConfiguredPackages(
 /**
  * Narrows what the configured packages publish to the requested kits, name-major.
  *
+ * A configured package not publishing a requested kit is skipped rather than reported: `--packages`
+ * asks whether this project satisfies what its configured packages require of it, and a package
+ * requiring nothing under that name has nothing to answer for.
+ *
  * Name-major so `--packages a b` runs every package's `a` before any package's `b`, matching the
  * order `rdy run a b` runs them in against a single source.
  */
 function selectRequestedKits(published: PackageKit[], requestedNames: string[]): PackageKit[] {
-  return requestedNames.flatMap((kitName) =>
-    kitName === DEFAULT_KIT_NAME ? selectDefaultKits(published) : selectNamedKits(published, kitName),
-  );
-}
-
-/**
- * Selects `default` from every configured package, failing on one that publishes none.
- *
- * A package missing `default` is drift between a hand-maintained list and a convention readyup's own
- * `publishing` kit enforces, so it fails the run the way an absent package already does. The kits it
- * does publish are named because the reader's next move is to run one of them by name.
- */
-function selectDefaultKits(published: PackageKit[]): PackageKit[] {
-  const packageNames = new Set(published.map((kit) => kit.packageName));
-
-  return [...packageNames].map((packageName) => {
-    const kits = published.filter((kit) => kit.packageName === packageName);
-    const defaultKit = kits.find((kit) => kit.kitName === DEFAULT_KIT_NAME);
-    if (defaultKit === undefined) {
-      const names = kits.map((kit) => kit.kitName).join(', ');
-      throw configError(
-        `Configured package "${packageName}" publishes no kit named "${DEFAULT_KIT_NAME}"; it publishes: ${names}.`,
-      );
+  return requestedNames.flatMap((kitName) => {
+    const selected = published.filter((kit) => kit.kitName === kitName);
+    if (selected.length === 0 && kitName !== DEFAULT_KIT_NAME) {
+      const available = [...new Set(published.map((kit) => kit.kitName))].join(', ');
+      throw usageError(`No configured package publishes a kit named "${kitName}"; available kits: ${available}.`);
     }
-    return defaultKit;
+    return selected;
   });
-}
-
-/**
- * Selects a named kit from every configured package publishing it, rejecting a name none publishes.
- *
- * A package without the kit is skipped rather than reported: naming a kit is a selection across the
- * configured set, and a package that does not participate is not drift. A name nothing publishes is a
- * bad invocation, and answering it with an empty pass would be the clean report of nothing checked.
- */
-function selectNamedKits(published: PackageKit[], kitName: string): PackageKit[] {
-  const selected = published.filter((kit) => kit.kitName === kitName);
-  if (selected.length === 0) {
-    const available = [...new Set(published.map((kit) => kit.kitName))].join(', ');
-    throw usageError(`No configured package publishes a kit named "${kitName}"; available kits: ${available}.`);
-  }
-  return selected;
 }
 
 /**
@@ -879,6 +850,13 @@ async function runMultiKitHumanMode(
   settings: HumanRunSettings,
   isJit: boolean,
 ): Promise<number> {
+  // Say so when a run selected nothing, which `--packages` reaches when no configured package publishes
+  // the requested kit. A blank screen reads as a tool that failed to start rather than as a pass.
+  if (kitEntries.length === 0) {
+    process.stdout.write('No kits to run.\n');
+    return EXIT_OK;
+  }
+
   const isMultiKit = kitEntries.length > 1;
   const tracking = readManifestTracking(isJit);
   const writeBlock = createBlockWriter();

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -95,7 +95,9 @@ export function formatOwnerView({
   }
 
   if (packageKits.length > 0) {
-    sections.push(formatSection('Packages', 'rdy run --packages', packageKits, 'sourcePackage'));
+    // The rows stay every published kit — discovery is not run selection — so the bracketed optional keeps
+    // the promise that every kit listed is reachable by the command above it.
+    sections.push(formatSection('Packages', 'rdy run --packages [<name>]', packageKits, 'sourcePackage'));
   }
 
   if (availablePackages.length > 0) {


### PR DESCRIPTION
## What

`rdy run --packages` now accepts positional arguments specifying the kits to run. Without positional arguments, `rdy run --packages` now runs only the kit named `default` (if it exists) from each package listed in the configuration.

## Why

A routine `rdy run --packages` failed on a fully conformant repo whenever a listed package published a kit that needs credentials or a deliberate setup, because every published kit ran whether or not the invocation asked for it. Exiting nonzero with a wall of unrelated failures is how a reader learns to stop reading the run at all. Holding a kit back needed no new surface: every other kit source already treats the kit name as the selector, and `--packages` was the lone exception.

## Details

### 🎉 Features

- `--packages` accepts a kit name. `rdy run --packages <name>` selects that kit across the configured set. Reaching one package's copy stays `rdy run --from npm:<package> <name>`.
- A name no listed package publishes is a usage error naming the available kits, since naming a kit asks for something specific rather than for whatever applies.
- Checklist selection stays rejected under `--packages`, now in both spellings. The inline `kit:checklist` form was unreachable while positionals were banned outright and would otherwise have parsed and been silently dropped. Both messages name the real ambiguity: several listed packages may publish the named kit, leaving the checklists no single one to select within.

### 🐛 Bug fixes

- `--packages` no longer fans out over every kit each listed package publishes. The bare form is resolved as `--packages default`, so the two forms cannot select different kits.
- A listed package publishing no `default` is skipped rather than failing the run. `--packages` asks whether this project satisfies what its listed packages require of it, and a package publishing nothing under the requested name requires nothing of it.
- A run that selects no kit now says so and passes, rather than printing nothing at all.

### 🧪 Tests

- The `--packages` wiring suite covers selection against a real fixture project: the default-only rule, a named kit across two packages, packages skipped for not publishing the requested kit, an empty selection passing without running anything, name-major ordering across several names, and the unpublished-name usage error asserted on code and message.
- Fixture packages publish `default`, and one exercises the filename-enumeration fallback used when a package ships no manifest, proving selection reads names identically on both paths.

### 📚 Documentation

- The README's package-hosted-kits section documents the two forms, when a listed package is skipped, and how a kit author holds a kit back from a routine run.
- Both `rdy run --help` forms and the `rdy list` Packages section heading show `--packages [<name>]`. The listing still reports every kit a listed package publishes: discovery is not run selection.

Closes #215

