### PR TITLE
#229 Compile kits under readyup's declared TypeScript settings

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -406,7 +406,7 @@ Two consequences follow from the value being resolved at compile time:
 
 Kits compile with no `tsconfig.json`. Whatever config sits above a kit is ignored, so the same source compiles to the same bytes in any repository and a published bundle is the one its author built.
 
-The compiler defaults apply, with two settings declared:
+Kits are bundled by esbuild, and its defaults apply, with two settings declared:
 
 | Setting                   | Value   |
 | ------------------------- | ------- |

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -402,6 +402,19 @@ Two consequences follow from the value being resolved at compile time:
 - `pickJson` throws if it is ever reached at runtime. A kit that hits it was not compiled.
 - Editing the JSON afterward leaves the bundle stale, and neither recorded hash changes -- the source did not move, and neither did the bundle. [`rdy verify --rebuild`](#verifying-by-recompiling) is what catches it.
 
+### TypeScript settings
+
+Kits compile with no `tsconfig.json`. Whatever config sits above a kit is ignored, so the same source compiles to the same bytes in any repository and a published bundle is the one its author built.
+
+The compiler defaults apply, with two settings declared:
+
+| Setting                   | Value   |
+| ------------------------- | ------- |
+| `experimentalDecorators`  | `false` |
+| `useDefineForClassFields` | `true`  |
+
+One consequence reaches every kit: `paths` aliases do not resolve. Import by relative path or package specifier. A kit that reaches for an alias fails to compile and is told why, rather than compiling into something that breaks when it runs.
+
 ## Running checks
 
 ```

--- a/packages/readyup/__tests__/compile/tsconfigIsolation.tool.test.ts
+++ b/packages/readyup/__tests__/compile/tsconfigIsolation.tool.test.ts
@@ -1,0 +1,72 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { buildBundle } from '../../src/compile/buildBundle.ts';
+
+// A decorator and a class field, so the fixture exercises both settings the kit tsconfig declares.
+const KIT_SOURCE = [
+  'declare const decorate: (...args: never[]) => void;',
+  'export class Kit {',
+  '  field = 1;',
+  '  @decorate run() {}',
+  '}',
+  '',
+].join('\n');
+
+// Declares the opposite of both kit settings: `experimentalDecorators` directly, and
+// `useDefineForClassFields` through the `target` esbuild derives it from.
+const HOST_TSCONFIG = JSON.stringify({ compilerOptions: { experimentalDecorators: true, target: 'ES2020' } });
+
+const treeRoots: string[] = [];
+
+describe(buildBundle, () => {
+  afterAll(async () => {
+    await Promise.all(treeRoots.map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it('compiles to identical bytes whether or not a tsconfig.json sits above the kit', async () => {
+    const entryPath = writeKitTree(KIT_SOURCE);
+
+    const withoutHostConfig = await buildBundle(entryPath);
+    writeHostTsconfig(entryPath);
+    const withHostConfig = await buildBundle(entryPath);
+
+    expect(withHostConfig.equals(withoutHostConfig)).toBe(true);
+  });
+
+  it('reports that kits compile without a tsconfig.json when an import does not resolve', async () => {
+    const entryPath = writeKitTree("import { thing } from '~/thing';\nexport const kit = thing;\n");
+    writeHostTsconfig(entryPath);
+
+    await expect(buildBundle(entryPath)).rejects.toThrow(/kits compile without a tsconfig\.json/i);
+  });
+});
+
+// region | Helpers
+
+/**
+ * Writes a kit source into a fresh temp tree and returns the kit's path.
+ *
+ * The tree sits outside the repository, so nothing above it is discoverable but what a test puts
+ * there, and the kit sits one directory below the tree root, leaving room for a config above it.
+ */
+function writeKitTree(source: string): string {
+  const treeRoot = mkdtempSync(path.join(tmpdir(), 'rdy-host-tsconfig-'));
+  treeRoots.push(treeRoot);
+  const kitsDir = path.join(treeRoot, 'kits');
+  mkdirSync(kitsDir);
+  const entryPath = path.join(kitsDir, 'kit.ts');
+  writeFileSync(entryPath, source, 'utf8');
+  return entryPath;
+}
+
+/** Writes the host config into the directory above a kit, where esbuild's search would reach it. */
+function writeHostTsconfig(entryPath: string): void {
+  writeFileSync(path.resolve(path.dirname(entryPath), '..', 'tsconfig.json'), HOST_TSCONFIG, 'utf8');
+}
+
+// endregion | Helpers

--- a/packages/readyup/__tests__/compile/tsconfigIsolation.tool.test.ts
+++ b/packages/readyup/__tests__/compile/tsconfigIsolation.tool.test.ts
@@ -17,9 +17,18 @@ const KIT_SOURCE = [
   '',
 ].join('\n');
 
-// Declares the opposite of both kit settings: `experimentalDecorators` directly, and
-// `useDefineForClassFields` through the `target` esbuild derives it from.
-const HOST_TSCONFIG = JSON.stringify({ compilerOptions: { experimentalDecorators: true, target: 'ES2020' } });
+// The same field without the decorator, which moves every field into the constructor and takes the
+// class-body form of a defined field with it.
+const FIELD_SOURCE = ['export class Kit {', '  field = 1;', '}', ''].join('\n');
+
+// Declares the opposite of both kit settings -- `experimentalDecorators` directly, and
+// `useDefineForClassFields` through the `target` esbuild derives it from -- plus an alias that
+// resolves, so every assertion below fails if a kit ever reads a host config again.
+const HOST_TSCONFIG = JSON.stringify({
+  compilerOptions: { experimentalDecorators: true, paths: { '~/*': ['./src/*'] }, target: 'ES2020' },
+});
+
+const ALIASED_MODULE = "export const thing = 'aliased';\n";
 
 const treeRoots: string[] = [];
 
@@ -36,6 +45,20 @@ describe(buildBundle, () => {
     const withHostConfig = await buildBundle(entryPath);
 
     expect(withHostConfig.equals(withoutHostConfig)).toBe(true);
+  });
+
+  it('compiles class fields and decorators under the declared settings', async () => {
+    const fieldBundle = (await buildBundle(writeKitTree(FIELD_SOURCE))).toString('utf8');
+    const decoratorBundle = (await buildBundle(writeKitTree(KIT_SOURCE))).toString('utf8');
+
+    // esbuild names no setting in its output, so the declared values are read back from the lowering
+    // they produce: a defined field stays in the class body where an assigned one moves into the
+    // constructor, and a proposal-style decorator reaches for `__decorateElement` where the legacy one
+    // reaches for `__decorateClass`.
+    expect(fieldBundle).toContain('field = 1');
+    expect(fieldBundle).not.toContain('this.field = 1');
+    expect(decoratorBundle).toContain('__decorateElement');
+    expect(decoratorBundle).not.toContain('__decorateClass');
   });
 
   it('reports that kits compile without a tsconfig.json when an import does not resolve', async () => {
@@ -64,9 +87,17 @@ function writeKitTree(source: string): string {
   return entryPath;
 }
 
-/** Writes the host config into the directory above a kit, where esbuild's search would reach it. */
+/**
+ * Writes the host config into the directory above a kit, where esbuild's search would reach it.
+ *
+ * The module the config's `paths` entry maps to is written alongside it, so the alias would resolve
+ * and a kit reading the config would compile rather than fail.
+ */
 function writeHostTsconfig(entryPath: string): void {
-  writeFileSync(path.resolve(path.dirname(entryPath), '..', 'tsconfig.json'), HOST_TSCONFIG, 'utf8');
+  const treeRoot = path.resolve(path.dirname(entryPath), '..');
+  mkdirSync(path.join(treeRoot, 'src'));
+  writeFileSync(path.join(treeRoot, 'src', 'thing.ts'), ALIASED_MODULE, 'utf8');
+  writeFileSync(path.join(treeRoot, 'tsconfig.json'), HOST_TSCONFIG, 'utf8');
 }
 
 // endregion | Helpers

--- a/packages/readyup/__tests__/compileConfig.unit.test.ts
+++ b/packages/readyup/__tests__/compileConfig.unit.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { KIT_COMPILE_TARGET } from '../src/compile/buildBundle.ts';
+import { KIT_COMPILE_TARGET, KIT_TSCONFIG } from '../src/compile/buildBundle.ts';
 import { compileConfig } from '../src/compile/compileConfig.ts';
 import { VERSION } from '../src/version.ts';
 
@@ -52,6 +52,7 @@ describe(compileConfig, () => {
       format: 'esm',
       platform: 'node',
       target: KIT_COMPILE_TARGET,
+      tsconfigRaw: KIT_TSCONFIG,
       external: ['node:*', 'readyup', 'readyup/*'],
       plugins: [expect.objectContaining({ name: 'pick-json' })],
       banner: { js: expect.stringContaining('@generated') },

--- a/packages/readyup/__tests__/compileConfig.unit.test.ts
+++ b/packages/readyup/__tests__/compileConfig.unit.test.ts
@@ -139,10 +139,11 @@ describe(compileConfig, () => {
     expect(mockWriteFileSync).not.toHaveBeenCalled();
   });
 
-  it('propagates errors from esbuild.build', async () => {
+  it('propagates a build failure that names no unresolved import, unchanged', async () => {
     mockBuild.mockRejectedValue(new Error('Build failed'));
 
-    await expect(compileConfig('input.ts')).rejects.toThrow('Build failed');
+    // Anchored, so a guard that started matching every failure would append its hint here and fail.
+    await expect(compileConfig('input.ts')).rejects.toThrow(/^Build failed$/);
   });
 
   it('throws a clear error when esbuild is not installed', async () => {

--- a/packages/readyup/__tests__/layout/layoutEngine.unit.test.ts
+++ b/packages/readyup/__tests__/layout/layoutEngine.unit.test.ts
@@ -134,6 +134,18 @@ describe('formatReasonBlock', () => {
 
     expect(reason).toBe('   lockfile out of date');
   });
+
+  it('indents every line of a reason that carries its own line breaks', () => {
+    const [reason] = engine.formatReasonBlock(['rebuild failed (first line\nsecond line)']);
+
+    expect(reason).toBe('   rebuild failed (first line\n   second line)');
+  });
+
+  it('leaves a blank line within a reason blank, rather than indenting it into whitespace', () => {
+    const [reason] = engine.formatReasonBlock(['first line\n\nthird line']);
+
+    expect(reason).toBe('   first line\n\n   third line');
+  });
 });
 
 describe('formatHeading', () => {

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -7,6 +7,22 @@ import { pickJsonPlugin } from './pickJsonPlugin.ts';
 /** esbuild target for compiled kits. Matches the Node floor of the `rdy` runner that executes them. */
 export const KIT_COMPILE_TARGET = 'es2025';
 
+/**
+ * TypeScript settings kits compile under.
+ *
+ * Supplying this at all is what stops esbuild searching for a `tsconfig.json` above the kit, so a kit's
+ * bytes are a function of its own sources rather than of whatever configuration the host repo happens to
+ * keep above it. The two settings are the ones esbuild derives rather than fixes; stating them keeps a
+ * version bump from moving kit semantics quietly. Everything else stays at esbuild's default.
+ *
+ * `target` is left undeclared, which is what keeps class-field semantics independent of
+ * `KIT_COMPILE_TARGET`: esbuild derives `useDefineForClassFields` from the TypeScript `target`, so
+ * declaring one here would tie the two back together.
+ */
+export const KIT_TSCONFIG = {
+  compilerOptions: { experimentalDecorators: false, useDefineForClassFields: true },
+};
+
 /** How to obtain esbuild, named wherever its absence is reported so every path prescribes one remedy. */
 export const ESBUILD_INSTALL_HINT = 'Install it with: pnpm add --save-dev esbuild';
 
@@ -59,6 +75,7 @@ export async function buildBundle(inputPath: string): Promise<Buffer> {
     format: 'esm',
     platform: 'node',
     target: KIT_COMPILE_TARGET,
+    tsconfigRaw: KIT_TSCONFIG,
     external: ['node:*', 'readyup', 'readyup/*'],
     plugins: [pickJsonPlugin()],
     banner: { js: GENERATED_HEADER },

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
 
+import { isRecord } from '../isRecord.ts';
+import { extractMessage } from '../utils/error-handling.ts';
 import { VERSION } from '../version.ts';
 import { loadEsbuild } from './loadEsbuild.ts';
 import { pickJsonPlugin } from './pickJsonPlugin.ts';
@@ -25,6 +27,16 @@ export const KIT_TSCONFIG = {
 
 /** How to obtain esbuild, named wherever its absence is reported so every path prescribes one remedy. */
 export const ESBUILD_INSTALL_HINT = 'Install it with: pnpm add --save-dev esbuild';
+
+/**
+ * Why an import a kit resolved under the host repo's configuration no longer resolves.
+ *
+ * esbuild answers an unresolved import by suggesting the path be marked external, which for a kit
+ * yields a bundle that fails at run time instead of at compile time. This names the cause its
+ * suggestion cannot: `KIT_TSCONFIG` leaves kits with no `paths` aliases to resolve through.
+ */
+const UNRESOLVED_SPECIFIER_HINT =
+  'Kits compile without a tsconfig.json, so tsconfig path aliases do not resolve. Import by relative path or package specifier, and check that any package imported is installed.';
 
 /**
  * Generated-file header prepended to compiled output.
@@ -69,18 +81,24 @@ export async function buildBundle(inputPath: string): Promise<Buffer> {
     });
   }
 
-  const result = await esbuild.build({
-    entryPoints: [resolvedInput],
-    bundle: true,
-    format: 'esm',
-    platform: 'node',
-    target: KIT_COMPILE_TARGET,
-    tsconfigRaw: KIT_TSCONFIG,
-    external: ['node:*', 'readyup', 'readyup/*'],
-    plugins: [pickJsonPlugin()],
-    banner: { js: GENERATED_HEADER },
-    write: false,
-  });
+  let result;
+  try {
+    result = await esbuild.build({
+      entryPoints: [resolvedInput],
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      target: KIT_COMPILE_TARGET,
+      tsconfigRaw: KIT_TSCONFIG,
+      external: ['node:*', 'readyup', 'readyup/*'],
+      plugins: [pickJsonPlugin()],
+      banner: { js: GENERATED_HEADER },
+      write: false,
+    });
+  } catch (error: unknown) {
+    if (!hasUnresolvedSpecifier(error)) throw error;
+    throw new Error(`${extractMessage(error)}\n\n${UNRESOLVED_SPECIFIER_HINT}`, { cause: error });
+  }
 
   const outputFile = result.outputFiles[0];
   if (outputFile === undefined) {
@@ -89,3 +107,25 @@ export async function buildBundle(inputPath: string): Promise<Buffer> {
 
   return Buffer.from(outputFile.contents);
 }
+
+// region | Helpers
+
+/**
+ * Reports whether an esbuild failure carries an import esbuild could not resolve.
+ *
+ * Reads the failure's own error list rather than its rendered message, and matches on message text
+ * because esbuild leaves the machine-readable `id` empty on a resolve error.
+ */
+function hasUnresolvedSpecifier(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+  const errors = error['errors'];
+  return (
+    Array.isArray(errors) &&
+    errors.some(
+      (message: unknown) =>
+        isRecord(message) && typeof message['text'] === 'string' && message['text'].startsWith('Could not resolve '),
+    )
+  );
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -171,9 +171,21 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
     return `${formatter.hintPrefix} ${hint}`;
   }
 
-  /** Returns each reason indented to the name column of a check at `depth`, one gutter further in. */
+  /**
+   * Returns each reason indented to the name column of a check at `depth`, one gutter further in.
+   *
+   * A reason carrying its own line breaks -- a bundler's rendered diagnostic, say -- is indented on
+   * every line, so it reads as one block rather than falling back to the left margin partway through.
+   * Blank lines within it stay blank rather than becoming trailing whitespace.
+   */
   function formatReasonBlock(reasons: string[], depth = 0): string[] {
-    return reasons.map((reason) => `${indent(depth + 1)}${reason}`);
+    const gutter = indent(depth + 1);
+    return reasons.map((reason) =>
+      reason
+        .split('\n')
+        .map((line) => (line === '' ? line : `${gutter}${line}`))
+        .join('\n'),
+    );
   }
 
   /**


### PR DESCRIPTION
## What

Kit compilation no longer reads the host repository's TypeScript configuration. Kits now compile under a fixed, documented set of settings, so the same kit source compiles to identical bytes in every repository. A kit that imports through a TypeScript path alias no longer compiles; kit imports must now be relative paths or package specifiers.

## Why

ReadyUp's model rests on publishing compiled kits for other people to run, and on comparing a kit's bytes to tell whether it is current. Both assumptions were false: whatever TypeScript configuration happened to sit above a kit in the host repository silently changed what it compiled to, so a bundle could differ between the author's machine and its consumer's, and a byte comparison could not be trusted across either. Nothing recorded that the configuration had been read, so the divergence left no trace to find it by.

## Details

### 🎉 Features

- Kit compilation declares the TypeScript settings it compiles under and passes them on every build, which stops the bundler searching upward for a `tsconfig.json`. The declared set is `experimentalDecorators: false` and `useDefineForClassFields: true`, the two settings whose defaults the bundler derives rather than fixes; everything else stays at its default. A compile target is deliberately not declared, since declaring one would tie class-field semantics back to the runner's target.
- A compile that fails on an unresolved import now names the cause: kits compile without a `tsconfig.json`, so path aliases do not resolve, and imports must be relative paths or package specifiers. The bundler answers the same failure by suggesting the path be marked external, which for a kit yields a bundle that fails when it runs rather than when it compiles.

### 🐛 Bug fixes

- A failure reason reported beneath a check now stays in its column for its whole length. A reason carrying its own line breaks, such as a rendered bundler diagnostic, previously fell back to the left margin after its first line, reading as though the report had ended and something else had begun. Blank lines within a reason stay blank rather than becoming trailing whitespace.

### 🧪 Tests

- A kit compiles to identical bytes whether or not a `tsconfig.json` sits above it. The host fixture declares the opposite of both settings kits compile under, plus a `paths` alias and the module it maps to, so every assertion in the file fails if kit compilation ever reads a host config again.
- The declared settings are read back from the lowering they produce, so flipping either one fails a test rather than silently changing kit semantics and falsifying the documented table.
- A build failure that names no unresolved import is asserted to propagate unchanged, anchored so that a guard which started matching every failure would be caught.

### 📚 Documentation

- The README's kit-authoring section states the TypeScript settings kits compile under, names esbuild as the bundler whose defaults fill in the rest, and explains why an import through a `paths` alias does not resolve.

Closes #229
