### PR TITLE
#268 Separate run verdict from counts and lead with failures

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -314,7 +314,7 @@ It produces:
          react resolves to both 18.3.1 and 19.0.0
    ⚪ Native modules are rebuilt · no native dependencies in this workspace
 ──
-🔴 3 passed | 1 error | 1 skipped (0ms)
+🔴 | 1 error, 3 passed, 1 skipped (0ms)
 
 ── Fixes
 💊 No dependency has duplicated majors
@@ -489,7 +489,7 @@ A check line reads `token name <separator> detail [progress] (duration)`. The se
 
 **A failed line carries only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. Passes and skips keep their detail inline.
 
-Tail and total lines lead with the run's worst severity, then report counts in a fixed order -- passed, errors, warnings, recommendations, blocked, skipped -- omitting any that is zero.
+Tail and total lines lead with the run's worst severity, then report counts in a fixed order -- errors, warnings, recommendations, passed, blocked, skipped -- omitting any that is zero. Commas part the counts from one another, and a `|` parts the verdict from the list wherever no label already does, so the verdict is never read as a label on the count beside it.
 
 **Every block heads itself with a breadcrumb.** A run block is headed `━━`, and its segments read source, then kit, then checklist, parted by a spaced slash. A segment appears only where it distinguishes something: the source where the kit came from anywhere but the local kits directory or the working directory, the kit where the run holds more than one or a source segment is already there, the checklist where the kit runs more than one. A lone local kit running one checklist heads nothing at all. The summary table heads itself at `━━` too, as a peer of the blocks it tallies; `Fixes` and each command's own heading stay at `──`, and a bare `──` closes a block above its count line.
 
@@ -500,7 +500,7 @@ Blank lines part blocks rather than decorate headings: none opens a command's ou
 🟢 Types check cleanly (343ms)
 🟢 Bundle is within budget · 42kB of a 50kB budget [84%]
 ──
-🟢 2 passed (343ms)
+🟢 | 2 passed (343ms)
 
 ━━ 📋 integration
 🟢 Database is reachable
@@ -508,18 +508,18 @@ Blank lines part blocks rather than decorate headings: none opens a command's ou
    2 migrations pending: add_users, add_index
 ⚪ Seed data is loaded · seeding is disabled outside CI
 ──
-🔴 1 passed | 1 error | 1 skipped (151ms)
+🔴 | 1 error, 1 passed, 1 skipped (151ms)
 
 ── Fixes
 💊 Migrations are applied
    Run `pnpm migrate` against the target database
 
 ━━ Summary
-─────────────────────────────────────────────────────
+───────────────────────────────────────────────────
 🟢 build        343ms  2 passed
