### PR TITLE
#238 Add a run-wide summary table to multi-kit runs

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -505,9 +505,9 @@ A check line reads `token name <separator> detail [progress] (duration)`. The se
 
 Tail and total lines lead with the run's worst severity, then report counts in a fixed order -- errors, warnings, recommendations, passed, blocked, skipped -- omitting any that is zero. Commas part the counts from one another, and a `|` parts the verdict from the list wherever no label already does, so the verdict is never read as a label on the count beside it.
 
-**Every block heads itself with a breadcrumb.** A run block is headed `━━`, and its segments read source, then kit, then checklist, parted by a spaced slash. A segment appears only where it distinguishes something: the source where the kit came from anywhere but the local kits directory or the working directory, the kit where the run holds more than one or a source segment is already there, the checklist where the kit runs more than one. A lone local kit running one checklist heads nothing at all. The summary table heads itself at `━━` too, as a peer of the blocks it tallies; `Fixes` and each command's own heading stay at `──`, and a bare `──` closes a block above its count line.
+**Every block heads itself with a breadcrumb.** A run block is headed `━━`, and its segments read source, then kit, then checklist, parted by a spaced slash. A segment appears only where it distinguishes something: the source where the kit came from anywhere but the local kits directory or the working directory, the kit where the run holds more than one or a source segment is already there, the checklist where the kit runs more than one. A lone local kit running one checklist heads nothing at all. The summary table heads itself at `━━` too, as a peer of the blocks it tallies, and each of its rows repeats the breadcrumb of the block it summarizes, the same segments elided; `Fixes` and each command's own heading stay at `──`, and a bare `──` closes a block above its count line.
 
-Blank lines part blocks rather than decorate headings: none opens a command's output or follows a heading, one parts one block from the next, and two appear only where one kit ends and the next begins. More than one checklist adds a summary table:
+Blank lines part blocks rather than decorate headings: none opens a command's output or follows a heading, one parts one block from the next, and two appear only where one kit ends and the next begins. More than one checklist anywhere in the run adds a summary table:
 
 ```
 ━━ 📋 build
@@ -542,6 +542,19 @@ A kit from an installed package, a repository, or a URL names where it came from
 ━━ 📦 @acme/release-kit@2.1.0 / 📓 npm-auto-publish / 📋 repo
 ━━ 🌐 github:acme/checks@main / 📓 default
 ━━ 📁 ../shared-kits / 📓 default
+```
+
+A run spanning several kits tallies them together, each row naming its source and kit so it reads without reference to the blocks above. Row names carry no role glyphs, since the padding that aligns the columns counts characters rather than terminal cells:
+
+```
+━━ Summary
+─────────────────────────────────────────────────────────────────────────────────
+🟢 @acme/release-kit@2.1.0 / npm-auto-publish / repo      12ms  4 passed
+🟢 @acme/release-kit@2.1.0 / npm-auto-publish / secrets    9ms  2 passed
+🔴 github:acme/checks@main / default                     151ms  1 error, 1 passed
+🟢 ../shared-kits / default                                4ms  3 passed
+─────────────────────────────────────────────────────────────────────────────────
+🔴 Total: 1 error, 10 passed (176ms)
 ```
 
 ### Output styles

--- a/packages/readyup/src/__tests__/cli.unit.test.ts
+++ b/packages/readyup/src/__tests__/cli.unit.test.ts
@@ -4,13 +4,14 @@ import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
+import type { SummaryRow } from '../layout/layoutEngine.ts';
 import { RemoteFetchError } from '../remote/RemoteFetchError.ts';
 import type { FailedResult, PassedResult, RdyKit, Severity } from '../types.ts';
 
 const mockLoadRdyKit = vi.hoisted(() => vi.fn());
 const mockRunRdy = vi.hoisted(() => vi.fn());
 const mockReportRdy = vi.hoisted(() => vi.fn());
-const mockFormatCombinedSummary = vi.hoisted(() => vi.fn());
+const mockFormatCombinedSummary = vi.hoisted(() => vi.fn<(rows: SummaryRow[]) => string>());
 const mockFormatJsonReport = vi.hoisted(() => vi.fn());
 const mockFormatJsonError = vi.hoisted(() => vi.fn());
 const mockResolveGitHubToken = vi.hoisted(() => vi.fn());
@@ -1167,7 +1168,7 @@ describe(runCommand, () => {
     expect(allOutput).not.toContain(`${KIT_BOUNDARY_GAP}\n`);
   });
 
