### PR TITLE
#280 Exempt a workspace specifier from the version floor

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1044,7 +1044,7 @@ import { fileExists, hasPackageJsonField } from 'readyup/check-utils';
 | `hasDevDependency(name)`                              | Dev dependency is declared                |
 | `hasMinDevDependencyVersion(name, version, options?)` | Dev dependency meets a minimum            |
 
-`hasMinDevDependencyVersion` reads the version it compares out of the specifier in `package.json`, so a specifier naming no version decides the answer on its own. A `workspace:` specifier satisfies any floor: it links to the package the repo builds, and a repo that publishes a package is not a consumer of it. A `catalog:` specifier does not, because the version it resolves to in `pnpm-workspace.yaml` can genuinely be below the floor. Pass `options.exempt` to exempt further specifiers; it receives the specifier as written and extends the built-in exemption rather than replacing it.
+`hasMinDevDependencyVersion` compares the floor against the version it reads out of the specifier in `package.json`, so the specifier's protocol can settle the answer before any comparison happens. Any `workspace:`-prefixed specifier satisfies any floor, `workspace:^1.2.3` included: it links to the package the repo builds, and a repo that publishes a package is not a consumer of it. A `catalog:` specifier does not, because the version it resolves to in `pnpm-workspace.yaml` can genuinely be below the floor. Pass `options.exempt` to exempt further specifiers; it receives the specifier as written and adds to the built-in exemption rather than replacing it.
 
 ### Versions and runtime alignment
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1037,12 +1037,14 @@ import { fileExists, hasPackageJsonField } from 'readyup/check-utils';
 
 ### Package manifests
 
-| Function                                    | Returns                                   |
-| ------------------------------------------- | ----------------------------------------- |
-| `readPackageJson()`                         | Parsed `package.json`                     |
-| `hasPackageJsonField(field, value?)`        | Field exists, optionally matching a value |
-| `hasDevDependency(name)`                    | Dev dependency is declared                |
-| `hasMinDevDependencyVersion(name, version)` | Dev dependency meets a minimum            |
+| Function                                              | Returns                                   |
+| ----------------------------------------------------- | ----------------------------------------- |
+| `readPackageJson()`                                   | Parsed `package.json`                     |
+| `hasPackageJsonField(field, value?)`                  | Field exists, optionally matching a value |
+| `hasDevDependency(name)`                              | Dev dependency is declared                |
+| `hasMinDevDependencyVersion(name, version, options?)` | Dev dependency meets a minimum            |
+
+`hasMinDevDependencyVersion` reads the version it compares out of the specifier in `package.json`, so a specifier naming no version decides the answer on its own. A `workspace:` specifier satisfies any floor: it links to the package the repo builds, and a repo that publishes a package is not a consumer of it. A `catalog:` specifier does not, because the version it resolves to in `pnpm-workspace.yaml` can genuinely be below the floor. Pass `options.exempt` to exempt further specifiers; it receives the specifier as written and extends the built-in exemption rather than replacing it.
 
 ### Versions and runtime alignment
 

--- a/packages/readyup/__tests__/check-utils/package-json.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/package-json.unit.test.ts
@@ -99,12 +99,30 @@ describe(hasMinDevDependencyVersion, () => {
     expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
   });
 