-🔴 integration  151ms  1 passed | 1 error | 1 skipped
-─────────────────────────────────────────────────────
-🔴 Total: 3 passed | 1 error | 1 skipped (494ms)
+🔴 integration  151ms  1 error, 1 passed, 1 skipped
+───────────────────────────────────────────────────
+🔴 Total: 1 error, 3 passed, 1 skipped (494ms)
 ```
 
 A kit from an installed package, a repository, or a URL names where it came from, so a long run says which checks belong to which kit without the reader scrolling for it:
@@ -551,7 +551,7 @@ FAIL  Migrations are applied (151ms)
       2 migrations pending: add_users, add_index
 SKIP  Seed data is loaded - seeding is disabled outside CI
 --
-FAIL  1 passed | 1 error | 1 skipped (151ms)
+FAIL  | 1 error, 1 passed, 1 skipped (151ms)
 ```
 
 ```

--- a/packages/readyup/__tests__/formatCombinedSummary.unit.test.ts
+++ b/packages/readyup/__tests__/formatCombinedSummary.unit.test.ts
@@ -64,7 +64,7 @@ describe(formatCombinedSummary, () => {
       makeSummary({ name: 'infra', passed: 2, errors: 1, worstSeverity: 'error', durationMs: 45 }),
     ]);
 
-    expect(output).toContain(`${FAILED_ERROR} infra  45ms  2 passed | 1 error`);
+    expect(output).toContain(`${FAILED_ERROR} infra  45ms  1 error, 2 passed`);
   });
 
   it('omits zero-count fields from a row', () => {
@@ -79,7 +79,7 @@ describe(formatCombinedSummary, () => {
       makeSummary({ name: 'checks', passed: 1, errors: 1, blocked: 2, optional: 1, worstSeverity: 'error' }),
     ]);
 
-    expect(output).toContain('1 passed | 1 error | 2 blocked | 1 skipped');
+    expect(output).toContain('1 error, 1 passed, 2 blocked, 1 skipped');
   });
 
   it('retires the prose count grammar', () => {
@@ -98,7 +98,7 @@ describe(formatCombinedSummary, () => {
         makeSummary({ name: 'other', passed: 5, errors: 2, blocked: 1, worstSeverity: 'error', durationMs: 200 }),
       ]);
 
-      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 15 passed | 2 errors | 1 blocked (300ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 2 errors, 15 passed, 1 blocked (300ms)`);
     });
 
     it('leads with the passed token when no checklist failed', () => {
@@ -118,7 +118,7 @@ describe(formatCombinedSummary, () => {
       const totalLine = output.split('\n').at(-1);
 
       expect(totalLine?.startsWith(FAILED_WARN)).toBe(true);
-      expect(totalLine).toContain('1 warning | 1 recommendation');
+      expect(totalLine).toContain('1 warning, 1 recommendation');
       expect(totalLine).not.toContain('passed');
     });
 

--- a/packages/readyup/__tests__/formatCombinedSummary.unit.test.ts
+++ b/packages/readyup/__tests__/formatCombinedSummary.unit.test.ts
@@ -59,7 +59,7 @@ describe(formatCombinedSummary, () => {
     expect(output).toContain(`${token} deploy`);
   });
 
-  it('renders each row as name, duration, then pipe counts', () => {
+  it('renders each row as name, duration, then comma-joined counts', () => {
     const output = formatCombinedSummary([
       makeSummary({ name: 'infra', passed: 2, errors: 1, worstSeverity: 'error', durationMs: 45 }),
     ]);

--- a/packages/readyup/__tests__/layout/layoutEngine.unit.test.ts
+++ b/packages/readyup/__tests__/layout/layoutEngine.unit.test.ts
@@ -204,7 +204,7 @@ describe('formatBreadcrumb', () => {
 });
 
 describe('formatCounts', () => {
-  it('joins non-zero fields with pipes in the fixed order', () => {
+  it('joins non-zero fields with commas in the fixed order', () => {
     const counts = makeCounts({
       passed: 14,
       errors: 1,
@@ -215,14 +215,12 @@ describe('formatCounts', () => {
       worstSeverity: 'error',
     });
 
-    expect(engine.formatCounts(counts)).toBe(
-      '14 passed | 1 error | 1 warning | 2 recommendations | 5 blocked | 2 skipped',
-    );
+    expect(engine.formatCounts(counts)).toBe('1 error, 1 warning, 2 recommendations, 14 passed, 5 blocked, 2 skipped');
   });
 
   it('omits zero-count fields', () => {
     expect(engine.formatCounts(makeCounts({ passed: 3, warnings: 1, worstSeverity: 'warn' }))).toBe(
-      '3 passed | 1 warning',
+      '1 warning, 3 passed',
     );
   });
 
@@ -232,12 +230,12 @@ describe('formatCounts', () => {
 
   it('pluralizes the severity labels', () => {
     expect(engine.formatCounts(makeCounts({ errors: 2, warnings: 2, recommendations: 2 }))).toBe(
-      '2 errors | 2 warnings | 2 recommendations',
+      '2 errors, 2 warnings, 2 recommendations',
     );
   });
 
   it('leaves the skip labels unchanged for any count', () => {
-    expect(engine.formatCounts(makeCounts({ blocked: 3, optional: 4 }))).toBe('3 blocked | 4 skipped');
+    expect(engine.formatCounts(makeCounts({ blocked: 3, optional: 4 }))).toBe('3 blocked, 4 skipped');
   });
 
   it('carries no per-field tokens', () => {
@@ -250,26 +248,26 @@ describe('formatCounts', () => {
 });
 
 describe('formatCountLine', () => {
-  it('leads with the worst severity rather than the first non-zero field', () => {
+  it('parts the verdict from the counts when no label does', () => {
     const counts = makeCounts({ passed: 9, errors: 1, worstSeverity: 'error' });
 
-    expect(engine.formatCountLine(counts, 1_200)).toBe(`${FAILED_ERROR} 9 passed | 1 error (1200ms)`);
+    expect(engine.formatCountLine(counts, 1_200)).toBe(`${FAILED_ERROR} | 1 error, 9 passed (1200ms)`);
   });
 
   it('leads with the passed token when nothing failed', () => {
-    expect(engine.formatCountLine(makeCounts({ passed: 4 }), 300)).toBe(`${PASSED} 4 passed (300ms)`);
+    expect(engine.formatCountLine(makeCounts({ passed: 4 }), 300)).toBe(`${PASSED} | 4 passed (300ms)`);
   });
 
   it('shows a duration below the check-line floor', () => {
     expect(engine.formatCountLine(makeCounts({ passed: 1 }), 4)).toContain('(4ms)');
   });
 
-  it('places an optional label between the token and the counts', () => {
+  it('takes no separator when a label already parts the verdict from the counts', () => {
     expect(engine.formatCountLine(makeCounts({ passed: 2 }), 500, 'Total:')).toBe(`${PASSED} Total: 2 passed (500ms)`);
   });
 
   it('leads a blocked-only run with the passed token, since nothing failed', () => {
-    expect(engine.formatCountLine(makeCounts({ blocked: 2 }), 100)).toBe(`${PASSED} 2 blocked (100ms)`);
+    expect(engine.formatCountLine(makeCounts({ blocked: 2 }), 100)).toBe(`${PASSED} | 2 blocked (100ms)`);
   });
 });
 
@@ -302,8 +300,8 @@ describe('formatSummaryTable', () => {
 
     expect(lines[0]).toBe('\u{2501}\u{2501} Summary');
     expect(lines[2]).toMatch(/^\S build\s+410ms {2}2 passed$/u);
-    expect(lines[3]).toMatch(/^\S integration {2}1400ms {2}1 passed \| 1 error$/u);
-    expect(lines.at(-1)).toBe(`${FAILED_ERROR} Total: 3 passed | 1 error (1810ms)`);
+    expect(lines[3]).toMatch(/^\S integration {2}1400ms {2}1 error, 1 passed$/u);
+    expect(lines.at(-1)).toBe(`${FAILED_ERROR} Total: 1 error, 3 passed (1810ms)`);
     expect(lines).toHaveLength(6);
   });
 
@@ -339,7 +337,7 @@ describe('formatSummaryTable', () => {
   it('pads names so the counts column starts at one place in every row', () => {
     const lines = engine.formatSummaryTable(input);
 
-    expect(lines[2]?.indexOf('2 passed')).toBe(lines[3]?.indexOf('1 passed'));
+    expect(lines[2]?.indexOf('2 passed')).toBe(lines[3]?.indexOf('1 error'));
   });
 
   it('right-aligns durations', () => {
@@ -371,6 +369,27 @@ describe('formatSummaryTable', () => {
     });
 
     expect(lines).toHaveLength(5);
+  });
+});
+
+describe('verdict adjacency', () => {
+  const counts = makeCounts({ passed: 2, errors: 1, worstSeverity: 'error' });
+  const verdict = engine.token('failedError');
+
+  it.each([
+    ['tail line', () => engine.formatCountLine(counts, 500)],
+    ['total line', () => engine.formatCountLine(counts, 500, 'Total:')],
+    [
+      'table row',
+      () =>
+        engine.formatSummaryTable({
+          rows: [makeRow({ name: 'infra', counts })],
+          totals: counts,
+          totalDurationMs: 500,
+        })[2],
+    ],
+  ])('leaves no count against the verdict glyph on a %s', (_kind, render) => {
+    expect((render() ?? '').slice(verdict.length)).not.toMatch(/^\d/u);
   });
 });
 

--- a/packages/readyup/__tests__/reportRdy.unit.test.ts
+++ b/packages/readyup/__tests__/reportRdy.unit.test.ts
@@ -286,7 +286,7 @@ describe(reportRdy, () => {
       expect(output.split('\n').at(-1)).toBe(`${FAILED_WARN} | 1 warning, 1 passed (142ms)`);
     });
 
-    it('orders the fields by decreasing severity and omits zeros', () => {
+    it('orders the fields by outcome, worst news first, and omits zeros', () => {
       const output = reportRdy(
         makeReport({
           results: [

--- a/packages/readyup/__tests__/reportRdy.unit.test.ts
+++ b/packages/readyup/__tests__/reportRdy.unit.test.ts
@@ -203,7 +203,7 @@ describe(reportRdy, () => {
     it('always shows the total duration on the count line', () => {
       const output = reportRdy(makeReport({ results: [makePassedResult()], durationMs: 4 }));
 
-      expect(output.split('\n').at(-1)).toBe(`${PASSED} 1 passed (4ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${PASSED} | 1 passed (4ms)`);
     });
   });
 
@@ -283,7 +283,7 @@ describe(reportRdy, () => {
         }),
       );
 
-      expect(output.split('\n').at(-1)).toBe(`${FAILED_WARN} 1 passed | 1 warning (142ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_WARN} | 1 warning, 1 passed (142ms)`);
     });
 
     it('orders the fields by decreasing severity and omits zeros', () => {
@@ -302,7 +302,7 @@ describe(reportRdy, () => {
       );
 
       expect(output.split('\n').at(-1)).toBe(
-        `${FAILED_ERROR} 1 passed | 1 error | 1 recommendation | 1 blocked | 1 skipped (500ms)`,
+        `${FAILED_ERROR} | 1 error, 1 recommendation, 1 passed, 1 blocked, 1 skipped (500ms)`,
       );
     });
 
@@ -528,7 +528,7 @@ describe(reportRdy, () => {
         }),
       );
 
-      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} 2 passed | 1 error (50ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} | 1 error, 2 passed (50ms)`);
     });
   });
 
@@ -614,7 +614,7 @@ describe(reportRdy, () => {
         { quiet: true },
       );
 
-      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} 2 passed | 1 error (90ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} | 1 error, 2 passed (90ms)`);
     });
 
     it('keeps the fix recap', () => {
@@ -661,7 +661,7 @@ describe(reportRdy, () => {
         { quiet: true },
       );
 
-      expect(output).toBe(`${PASSED} 2 passed (30ms)`);
+      expect(output).toBe(`${PASSED} | 2 passed (30ms)`);
     });
   });
 
@@ -718,7 +718,7 @@ describe(reportRdy, () => {
         }),
       );
 
-      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} 2 passed | 1 error (90ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} | 1 error, 2 passed (90ms)`);
     });
 
     it('retains a quiet passing parent so a deep failure stays reachable', () => {
@@ -802,7 +802,7 @@ describe(reportRdy, () => {
         { reportOn: 'error' },
       );
 
-      expect(output.split('\n').at(-1)).toContain(`${FAILED_WARN} 1 passed | 1 warning`);
+      expect(output.split('\n').at(-1)).toContain(`${FAILED_WARN} | 1 warning, 1 passed`);
       expect(output).not.toContain('warn-fail');
     });
 

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -25,6 +25,17 @@ const TOTAL_LABEL = 'Total:';
 /** Heading over the combined summary table. */
 const SUMMARY_HEADING = 'Summary';
 
+/**
+ * Text parting a count line's verdict from its counts, used wherever no label already parts them.
+ *
+ * Heavier than `COUNT_SEPARATOR`, so the counts read as one list under the verdict rather than binding
+ * their first field to the glyph beside it.
+ */
+const VERDICT_SEPARATOR = '|';
+
+/** Text parting one count from the next. */
+const COUNT_SEPARATOR = ', ';
+
 /** Statement a count line makes when there is nothing at all to report. */
 const EMPTY_COUNTS = '0 passed';
 
@@ -41,14 +52,15 @@ interface CountField {
 /**
  * Count fields in the order every count line presents them.
  *
- * Ordered by decreasing severity rather than alphabetically: the reader scans left to right for the
- * worst news, and a fixed order is what lets them find a field without reading every label.
+ * Ordered by outcome rather than alphabetically: the checks that ran, worst news first, then the checks
+ * that did not. The reader scans left to right and meets the failures before anything else, and a fixed
+ * order is what lets them find a field without reading every label.
  */
 const COUNT_FIELDS: readonly CountField[] = [
-  { key: 'passed', singular: 'passed', plural: 'passed' },
   { key: 'errors', singular: 'error', plural: 'errors' },
   { key: 'warnings', singular: 'warning', plural: 'warnings' },
   { key: 'recommendations', singular: 'recommendation', plural: 'recommendations' },
+  { key: 'passed', singular: 'passed', plural: 'passed' },
   { key: 'blocked', singular: 'blocked', plural: 'blocked' },
   { key: 'optional', singular: 'skipped', plural: 'skipped' },
 ];
@@ -134,7 +146,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   }
 
   /**
-   * Returns `token label counts (duration)`, led by the token for `counts.worstSeverity`.
+   * Returns `token <label or separator> counts (duration)`, led by the token for `counts.worstSeverity`.
    *
    * The duration always appears, whatever its magnitude.
    */
@@ -219,10 +231,14 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
 
   // -- Helpers --
 
-  /** Returns everything a count line carries after its leading token. */
+  /**
+   * Returns everything a count line carries after its leading token.
+   *
+   * A label and the verdict separator occupy one slot, so a labelled line takes no separator: whichever
+   * fills the slot is what keeps the verdict from touching the first count.
+   */
   function buildCountBody(counts: SummaryCounts, durationMs: number, label?: string): string {
-    const prefix = label === undefined ? '' : `${label} `;
-    return `${prefix}${formatCounts(counts)} (${formatDuration(durationMs)})`;
+    return `${label ?? VERDICT_SEPARATOR} ${formatCounts(counts)} (${formatDuration(durationMs)})`;
   }
 
   return {
@@ -249,12 +265,12 @@ export function resolveWorstToken(worstSeverity: Severity | null): TokenName {
   return 'passed';
 }
 
-/** Returns the non-zero counts pipe-joined in field order, or `0 passed` when every count is zero. */
+/** Returns the non-zero counts joined in field order, or `0 passed` when every count is zero. */
 function formatCounts(counts: SummaryCounts): string {
   const fields = COUNT_FIELDS.filter((field) => counts[field.key] > 0).map((field) =>
     pluralizeWithCount(counts[field.key], field.singular, field.plural),
   );
-  return fields.length > 0 ? fields.join(' | ') : EMPTY_COUNTS;
+  return fields.length > 0 ? fields.join(COUNT_SEPARATOR) : EMPTY_COUNTS;
 }
 
 /** Returns the formatted duration, or nothing for a skipped token or a duration under the floor. */

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -29,7 +29,8 @@ const SUMMARY_HEADING = 'Summary';
  * Text parting a count line's verdict from its counts, used wherever no label already parts them.
  *
  * Heavier than `COUNT_SEPARATOR`, so the counts read as one list under the verdict rather than binding
- * their first field to the glyph beside it.
+ * their first field to the glyph beside it. `buildCountBody` supplies the space after it, as it does for
+ * the label it stands in for.
  */
 const VERDICT_SEPARATOR = '|';
 


### PR DESCRIPTION
## What

Refines readyup's human-readable report to distinguish the verdict for a run from the counts for each kind of result. Counts now lead with errors instead of passes.

## Why

A failing run announced itself as `🔴 2 passed | 1 error | 95 blocked`. The verdict is a claim about the whole run, but sitting immediately beside the first count it read as a label on that count, so the run appeared to report two errors. Two things produced the misreading: nothing stood between the verdict and the list, and the list led with the count least related to the verdict.

## Details

### 🎉 Features

- A count line with no label of its own now parts its verdict from its counts with `|`, and counts are parted from one another with `,`: `🔴 | 1 error, 2 passed, 95 blocked`. Both glyphs are ASCII, so `rich` and `plain` carry the same punctuation.
- Counts read in the order errors, warnings, recommendations, passed, blocked, skipped -- the checks that ran, worst news first, then the checks that did not. Zero counts are still omitted.
- Lines that already part their verdict from their counts keep what parts them and gain no second  parter: the summary table's rows by the checklist name, its total line by the `Total:` label.
- The `--json` document is untouched. Its `counts` object keeps its key order, since consumers read it by key rather than by position.

### 🧪 Tests

- A new `verdict adjacency` case asserts the rule directly -- no count sits against the verdict glyph -- across all three count-bearing line kinds, so the invariant is pinned rather than inferred from literal expectations.
- Count-line test titles now name the rule each one pins, replacing two that described the retired rendering.

### 📚 Documentation

- The README's five output samples and its sentence documenting count order match what the code renders, including the summary table's rule, whose width is computed from the widest row it encloses.

Closes #268
