### PR TITLE
#277 Stop failing a kit-less project, and report check details as sentences

### DIFF
--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -28,7 +28,7 @@ var projectFoundations = {
       name: "Project is ESM",
       check: () => {
         const type = readJsonValue("package.json", "type");
-        const detail = type === void 0 ? 'no "type" field' : `"type": ${JSON.stringify(type)}`;
+        const detail = type === void 0 ? 'package.json declares no "type" field' : `"type" is ${JSON.stringify(type)}`;
         return { ok: type === "module", detail };
       },
       fix: 'Add "type": "module" to package.json'
@@ -37,7 +37,7 @@ var projectFoundations = {
       name: "packageManager field is set",
       check: () => {
         const value = readJsonValue("package.json", "packageManager");
-        return typeof value === "string" ? { ok: true, detail: value } : { ok: false };
+        return typeof value === "string" ? { ok: true, detail: `packageManager is ${value}` } : { ok: false };
       },
       fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")'
     },
@@ -59,7 +59,7 @@ var optionalIntegrations = {
   checks: [
     {
       name: "Docker is configured",
-      skip: () => !fileExists("Dockerfile") ? "no Dockerfile" : false,
+      skip: () => !fileExists("Dockerfile") ? "This project has no Dockerfile" : false,
       check: () => true,
       checks: [
         {
@@ -70,7 +70,7 @@ var optionalIntegrations = {
     },
     {
       name: "Renovate is configured",
-      skip: () => !fileExists("renovate.json") ? "no renovate.json" : false,
+      skip: () => !fileExists("renovate.json") ? "This project has no renovate.json" : false,
       check: () => true,
       checks: [
         {

--- a/.readyup/kits/demo.ts
+++ b/.readyup/kits/demo.ts
@@ -36,7 +36,8 @@ const projectFoundations = {
       name: 'Project is ESM',
       check: () => {
         const type = readJsonValue('package.json', 'type');
-        const detail = type === undefined ? 'no "type" field' : `"type": ${JSON.stringify(type)}`;
+        const detail =
+          type === undefined ? 'package.json declares no "type" field' : `"type" is ${JSON.stringify(type)}`;
         return { ok: type === 'module', detail };
       },
       fix: 'Add "type": "module" to package.json',
@@ -45,7 +46,7 @@ const projectFoundations = {
       name: 'packageManager field is set',
       check: () => {
         const value = readJsonValue('package.json', 'packageManager');
-        return typeof value === 'string' ? { ok: true, detail: value } : { ok: false };
+        return typeof value === 'string' ? { ok: true, detail: `packageManager is ${value}` } : { ok: false };
       },
       fix: 'Add "packageManager" to package.json (e.g., "pnpm@10.x.x")',
     },
@@ -72,7 +73,7 @@ const optionalIntegrations = {
   checks: [
     {
       name: 'Docker is configured',
-      skip: () => (!fileExists('Dockerfile') ? 'no Dockerfile' : false),
+      skip: () => (!fileExists('Dockerfile') ? 'This project has no Dockerfile' : false),
       check: () => true,
       checks: [
         {
@@ -83,7 +84,7 @@ const optionalIntegrations = {
     },
     {
       name: 'Renovate is configured',
-      skip: () => (!fileExists('renovate.json') ? 'no renovate.json' : false),
+      skip: () => (!fileExists('renovate.json') ? 'This project has no renovate.json' : false),
       check: () => true,
       checks: [
         {

--- a/.readyup/kits/internal/default.ts
+++ b/.readyup/kits/internal/default.ts
@@ -18,7 +18,8 @@ export default defineRdyKit({
           name: 'NODE_ENV is set',
           check: () => {
             const value = process.env['NODE_ENV'];
-            return { ok: Boolean(value), detail: value ?? 'no value in the environment' };
+            if (!value) return { ok: false, detail: 'NODE_ENV has no value in the environment' };
+            return { ok: true, detail: `NODE_ENV is ${value}` };
           },
           fix: 'Set NODE_ENV before deploying',
         },

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -12,8 +12,8 @@
       "path": "kits/demo.js",
       "readyupVersion": "0.26.0",
       "source": "kits/demo.ts",
-      "sourceHash": "32c98768",
-      "targetHash": "33d82a82"
+      "sourceHash": "33b6ea59",
+      "targetHash": "898d00c0"
     }
   ]
 }

--- a/packages/readyup/.readyup/kits/__tests__/bundledKits.tool.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/bundledKits.tool.test.ts
@@ -106,8 +106,9 @@ describe('kits readyup publishes', () => {
     ]);
   });
 
-  // A consuming project has no kit directory of its own, and the kits report on that rather than
-  // mistaking the absence for nothing to say.
+  // The kits read the consuming project's working directory, and this one defines no kits of its own.
+  // Every setup check standing down is what says so: a pass would mean they had judged readyup's own
+  // kit directory, which travelled in with the package.
   it('judges the consuming project rather than the package it came from', async () => {
     const entries = resolveKitSources({ ...baseArgs, fromValue: 'npm:readyup' });
 
@@ -115,8 +116,7 @@ describe('kits readyup publishes', () => {
 
     const kit = pickKitResult(ReportSchema.parse(JSON.parse(stdout.join(''))), 'default');
     const setup = kit.checklists.find((checklist) => checklist.name === 'setup');
-    expect(setup?.counts.warnings).toBeGreaterThan(0);
-    // Advisory findings alone, so a bare run still exits clean.
+    expect(setup?.counts).toMatchObject({ passed: 0, warnings: 0, optional: 2 });
     expect(exitCode).toBe(0);
   });
 });

--- a/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
@@ -108,7 +108,7 @@ describe('default kit', () => {
 
       expect(pickResult(results, 'Its source')).toMatchObject({
         status: 'failed',
-        detail: expect.stringContaining('expected 0badcafe'),
+        detail: expect.stringContaining('not the recorded 0badcafe'),
       });
       expect(pickResult(results, 'Its bundle')).toMatchObject({ status: 'passed' });
     });
@@ -121,7 +121,7 @@ describe('default kit', () => {
 
       expect(pickResult(results, 'Its bundle')).toMatchObject({
         status: 'failed',
-        detail: expect.stringContaining('expected 0badcafe'),
+        detail: expect.stringContaining('not the recorded 0badcafe'),
       });
     });
 
@@ -148,7 +148,7 @@ describe('default kit', () => {
 
       expect(pickResult(results, 'recorded with a source and a bundle hash')).toMatchObject({
         status: 'failed',
-        detail: 'no source or bundle hash recorded',
+        detail: 'The manifest records no source or bundle hash',
       });
       expect(pickResult(results, 'Its source')).toMatchObject({ status: 'skipped' });
       expect(pickResult(results, 'Its bundle')).toMatchObject({ status: 'skipped' });
@@ -160,7 +160,7 @@ describe('default kit', () => {
       const results = await runFreshness();
 
       expect(results).toHaveLength(1);
-      expect(results[0]).toMatchObject({ status: 'skipped', detail: 'nothing compiled' });
+      expect(results[0]).toMatchObject({ status: 'skipped', detail: 'There are no compiled kits' });
     });
 
     it('reports bundles no manifest accounts for', async () => {

--- a/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
@@ -39,17 +39,31 @@ describe('default kit', () => {
 
       const results = await runSetup();
 
-      expect(results.map((result) => result.status)).toStrictEqual(['passed', 'passed', 'passed']);
+      expect(results.map((result) => result.status)).toStrictEqual(['passed', 'passed']);
     });
 
-    it('reports a missing kit directory', async () => {
+    // A monorepo root that lists `packages` authors no kits of its own, and is not defective for it.
+    it('stands down for a project that defines no kits', async () => {
       const results = await runSetup();
 
-      expect(pickResult(results, 'kits')).toMatchObject({ status: 'failed' });
+      expect(results).toHaveLength(2);
+      expect(results.every((result) => result.status === 'skipped')).toBe(true);
+      expect(results.every((result) => result.detail === 'This project defines no kits')).toBe(true);
+    });
+
+    // The manifest is where a project compiling to a non-default `outDir` declares that it has kits.
+    it('applies to a project holding a manifest but no kit directory', async () => {
+      writeKitManifest(projectRoot, []);
+
+      const results = await runSetup();
+
+      expect(pickResult(results, 'readyup.config.ts')).toMatchObject({ status: 'failed' });
     });
 
     // A project can be perfectly functional without one; the defaults it would have declared still apply.
     it('reports a missing config at the lowest severity', async () => {
+      mkdirSync(path.join(projectRoot, FIXTURE_KITS_DIR), { recursive: true });
+
       const results = await runSetup();
 
       expect(pickResult(results, 'readyup.config.ts')).toMatchObject({ status: 'failed', severity: 'recommend' });
@@ -61,7 +75,10 @@ describe('default kit', () => {
 
       const results = await runSetup();
 
-      expect(pickResult(results, 'manifest.json')).toMatchObject({ status: 'skipped', detail: 'nothing compiled' });
+      expect(pickResult(results, 'manifest.json')).toMatchObject({
+        status: 'skipped',
+        detail: 'There are no compiled kits',
+      });
     });
 
     it('asks for a manifest once a bundle exists', async () => {

--- a/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
@@ -130,7 +130,7 @@ describe('publishing kit', () => {
 
       expect(pickResult(results, 'under its own name')).toMatchObject({
         status: 'failed',
-        detail: `default at ${path.join('.readyup', 'kits', 'nested', 'default.js')}`,
+        detail: `The manifest records default at ${path.join('.readyup', 'kits', 'nested', 'default.js')}`,
       });
     });
   });
@@ -150,7 +150,7 @@ describe('publishing kit', () => {
 
       const results = await runSelfContainment();
 
-      expect(results[0]).toMatchObject({ status: 'failed', detail: 'imports picomatch' });
+      expect(results[0]).toMatchObject({ status: 'failed', detail: 'It imports picomatch' });
     });
 
     it('stands down when the package compiles nothing', async () => {
@@ -159,7 +159,7 @@ describe('publishing kit', () => {
       const results = await runSelfContainment();
 
       expect(results).toHaveLength(1);
-      expect(results[0]).toMatchObject({ status: 'skipped', detail: 'nothing compiled' });
+      expect(results[0]).toMatchObject({ status: 'skipped', detail: 'There are no compiled kits' });
     });
   });
 

--- a/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
@@ -110,6 +110,16 @@ describe('publishing kit', () => {
       expect(pickResult(results, 'manifest.json')).toMatchObject({ status: 'failed' });
     });
 
+    // `default` stands down for a project that defines no kits; a package that ships them and has none
+    // is broken, so this kit keeps reading the absence as an error.
+    it('reports a package holding no kit directory at all', async () => {
+      writePackageJson(projectRoot, { files: ['.readyup'] });
+
+      const results = await runPackaging();
+
+      expect(pickResult(results, 'manifest.json')).toMatchObject({ status: 'failed', severity: 'error' });
+    });
+
     // Publishing only named kits is legitimate, but a consumer's first invocation is a bare one.
     it('reports a missing default kit without blocking the publish', async () => {
       writePublishablePackage(projectRoot, { files: ['.readyup'] }, 'release');

--- a/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
@@ -3,7 +3,7 @@ import type { CheckOutcome, RdyCheck } from 'readyup';
 import { computeHash, readFile } from 'readyup/check-utils';
 
 import type { ManifestEntry } from './kit-layout.ts';
-import { listCompiledBundlePaths, readManifestEntries, resolveRecordedPath } from './kit-layout.ts';
+import { readManifestEntries, resolveRecordedPath, skipWithoutBundles } from './kit-layout.ts';
 
 /**
  * Checks asserting that every kit the manifest records still matches the hashes recorded for it.
@@ -50,7 +50,7 @@ function buildEntryCheck(entry: ManifestEntry): RdyCheck {
 function buildUnrecordedBundlesCheck(): RdyCheck {
   return {
     name: 'Every compiled kit is recorded in the manifest',
-    skip: () => (listCompiledBundlePaths().length === 0 ? 'nothing compiled' : false),
+    skip: skipWithoutBundles,
     check: () => ({ ok: false, detail: `${DEFAULT_MANIFEST_PATH} records no kit` }),
     fix: `Run 'rdy compile' to record every compiled kit and its hashes`,
   };
@@ -64,7 +64,7 @@ function buildUnrecordedBundlesCheck(): RdyCheck {
  */
 function compareToRecordedHash(recordedPath: string | undefined, expected: string | undefined): CheckOutcome {
   if (recordedPath === undefined || expected === undefined) {
-    return { ok: false, detail: 'the manifest records nothing to compare against' };
+    return { ok: false, detail: 'The manifest records nothing to compare against' };
   }
 
   const filePath = resolveRecordedPath(recordedPath);
@@ -72,9 +72,11 @@ function compareToRecordedHash(recordedPath: string | undefined, expected: strin
   if (content === undefined) return { ok: false, detail: `${filePath} is missing` };
 
   const actual = computeHash(content).slice(0, expected.length);
-  if (actual !== expected) return { ok: false, detail: `${filePath}: expected ${expected}, got ${actual}` };
+  if (actual !== expected) {
+    return { ok: false, detail: `${filePath} hashes to ${actual}, not the recorded ${expected}` };
+  }
 
-  return { ok: true, detail: filePath };
+  return { ok: true, detail: `${filePath} matches the recorded hash` };
 }
 
 /** Reports which of a manifest entry's two hash records are absent. */
@@ -84,7 +86,7 @@ function describeRecordedHashes(entry: ManifestEntry): CheckOutcome {
   if (entry.path === undefined || entry.targetHash === undefined) unrecorded.push('bundle');
 
   if (unrecorded.length === 0) return { ok: true };
-  return { ok: false, detail: `no ${unrecorded.join(' or ')} hash recorded` };
+  return { ok: false, detail: `The manifest records no ${unrecorded.join(' or ')} hash` };
 }
 
 // endregion | Helpers

--- a/packages/readyup/.readyup/kits/checks/buildSelfContainmentChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildSelfContainmentChecks.ts
@@ -1,7 +1,7 @@
 import type { CheckOutcome, RdyCheck } from 'readyup';
 import { readFile } from 'readyup/check-utils';
 
-import { listCompiledBundlePaths, skipWithoutBundles } from './kit-layout.ts';
+import { listCompiledBundlePaths, NO_BUNDLES_REASON } from './kit-layout.ts';
 
 /**
  * Module specifiers a compiled kit may import verbatim.
@@ -43,7 +43,7 @@ export function buildSelfContainmentChecks(): RdyCheck[] {
     return [
       {
         name: 'Every compiled kit imports only what the runner supplies',
-        skip: skipWithoutBundles,
+        skip: () => NO_BUNDLES_REASON,
         check: () => true,
       },
     ];

--- a/packages/readyup/.readyup/kits/checks/buildSelfContainmentChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildSelfContainmentChecks.ts
@@ -1,7 +1,7 @@
 import type { CheckOutcome, RdyCheck } from 'readyup';
 import { readFile } from 'readyup/check-utils';
 
-import { listCompiledBundlePaths } from './kit-layout.ts';
+import { listCompiledBundlePaths, skipWithoutBundles } from './kit-layout.ts';
 
 /**
  * Module specifiers a compiled kit may import verbatim.
@@ -43,7 +43,7 @@ export function buildSelfContainmentChecks(): RdyCheck[] {
     return [
       {
         name: 'Every compiled kit imports only what the runner supplies',
-        skip: () => 'nothing compiled',
+        skip: skipWithoutBundles,
         check: () => true,
       },
     ];
@@ -72,7 +72,7 @@ function describeSelfContainment(bundlePath: string): CheckOutcome {
 
   const foreign = findForeignSpecifiers(bundle);
   if (foreign.length === 0) return { ok: true };
-  return { ok: false, detail: `imports ${foreign.join(', ')}` };
+  return { ok: false, detail: `It imports ${foreign.join(', ')}` };
 }
 
 /** Returns true when a specifier is one esbuild was told to leave external. */

--- a/packages/readyup/.readyup/kits/checks/describeFilesCoverage.ts
+++ b/packages/readyup/.readyup/kits/checks/describeFilesCoverage.ts
@@ -17,7 +17,8 @@ export function describeFilesCoverage(): CheckOutcome {
   if (packageJson === undefined) return { ok: false, detail: 'package.json is missing or unreadable' };
 
   const files = packageJson['files'];
-  if (files === undefined) return { ok: true, detail: 'no "files" allowlist, so everything ships' };
+  if (files === undefined)
+    return { ok: true, detail: 'package.json declares no "files" allowlist, so everything ships' };
   if (!Array.isArray(files)) return { ok: false, detail: '"files" is not an array' };
 
   const covering = files

--- a/packages/readyup/.readyup/kits/checks/describeFilesCoverage.ts
+++ b/packages/readyup/.readyup/kits/checks/describeFilesCoverage.ts
@@ -17,8 +17,9 @@ export function describeFilesCoverage(): CheckOutcome {
   if (packageJson === undefined) return { ok: false, detail: 'package.json is missing or unreadable' };
 
   const files = packageJson['files'];
-  if (files === undefined)
+  if (files === undefined) {
     return { ok: true, detail: 'package.json declares no "files" allowlist, so everything ships' };
+  }
   if (!Array.isArray(files)) return { ok: false, detail: '"files" is not an array' };
 
   const covering = files

--- a/packages/readyup/.readyup/kits/checks/describeLoadablePaths.ts
+++ b/packages/readyup/.readyup/kits/checks/describeLoadablePaths.ts
@@ -19,7 +19,7 @@ export function describeLoadablePaths(): CheckOutcome {
   });
 
   if (misplaced.length === 0) return { ok: true };
-  return { ok: false, detail: misplaced.join(', ') };
+  return { ok: false, detail: `The manifest records ${misplaced.join(', ')}` };
 }
 
 // region | Helpers

--- a/packages/readyup/.readyup/kits/checks/kit-layout.ts
+++ b/packages/readyup/.readyup/kits/checks/kit-layout.ts
@@ -14,6 +14,11 @@ export const MANIFEST_DIR = path.dirname(DEFAULT_MANIFEST_PATH);
 /** Directory holding kit sources and the bundles compiled from them. */
 export const KITS_DIR = path.join(MANIFEST_DIR, 'kits');
 
+// -- Skip reasons --
+
+/** Detail reported by a check that stands down for want of a compiled bundle. */
+export const NO_BUNDLES_REASON = 'There are no compiled kits';
+
 /**
  * Paths of the compiled bundles in the kit directory, relative to the working directory.
  *
@@ -66,7 +71,7 @@ export function resolveRecordedPath(recordedPath: string): string {
 
 /** Skip reason for a check that has nothing to say until a bundle exists, or `false` once one does. */
 export function skipWithoutBundles(): SkipResult {
-  return listCompiledBundlePaths().length === 0 ? 'There are no compiled kits' : false;
+  return listCompiledBundlePaths().length === 0 ? NO_BUNDLES_REASON : false;
 }
 
 /**

--- a/packages/readyup/.readyup/kits/checks/kit-layout.ts
+++ b/packages/readyup/.readyup/kits/checks/kit-layout.ts
@@ -3,7 +3,8 @@ import path from 'node:path';
 import process from 'node:process';
 
 import { DEFAULT_MANIFEST_PATH } from 'readyup';
-import { isRecord, readJsonFile } from 'readyup/check-utils';
+import type { SkipResult } from 'readyup';
+import { fileExists, isRecord, readJsonFile } from 'readyup/check-utils';
 
 // -- Paths --
 
@@ -61,6 +62,23 @@ export function readManifestEntries(): ManifestEntry[] {
 /** Path to a file the manifest names, relative to the working directory. */
 export function resolveRecordedPath(recordedPath: string): string {
   return path.join(MANIFEST_DIR, recordedPath);
+}
+
+/** Skip reason for a check that has nothing to say until a bundle exists, or `false` once one does. */
+export function skipWithoutBundles(): SkipResult {
+  return listCompiledBundlePaths().length === 0 ? 'There are no compiled kits' : false;
+}
+
+/**
+ * Skip reason for a check about a project that defines no kits, or `false` for one that does.
+ *
+ * A project defining none is outside these kits' subject rather than failing them: a monorepo root
+ * that lists `packages` authors no kits of its own, and no consumer is expected to keep them at its
+ * root. The manifest arm admits a project compiling to a non-default `outDir`, whose recorded kits
+ * are still worth checking.
+ */
+export function skipWithoutKits(): SkipResult {
+  return fileExists(KITS_DIR) || fileExists(DEFAULT_MANIFEST_PATH) ? false : 'This project defines no kits';
 }
 
 // region | Helpers

--- a/packages/readyup/.readyup/kits/default.ts
+++ b/packages/readyup/.readyup/kits/default.ts
@@ -10,7 +10,7 @@ import { DEFAULT_MANIFEST_PATH, defineRdyKit } from 'readyup';
 import { fileExists } from 'readyup/check-utils';
 
 import { buildFreshnessChecks } from './checks/buildFreshnessChecks.ts';
-import { KITS_DIR, listCompiledBundlePaths } from './checks/kit-layout.ts';
+import { skipWithoutBundles, skipWithoutKits } from './checks/kit-layout.ts';
 
 /** The one path `loadConfig` looks in; see `src/loadConfig.ts`. */
 const CONFIG_PATH = '.config/readyup.config.ts';
@@ -23,21 +23,18 @@ export default defineRdyKit({
       name: 'setup',
       checks: [
         {
-          name: `${KITS_DIR} exists`,
-          check: () => fileExists(KITS_DIR),
-          fix: `Run 'rdy init' to scaffold a starter config and kit`,
-        },
-        {
           name: `${CONFIG_PATH} exists`,
           severity: 'recommend',
+          skip: skipWithoutKits,
           check: () => fileExists(CONFIG_PATH),
           fix: `Run 'rdy init' to scaffold one; without it, compile settings fall back to their defaults`,
         },
         {
           // A project running its kits with `--jit` compiles nothing and needs no manifest, so the
-          // claim only applies once a bundle exists to be recorded.
+          // claim only applies once a bundle exists to be recorded. The broader reason comes first:
+          // a project with no kits at all has not declined to compile them.
           name: `${DEFAULT_MANIFEST_PATH} exists`,
-          skip: () => (listCompiledBundlePaths().length === 0 ? 'nothing compiled' : false),
+          skip: () => skipWithoutKits() || skipWithoutBundles(),
           check: () => fileExists(DEFAULT_MANIFEST_PATH),
           fix: `Run 'rdy compile' to record every compiled kit and its hashes`,
         },

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -60,7 +60,7 @@ export default defineRdyKit({
           name: 'NODE_ENV is set',
           check: () => {
             const value = process.env['NODE_ENV'];
-            return { ok: Boolean(value), detail: value ?? 'no value in the environment' };
+            return { ok: Boolean(value), detail: value ?? 'NODE_ENV has no value in the environment' };
           },
           fix: 'Set NODE_ENV before deploying',
         },
@@ -81,7 +81,7 @@ With `NODE_ENV` unset:
 
 ```
 🔴 NODE_ENV is set
-   no value in the environment
+   NODE_ENV has no value in the environment
 ──
 🔴 1 error (0ms)
 
@@ -252,7 +252,7 @@ Neither is a `quiet` check, though it looks like one: its name reaches the reade
 
 ### The detail contract
 
-`detail` answers "why this status" -- not "what this check asserts", which the name already says. On a pass it reports the evidence; on a skip, why the check did not apply; on a failure, what went wrong. It opens in lower case, continuing the claim it hangs from rather than standing as a sentence of its own.
+`detail` answers "why this status" -- not "what this check asserts", which the name already says. On a pass it reports the evidence; on a skip, why the check did not apply; on a failure, what went wrong. Write it as a complete sentence, capitalized and carrying no terminal period -- the register `name` and `fix` already use. A sentence whose subject is a code identifier keeps that identifier's own case, as in `package.json is missing or unreadable`.
 
 | Status  | Where `detail` renders                                  |
 | ------- | ------------------------------------------------------- |
@@ -274,7 +274,7 @@ export default defineRdyKit({
       checks: [
         {
           name: 'Working tree is clean',
-          check: () => ({ ok: true, detail: 'no uncommitted changes' }),
+          check: () => ({ ok: true, detail: 'There are no uncommitted changes' }),
         },
         {
           name: 'Dependencies are installed',
@@ -294,7 +294,7 @@ export default defineRdyKit({
             {
               name: 'Native modules are rebuilt',
               check: () => true,
-              skip: () => 'no native dependencies in this workspace',
+              skip: () => 'This workspace has no native dependencies',
             },
           ],
         },
@@ -307,12 +307,12 @@ export default defineRdyKit({
 It produces:
 
 ```
-🟢 Working tree is clean · no uncommitted changes
+🟢 Working tree is clean · There are no uncommitted changes
 🟢 Dependencies are installed
    🟢 Lockfile is current [4 of 4]
       🔴 No dependency has duplicated majors
          react resolves to both 18.3.1 and 19.0.0
-   ⚪ Native modules are rebuilt · no native dependencies in this workspace
+   ⚪ Native modules are rebuilt · This workspace has no native dependencies
 ──
 🔴 | 1 error, 3 passed, 1 skipped (0ms)
 
@@ -897,12 +897,12 @@ rdy list --from npm:readyup           # both, with the checklists each one carri
 
 `default` reports at `warn` and below, so it is safe to run mid-edit:
 
-| Checklist   | What it asserts                                                                                                     |
-| ----------- | ------------------------------------------------------------------------------------------------------------------- |
-| `setup`     | The kit directory exists, a config file is present (at `recommend`), and a manifest records what has been compiled. |
-| `freshness` | Every kit the manifest records still matches the hashes recorded for it, on the source side and the bundle side.    |
+| Checklist   | What it asserts                                                                                                  |
+| ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| `setup`     | A config file is present (at `recommend`), and a manifest records what has been compiled.                        |
+| `freshness` | Every kit the manifest records still matches the hashes recorded for it, on the source side and the bundle side. |
 
-The manifest check stands down when nothing is compiled, since a project running its kits with `--jit` has nothing to record. So does `freshness`, which otherwise names one check per recorded kit.
+Both `setup` checks stand down for a project that defines no kits of its own: a monorepo root that lists `packages` rather than authoring kits is not expected to keep any at its root, and a project is judged to define kits once it holds either `.readyup/kits` or `.readyup/manifest.json`. The manifest check stands down for a second reason, when nothing is compiled, since a project running its kits with `--jit` has nothing to record. So does `freshness`, which otherwise names one check per recorded kit.
 
 `publishing` reports at `error`, for a package that distributes its kits:
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -60,7 +60,8 @@ export default defineRdyKit({
           name: 'NODE_ENV is set',
           check: () => {
             const value = process.env['NODE_ENV'];
-            return { ok: Boolean(value), detail: value ?? 'NODE_ENV has no value in the environment' };
+            if (!value) return { ok: false, detail: 'NODE_ENV has no value in the environment' };
+            return { ok: true, detail: `NODE_ENV is ${value}` };
           },
           fix: 'Set NODE_ENV before deploying',
         },

--- a/packages/readyup/__tests__/initCommand.scaffold.unit.test.ts
+++ b/packages/readyup/__tests__/initCommand.scaffold.unit.test.ts
@@ -52,7 +52,7 @@ describe('scaffolded kit', () => {
       {
         name: 'NODE_ENV is set',
         status: 'failed',
-        detail: 'no value in the environment',
+        detail: 'NODE_ENV has no value in the environment',
         fix: 'Set NODE_ENV before deploying',
       },
     ]);

--- a/packages/readyup/__tests__/initCommand.scaffold.unit.test.ts
+++ b/packages/readyup/__tests__/initCommand.scaffold.unit.test.ts
@@ -39,7 +39,7 @@ describe('scaffolded kit', () => {
 
     const results = await runScaffoldedKit();
 
-    expect(results).toMatchObject([{ name: 'NODE_ENV is set', status: 'passed', detail: 'production' }]);
+    expect(results).toMatchObject([{ name: 'NODE_ENV is set', status: 'passed', detail: 'NODE_ENV is production' }]);
   });
 
   it('fails with NODE_ENV unset, reporting that the environment carries no value', async () => {

--- a/packages/readyup/src/init/templates.ts
+++ b/packages/readyup/src/init/templates.ts
@@ -31,7 +31,8 @@ export default defineRdyKit({
           name: 'NODE_ENV is set',
           check: () => {
             const value = process.env['NODE_ENV'];
-            return { ok: Boolean(value), detail: value ?? 'NODE_ENV has no value in the environment' };
+            if (!value) return { ok: false, detail: 'NODE_ENV has no value in the environment' };
+            return { ok: true, detail: \`NODE_ENV is \${value}\` };
           },
           fix: 'Set NODE_ENV before deploying',
         },

--- a/packages/readyup/src/init/templates.ts
+++ b/packages/readyup/src/init/templates.ts
@@ -31,7 +31,7 @@ export default defineRdyKit({
           name: 'NODE_ENV is set',
           check: () => {
             const value = process.env['NODE_ENV'];
-            return { ok: Boolean(value), detail: value ?? 'no value in the environment' };
+            return { ok: Boolean(value), detail: value ?? 'NODE_ENV has no value in the environment' };
           },
           fix: 'Set NODE_ENV before deploying',
         },


### PR DESCRIPTION
## What

Fixes the issue that a project that had `readyup` installed but no kits at its root was flagged as defective. Separately, the guidance on writing good kits now encourages the use of full-sentence messages for clarity, and ReadyUp's own kits have been revised accordingly.

## Why

Running readyup against a monorepo root reported it as defective for keeping no kits there, which is the ordinary shape for a root that lists its packages instead. Nothing was wrong with the project, so the finding was noise a reader had to learn to ignore.

The status messages compounded it. `nothing compiled` left a reader to work out what had not been compiled and whether that was the complaint, and the README licensed the form rather than correcting it.

## Details

### 🐛 Bug fixes

- The `default` kit no longer asserts that `.readyup/kits` exists. Both `setup` checks stand down for a project that defines no kits, reporting `This project defines no kits`. A project counts as defining them once it holds either `.readyup/kits` or `.readyup/manifest.json`, so a project compiling to a non-default `outDir` stays inside the gate and keeps its freshness coverage.
- `publishing` keeps its strict reading: a package that ships kits and has none is broken, and still fails at `error`.
- Every `detail` the published kits emit is now a complete sentence, capitalized and without a terminal period, matching the register `name` and `fix` already use. A skipped manifest check reads `There are no compiled kits`; a drifted kit reads `.readyup/kits/default.js hashes to 4f21ae, not the recorded 0badca`.
- A passing freshness comparison names what the file proved (`.readyup/kits/default.ts matches the recorded hash`) rather than reporting the path alone.
- The kit `rdy init` scaffolds reports `NODE_ENV is production` on the pass path, where it previously printed the bare environment value.

### 🧪 Tests

- Three `default` kit tests cover both arms of the new gate and the precedence between its two skip reasons, so a kit-less project cannot regress to the narrower `There are no compiled kits`.
- The end-to-end test reaching the published kits through `--from npm:readyup` asserts that a consuming project sees every setup check stand down, where it previously asserted a warning.
- `publishing` gains a test pinning that a package holding no kit directory at all still fails at `error`.

### 📚 Documentation

- The README's detail contract states the sentence rule and the identifier-subject carve-out, and every example in it obeys the rule.
- The `setup` table row and the stand-down paragraph describe the kit's new behavior, naming what makes a project count as defining kits.
- The repo's own `demo` and internal kits follow the contract, so running the showcase no longer contradicts the guidance that sends a reader to it.

Closes #277