-  it('returns true when the exempt predicate matches', () => {
+  it('returns true for a workspace specifier naming no version', () => {
     writePackageJson({ devDependencies: { core: 'workspace:*' } });
+
+    expect(hasMinDevDependencyVersion('core', '99.0.0')).toBe(true);
+  });
+
+  it('returns true for a workspace specifier naming a version below the minimum', () => {
+    writePackageJson({ devDependencies: { core: 'workspace:^1.2.3' } });
+
+    expect(hasMinDevDependencyVersion('core', '2.0.0')).toBe(true);
+  });
+
+  it('returns false for a catalog specifier', () => {
+    writePackageJson({ devDependencies: { vitest: 'catalog:' } });
+
+    expect(hasMinDevDependencyVersion('vitest', '1.0.0')).toBe(false);
+  });
+
+  it('returns true when the exempt predicate matches', () => {
+    writePackageJson({ devDependencies: { core: 'link:../core' } });
 
     expect(
       hasMinDevDependencyVersion('core', '1.0.0', {
-        exempt: (range) => range.startsWith('workspace:'),
+        exempt: (range) => range.startsWith('link:'),
       }),
     ).toBe(true);
   });

--- a/packages/readyup/__tests__/check-utils/package-json.unit.test.ts
+++ b/packages/readyup/__tests__/check-utils/package-json.unit.test.ts
@@ -122,7 +122,7 @@ describe(hasMinDevDependencyVersion, () => {
 
     expect(
       hasMinDevDependencyVersion('core', '1.0.0', {
-        exempt: (range) => range.startsWith('link:'),
+        exempt: (specifier) => specifier.startsWith('link:'),
       }),
     ).toBe(true);
   });

--- a/packages/readyup/src/check-utils/package-json.ts
+++ b/packages/readyup/src/check-utils/package-json.ts
@@ -21,25 +21,25 @@ export function hasDevDependency(name: string): boolean {
 }
 
 /**
- * Checks whether a dev dependency meets a minimum version. A `workspace:` specifier satisfies any floor, because it
- * links to the package the repo builds rather than to a version the specifier can be read for. `exempt` extends that
- * exemption to further specifiers rather than replacing it.
+ * Checks whether a dev dependency meets a minimum version. Any `workspace:`-prefixed specifier satisfies any floor,
+ * including one that names a version: the specifier links to the package the repo builds, and a version it names is a
+ * publish range, not the version that resolves. `exempt` adds further exemptions; it cannot remove this one.
  */
 export function hasMinDevDependencyVersion(
   name: string,
   minVersion: string,
-  options?: { exempt?: (range: string) => boolean },
+  options?: { exempt?: (specifier: string) => boolean },
 ): boolean {
   const pkg = readJsonFile('package.json');
   if (pkg === undefined) return false;
   const devDeps = pkg['devDependencies'];
   if (!isRecord(devDeps) || !Object.hasOwn(devDeps, name)) return false;
-  const range = devDeps[name];
-  if (typeof range !== 'string') return false;
-  if (range.startsWith('workspace:')) return true;
-  if (options?.exempt?.(range)) return true;
+  const specifier = devDeps[name];
+  if (typeof specifier !== 'string') return false;
+  if (specifier.startsWith('workspace:')) return true;
+  if (options?.exempt?.(specifier)) return true;
   // Strip leading semver range operators to extract the base version.
-  const versionMatch = /(\d+\.\d+\.\d+)/.exec(range)?.[1];
+  const versionMatch = /(\d+\.\d+\.\d+)/.exec(specifier)?.[1];
   if (versionMatch === undefined) return false;
   return compareVersions(versionMatch, minVersion) >= 0;
 }

--- a/packages/readyup/src/check-utils/package-json.ts
+++ b/packages/readyup/src/check-utils/package-json.ts
@@ -20,7 +20,11 @@ export function hasDevDependency(name: string): boolean {
   return isRecord(devDeps) && Object.hasOwn(devDeps, name);
 }
 
-/** Check whether a dev dependency meets a minimum version, with optional exemption predicate. */
+/**
+ * Checks whether a dev dependency meets a minimum version. A `workspace:` specifier satisfies any floor, because it
+ * links to the package the repo builds rather than to a version the specifier can be read for. `exempt` extends that
+ * exemption to further specifiers rather than replacing it.
+ */
 export function hasMinDevDependencyVersion(
   name: string,
   minVersion: string,
@@ -32,6 +36,7 @@ export function hasMinDevDependencyVersion(
   if (!isRecord(devDeps) || !Object.hasOwn(devDeps, name)) return false;
   const range = devDeps[name];
   if (typeof range !== 'string') return false;
+  if (range.startsWith('workspace:')) return true;
   if (options?.exempt?.(range)) return true;
   // Strip leading semver range operators to extract the base version.
   const versionMatch = /(\d+\.\d+\.\d+)/.exec(range)?.[1];


### PR DESCRIPTION
## What

Fixes an issue where a minimum-version check reported a repository as running an outdated version of a package that the repository builds itself. `hasMinDevDependencyVersion` now includes this exemption automatically, and kit authors can remove any custom checks to exempt `workspace:` from version requirements.

## Why

A minimum-version check asks whether a consumer is current, and the repository that builds the package is not a
consumer of it. Reporting the publisher as behind its own published floor is the one answer that is guaranteed wrong,
and every caller who wanted the right one was writing the same exemption by hand.

## Details

### 🐛 Bug fixes

- `hasMinDevDependencyVersion` treats any `workspace:`-prefixed specifier as satisfying any floor, decided from the
  prefix before version extraction runs. The exemption covers version-carrying forms such as `workspace:^1.2.3`,
  whose declared range is a publish constraint rather than the version that resolves; those forms were previously
  compared against the floor and could fail.
- A `catalog:` specifier still fails a floor it does not meet. The version it resolves to in `pnpm-workspace.yaml`
  can genuinely be below one, so exempting it would hide real drift.
- `options.exempt` is consulted for every specifier the built-in rule does not claim, so a caller can add exemptions
  but never remove the built-in one.

### 🧪 Tests

- Covers both workspace forms, pins the `catalog:` outcome against a later sweep that might fold it in with
  `workspace:`, and moves the `exempt` composition case to a `link:` specifier so it proves composition rather than
  passing on the new default.

### 📚 Documentation

- The check-utilities reference in `packages/readyup/README.md` states the workspace default, the `catalog:`
  exclusion, and how `exempt` composes; the table row now exposes the `options` argument.
- The helper's description carries the same contract, and `exempt` receives its argument as `specifier` rather than
  `range` — the word the documentation uses, and an accurate one for the values the option actually sees.

Closes #280