-  it('does not print combined summary when running multiple kits', async () => {
+  it('prints one combined summary covering every kit in a multi-kit run', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
@@ -1180,7 +1181,47 @@ describe(runCommand, () => {
       json: false,
     });
 
-    expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
+    expect(mockFormatCombinedSummary).toHaveBeenCalledTimes(1);
+    expect(mockFormatCombinedSummary.mock.calls[0]?.[0].map((row) => row.segments)).toStrictEqual([
+      [
+        { role: 'kit', text: 'kit1' },
+        { role: 'checklist', text: 'deploy' },
+      ],
+      [
+        { role: 'kit', text: 'kit1' },
+        { role: 'checklist', text: 'infra' },
+      ],
+      [
+        { role: 'kit', text: 'kit2' },
+        { role: 'checklist', text: 'deploy' },
+      ],
+      [
+        { role: 'kit', text: 'kit2' },
+        { role: 'checklist', text: 'infra' },
+      ],
+    ]);
+  });
+
+  // A kit running one checklist heads its block without naming it, and still belongs in the run's tally.
+  it('gives a single-checklist kit a row of its own in a multi-kit run', async () => {
+    mockLoadRdyKit.mockResolvedValue({
+      kit: makeKit({ checklists: [{ name: 'only', checks: [{ name: 'a', check: () => true }] }] }),
+      compileTimeVersion: undefined,
+    });
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runCommand({
+      kitEntries: [
+        { name: 'kit1', source: { path: '.readyup/kits/kit1.js' }, checklists: [] },
+        { name: 'kit2', source: { path: '.readyup/kits/kit2.js' }, checklists: [] },
+      ],
+      json: false,
+    });
+
+    expect(mockFormatCombinedSummary.mock.calls[0]?.[0].map((row) => row.segments)).toStrictEqual([
+      [{ role: 'kit', text: 'kit1' }],
+      [{ role: 'kit', text: 'kit2' }],
+    ]);
   });
 
   it('uses per-checklist fixLocation over kit default', async () => {
@@ -1236,9 +1277,10 @@ describe(runCommand, () => {
     });
 
     expect(mockFormatCombinedSummary).toHaveBeenCalledTimes(1);
-    expect(mockFormatCombinedSummary).toHaveBeenCalledWith(
-      expect.arrayContaining([expect.objectContaining({ name: 'deploy' }), expect.objectContaining({ name: 'infra' })]),
-    );
+    expect(mockFormatCombinedSummary.mock.calls[0]?.[0].map((row) => row.segments)).toStrictEqual([
+      [{ role: 'checklist', text: 'deploy' }],
+      [{ role: 'checklist', text: 'infra' }],
+    ]);
   });
 
   it('counts results pruned by the reporting threshold in each combined-summary row', async () => {
@@ -1257,8 +1299,14 @@ describe(runCommand, () => {
     });
 
     expect(mockFormatCombinedSummary).toHaveBeenCalledWith([
-      expect.objectContaining({ name: 'deploy', passed: 1, warnings: 1, worstSeverity: 'warn' }),
-      expect.objectContaining({ name: 'infra', passed: 1, warnings: 1, worstSeverity: 'warn' }),
+      expect.objectContaining({
+        counts: expect.objectContaining({ passed: 1, warnings: 1, worstSeverity: 'warn' }),
+        segments: [{ role: 'checklist', text: 'deploy' }],
+      }),
+      expect.objectContaining({
+        counts: expect.objectContaining({ passed: 1, warnings: 1, worstSeverity: 'warn' }),
+        segments: [{ role: 'checklist', text: 'infra' }],
+      }),
     ]);
   });
 

--- a/packages/readyup/src/__tests__/countAgreement.unit.test.ts
+++ b/packages/readyup/src/__tests__/countAgreement.unit.test.ts
@@ -74,7 +74,9 @@ describe('count agreement across views', () => {
     expect(human).toContain(expectedFields);
 
     // Combined-summary table row.
-    const table = formatCombinedSummary([{ name: 'deploy', ...counts, durationMs: report.durationMs }]);
+    const table = formatCombinedSummary([
+      { counts, durationMs: report.durationMs, segments: [{ role: 'checklist', text: 'deploy' }] },
+    ]);
     expect(table).toContain(expectedFields);
 
     // JSON payload: the same tally, nested under `counts` with the verdict beside it.

--- a/packages/readyup/src/__tests__/formatCombinedSummary.unit.test.ts
+++ b/packages/readyup/src/__tests__/formatCombinedSummary.unit.test.ts
@@ -1,48 +1,54 @@
 import { describe, expect, it } from 'vitest';
 
 import { formatCombinedSummary } from '../formatCombinedSummary.ts';
+import type { SummaryRow } from '../layout/layoutEngine.ts';
 import { richFormatter } from '../layout/richFormatter.ts';
-import type { ChecklistSummary } from '../types.ts';
+import type { SummaryCounts } from '../types.ts';
 
 const PASSED = richFormatter.tokens.passed.glyph;
 const FAILED_ERROR = richFormatter.tokens.failedError.glyph;
 const FAILED_WARN = richFormatter.tokens.failedWarn.glyph;
 const FAILED_RECOMMEND = richFormatter.tokens.failedRecommend.glyph;
 
-function makeSummary(overrides?: Partial<ChecklistSummary>): ChecklistSummary {
+/** What a test row varies: the counts it reports, flattened, alongside its name and duration. */
+type RowOverrides = Partial<SummaryCounts> & { durationMs?: number; name?: string };
+
+function makeRow({ durationMs = 100, name = 'test-checklist', ...counts }: RowOverrides = {}): SummaryRow {
   return {
-    name: 'test-checklist',
-    passed: 3,
-    errors: 0,
-    warnings: 0,
-    recommendations: 0,
-    blocked: 0,
-    optional: 0,
-    worstSeverity: null,
-    durationMs: 100,
-    ...overrides,
+    counts: {
+      passed: 3,
+      errors: 0,
+      warnings: 0,
+      recommendations: 0,
+      blocked: 0,
+      optional: 0,
+      worstSeverity: null,
+      ...counts,
+    },
+    durationMs,
+    segments: [{ role: 'checklist', text: name }],
   };
 }
 
 /** Returns the table's lines, the leading blank included. */
-function renderLines(summaries: ChecklistSummary[]): string[] {
-  return formatCombinedSummary(summaries).split('\n');
+function renderLines(rows: SummaryRow[]): string[] {
+  return formatCombinedSummary(rows).split('\n');
 }
 
 describe(formatCombinedSummary, () => {
   // The run's writer parts one block from the next, so a table carrying its own blank would double the gap.
   it('carries no separation of its own', () => {
-    expect(renderLines([makeSummary()])[0]).not.toBe('');
+    expect(renderLines([makeRow()])[0]).not.toBe('');
   });
 
   it('heads the table as a block of the run rather than a full-width banner', () => {
-    const lines = renderLines([makeSummary()]);
+    const lines = renderLines([makeRow()]);
 
     expect(lines[0]).toBe('\u{2501}\u{2501} Summary');
   });
 
   it('encloses the rows in two equal rules', () => {
-    const lines = renderLines([makeSummary()]);
+    const lines = renderLines([makeRow()]);
 
     expect(lines[1]).toMatch(/^\u{2500}+$/u);
     expect(lines[3]).toBe(lines[1]);
@@ -54,21 +60,21 @@ describe(formatCombinedSummary, () => {
     ['a warning failed', { warnings: 1, worstSeverity: 'warn' as const }, FAILED_WARN],
     ['a recommendation failed', { recommendations: 1, worstSeverity: 'recommend' as const }, FAILED_RECOMMEND],
   ])('leads a row with the worst-severity token when %s', (_case, overrides, token) => {
-    const output = formatCombinedSummary([makeSummary({ name: 'deploy', ...overrides })]);
+    const output = formatCombinedSummary([makeRow({ name: 'deploy', ...overrides })]);
 
     expect(output).toContain(`${token} deploy`);
   });
 
   it('renders each row as name, duration, then comma-joined counts', () => {
     const output = formatCombinedSummary([
-      makeSummary({ name: 'infra', passed: 2, errors: 1, worstSeverity: 'error', durationMs: 45 }),
+      makeRow({ name: 'infra', passed: 2, errors: 1, worstSeverity: 'error', durationMs: 45 }),
     ]);
 
     expect(output).toContain(`${FAILED_ERROR} infra  45ms  1 error, 2 passed`);
   });
 
   it('omits zero-count fields from a row', () => {
-    const output = formatCombinedSummary([makeSummary({ name: 'deploy', passed: 5, durationMs: 200 })]);
+    const output = formatCombinedSummary([makeRow({ name: 'deploy', passed: 5, durationMs: 200 })]);
 
     expect(output).toContain(`${PASSED} deploy  200ms  5 passed`);
     expect(output).not.toContain('|');
@@ -76,7 +82,7 @@ describe(formatCombinedSummary, () => {
 
   it('includes skip fields in a row when their counts are non-zero', () => {
     const output = formatCombinedSummary([
-      makeSummary({ name: 'checks', passed: 1, errors: 1, blocked: 2, optional: 1, worstSeverity: 'error' }),
+      makeRow({ name: 'checks', passed: 1, errors: 1, blocked: 2, optional: 1, worstSeverity: 'error' }),
     ]);
 
     expect(output).toContain('1 error, 1 passed, 2 blocked, 1 skipped');
@@ -84,7 +90,7 @@ describe(formatCombinedSummary, () => {
 
   it('retires the prose count grammar', () => {
     const output = formatCombinedSummary([
-      makeSummary({ name: 'infra', passed: 2, errors: 1, blocked: 1, worstSeverity: 'error' }),
+      makeRow({ name: 'infra', passed: 2, errors: 1, blocked: 1, worstSeverity: 'error' }),
     ]);
 
     expect(output).not.toContain('Failed:');
@@ -94,8 +100,8 @@ describe(formatCombinedSummary, () => {
   describe('total line', () => {
     it('leads with the aggregate worst severity and sums the durations', () => {
       const output = formatCombinedSummary([
-        makeSummary({ passed: 10, durationMs: 100 }),
-        makeSummary({ name: 'other', passed: 5, errors: 2, blocked: 1, worstSeverity: 'error', durationMs: 200 }),
+        makeRow({ passed: 10, durationMs: 100 }),
+        makeRow({ name: 'other', passed: 5, errors: 2, blocked: 1, worstSeverity: 'error', durationMs: 200 }),
       ]);
 
       expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 2 errors, 15 passed, 1 blocked (300ms)`);
@@ -103,8 +109,8 @@ describe(formatCombinedSummary, () => {
 
     it('leads with the passed token when no checklist failed', () => {
       const output = formatCombinedSummary([
-        makeSummary({ passed: 3, durationMs: 50 }),
-        makeSummary({ name: 'other', passed: 7, durationMs: 150 }),
+        makeRow({ passed: 3, durationMs: 50 }),
+        makeRow({ name: 'other', passed: 7, durationMs: 150 }),
       ]);
 
       expect(output.split('\n').at(-1)).toBe(`${PASSED} Total: 10 passed (200ms)`);
@@ -112,8 +118,8 @@ describe(formatCombinedSummary, () => {
 
     it('escalates to the worst severity across checklists', () => {
       const output = formatCombinedSummary([
-        makeSummary({ name: 'only-recommend', passed: 0, recommendations: 1, worstSeverity: 'recommend' }),
-        makeSummary({ name: 'has-warn', passed: 0, warnings: 1, worstSeverity: 'warn' }),
+        makeRow({ name: 'only-recommend', passed: 0, recommendations: 1, worstSeverity: 'recommend' }),
+        makeRow({ name: 'has-warn', passed: 0, warnings: 1, worstSeverity: 'warn' }),
       ]);
       const totalLine = output.split('\n').at(-1);
 
@@ -123,7 +129,7 @@ describe(formatCombinedSummary, () => {
     });
 
     it('carries no per-field tokens', () => {
-      const output = formatCombinedSummary([makeSummary({ passed: 1, errors: 1, worstSeverity: 'error' })]);
+      const output = formatCombinedSummary([makeRow({ passed: 1, errors: 1, worstSeverity: 'error' })]);
       const totalLine = output.split('\n').at(-1) ?? '';
 
       expect(totalLine.slice(FAILED_ERROR.length)).not.toContain(PASSED);
@@ -131,18 +137,15 @@ describe(formatCombinedSummary, () => {
   });
 
   it('left-aligns names and right-aligns durations across rows', () => {
-    const lines = renderLines([
-      makeSummary({ name: 'ab', durationMs: 5 }),
-      makeSummary({ name: 'cdef', durationMs: 1_200 }),
-    ]);
+    const lines = renderLines([makeRow({ name: 'ab', durationMs: 5 }), makeRow({ name: 'cdef', durationMs: 1_200 })]);
 
     expect(lines[2]).toContain(`${PASSED} ab       5ms`);
     expect(lines[3]).toContain(`${PASSED} cdef  1200ms`);
   });
 
   it('sizes the rules to the widest line rather than a fixed width', () => {
-    const narrow = renderLines([makeSummary({ name: 'a', passed: 1, durationMs: 1 })]);
-    const wide = renderLines([makeSummary({ name: 'a-considerably-longer-checklist-name', passed: 1, durationMs: 1 })]);
+    const narrow = renderLines([makeRow({ name: 'a', passed: 1, durationMs: 1 })]);
+    const wide = renderLines([makeRow({ name: 'a-considerably-longer-checklist-name', passed: 1, durationMs: 1 })]);
 
     expect(wide[1]?.length).toBeGreaterThan(narrow[1]?.length ?? 0);
   });

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -870,7 +870,7 @@ async function runMultiKitHumanMode(
         writeBlock,
       });
       rows.push(...kitResult.rows);
-      if (kitResult.exitCode !== EXIT_OK) allPassed = false;
+      if (!kitResult.passed) allPassed = false;
     } catch (error: unknown) {
       // A kit that never ran is still headed, so stdout lists every kit the invocation asked for.
       if (kitSegments.length > 0) writeBlock(getLayout().formatBreadcrumb(kitSegments, 'kit'), true);
@@ -901,7 +901,7 @@ interface KitBlockContext {
 
 /** A kit's verdict alongside the rows its checklists contribute to the run's summary table. */
 interface KitRunResult {
-  exitCode: number;
+  passed: boolean;
   rows: SummaryRow[];
 }
 
@@ -942,7 +942,7 @@ async function runSingleKitHumanMode(
     rows.push(toSummaryRow(segments, report));
   }
 
-  return { exitCode: allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND, rows };
+  return { passed: allPassed, rows };
 }
 
 /**

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -13,7 +13,7 @@ import { UnresolvableKitImportsError } from './kitImports/UnresolvableKitImports
 import type { KitProvenance } from './KitProvenance.ts';
 import { KITS_DIR, resolveHomeDir } from './kitsDir.ts';
 import { getLayout } from './layout/engine.ts';
-import { type BreadcrumbSegment, SEGMENT_SEPARATOR } from './layout/layoutEngine.ts';
+import type { BreadcrumbSegment, SummaryRow } from './layout/layoutEngine.ts';
 import { DEFAULT_MANIFEST_PATH } from './manifest/manifestPath.ts';
 import type { RdyManifest } from './manifest/manifestSchema.ts';
 import { readManifest } from './manifest/readManifest.ts';
@@ -29,15 +29,7 @@ import { resolveRequestedNames } from './resolveRequestedNames.ts';
 import { runRdy } from './runRdy.ts';
 import type { JsonWarning, RaisedWarning } from './schemas/common.ts';
 import type { JsonDetail, JsonKitOrigin } from './schemas/reportSchema.ts';
-import type {
-  ChecklistSummary,
-  FixLocation,
-  RdyChecklist,
-  RdyKit,
-  RdyReport,
-  RdyStagedChecklist,
-  Severity,
-} from './types.ts';
+import type { FixLocation, RdyChecklist, RdyKit, RdyReport, RdyStagedChecklist, Severity } from './types.ts';
 import { extractHint, extractMessage } from './utils/error-handling.ts';
 import { translateParseArgsError } from './utils/parse-args-error.ts';
 import { checkDrift } from './verify/checkDrift.ts';
@@ -567,9 +559,9 @@ function resolveFixLocation(checklist: RdyChecklist | RdyStagedChecklist, kitDef
   return checklist.fixLocation ?? kitDefault ?? 'end';
 }
 
-/** Build a checklist summary from a report. */
-function summarizeReport(name: string, report: RdyReport): ChecklistSummary {
-  return { name, ...countResults(report.results), durationMs: report.durationMs };
+/** Builds a summary row from a report, named by the breadcrumb heading the block the report renders into. */
+function toSummaryRow(segments: BreadcrumbSegment[], report: RdyReport): SummaryRow {
+  return { counts: countResults(report.results), durationMs: report.durationMs, segments };
 }
 
 /** Resolve threshold values from the cascade: CLI flag > kit field > default. */
@@ -861,6 +853,7 @@ async function runMultiKitHumanMode(
   const isMultiKit = kitEntries.length > 1;
   const tracking = readManifestTracking(isJit);
   const writeBlock = createBlockWriter();
+  const rows: SummaryRow[] = [];
   let allPassed = true;
   let anyKitFailed = false;
 
@@ -872,18 +865,18 @@ async function runMultiKitHumanMode(
 
       warnOnKitStaleness(entry.name, entry.source, tracking);
 
-      const exitCode = await runSingleKitHumanMode(kit, entry.checklists, settings, {
-        isMultiKit,
+      const kitResult = await runSingleKitHumanMode(kit, entry.checklists, settings, {
         kitSegments,
         writeBlock,
       });
-      if (exitCode !== EXIT_OK) allPassed = false;
+      rows.push(...kitResult.rows);
+      if (kitResult.exitCode !== EXIT_OK) allPassed = false;
     } catch (error: unknown) {
       // A kit that never ran is still headed, so stdout lists every kit the invocation asked for.
       if (kitSegments.length > 0) writeBlock(getLayout().formatBreadcrumb(kitSegments, 'kit'), true);
 
       // A lone kit needs no label: nothing to disambiguate, and its source is already in the message.
-      const label = kitSegments.length > 0 ? ` [${toBreadcrumbLabel(kitSegments)}]` : '';
+      const label = kitSegments.length > 0 ? ` [${getLayout().formatBreadcrumbLabel(kitSegments)}]` : '';
       const rdyError = toRdyError(error);
       process.stderr.write(`Error${label}: ${rdyError.message}\n`);
       if (rdyError.hint !== undefined) {
@@ -893,14 +886,23 @@ async function runMultiKitHumanMode(
     }
   }
 
+  // Tallying follows the last kit rather than riding inside one, so a kit that failed to load still leaves
+  // the table covering the checklists that did run. Two blanks mark a kit boundary, and this is a block.
+  if (rows.length > 1) writeBlock(formatCombinedSummary(rows), false);
+
   return resolveRunExitCode(anyKitFailed, allPassed);
 }
 
 /** What a kit's checklists need in order to take their place in the run's sequence of blocks. */
 interface KitBlockContext {
-  isMultiKit: boolean;
   kitSegments: BreadcrumbSegment[];
   writeBlock: BlockWriter;
+}
+
+/** A kit's verdict alongside the rows its checklists contribute to the run's summary table. */
+interface KitRunResult {
+  exitCode: number;
+  rows: SummaryRow[];
 }
 
 /** Run checklists from a single kit in human-readable mode. */
@@ -908,14 +910,14 @@ async function runSingleKitHumanMode(
   kit: RdyKit,
   checklistFilter: string[],
   settings: HumanRunSettings,
-  { isMultiKit, kitSegments, writeBlock }: KitBlockContext,
-): Promise<number> {
+  { kitSegments, writeBlock }: KitBlockContext,
+): Promise<KitRunResult> {
   const checklists = selectChecklists(kit, checklistFilter);
   const thresholds = resolveThresholds(kit, settings.failOn, settings.reportOn);
   const showChecklistSegment = checklists.length > 1;
+  const rows: SummaryRow[] = [];
   let allPassed = true;
   let startsKit = true;
-  const summaries: ChecklistSummary[] = [];
 
   for (const checklist of checklists) {
     const report = await runRdy(checklist, {
@@ -937,16 +939,10 @@ async function runSingleKitHumanMode(
       allPassed = false;
     }
 
-    if (showChecklistSegment) {
-      summaries.push(summarizeReport(checklist.name, report));
-    }
+    rows.push(toSummaryRow(segments, report));
   }
 
-  if (summaries.length > 1 && !isMultiKit) {
-    writeBlock(formatCombinedSummary(summaries), false);
-  }
-
-  return allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
+  return { exitCode: allPassed ? EXIT_OK : EXIT_PROBLEMS_FOUND, rows };
 }
 
 /**
@@ -1017,11 +1013,6 @@ function describeKitProvenance(provenance: KitProvenance | undefined): Breadcrum
 
   const version = provenance.version === undefined ? '' : `@${provenance.version}`;
   return { role: 'sourcePackage', text: `${provenance.packageName}${version}` };
-}
-
-/** Returns a breadcrumb as plain text, for a stderr line that carries no layout of its own. */
-function toBreadcrumbLabel(segments: BreadcrumbSegment[]): string {
-  return segments.map((segment) => segment.text).join(SEGMENT_SEPARATOR);
 }
 
 /**

--- a/packages/readyup/src/formatCombinedSummary.ts
+++ b/packages/readyup/src/formatCombinedSummary.ts
@@ -1,29 +1,28 @@
 import { getLayout } from './layout/engine.ts';
+import type { SummaryRow } from './layout/layoutEngine.ts';
 import { emptyCounts, mergeCounts } from './reportRdy.ts';
-import type { ChecklistSummary, SummaryCounts } from './types.ts';
+import type { SummaryCounts } from './types.ts';
 
-/** Returns the summary table for `summaries`, one row each, carrying no separation of its own. */
-export function formatCombinedSummary(summaries: ChecklistSummary[]): string {
-  const rows = summaries.map((summary) => ({
-    name: summary.name,
-    counts: summary,
-    durationMs: summary.durationMs,
-  }));
-
+/** Returns the summary table for `rows`, one row each, carrying no separation of its own. */
+export function formatCombinedSummary(rows: SummaryRow[]): string {
   return getLayout()
     .formatSummaryTable({
       rows,
-      totals: aggregateCounts(summaries),
-      totalDurationMs: summaries.reduce((sum, summary) => sum + summary.durationMs, 0),
+      totals: aggregateCounts(rows),
+      totalDurationMs: rows.reduce((sum, row) => sum + row.durationMs, 0),
     })
     .join('\n');
 }
 
-/** Returns the sum of every summary's counts, carrying the worst severity among them. */
-function aggregateCounts(summaries: ChecklistSummary[]): SummaryCounts {
+// region | Helpers
+
+/** Returns the sum of every row's counts, carrying the worst severity among them. */
+function aggregateCounts(rows: SummaryRow[]): SummaryCounts {
   const totals = emptyCounts();
-  for (const summary of summaries) {
-    mergeCounts(totals, summary);
+  for (const row of rows) {
+    mergeCounts(totals, row.counts);
   }
   return totals;
 }
+
+// endregion | Helpers

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -1,7 +1,6 @@
 // Types
 export type {
   AheadBehind,
-  ChecklistSummary,
   CheckOutcome,
   CheckReturnValue,
   FailedResult,

--- a/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
@@ -215,6 +215,30 @@ describe('formatBreadcrumb', () => {
   });
 });
 
+describe('formatBreadcrumbLabel', () => {
+  const segments: SummaryRow['segments'] = [
+    { role: 'sourcePackage', text: '@acme/release-kit@2.1.0' },
+    { role: 'kit', text: 'npm-auto-publish' },
+    { role: 'checklist', text: 'repo' },
+  ];
+
+  it('parts the segments as a heading does, carrying none of their glyphs', () => {
+    expect(engine.formatBreadcrumbLabel(segments)).toBe('@acme/release-kit@2.1.0 / npm-auto-publish / repo');
+  });
+
+  it('renders a lone segment as its bare text', () => {
+    expect(engine.formatBreadcrumbLabel([{ role: 'checklist', text: 'repo' }])).toBe('repo');
+  });
+
+  // The label is the heading with the glyphs taken out, so the two cannot drift into naming one thing twice.
+  it('renders what the heading renders once the sigil and glyphs are removed', () => {
+    const heading = engine.formatBreadcrumb(segments, 'kit');
+    const withoutGlyphs = heading.replace(/^\u{2501}\u{2501} /u, '').replaceAll(/\p{Emoji_Presentation} /gu, '');
+
+    expect(engine.formatBreadcrumbLabel(segments)).toBe(withoutGlyphs);
+  });
+});
+
 describe('formatCounts', () => {
   it('joins non-zero fields with commas in the fixed order', () => {
     const counts = makeCounts({
@@ -373,6 +397,42 @@ describe('formatSummaryTable', () => {
     expect(lines[3]?.startsWith(PASSED)).toBe(true);
   });
 
+  it('names a row by its breadcrumb, carrying no role glyphs', () => {
+    const lines = engine.formatSummaryTable({
+      rows: [
+        makeRow({
+          segments: [
+            { role: 'sourcePackage', text: '@acme/release-kit@2.1.0' },
+            { role: 'kit', text: 'default' },
+            { role: 'checklist', text: 'repo' },
+          ],
+        }),
+      ],
+      totals: makeCounts({ passed: 1 }),
+      totalDurationMs: 100,
+    });
+
+    expect(lines[2]).toBe(`${PASSED} @acme/release-kit@2.1.0 / default / repo  100ms  1 passed`);
+  });
+
+  it('pads to the widest breadcrumb when rows carry different segment counts', () => {
+    const lines = engine.formatSummaryTable({
+      rows: [
+        makeRow({
+          segments: [
+            { role: 'sourcePackage', text: '@acme/long-package-name' },
+            { role: 'kit', text: 'default' },
+          ],
+        }),
+        makeRow({ segments: [{ role: 'checklist', text: 'short' }] }),
+      ],
+      totals: makeCounts({ passed: 2 }),
+      totalDurationMs: 200,
+    });
+
+    expect(lines[2]?.indexOf('1 passed')).toBe(lines[3]?.indexOf('1 passed'));
+  });
+
   it('handles a single row', () => {
     const lines = engine.formatSummaryTable({
       rows: [makeRow({ name: 'only', counts: makeCounts({ passed: 1 }), durationMs: 100 })],
@@ -459,8 +519,13 @@ function makeCounts(overrides?: Partial<SummaryCounts>): SummaryCounts {
   };
 }
 
-function makeRow(overrides?: Partial<SummaryRow>): SummaryRow {
-  return { name: 'checklist', counts: makeCounts({ passed: 1 }), durationMs: 100, ...overrides };
+function makeRow({ name = 'checklist', ...overrides }: Partial<SummaryRow> & { name?: string } = {}): SummaryRow {
+  return {
+    counts: makeCounts({ passed: 1 }),
+    durationMs: 100,
+    segments: [{ role: 'checklist', text: name }],
+    ...overrides,
+  };
 }
 
 /**

--- a/packages/readyup/src/layout/__tests__/plainFormatter.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/plainFormatter.unit.test.ts
@@ -171,8 +171,16 @@ function renderEverything(): string {
     engine.formatCountLine(counts, 800),
     ...engine.formatSummaryTable({
       rows: [
-        { name: 'build', counts: makeCounts({ passed: 2 }), durationMs: 410 },
-        { name: 'integration', counts, durationMs: 1_400 },
+        { counts: makeCounts({ passed: 2 }), durationMs: 410, segments: [{ role: 'checklist', text: 'build' }] },
+        {
+          counts,
+          durationMs: 1_400,
+          segments: [
+            { role: 'sourcePackage', text: '@acme/release-kit@2.1.0' },
+            { role: 'kit', text: 'npm-auto-publish' },
+            { role: 'checklist', text: 'integration' },
+          ],
+        },
       ],
       totals: counts,
       totalDurationMs: 1_810,

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -86,7 +86,7 @@ export interface CheckLineInput {
 export interface SummaryRow {
   counts: SummaryCounts;
   durationMs: number;
-  name: string;
+  segments: BreadcrumbSegment[];
 }
 
 /** The combined summary table's rows alongside the totals its final line reports. */
@@ -100,6 +100,7 @@ export interface SummaryTableInput {
 export interface LayoutEngine {
   formatBlockRule(): string;
   formatBreadcrumb(segments: BreadcrumbSegment[], level: HeadingLevel): string;
+  formatBreadcrumbLabel(segments: BreadcrumbSegment[]): string;
   formatCheckLine(input: CheckLineInput): string;
   formatCountLine(counts: SummaryCounts, durationMs: number, label?: string): string;
   formatCounts(counts: SummaryCounts): string;
@@ -192,13 +193,16 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
    * Returns the summary table's lines: a heading, a rule, one line per row, a closing rule, and a total.
    *
    * Names are padded and durations right-aligned, so every row's counts begin at the same column. Both
-   * rules span the widest line they enclose, the total included.
+   * rules span the widest line they enclose, the total included. A row names itself by its breadcrumb
+   * without the role glyphs the matching heading carries, because padding counts characters while the
+   * terminal lays out display width, and a glyph makes the two disagree.
    */
   function formatSummaryTable({ rows, totalDurationMs, totals }: SummaryTableInput): string[] {
-    const nameWidth = Math.max(...rows.map((row) => row.name.length));
-    const durationWidth = Math.max(...rows.map((row) => formatDuration(row.durationMs).length));
+    const named = rows.map((row) => ({ ...row, name: formatBreadcrumbLabel(row.segments) }));
+    const nameWidth = Math.max(...named.map((row) => row.name.length));
+    const durationWidth = Math.max(...named.map((row) => formatDuration(row.durationMs).length));
 
-    const entries = rows.map((row) => ({
+    const entries = named.map((row) => ({
       token: resolveWorstToken(row.counts.worstSeverity),
       body: [
         row.name.padEnd(nameWidth),
@@ -257,6 +261,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   return {
     formatBlockRule,
     formatBreadcrumb,
+    formatBreadcrumbLabel,
     formatCheckLine,
     formatCountLine,
     formatCounts,
@@ -268,6 +273,11 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
     inlineGlyph,
     token,
   };
+}
+
+/** Returns `segments` parted as a heading parts them, carrying none of the role glyphs a heading adds. */
+function formatBreadcrumbLabel(segments: BreadcrumbSegment[]): string {
+  return segments.map((segment) => segment.text).join(SEGMENT_SEPARATOR);
 }
 
 /** Returns the token for a severity, or the `passed` token for `null`. */

--- a/packages/readyup/src/packages/__tests__/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/src/packages/__tests__/packagesRun.wiring.unit.test.ts
@@ -292,10 +292,12 @@ describe('--packages run path wiring', () => {
     });
 
     await runCommand({ kitEntries: entries, json: false });
-    const output = stdout.join('');
+    const table = stdout.join('').split('\u{2501}\u{2501} Summary\n', 2)[1] ?? '';
 
-    expect(output).toContain('Total: 2 passed');
-    expect(output).not.toContain('broken-kit@3.0.0 / default  ');
+    expect(table).toContain('@acme/kits@2.1.0 / default');
+    expect(table).toContain('plain-kit@1.0.0 / default');
+    expect(table).not.toContain('broken-kit');
+    expect(table).toContain('Total: 2 passed');
   });
 });
 

--- a/packages/readyup/src/packages/__tests__/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/src/packages/__tests__/packagesRun.wiring.unit.test.ts
@@ -232,6 +232,71 @@ describe('--packages run path wiring', () => {
 
     expect(stdout.join('')).toContain('\u{1F4E6} @acme/kits@2.1.0 / \u{1F4D3} default');
   });
+
+  // The defect #238 reports: every package kit here runs one checklist, so the run tallied nothing at all.
+  it('ends a multi-package run with a table covering every checklist that ran', async () => {
+    installPackage('plain-kit', ['default'], { version: '1.0.0' });
+    installPackage('@acme/kits', ['default'], { version: '2.1.0' });
+    const entries = resolveKitSources({
+      ...baseArgs,
+      packages: true,
+      configuredPackages: ['plain-kit', '@acme/kits'],
+    });
+
+    await runCommand({ kitEntries: entries, json: false });
+    const lines = stdout.join('').trimEnd().split('\n');
+
+    // Heading, rule, one row per checklist, rule, total.
+    expect(lines.at(-6)).toContain('Summary');
+    expect(lines.at(-4)).toContain('plain-kit@1.0.0 / default');
+    expect(lines.at(-3)).toContain('@acme/kits@2.1.0 / default');
+    expect(lines.at(-1)).toContain('Total: 2 passed');
+  });
+
+  // A row is an index into the blocks above it, so it repeats its heading rather than naming its own scheme.
+  it('names each row by the breadcrumb heading its block carries', async () => {
+    installPackage('@acme/kits', ['default'], { version: '2.1.0' });
+    installPackage('plain-kit', ['default'], { version: '1.0.0' });
+    const entries = resolveKitSources({
+      ...baseArgs,
+      packages: true,
+      configuredPackages: ['@acme/kits', 'plain-kit'],
+    });
+
+    await runCommand({ kitEntries: entries, json: false });
+    const output = stdout.join('');
+    const headings = output
+      .matchAll(/^\u{2501}\u{2501} \u{1F4E6} (?<crumb>.+)$/gmu)
+      .map((match) => (match.groups?.['crumb'] ?? '').replaceAll(/\p{Emoji_Presentation} /gu, ''))
+      .toArray();
+
+    expect(headings).toStrictEqual(['@acme/kits@2.1.0 / default', 'plain-kit@1.0.0 / default']);
+    for (const heading of headings) {
+      expect(output).toContain(`\u{1F7E2} ${heading}`);
+    }
+  });
+
+  // A kit that never loaded ran no checklist, and the ones that did are still worth tallying.
+  it('tallies the checklists that ran when a kit fails to load', async () => {
+    installPackage('@acme/kits', ['default'], { version: '2.1.0' });
+    installPackage('plain-kit', ['default'], { version: '1.0.0' });
+    installPackage('broken-kit', ['default'], { version: '3.0.0' });
+    writeFileSync(
+      path.join(process.cwd(), 'node_modules', 'broken-kit', '.readyup', 'kits', 'default.js'),
+      'export default { nope: true };\n',
+    );
+    const entries = resolveKitSources({
+      ...baseArgs,
+      packages: true,
+      configuredPackages: ['@acme/kits', 'broken-kit', 'plain-kit'],
+    });
+
+    await runCommand({ kitEntries: entries, json: false });
+    const output = stdout.join('');
+
+    expect(output).toContain('Total: 2 passed');
+    expect(output).not.toContain('broken-kit@3.0.0 / default  ');
+  });
 });
 
 // region | Helpers

--- a/packages/readyup/src/types.ts
+++ b/packages/readyup/src/types.ts
@@ -263,12 +263,6 @@ export interface SummaryCounts {
   worstSeverity: Severity | null;
 }
 
-/** Per-checklist aggregate for the combined summary table. */
-export interface ChecklistSummary extends SummaryCounts {
-  name: string;
-  durationMs: number;
-}
-
 // -- Checklists --
 
 /** A flat checklist where all checks run concurrently. */


### PR DESCRIPTION
## What

A `rdy run` command that runs more than one kit now ends with a summary table: one row for every checklist that ran, and a total across all of them. A failing row points at the output block that explains it. The table is no longer suppressed if a kit fails to load.

## Why

`rdy run --packages` produces the longest output ReadyUp emits -- in this repo, 111 lines across 7 kits and 11 checklists -- and it ended with no aggregate, so a reader asking whether the run passed had to scan every block to find out. The README already promised a summary table for runs of more than one checklist, and the runs most in need of one were exactly the runs that never got it.

## Details

### 🎉 Features

- A run ends with the summary table whenever it produced more than one checklist summary, whatever selected the kits. Every checklist contributes a row, including one that is the only checklist in its kit: five of this repo's seven package kits run a single checklist and previously contributed nothing to any tally.
- Each row is named by the breadcrumb of the block it summarizes, applying the same segment elision, so a row indexes the output above it rather than introducing a second naming scheme. A single kit from a named source, which previously named its rows by bare checklist name, now carries the full breadcrumb; a lone local kit's rows keep their bare names.
- The totals line aggregates across kits.
- The tally follows the kit loop, so a kit that fails to load still leaves a table covering the checklists that did run.

### ♻️ Refactoring

- Breadcrumb rendering for table rows resolves in the layout engine: a row carries breadcrumb segments rather than a pre-joined name, and the CLI no longer imports a layout constant. This keeps #281, which reworks the grouping vocabulary of run output, to a single edit site.
- Removed `ChecklistSummary`. This change replaced its only producer, and the type had never been consumed.
- A kit reports its verdict as a boolean rather than as an exit code the caller decoded back.

### 🧪 Tests

- Coverage over the real `--packages` path for the multi-kit table, including a run in which one kit fails to load, and coverage pinning the plain-text breadcrumb renderer to the heading it mirrors.

### 📚 Documentation

- The README's output section shows a multi-kit table and states that a row repeats the breadcrumb of the block it summarizes.

Closes #238
