### PR TITLE
#281 Thin quiet-mode output and settle one grammar for run blocks

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -83,12 +83,10 @@ With `NODE_ENV` unset:
 ```
 🔴 NODE_ENV is set
    NODE_ENV has no value in the environment
-──
-🔴 1 error (0ms)
-
 ── Fixes
-💊 NODE_ENV is set
-   Set NODE_ENV before deploying
+🔴 NODE_ENV is set
+   💊 Set NODE_ENV before deploying
+🔴 Total: 1 error (0ms)
 ```
 
 `rdy run --jit` skips compilation and runs the TypeScript source directly, which is the faster loop while writing checks. Compiled kits stay the vetted artifact: they are what `rdy verify` hashes and what a consumer running `rdy run --from` gets.
@@ -314,12 +312,10 @@ It produces:
       🔴 No dependency has duplicated majors
          react resolves to both 18.3.1 and 19.0.0
    ⚪ Native modules are rebuilt · This workspace has no native dependencies
-──
-🔴 | 1 error, 3 passed, 1 skipped (0ms)
-
 ── Fixes
-💊 No dependency has duplicated majors
-   Run `pnpm dedupe`, then commit the lockfile
+🔴 No dependency has duplicated majors
+   💊 Run `pnpm dedupe`, then commit the lockfile
+🔴 Total: 1 error, 3 passed, 1 skipped (0ms)
 ```
 
 A failing descendant turns the tail line red while every ancestor stays green. `progress` needs no `detail`: `[4 of 4]` is already the evidence.
@@ -470,6 +466,8 @@ rdy run -- "--odd-kit-name"
 
 `--quiet` filters by status where `--report-on` filters by severity, so the two compose rather than override. Both keep the parent checks of anything they show, so a failure nested under passing parents stays reachable.
 
+A checklist either filter empties renders no block at all: its summary-table row states the same counts in a column the reader can compare across the run. A block is withheld only where a table will carry its row, so a run of one checklist reports its block however little it has to say, and a run that withholds one always ends with the table.
+
 A check's own [`quiet`](#checks) is this flag narrowed to that one check, and a kit whose every check declares it renders what `--quiet` renders. It is not `skip`, which reports that the check did not run and why: a quiet check runs, and its pass reaches the count line and the exit code like any other -- only the line is withheld. `--json` is unaffected, so `rdy run --json --detail full` shows a quiet check that passed.
 
 ### Global options
@@ -503,30 +501,27 @@ A check line reads `token name <separator> detail [progress] (duration)`. The se
 
 **A failed line carries only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. Passes and skips keep their detail inline.
 
-Tail and total lines lead with the run's worst severity, then report counts in a fixed order -- errors, warnings, recommendations, passed, blocked, skipped -- omitting any that is zero. Commas part the counts from one another, and a `|` parts the verdict from the list wherever no label already does, so the verdict is never read as a label on the count beside it.
+**Every block closes with its count line.** A count line is labelled `Total:`, leads with the run's worst severity, and reports counts in a fixed order -- errors, warnings, recommendations, passed, blocked, skipped -- omitting any that is zero, parted by commas. The label is what tells the line from the check lines above it, which lead with a token in the same column. It is the block's last line, following any `Fixes` recap.
 
-**Every block heads itself with a breadcrumb.** A run block is headed `━━`, and its segments read source, then kit, then checklist, parted by a spaced slash. A segment appears only where it distinguishes something: the source where the kit came from anywhere but the local kits directory or the working directory, the kit where the run holds more than one or a source segment is already there, the checklist where the kit runs more than one. A lone local kit running one checklist heads nothing at all. The summary table heads itself at `━━` too, as a peer of the blocks it tallies, and each of its rows repeats the breadcrumb of the block it summarizes, the same segments elided; `Fixes` and each command's own heading stay at `──`, and a bare `──` closes a block above its count line.
+**Every block heads itself with a breadcrumb.** A run block is headed `━━`, and its segments read source, then kit, then checklist, parted by a spaced slash. A segment appears only where it distinguishes something: the source where the kit came from anywhere but the local kits directory or the working directory, the kit where the run holds more than one or a source segment is already there, the checklist where the kit runs more than one. A lone local kit running one checklist heads nothing at all. The summary table heads itself at `━━` too, as a peer of the blocks it tallies, and each of its rows repeats the breadcrumb of the block it summarizes, the same segments elided; `Fixes` and each command's own heading stay at `──`, which heads a section and nothing else.
 
-Blank lines part blocks rather than decorate headings: none opens a command's output or follows a heading, one parts one block from the next, and two appear only where one kit ends and the next begins. More than one checklist anywhere in the run adds a summary table:
+Blank lines part blocks rather than decorate headings: none opens a command's output, follows a heading, or falls inside a block, and exactly one parts one block from the next, a kit boundary included. More than one checklist anywhere in the run adds a summary table:
 
 ```
 ━━ 📋 build
 🟢 Types check cleanly (343ms)
 🟢 Bundle is within budget · 42kB of a 50kB budget [84%]
-──
-🟢 | 2 passed (343ms)
+🟢 Total: 2 passed (343ms)
 
 ━━ 📋 integration
 🟢 Database is reachable
 🔴 Migrations are applied (151ms)
    2 migrations pending: add_users, add_index
 ⚪ Seed data is loaded · seeding is disabled outside CI
-──
-🔴 | 1 error, 1 passed, 1 skipped (151ms)
-
 ── Fixes
-💊 Migrations are applied
-   Run `pnpm migrate` against the target database
+🔴 Migrations are applied
+   💊 Run `pnpm migrate` against the target database
+🔴 Total: 1 error, 1 passed, 1 skipped (151ms)
 
 ━━ Summary
 ───────────────────────────────────────────────────
@@ -577,8 +572,7 @@ PASS  Database is reachable
 FAIL  Migrations are applied (151ms)
       2 migrations pending: add_users, add_index
 SKIP  Seed data is loaded - seeding is disabled outside CI
---
-FAIL  | 1 error, 1 passed, 1 skipped (151ms)
+FAIL  Total: 1 error, 1 passed, 1 skipped (151ms)
 ```
 
 ```

--- a/packages/readyup/src/__tests__/cli.unit.test.ts
+++ b/packages/readyup/src/__tests__/cli.unit.test.ts
@@ -976,7 +976,7 @@ describe(runCommand, () => {
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    mockReportRdy.mockReturnValue('report output');
+    mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: true });
     mockFormatCombinedSummary.mockReturnValue('combined summary');
   });
 
@@ -1166,6 +1166,61 @@ describe(runCommand, () => {
     expect(allOutput.startsWith('\u{2501}\u{2501} \u{1F4D3} kit1')).toBe(true);
     expect(allOutput).toContain(`${KIT_BOUNDARY_GAP}\u{2501}\u{2501} \u{1F4D3} kit2`);
     expect(allOutput).not.toContain(`${KIT_BOUNDARY_GAP}\n`);
+  });
+
+  // A bodiless block states nothing its table row does not, so it goes and the row reports it.
+  it('leaves out a block whose tree rendered nothing', async () => {
+    const kit = makeKit();
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+    mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: false });
+
+    await runCommand({
+      kitEntries: singleKitEntry(),
+      json: false,
+    });
+
+    const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(allOutput).not.toContain('report output');
+    expect(allOutput).toContain('combined summary');
+  });
+
+  // Nothing tabulates a run of one checklist, so its block stands however little it has to say.
+  it('keeps a bodiless block when the run will tabulate nothing', async () => {
+    const kit = makeKit({ checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }] });
+    mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+    mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: false });
+
+    await runCommand({
+      kitEntries: singleKitEntry(),
+      json: false,
+    });
+
+    const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(allOutput).toContain('report output');
+    expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
+  });
+
+  // The row is the only report a dropped block gets, so it is tabulated even with no sibling row beside it.
+  it('tabulates a dropped block even when one row is all that survives', async () => {
+    const kit = makeKit({ checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }] });
+    mockLoadRdyKit.mockResolvedValueOnce({ kit, compileTimeVersion: undefined });
+    mockLoadRdyKit.mockRejectedValueOnce(new Error('kit2 cannot be read'));
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+    mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: false });
+
+    await runCommand({
+      kitEntries: [
+        { name: 'kit1', source: { path: '.readyup/kits/kit1.js' }, checklists: [] },
+        { name: 'kit2', source: { path: '.readyup/kits/kit2.js' }, checklists: [] },
+      ],
+      json: false,
+    });
+
+    const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(allOutput).not.toContain('report output');
+    expect(allOutput).toContain('combined summary');
   });
 
   it('prints one combined summary covering every kit in a multi-kit run', async () => {

--- a/packages/readyup/src/__tests__/cli.unit.test.ts
+++ b/packages/readyup/src/__tests__/cli.unit.test.ts
@@ -966,8 +966,11 @@ describe(resolveKitSources, () => {
  *
  * Each count includes the newline terminating the block above, so the gap a reader sees is one blank fewer.
  */
-const WITHIN_KIT_GAP = '\n'.repeat(2);
-const KIT_BOUNDARY_GAP = '\n'.repeat(3);
+/** The blank line parting one block from the next, as it reads in concatenated stdout writes. */
+const BLOCK_GAP = '\n'.repeat(2);
+
+/** A gap wider than one blank line, which no boundary opens. */
+const WIDER_GAP = '\n'.repeat(3);
 
 describe(runCommand, () => {
   let stdoutSpy: MockInstance;
@@ -1090,7 +1093,7 @@ describe(runCommand, () => {
 
   // One blank parts blocks of the same kit, and the summary that tallies them is parted the same way. The
   // wider gap is reserved for a kit boundary, which is the reader's only cue that the kit has changed.
-  it('parts blocks of one kit with a single blank line', async () => {
+  it('parts one block from the next with a single blank line', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
@@ -1101,9 +1104,9 @@ describe(runCommand, () => {
     });
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(allOutput).not.toContain(KIT_BOUNDARY_GAP);
-    expect(allOutput).toContain(`${WITHIN_KIT_GAP}\u{2501}\u{2501} \u{1F4CB} infra`);
-    expect(allOutput).toContain(`${WITHIN_KIT_GAP}combined summary`);
+    expect(allOutput).not.toContain(WIDER_GAP);
+    expect(allOutput).toContain(`${BLOCK_GAP}\u{2501}\u{2501} \u{1F4CB} infra`);
+    expect(allOutput).toContain(`${BLOCK_GAP}combined summary`);
   });
 
   // A lone local kit running one checklist has no source to name, nothing to be told apart from, and one
@@ -1145,9 +1148,9 @@ describe(runCommand, () => {
     expect(allOutput).toContain('\u{2501}\u{2501} \u{1F4D3} kit2');
   });
 
-  // Two blanks at a kit boundary, none before the first block. Once headings stopped nesting, the wider
-  // gap is all that tells the reader one kit ended and the next began.
-  it('parts one kit from the next with two blank lines, opening with none', async () => {
+  // The heading below a gap names the kit it opens, so a kit boundary takes the same one blank line every
+  // other boundary takes. The run's first block opens with none.
+  it('parts one kit from the next with the same single blank line, opening with none', async () => {
     const kit = makeKit({
       checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
     });
@@ -1164,8 +1167,8 @@ describe(runCommand, () => {
 
     const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(allOutput.startsWith('\u{2501}\u{2501} \u{1F4D3} kit1')).toBe(true);
-    expect(allOutput).toContain(`${KIT_BOUNDARY_GAP}\u{2501}\u{2501} \u{1F4D3} kit2`);
-    expect(allOutput).not.toContain(`${KIT_BOUNDARY_GAP}\n`);
+    expect(allOutput).toContain(`${BLOCK_GAP}\u{2501}\u{2501} \u{1F4D3} kit2`);
+    expect(allOutput).not.toContain(WIDER_GAP);
   });
 
   // A bodiless block states nothing its table row does not, so it goes and the row reports it.

--- a/packages/readyup/src/__tests__/cli.unit.test.ts
+++ b/packages/readyup/src/__tests__/cli.unit.test.ts
@@ -962,11 +962,10 @@ describe(resolveKitSources, () => {
 });
 
 /**
- * Newline runs the block writer emits between blocks: one blank within a kit, two at a kit boundary.
+ * The blank line parting one block from the next, as it reads in concatenated stdout writes.
  *
- * Each count includes the newline terminating the block above, so the gap a reader sees is one blank fewer.
+ * The count includes the newline terminating the block above, so the gap a reader sees is one blank fewer.
  */
-/** The blank line parting one block from the next, as it reads in concatenated stdout writes. */
 const BLOCK_GAP = '\n'.repeat(2);
 
 /** A gap wider than one blank line, which no boundary opens. */
@@ -1091,8 +1090,7 @@ describe(runCommand, () => {
     expect(allOutput).toContain('\u{2501}\u{2501} \u{1F4CB} infra');
   });
 
-  // One blank parts blocks of the same kit, and the summary that tallies them is parted the same way. The
-  // wider gap is reserved for a kit boundary, which is the reader's only cue that the kit has changed.
+  // One blank parts blocks of the same kit, and the summary that tallies them is parted the same way.
   it('parts one block from the next with a single blank line', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });

--- a/packages/readyup/src/__tests__/countAgreement.unit.test.ts
+++ b/packages/readyup/src/__tests__/countAgreement.unit.test.ts
@@ -70,7 +70,7 @@ describe('count agreement across views', () => {
     const expectedFields = getLayout().formatCounts(expectedCounts);
 
     // Human tail line.
-    const human = reportRdy(report, { reportOn: 'error' });
+    const human = reportRdy(report, { reportOn: 'error' }).body;
     expect(human).toContain(expectedFields);
 
     // Combined-summary table row.
@@ -90,7 +90,7 @@ describe('count agreement across views', () => {
   it('prunes below-threshold results from the detail tree without altering the counts', async () => {
     const report = await runRdy(checklist);
 
-    const human = reportRdy(report, { reportOn: 'error' });
+    const human = reportRdy(report, { reportOn: 'error' }).body;
     const json = formatReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }], { reportOn: 'error' });
 
     expect(human).not.toContain('warn-fail');
@@ -102,7 +102,7 @@ describe('count agreement across views', () => {
   it('retains the parent chain of a visible result in every view', async () => {
     const report = await runRdy(nestedChecklist);
 
-    const human = reportRdy(report, { reportOn: 'error' });
+    const human = reportRdy(report, { reportOn: 'error' }).body;
     const parsed: unknown = JSON.parse(
       formatReport([{ name: 'kit', entries: [{ name: 'nested', report }] }], { reportOn: 'error' }),
     );
@@ -117,7 +117,7 @@ describe('count agreement across views', () => {
   it('emits no descendants of an n/a result in any view', async () => {
     const report = await runRdy(checklist);
 
-    const human = reportRdy(report);
+    const human = reportRdy(report).body;
     const json = formatReport([{ name: 'kit', entries: [{ name: 'deploy', report }] }]);
 
     for (const name of ['na-child', 'na-grandchild']) {

--- a/packages/readyup/src/__tests__/kitImportFailure.unit.test.ts
+++ b/packages/readyup/src/__tests__/kitImportFailure.unit.test.ts
@@ -61,7 +61,7 @@ describe('kit-import failure', () => {
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    mockReportRdy.mockReturnValue('report output');
+    mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: true });
     mockFormatCombinedSummary.mockReturnValue('');
     mockFormatJsonReport.mockReturnValue('{}');
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });

--- a/packages/readyup/src/__tests__/reportRdy.unit.test.ts
+++ b/packages/readyup/src/__tests__/reportRdy.unit.test.ts
@@ -459,7 +459,7 @@ describe(reportRdy, () => {
       const inline = reportRdy(makeReport({ results, passed: false }), { fixLocation: 'inline' }).body.split('\n');
       const heading = indexNaming(recapped.join('\n'), 'Fixes');
 
-      expect(recapped.slice(heading + 1, heading + 3)).toEqual([inline[0], inline[2]]);
+      expect(recapped.slice(heading + 1, heading + 3)).toStrictEqual([inline[0], inline[2]]);
     });
 
     it('is the default when no options are given', () => {

--- a/packages/readyup/src/__tests__/reportRdy.unit.test.ts
+++ b/packages/readyup/src/__tests__/reportRdy.unit.test.ts
@@ -98,7 +98,7 @@ describe(reportRdy, () => {
       ['n/a-skipped', makeSkippedResult({ name: 'target', skipReason: 'n/a' }), SKIPPED_OPTIONAL],
       ['precondition-skipped', makeSkippedResult({ name: 'target', skipReason: 'precondition' }), BLOCKED],
     ])('leads a %s check with its token', (_case, result, token) => {
-      const output = reportRdy(makeReport({ results: [result], passed: false }));
+      const output = reportRdy(makeReport({ results: [result], passed: false })).body;
 
       expect(lineNaming(output, 'target')).toBe(`${token} target`);
     });
@@ -116,7 +116,7 @@ describe(reportRdy, () => {
             ],
             passed: false,
           }),
-        );
+        ).body;
 
         expect(output).not.toContain(retired);
       },
@@ -125,7 +125,9 @@ describe(reportRdy, () => {
 
   describe('inline detail', () => {
     it('separates a passed check detail with a middle dot', () => {
-      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target', detail: 'up to date' })] }));
+      const output = reportRdy(
+        makeReport({ results: [makePassedResult({ name: 'target', detail: 'up to date' })] }),
+      ).body;
 
       expect(lineNaming(output, 'target')).toBe(`${PASSED} target \u{00B7} up to date`);
     });
@@ -133,7 +135,7 @@ describe(reportRdy, () => {
     it('separates a skip reason with a middle dot', () => {
       const output = reportRdy(
         makeReport({ results: [makeSkippedResult({ name: 'target', skipReason: 'n/a', detail: 'no lockfile' })] }),
-      );
+      ).body;
 
       expect(lineNaming(output, 'target')).toBe(`${SKIPPED_OPTIONAL} target \u{00B7} no lockfile`);
     });
@@ -143,7 +145,7 @@ describe(reportRdy, () => {
         makeReport({
           results: [makePassedResult({ name: 'target', progress: { type: 'fraction', passedCount: 7, count: 10 } })],
         }),
-      );
+      ).body;
 
       expect(lineNaming(output, 'target')).toBe(`${PASSED} target [7 of 10]`);
     });
@@ -151,7 +153,7 @@ describe(reportRdy, () => {
     it('renders percent progress', () => {
       const output = reportRdy(
         makeReport({ results: [makePassedResult({ name: 'target', progress: { type: 'percent', percent: 85 } })] }),
-      );
+      ).body;
 
       expect(lineNaming(output, 'target')).toBe(`${PASSED} target [85%]`);
     });
@@ -167,13 +169,15 @@ describe(reportRdy, () => {
             }),
           ],
         }),
-      );
+      ).body;
 
       expect(lineNaming(output, 'target')).toBe(`${PASSED} target \u{00B7} all good [100%]`);
     });
 
     it('retires the em-dash separator', () => {
-      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target', detail: 'up to date' })] }));
+      const output = reportRdy(
+        makeReport({ results: [makePassedResult({ name: 'target', detail: 'up to date' })] }),
+      ).body;
 
       expect(output).not.toContain('\u{2014}');
     });
@@ -181,13 +185,15 @@ describe(reportRdy, () => {
 
   describe('duration', () => {
     it('omits a duration below the floor', () => {
-      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target', durationMs: 10 })] }));
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target', durationMs: 10 })] })).body;
 
       expect(lineNaming(output, 'target')).toBe(`${PASSED} target`);
     });
 
     it('shows a duration at or above the floor', () => {
-      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target', durationMs: SLOW_MS })] }));
+      const output = reportRdy(
+        makeReport({ results: [makePassedResult({ name: 'target', durationMs: SLOW_MS })] }),
+      ).body;
 
       expect(lineNaming(output, 'target')).toBe(`${PASSED} target (250ms)`);
     });
@@ -195,13 +201,13 @@ describe(reportRdy, () => {
     it.each(['n/a', 'precondition'] as const)('omits the duration on a %s-skipped check', (skipReason) => {
       const output = reportRdy(
         makeReport({ results: [makeSkippedResult({ name: 'target', skipReason, durationMs: SLOW_MS })] }),
-      );
+      ).body;
 
       expect(lineNaming(output, 'target')).not.toContain('ms');
     });
 
     it('always shows the total duration on the count line', () => {
-      const output = reportRdy(makeReport({ results: [makePassedResult()], durationMs: 4 }));
+      const output = reportRdy(makeReport({ results: [makePassedResult()], durationMs: 4 })).body;
 
       expect(output.split('\n').at(-1)).toBe(`${PASSED} Total: 1 passed (4ms)`);
     });
@@ -211,7 +217,7 @@ describe(reportRdy, () => {
     it('leaves the failed line carrying only its claim', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'target', detail: 'lockfile is stale' })], passed: false }),
-      );
+      ).body;
 
       expect(lineNaming(output, 'target')).toBe(`${FAILED_ERROR} target`);
     });
@@ -219,7 +225,7 @@ describe(reportRdy, () => {
     it('renders the authored detail beneath, indented to the name column', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'target', detail: 'lockfile is stale' })], passed: false }),
-      );
+      ).body;
       const lines = output.split('\n');
 
       expect(lines[1]).toBe('   lockfile is stale');
@@ -231,7 +237,7 @@ describe(reportRdy, () => {
           results: [makeFailedResult({ name: 'target', detail: 'lockfile is stale', error: new Error('ENOENT') })],
           passed: false,
         }),
-      );
+      ).body;
       const lines = output.split('\n');
 
       expect(lines[1]).toBe('   lockfile is stale');
@@ -241,7 +247,7 @@ describe(reportRdy, () => {
     it('renders an exception alone when no detail was authored', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'target', error: new Error('boom') })], passed: false }),
-      );
+      ).body;
 
       expect(output.split('\n', 2)[1]).toBe('   Error: boom');
     });
@@ -252,7 +258,7 @@ describe(reportRdy, () => {
           results: [makeFailedResult({ name: 'parent' }), makeFailedResult({ name: 'child', depth: 1 })],
           passed: false,
         }),
-      );
+      ).body;
 
       expect(output.split('\n').slice(0, 2)).toStrictEqual([`${FAILED_ERROR} parent`, `   ${FAILED_ERROR} child`]);
     });
@@ -267,7 +273,7 @@ describe(reportRdy, () => {
           ],
           passed: false,
         }),
-      );
+      ).body;
 
       expect(output.split('\n', 4)[3]).toBe('         went wrong');
     });
@@ -281,7 +287,7 @@ describe(reportRdy, () => {
           passed: false,
           durationMs: 142,
         }),
-      );
+      ).body;
 
       expect(output.split('\n').at(-1)).toBe(`${FAILED_WARN} Total: 1 warning, 1 passed (142ms)`);
     });
@@ -299,7 +305,7 @@ describe(reportRdy, () => {
           passed: false,
           durationMs: 500,
         }),
-      );
+      ).body;
 
       expect(output.split('\n').at(-1)).toBe(
         `${FAILED_ERROR} Total: 1 error, 1 recommendation, 1 passed, 1 blocked, 1 skipped (500ms)`,
@@ -315,7 +321,7 @@ describe(reportRdy, () => {
           ],
         }),
         { reportOn: 'error' },
-      );
+      ).body;
 
       expect(output).not.toContain('pruned');
       expect(output.split('\n').at(-1)).toContain('2 passed');
@@ -324,13 +330,13 @@ describe(reportRdy, () => {
     // The label is what tells the tally from the check lines above it, which lead with a token in the
     // same column.
     it('labels the count line so it does not read as a check', () => {
-      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] }));
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] })).body;
 
       expect(output.split('\n').at(-1)).toBe(`${PASSED} Total: 1 passed (100ms)`);
     });
 
     it('carries no bare rule between the tree and the count line', () => {
-      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] }));
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] })).body;
 
       expect(output).not.toContain('\u{2500}\u{2500}\n');
     });
@@ -338,7 +344,7 @@ describe(reportRdy, () => {
     it('closes the block with the count line, after the fix recap', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run pnpm install' })], passed: false }),
-      );
+      ).body;
       const lines = output.split('\n');
 
       expect(lines.at(-1)).toBe(`${FAILED_ERROR} Total: 1 error (100ms)`);
@@ -348,9 +354,24 @@ describe(reportRdy, () => {
     it('carries no blank line inside the block', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run pnpm install' })], passed: false }),
-      );
+      ).body;
 
       expect(output.split('\n')).not.toContain('');
+    });
+  });
+
+  describe('visible-result reporting', () => {
+    it('reports an empty tree when every result is hidden', () => {
+      const rendered = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] }), { quiet: true });
+
+      expect(rendered.hasVisibleResults).toBe(false);
+      expect(rendered.body).toBe(`${PASSED} Total: 1 passed (100ms)`);
+    });
+
+    it('reports a rendered tree when a result survives', () => {
+      const rendered = reportRdy(makeReport({ results: [makeFailedResult({ name: 'broken' })], passed: false }));
+
+      expect(rendered.hasVisibleResults).toBe(true);
     });
   });
 
@@ -358,7 +379,7 @@ describe(reportRdy, () => {
     it('attributes each fix to the check that raised it', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run pnpm install' })], passed: false }),
-      );
+      ).body;
       const lines = output.split('\n');
       const heading = indexNaming(output, 'Fixes');
 
@@ -376,7 +397,7 @@ describe(reportRdy, () => {
           ],
           passed: false,
         }),
-      );
+      ).body;
 
       expect(output).toContain(`${FIX} fix one`);
       expect(output).toContain(`${FIX} fix two`);
@@ -388,7 +409,7 @@ describe(reportRdy, () => {
           results: [makeFailedResult({ name: 'broken', error: new Error('bad'), fix: 'Update config' })],
           passed: false,
         }),
-      );
+      ).body;
       const checkLine = indexNaming(output, 'broken');
 
       expect(output.split('\n')[checkLine + 1]).toBe('   Error: bad');
@@ -398,7 +419,7 @@ describe(reportRdy, () => {
     it('omits the recap when no failed check carries a fix', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'broken', error: new Error('bad') })], passed: false }),
-      );
+      ).body;
 
       expect(output).not.toContain('Fixes');
       expect(output).not.toContain(FIX);
@@ -413,7 +434,7 @@ describe(reportRdy, () => {
           ],
           passed: false,
         }),
-      );
+      ).body;
 
       expect(output).toContain(`${FAILED_ERROR} child`);
       expect(output).toContain(`   ${FIX} fix child`);
@@ -427,15 +448,15 @@ describe(reportRdy, () => {
           results: [makeFailedResult({ name: 'drifted', severity: 'recommend', fix: 'Rerun the sync' })],
           passed: false,
         }),
-      );
+      ).body;
 
       expect(output).toContain(`${FAILED_RECOMMEND} drifted`);
     });
 
     it('renders the shape an inline fix renders, less the reason', () => {
       const results = [makeFailedResult({ name: 'broken', detail: 'two files drifted', fix: 'Run pnpm install' })];
-      const recapped = reportRdy(makeReport({ results, passed: false })).split('\n');
-      const inline = reportRdy(makeReport({ results, passed: false }), { fixLocation: 'inline' }).split('\n');
+      const recapped = reportRdy(makeReport({ results, passed: false })).body.split('\n');
+      const inline = reportRdy(makeReport({ results, passed: false }), { fixLocation: 'inline' }).body.split('\n');
       const heading = indexNaming(recapped.join('\n'), 'Fixes');
 
       expect(recapped.slice(heading + 1, heading + 3)).toEqual([inline[0], inline[2]]);
@@ -444,7 +465,7 @@ describe(reportRdy, () => {
     it('is the default when no options are given', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Fix it' })], passed: false }),
-      );
+      ).body;
 
       expect(output).toContain('\u{2500}\u{2500} Fixes');
     });
@@ -458,7 +479,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { fixLocation: 'inline' },
-      );
+      ).body;
 
       expect(output.split('\n').slice(0, 3)).toStrictEqual([
         `${FAILED_ERROR} broken`,
@@ -471,7 +492,7 @@ describe(reportRdy, () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run install' })], passed: false }),
         { fixLocation: 'inline' },
-      );
+      ).body;
 
       expect(output.split('\n', 2)[1]).toBe(`   ${FIX} Run install`);
       expect(output).not.toContain('Error:');
@@ -484,7 +505,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { fixLocation: 'inline' },
-      );
+      ).body;
 
       expect(output).toContain('Error: Missing file');
       expect(output).not.toContain(FIX);
@@ -494,7 +515,7 @@ describe(reportRdy, () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run install' })], passed: false }),
         { fixLocation: 'inline' },
-      );
+      ).body;
 
       expect(output).not.toContain('Fixes');
     });
@@ -509,7 +530,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { fixLocation: 'inline' },
-      );
+      ).body;
       const lines = output.split('\n');
 
       expect(lines[2]).toBe('      Error: child error');
@@ -528,7 +549,7 @@ describe(reportRdy, () => {
             makePassedResult({ name: 'great-grandchild', depth: 3 }),
           ],
         }),
-      );
+      ).body;
 
       expect(output.split('\n').slice(0, 4)).toStrictEqual([
         `${PASSED} parent`,
@@ -548,7 +569,7 @@ describe(reportRdy, () => {
             makePassedResult({ name: 'sibling', depth: 1 }),
           ],
         }),
-      );
+      ).body;
 
       expect(output).toContain('na-check');
       expect(output).toContain('deeper');
@@ -567,7 +588,7 @@ describe(reportRdy, () => {
           passed: false,
           durationMs: 50,
         }),
-      );
+      ).body;
 
       expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 1 error, 2 passed (50ms)`);
     });
@@ -581,7 +602,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { quiet: true },
-      );
+      ).body;
 
       expect(output).not.toContain('quiet-pass');
       expect(output).toContain('loud-fail');
@@ -599,7 +620,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { quiet: true },
-      );
+      ).body;
 
       expect(output).not.toContain('hidden');
       for (const name of ['failure', 'optional-skip', 'blocked-skip']) {
@@ -618,7 +639,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { quiet: true },
-      );
+      ).body;
 
       expect(output.split('\n').slice(0, 3)).toStrictEqual([
         `${PASSED} passed-parent`,
@@ -638,7 +659,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { quiet: true },
-      );
+      ).body;
 
       expect(output).not.toContain('clean-parent');
       expect(output).not.toContain('clean-child');
@@ -653,7 +674,7 @@ describe(reportRdy, () => {
           durationMs: 90,
         }),
         { quiet: true },
-      );
+      ).body;
 
       expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 1 error, 2 passed (90ms)`);
     });
@@ -665,7 +686,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { quiet: true },
-      );
+      ).body;
 
       expect(output).toContain(`${FAILED_ERROR} broken`);
       expect(output).toContain(`   ${FIX} Run install`);
@@ -682,7 +703,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { quiet: true, reportOn: 'error' },
-      );
+      ).body;
 
       // Hidden by quiet (passed), by the threshold (warn), and shown by both (error failure).
       expect(output).not.toContain('passed-error-sev');
@@ -691,7 +712,7 @@ describe(reportRdy, () => {
     });
 
     it('shows every passed check when off', () => {
-      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'visible' })] }), { quiet: false });
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'visible' })] }), { quiet: false }).body;
 
       expect(output).toContain('visible');
     });
@@ -700,7 +721,7 @@ describe(reportRdy, () => {
       const output = reportRdy(
         makeReport({ results: [makePassedResult({ name: 'a' }), makePassedResult({ name: 'b' })], durationMs: 30 }),
         { quiet: true },
-      );
+      ).body;
 
       expect(output).toBe(`${PASSED} Total: 2 passed (30ms)`);
     });
@@ -712,7 +733,7 @@ describe(reportRdy, () => {
         makeReport({
           results: [makePassedResult({ name: 'quiet-pass', quiet: true }), makePassedResult({ name: 'loud-pass' })],
         }),
-      );
+      ).body;
 
       expect(output).not.toContain('quiet-pass');
       expect(output).toContain('loud-pass');
@@ -724,7 +745,7 @@ describe(reportRdy, () => {
           results: [makeFailedResult({ name: 'quiet-fail', quiet: true, detail: 'two remain', fix: 'Run install' })],
           passed: false,
         }),
-      );
+      ).body;
 
       expect(output).toContain('quiet-fail');
       expect(output).toContain('   two remain');
@@ -740,7 +761,7 @@ describe(reportRdy, () => {
             makeSkippedResult({ name: 'quiet-blocked', quiet: true, skipReason: 'precondition' }),
           ],
         }),
-      );
+      ).body;
 
       expect(lineNaming(output, 'quiet-optional')).toBe(`${SKIPPED_OPTIONAL} quiet-optional \u{00B7} no target`);
       expect(lineNaming(output, 'quiet-blocked')).toBe(`${BLOCKED} quiet-blocked`);
@@ -757,7 +778,7 @@ describe(reportRdy, () => {
           passed: false,
           durationMs: 90,
         }),
-      );
+      ).body;
 
       expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 1 error, 2 passed (90ms)`);
     });
@@ -771,7 +792,7 @@ describe(reportRdy, () => {
           ],
           passed: false,
         }),
-      );
+      ).body;
 
       expect(output.split('\n').slice(0, 2)).toStrictEqual([
         `${PASSED} quiet-parent`,
@@ -787,7 +808,7 @@ describe(reportRdy, () => {
             makePassedResult({ name: 'quiet-child', depth: 1, quiet: true }),
           ],
         }),
-      );
+      ).body;
 
       expect(output).toContain('loud-parent');
       expect(output).not.toContain('quiet-child');
@@ -804,10 +825,10 @@ describe(reportRdy, () => {
 
       const byFlag = reportRdy(makeReport({ results: buildResults(false), passed: false, durationMs: 90 }), {
         quiet: true,
-      });
+      }).body;
       const byField = reportRdy(makeReport({ results: buildResults(true), passed: false, durationMs: 90 }), {
         quiet: false,
-      });
+      }).body;
 
       expect(byField).toBe(byFlag);
       expect(byField).not.toContain('clean');
@@ -825,7 +846,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { reportOn: 'error' },
-      );
+      ).body;
 
       expect(output).toContain('error-check');
       expect(output).not.toContain('recommend-check');
@@ -841,7 +862,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { reportOn: 'error' },
-      );
+      ).body;
 
       expect(output.split('\n').at(-1)).toContain(`${FAILED_WARN} Total: 1 warning, 1 passed`);
       expect(output).not.toContain('warn-fail');
@@ -857,7 +878,7 @@ describe(reportRdy, () => {
           passed: false,
         }),
         { reportOn: 'error' },
-      );
+      ).body;
 
       expect(output).toContain('error-check');
       expect(output).not.toContain('precond');
@@ -872,7 +893,7 @@ describe(reportRdy, () => {
           ],
         }),
         { reportOn: 'warn' },
-      );
+      ).body;
 
       expect(output).toContain('high-sev-dep');
       expect(output).not.toContain('low-sev-dep');
@@ -881,7 +902,7 @@ describe(reportRdy, () => {
     it('defaults reportOn to recommend, showing everything', () => {
       const output = reportRdy(
         makeReport({ results: [makePassedResult({ name: 'recommend-check', severity: 'recommend' })] }),
-      );
+      ).body;
 
       expect(output).toContain('recommend-check');
     });

--- a/packages/readyup/src/__tests__/reportRdy.unit.test.ts
+++ b/packages/readyup/src/__tests__/reportRdy.unit.test.ts
@@ -203,7 +203,7 @@ describe(reportRdy, () => {
     it('always shows the total duration on the count line', () => {
       const output = reportRdy(makeReport({ results: [makePassedResult()], durationMs: 4 }));
 
-      expect(output.split('\n').at(-1)).toBe(`${PASSED} | 1 passed (4ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${PASSED} Total: 1 passed (4ms)`);
     });
   });
 
@@ -283,7 +283,7 @@ describe(reportRdy, () => {
         }),
       );
 
-      expect(output.split('\n').at(-1)).toBe(`${FAILED_WARN} | 1 warning, 1 passed (142ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_WARN} Total: 1 warning, 1 passed (142ms)`);
     });
 
     it('orders the fields by outcome, worst news first, and omits zeros', () => {
@@ -302,7 +302,7 @@ describe(reportRdy, () => {
       );
 
       expect(output.split('\n').at(-1)).toBe(
-        `${FAILED_ERROR} | 1 error, 1 recommendation, 1 passed, 1 blocked, 1 skipped (500ms)`,
+        `${FAILED_ERROR} Total: 1 error, 1 recommendation, 1 passed, 1 blocked, 1 skipped (500ms)`,
       );
     });
 
@@ -321,17 +321,36 @@ describe(reportRdy, () => {
       expect(output.split('\n').at(-1)).toContain('2 passed');
     });
 
-    it('parts the count line from the tree with a bare rule', () => {
+    // The label is what tells the tally from the check lines above it, which lead with a token in the
+    // same column.
+    it('labels the count line so it does not read as a check', () => {
       const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] }));
 
-      expect(output.split('\n', 2)[1]).toBe('\u{2500}\u{2500}');
+      expect(output.split('\n').at(-1)).toBe(`${PASSED} Total: 1 passed (100ms)`);
     });
 
-    // Nothing to part it from, and a rule under a heading would read as a tree that rendered empty.
-    it('omits the rule when every result is hidden', () => {
-      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] }), { quiet: true });
+    it('carries no bare rule between the tree and the count line', () => {
+      const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] }));
 
       expect(output).not.toContain('\u{2500}\u{2500}\n');
+    });
+
+    it('closes the block with the count line, after the fix recap', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run pnpm install' })], passed: false }),
+      );
+      const lines = output.split('\n');
+
+      expect(lines.at(-1)).toBe(`${FAILED_ERROR} Total: 1 error (100ms)`);
+      expect(indexNaming(output, 'Fixes')).toBeLessThan(lines.length - 1);
+    });
+
+    it('carries no blank line inside the block', () => {
+      const output = reportRdy(
+        makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run pnpm install' })], passed: false }),
+      );
+
+      expect(output.split('\n')).not.toContain('');
     });
   });
 
@@ -528,7 +547,7 @@ describe(reportRdy, () => {
         }),
       );
 
-      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} | 1 error, 2 passed (50ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 1 error, 2 passed (50ms)`);
     });
   });
 
@@ -614,7 +633,7 @@ describe(reportRdy, () => {
         { quiet: true },
       );
 
-      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} | 1 error, 2 passed (90ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 1 error, 2 passed (90ms)`);
     });
 
     it('keeps the fix recap', () => {
@@ -661,7 +680,7 @@ describe(reportRdy, () => {
         { quiet: true },
       );
 
-      expect(output).toBe(`${PASSED} | 2 passed (30ms)`);
+      expect(output).toBe(`${PASSED} Total: 2 passed (30ms)`);
     });
   });
 
@@ -718,7 +737,7 @@ describe(reportRdy, () => {
         }),
       );
 
-      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} | 1 error, 2 passed (90ms)`);
+      expect(output.split('\n').at(-1)).toBe(`${FAILED_ERROR} Total: 1 error, 2 passed (90ms)`);
     });
 
     it('retains a quiet passing parent so a deep failure stays reachable', () => {
@@ -802,7 +821,7 @@ describe(reportRdy, () => {
         { reportOn: 'error' },
       );
 
-      expect(output.split('\n').at(-1)).toContain(`${FAILED_WARN} | 1 warning, 1 passed`);
+      expect(output.split('\n').at(-1)).toContain(`${FAILED_WARN} Total: 1 warning, 1 passed`);
       expect(output).not.toContain('warn-fail');
     });
 

--- a/packages/readyup/src/__tests__/reportRdy.unit.test.ts
+++ b/packages/readyup/src/__tests__/reportRdy.unit.test.ts
@@ -363,8 +363,8 @@ describe(reportRdy, () => {
       const heading = indexNaming(output, 'Fixes');
 
       expect(lines[heading]).toBe('\u{2500}\u{2500} Fixes');
-      expect(lines[heading + 1]).toBe(`${FIX} broken`);
-      expect(lines[heading + 2]).toBe('   Run pnpm install');
+      expect(lines[heading + 1]).toBe(`${FAILED_ERROR} broken`);
+      expect(lines[heading + 2]).toBe(`   ${FIX} Run pnpm install`);
     });
 
     it('recaps a fix from each failed check', () => {
@@ -378,8 +378,8 @@ describe(reportRdy, () => {
         }),
       );
 
-      expect(output).toContain(`${FIX} first`);
-      expect(output).toContain(`${FIX} second`);
+      expect(output).toContain(`${FIX} fix one`);
+      expect(output).toContain(`${FIX} fix two`);
     });
 
     it('keeps the fix out of the reason block', () => {
@@ -415,8 +415,30 @@ describe(reportRdy, () => {
         }),
       );
 
-      expect(output).toContain(`${FIX} child`);
-      expect(output).toContain('   fix child');
+      expect(output).toContain(`${FAILED_ERROR} child`);
+      expect(output).toContain(`   ${FIX} fix child`);
+    });
+
+    // The recap names the check with the token the tree gave it, so a reader scanning fixes sees which
+    // answer errors and which answer recommendations.
+    it('leads a recapped check with its own severity token', () => {
+      const output = reportRdy(
+        makeReport({
+          results: [makeFailedResult({ name: 'drifted', severity: 'recommend', fix: 'Rerun the sync' })],
+          passed: false,
+        }),
+      );
+
+      expect(output).toContain(`${FAILED_RECOMMEND} drifted`);
+    });
+
+    it('renders the shape an inline fix renders, less the reason', () => {
+      const results = [makeFailedResult({ name: 'broken', detail: 'two files drifted', fix: 'Run pnpm install' })];
+      const recapped = reportRdy(makeReport({ results, passed: false })).split('\n');
+      const inline = reportRdy(makeReport({ results, passed: false }), { fixLocation: 'inline' }).split('\n');
+      const heading = indexNaming(recapped.join('\n'), 'Fixes');
+
+      expect(recapped.slice(heading + 1, heading + 3)).toEqual([inline[0], inline[2]]);
     });
 
     it('is the default when no options are given', () => {
@@ -645,8 +667,8 @@ describe(reportRdy, () => {
         { quiet: true },
       );
 
-      expect(output).toContain(`${FIX} broken`);
-      expect(output).toContain('   Run install');
+      expect(output).toContain(`${FAILED_ERROR} broken`);
+      expect(output).toContain(`   ${FIX} Run install`);
     });
 
     it('composes with the reporting threshold rather than overriding it', () => {
@@ -706,8 +728,8 @@ describe(reportRdy, () => {
 
       expect(output).toContain('quiet-fail');
       expect(output).toContain('   two remain');
-      expect(output).toContain(`${FIX} quiet-fail`);
-      expect(output).toContain('   Run install');
+      expect(output).toContain(`${FAILED_ERROR} quiet-fail`);
+      expect(output).toContain(`   ${FIX} Run install`);
     });
 
     it('reports a quiet check that is skipped', () => {

--- a/packages/readyup/src/__tests__/reportRdy.unit.test.ts
+++ b/packages/readyup/src/__tests__/reportRdy.unit.test.ts
@@ -436,8 +436,10 @@ describe(reportRdy, () => {
         }),
       ).body;
 
-      expect(output).toContain(`${FAILED_ERROR} child`);
-      expect(output).toContain(`   ${FIX} fix child`);
+      // The tree's own `   🔴 child` satisfies a substring match, so the recapped line is pinned by its
+      // exact form: the recap flattens nesting rather than mirroring the tree's indent.
+      expect(output.split('\n')).toContain(`${FAILED_ERROR} child`);
+      expect(output.split('\n')).toContain(`   ${FIX} fix child`);
     });
 
     // The recap names the check with the token the tree gave it, so a reader scanning fixes sees which

--- a/packages/readyup/src/__tests__/stalenessWarning.unit.test.ts
+++ b/packages/readyup/src/__tests__/stalenessWarning.unit.test.ts
@@ -87,7 +87,7 @@ describe('staleness warnings', () => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
-    mockReportRdy.mockReturnValue('report output');
+    mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: true });
     mockFormatCombinedSummary.mockReturnValue('');
     mockFormatJsonReport.mockReturnValue('{}');
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -872,7 +872,7 @@ async function runMultiKitHumanMode(
         writeBlock,
       });
       rows.push(...kitResult.rows);
-      if (kitResult.droppedBlock) anyBlockDropped = true;
+      if (kitResult.hasDroppedBlock) anyBlockDropped = true;
       if (!kitResult.passed) allPassed = false;
     } catch (error: unknown) {
       // A kit that never ran is still headed, so stdout lists every kit the invocation asked for.
@@ -906,7 +906,7 @@ interface KitBlockContext {
 
 /** A kit's verdict alongside the rows its checklists contribute to the run's summary table. */
 interface KitRunResult {
-  droppedBlock: boolean;
+  hasDroppedBlock: boolean;
   passed: boolean;
   rows: SummaryRow[];
 }
@@ -926,7 +926,7 @@ async function runSingleKitHumanMode(
   const willTabulate = isMultiKit || checklists.length > 1;
   const rows: SummaryRow[] = [];
   let allPassed = true;
-  let droppedBlock = false;
+  let hasDroppedBlock = false;
 
   for (const checklist of checklists) {
     const report = await runRdy(checklist, {
@@ -948,7 +948,7 @@ async function runSingleKitHumanMode(
       const heading = segments.length > 0 ? `${getLayout().formatBreadcrumb(segments, 'kit')}\n` : '';
       writeBlock(heading + body);
     } else {
-      droppedBlock = true;
+      hasDroppedBlock = true;
     }
 
     if (!report.passed) {
@@ -958,7 +958,7 @@ async function runSingleKitHumanMode(
     rows.push(toSummaryRow(segments, report));
   }
 
-  return { droppedBlock, passed: allPassed, rows };
+  return { hasDroppedBlock, passed: allPassed, rows };
 }
 
 /**

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -876,7 +876,7 @@ async function runMultiKitHumanMode(
       if (!kitResult.passed) allPassed = false;
     } catch (error: unknown) {
       // A kit that never ran is still headed, so stdout lists every kit the invocation asked for.
-      if (kitSegments.length > 0) writeBlock(getLayout().formatBreadcrumb(kitSegments, 'kit'), true);
+      if (kitSegments.length > 0) writeBlock(getLayout().formatBreadcrumb(kitSegments, 'kit'));
 
       // A lone kit needs no label: nothing to disambiguate, and its source is already in the message.
       const label = kitSegments.length > 0 ? ` [${getLayout().formatBreadcrumbLabel(kitSegments)}]` : '';
@@ -892,7 +892,7 @@ async function runMultiKitHumanMode(
   // Tallying follows the last kit rather than riding inside one, so a kit that failed to load still leaves
   // the table covering the checklists that did run. A dropped block is reported by its row alone, so one
   // dropped block earns the table even where a single row is all it has to carry.
-  if (rows.length > 1 || anyBlockDropped) writeBlock(formatCombinedSummary(rows), false);
+  if (rows.length > 1 || anyBlockDropped) writeBlock(formatCombinedSummary(rows));
 
   return resolveRunExitCode(anyKitFailed, allPassed);
 }
@@ -927,7 +927,6 @@ async function runSingleKitHumanMode(
   const rows: SummaryRow[] = [];
   let allPassed = true;
   let droppedBlock = false;
-  let startsKit = true;
 
   for (const checklist of checklists) {
     const report = await runRdy(checklist, {
@@ -947,8 +946,7 @@ async function runSingleKitHumanMode(
 
     if (hasVisibleResults || !willTabulate) {
       const heading = segments.length > 0 ? `${getLayout().formatBreadcrumb(segments, 'kit')}\n` : '';
-      writeBlock(heading + body, startsKit);
-      startsKit = false;
+      writeBlock(heading + body);
     } else {
       droppedBlock = true;
     }
@@ -981,21 +979,22 @@ function toJsonOriginField(provenance: KitProvenance | undefined): { origin?: Js
   };
 }
 
-/** Writes one block of a run to stdout, `startsKit` widening the gap that parts it from the block before. */
-type BlockWriter = (text: string, startsKit: boolean) => void;
+/** Writes one block of a run to stdout, parted from the block before it by a blank line. */
+type BlockWriter = (text: string) => void;
 
 /**
- * Returns a writer that parts each block of a run from the one before, opening a wider gap at a kit boundary.
+ * Returns a writer that parts each block of a run from the one before with a single blank line.
  *
- * Separation lives here rather than in the headings because only a sequence can see what precedes it: the
- * run's first block needs no blank at all, and once headings stopped nesting, a gap wider than the ones
- * within a kit is the reader's only remaining cue that the kit has changed.
+ * Separation lives here rather than in the headings because only a sequence can see what precedes it, and
+ * the run's first block needs no blank at all. One width serves every boundary, a kit's included: the
+ * heading below a gap names the kit it opens, so a wider gap would restate in whitespace what the next
+ * line already states in words.
  */
 function createBlockWriter(): BlockWriter {
   let hasWritten = false;
 
-  return (text, startsKit) => {
-    if (hasWritten) process.stdout.write(startsKit ? '\n\n' : '\n');
+  return (text) => {
+    if (hasWritten) process.stdout.write('\n');
     hasWritten = true;
     process.stdout.write(`${text}\n`);
   };

--- a/packages/readyup/src/cli.ts
+++ b/packages/readyup/src/cli.ts
@@ -855,6 +855,7 @@ async function runMultiKitHumanMode(
   const writeBlock = createBlockWriter();
   const rows: SummaryRow[] = [];
   let allPassed = true;
+  let anyBlockDropped = false;
   let anyKitFailed = false;
 
   for (const entry of kitEntries) {
@@ -866,10 +867,12 @@ async function runMultiKitHumanMode(
       warnOnKitStaleness(entry.name, entry.source, tracking);
 
       const kitResult = await runSingleKitHumanMode(kit, entry.checklists, settings, {
+        isMultiKit,
         kitSegments,
         writeBlock,
       });
       rows.push(...kitResult.rows);
+      if (kitResult.droppedBlock) anyBlockDropped = true;
       if (!kitResult.passed) allPassed = false;
     } catch (error: unknown) {
       // A kit that never ran is still headed, so stdout lists every kit the invocation asked for.
@@ -887,20 +890,23 @@ async function runMultiKitHumanMode(
   }
 
   // Tallying follows the last kit rather than riding inside one, so a kit that failed to load still leaves
-  // the table covering the checklists that did run. Two blanks mark a kit boundary, and this is a block.
-  if (rows.length > 1) writeBlock(formatCombinedSummary(rows), false);
+  // the table covering the checklists that did run. A dropped block is reported by its row alone, so one
+  // dropped block earns the table even where a single row is all it has to carry.
+  if (rows.length > 1 || anyBlockDropped) writeBlock(formatCombinedSummary(rows), false);
 
   return resolveRunExitCode(anyKitFailed, allPassed);
 }
 
 /** What a kit's checklists need in order to take their place in the run's sequence of blocks. */
 interface KitBlockContext {
+  isMultiKit: boolean;
   kitSegments: BreadcrumbSegment[];
   writeBlock: BlockWriter;
 }
 
 /** A kit's verdict alongside the rows its checklists contribute to the run's summary table. */
 interface KitRunResult {
+  droppedBlock: boolean;
   passed: boolean;
   rows: SummaryRow[];
 }
@@ -910,13 +916,17 @@ async function runSingleKitHumanMode(
   kit: RdyKit,
   checklistFilter: string[],
   settings: HumanRunSettings,
-  { kitSegments, writeBlock }: KitBlockContext,
+  { isMultiKit, kitSegments, writeBlock }: KitBlockContext,
 ): Promise<KitRunResult> {
   const checklists = selectChecklists(kit, checklistFilter);
   const thresholds = resolveThresholds(kit, settings.failOn, settings.reportOn);
   const showChecklistSegment = checklists.length > 1;
+  // A block may go unwritten only where the summary table will carry the row it leaves behind. A run of
+  // one checklist tabulates nothing, so its block stands however little it has to say.
+  const willTabulate = isMultiKit || checklists.length > 1;
   const rows: SummaryRow[] = [];
   let allPassed = true;
+  let droppedBlock = false;
   let startsKit = true;
 
   for (const checklist of checklists) {
@@ -925,15 +935,23 @@ async function runSingleKitHumanMode(
       failOn: thresholds.failOn,
     });
     const fixLocation = resolveFixLocation(checklist, kit.fixLocation);
-    const body = reportRdy(report, { fixLocation, quiet: settings.quiet, reportOn: thresholds.reportOn });
+    const { body, hasVisibleResults } = reportRdy(report, {
+      fixLocation,
+      quiet: settings.quiet,
+      reportOn: thresholds.reportOn,
+    });
 
     const segments: BreadcrumbSegment[] = showChecklistSegment
       ? [...kitSegments, { role: 'checklist', text: checklist.name }]
       : kitSegments;
-    const heading = segments.length > 0 ? `${getLayout().formatBreadcrumb(segments, 'kit')}\n` : '';
 
-    writeBlock(heading + body, startsKit);
-    startsKit = false;
+    if (hasVisibleResults || !willTabulate) {
+      const heading = segments.length > 0 ? `${getLayout().formatBreadcrumb(segments, 'kit')}\n` : '';
+      writeBlock(heading + body, startsKit);
+      startsKit = false;
+    } else {
+      droppedBlock = true;
+    }
 
     if (!report.passed) {
       allPassed = false;
@@ -942,7 +960,7 @@ async function runSingleKitHumanMode(
     rows.push(toSummaryRow(segments, report));
   }
 
-  return { passed: allPassed, rows };
+  return { droppedBlock, passed: allPassed, rows };
 }
 
 /**

--- a/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
@@ -170,17 +170,6 @@ describe('formatHeading', () => {
   });
 });
 
-describe('formatBlockRule', () => {
-  it('closes a block with a bare rule at section weight', () => {
-    expect(engine.formatBlockRule()).toBe('\u{2500}\u{2500}');
-  });
-
-  // A heading always carries text after its rule, so the bare form cannot be mistaken for one.
-  it('carries no text, so it does not read as a heading', () => {
-    expect(engine.formatBlockRule()).not.toContain(' ');
-  });
-});
-
 describe('formatBreadcrumb', () => {
   it('parts each segment from the next with a spaced separator', () => {
     const rendered = engine.formatBreadcrumb(
@@ -284,26 +273,22 @@ describe('formatCounts', () => {
 });
 
 describe('formatCountLine', () => {
-  it('parts the verdict from the counts when no label does', () => {
+  it('labels the counts, so the line names itself as a tally', () => {
     const counts = makeCounts({ passed: 9, errors: 1, worstSeverity: 'error' });
 
-    expect(engine.formatCountLine(counts, 1_200)).toBe(`${FAILED_ERROR} | 1 error, 9 passed (1200ms)`);
+    expect(engine.formatCountLine(counts, 1_200)).toBe(`${FAILED_ERROR} Total: 1 error, 9 passed (1200ms)`);
   });
 
   it('leads with the passed token when nothing failed', () => {
-    expect(engine.formatCountLine(makeCounts({ passed: 4 }), 300)).toBe(`${PASSED} | 4 passed (300ms)`);
+    expect(engine.formatCountLine(makeCounts({ passed: 4 }), 300)).toBe(`${PASSED} Total: 4 passed (300ms)`);
   });
 
   it('shows a duration below the check-line floor', () => {
     expect(engine.formatCountLine(makeCounts({ passed: 1 }), 4)).toContain('(4ms)');
   });
 
-  it('takes no separator when a label already parts the verdict from the counts', () => {
-    expect(engine.formatCountLine(makeCounts({ passed: 2 }), 500, 'Total:')).toBe(`${PASSED} Total: 2 passed (500ms)`);
-  });
-
   it('leads a blocked-only run with the passed token, since nothing failed', () => {
-    expect(engine.formatCountLine(makeCounts({ blocked: 2 }), 100)).toBe(`${PASSED} | 2 blocked (100ms)`);
+    expect(engine.formatCountLine(makeCounts({ blocked: 2 }), 100)).toBe(`${PASSED} Total: 2 blocked (100ms)`);
   });
 });
 
@@ -449,8 +434,7 @@ describe('verdict adjacency', () => {
   const verdict = engine.token('failedError');
 
   it.each([
-    ['tail line', () => engine.formatCountLine(counts, 500)],
-    ['total line', () => engine.formatCountLine(counts, 500, 'Total:')],
+    ['count line', () => engine.formatCountLine(counts, 500)],
     [
       'table row',
       () =>

--- a/packages/readyup/src/layout/__tests__/plainFormatter.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/plainFormatter.unit.test.ts
@@ -157,7 +157,6 @@ function renderEverything(): string {
     ),
     engine.formatHeading('deploy', 'kit'),
     engine.formatHeading('build', 'section'),
-    engine.formatBlockRule(),
     engine.formatBreadcrumb(
       [
         { role: 'sourcePackage', text: '@acme/release-kit@2.1.0' },

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -19,20 +19,16 @@ export const SEGMENT_SEPARATOR = ' / ';
 /** Columns between one summary-table cell and the next. */
 const TABLE_CELL_GAP = '  ';
 
-/** Label leading the combined summary table's final line. */
+/**
+ * Label leading every count line.
+ *
+ * The word is what tells a count line apart from the check lines above it: both lead with a severity
+ * token in the same column, so the tally needs to name itself rather than rely on the glyph.
+ */
 const TOTAL_LABEL = 'Total:';
 
 /** Heading over the combined summary table. */
 const SUMMARY_HEADING = 'Summary';
-
-/**
- * Text parting a count line's verdict from its counts, used wherever no label already parts them.
- *
- * Heavier than `COUNT_SEPARATOR`, so the counts read as one list under the verdict rather than binding
- * their first field to the glyph beside it. `buildCountBody` supplies the space after it, as it does for
- * the label it stands in for.
- */
-const VERDICT_SEPARATOR = '|';
 
 /** Text parting one count from the next. */
 const COUNT_SEPARATOR = ', ';
@@ -98,11 +94,10 @@ export interface SummaryTableInput {
 
 /** String builders that lay out a formatter's tokens. */
 export interface LayoutEngine {
-  formatBlockRule(): string;
   formatBreadcrumb(segments: BreadcrumbSegment[], level: HeadingLevel): string;
   formatBreadcrumbLabel(segments: BreadcrumbSegment[]): string;
   formatCheckLine(input: CheckLineInput): string;
-  formatCountLine(counts: SummaryCounts, durationMs: number, label?: string): string;
+  formatCountLine(counts: SummaryCounts, durationMs: number): string;
   formatCounts(counts: SummaryCounts): string;
   formatHeading(name: string, level: HeadingLevel): string;
   formatHint(hint: string): string;
@@ -115,11 +110,6 @@ export interface LayoutEngine {
 
 /** Returns string builders bound to `formatter`, each deriving its spacing from the formatter's gutter. */
 export function createLayoutEngine(formatter: Formatter): LayoutEngine {
-  /** Returns the bare rule closing a block, carrying no text so it reads as a rule rather than a heading. */
-  function formatBlockRule(): string {
-    return formatter.rules.section.repeat(HEADING_SIGIL_WIDTH);
-  }
-
   /**
    * Returns `segments` as one heading, each behind its role's glyph and parted by the segment separator.
    *
@@ -148,12 +138,12 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   }
 
   /**
-   * Returns `token <label or separator> counts (duration)`, led by the token for `counts.worstSeverity`.
+   * Returns `token Total: counts (duration)`, led by the token for `counts.worstSeverity`.
    *
    * The duration always appears, whatever its magnitude.
    */
-  function formatCountLine(counts: SummaryCounts, durationMs: number, label?: string): string {
-    return token(resolveWorstToken(counts.worstSeverity)) + buildCountBody(counts, durationMs, label);
+  function formatCountLine(counts: SummaryCounts, durationMs: number): string {
+    return token(resolveWorstToken(counts.worstSeverity)) + buildCountBody(counts, durationMs);
   }
 
   /**
@@ -210,7 +200,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
         formatCounts(row.counts),
       ].join(TABLE_CELL_GAP),
     }));
-    const totalBody = buildCountBody(totals, totalDurationMs, TOTAL_LABEL);
+    const totalBody = buildCountBody(totals, totalDurationMs);
 
     const bodyWidth = Math.max(...entries.map((entry) => entry.body.length), totalBody.length);
     const rule = formatter.rules.section.repeat(formatter.gutter + bodyWidth);
@@ -248,18 +238,12 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
 
   // -- Helpers --
 
-  /**
-   * Returns everything a count line carries after its leading token.
-   *
-   * A label and the verdict separator occupy one slot, so a labelled line takes no separator: whichever
-   * fills the slot is what keeps the verdict from touching the first count.
-   */
-  function buildCountBody(counts: SummaryCounts, durationMs: number, label?: string): string {
-    return `${label ?? VERDICT_SEPARATOR} ${formatCounts(counts)} (${formatDuration(durationMs)})`;
+  /** Returns everything a count line carries after its leading token. */
+  function buildCountBody(counts: SummaryCounts, durationMs: number): string {
+    return `${TOTAL_LABEL} ${formatCounts(counts)} (${formatDuration(durationMs)})`;
   }
 
   return {
-    formatBlockRule,
     formatBreadcrumb,
     formatBreadcrumbLabel,
     formatCheckLine,

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -11,6 +11,7 @@ const FIXES_HEADING = 'Fixes';
 interface AttributedFix {
   fix: string;
   name: string;
+  severity: Severity;
 }
 
 /** Options controlling how the report is formatted. */
@@ -155,22 +156,34 @@ function collectReasons(result: RdyResult, includeFix: boolean): string[] {
   const reasons: string[] = [];
   if (result.detail !== null) reasons.push(result.detail);
   if (result.error !== null) reasons.push(`Error: ${result.error.message}`);
-  if (includeFix && result.fix !== null) reasons.push(`${getLayout().token('fix')}${result.fix}`);
+  if (includeFix && result.fix !== null) reasons.push(formatFixReason(result.fix));
   return reasons;
 }
 
-/** Returns each failed result's fix paired with the name of the check carrying it. */
+/** Returns each failed result's fix paired with the name and severity of the check carrying it. */
 function collectFixes(results: RdyResult[]): AttributedFix[] {
   return results.flatMap((result) =>
-    result.status === 'failed' && result.fix !== null ? [{ name: result.name, fix: result.fix }] : [],
+    result.status === 'failed' && result.fix !== null
+      ? [{ fix: result.fix, name: result.name, severity: result.severity }]
+      : [],
   );
 }
 
-/** Returns two lines per fix: the check's name behind a token, then the fix indented beneath. */
+/** Returns a fix as one reason line, behind the token marking fix text wherever a kit places it. */
+function formatFixReason(fix: string): string {
+  return `${getLayout().token('fix')}${fix}`;
+}
+
+/**
+ * Returns each fix as its failed check re-rendered, the fix standing where the reason would.
+ *
+ * A recapped fix and an inline one are then one shape, so the fix token marks fix text under either
+ * `fixLocation` rather than marking the check's name in the recap and the fix itself inline.
+ */
 function renderFixRecap(fixes: AttributedFix[]): string[] {
   return fixes.flatMap((entry) => [
-    `${getLayout().token('fix')}${entry.name}`,
-    ...getLayout().formatReasonBlock([entry.fix]),
+    getLayout().formatCheckLine({ token: resolveWorstToken(entry.severity), name: entry.name }),
+    ...getLayout().formatReasonBlock([formatFixReason(entry.fix)]),
   ]);
 }
 

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -54,7 +54,7 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): Render
 
   const countLine = getLayout().formatCountLine(countResults(report.results), report.durationMs);
 
-  return { body: [...lines, countLine].join('\n'), hasVisibleResults: lines.length > 0 };
+  return { body: [...lines, countLine].join('\n'), hasVisibleResults: visibleResults.length > 0 };
 }
 
 /** Returns counts with every field at zero and no worst severity. */

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -21,11 +21,12 @@ export interface ReportRdyOptions {
 }
 
 /**
- * Returns a report rendered for a terminal: a tree of check lines, a count line, and any fix recap.
+ * Returns a report rendered for a terminal: a tree of check lines, any fix recap, then the count line.
  *
  * A failed check contributes its claim plus a reason block; every other status contributes one line.
  * `fixLocation` places each fix either in the recap or in its check's reason block. The count line
- * tallies every result in `report`, including those `reportOn` and `quiet` omit from the tree.
+ * tallies every result in `report`, including those `reportOn` and `quiet` omit from the tree, and it
+ * closes the block: the last line a reader meets before the blank parting one block from the next.
  */
 export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string {
   const fixLocation = options?.fixLocation ?? 'end';
@@ -34,17 +35,14 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
   const visibleResults = selectReportedResults(report.results, reportOn, options?.quiet === true);
   const lines = visibleResults.flatMap((result) => renderResult(result, fixLocation));
 
-  // The rule parts the count line from the tree it tallies, so an empty tree needs none: a checklist whose
-  // every result is hidden closes with its count line sitting directly under its heading.
-  if (lines.length > 0) lines.push(getLayout().formatBlockRule());
-  lines.push(getLayout().formatCountLine(countResults(report.results), report.durationMs));
-
   if (fixLocation === 'end') {
     const fixes = collectFixes(visibleResults);
     if (fixes.length > 0) {
-      lines.push('', getLayout().formatHeading(FIXES_HEADING, 'section'), ...renderFixRecap(fixes));
+      lines.push(getLayout().formatHeading(FIXES_HEADING, 'section'), ...renderFixRecap(fixes));
     }
   }
+
+  lines.push(getLayout().formatCountLine(countResults(report.results), report.durationMs));
 
   return lines.join('\n');
 }

--- a/packages/readyup/src/reportRdy.ts
+++ b/packages/readyup/src/reportRdy.ts
@@ -14,6 +14,12 @@ interface AttributedFix {
   severity: Severity;
 }
 
+/** A rendered report, alongside whether its check tree rendered anything at all. */
+export interface RenderedReport {
+  body: string;
+  hasVisibleResults: boolean;
+}
+
 /** Options controlling how the report is formatted. */
 export interface ReportRdyOptions {
   fixLocation?: FixLocation;
@@ -28,8 +34,11 @@ export interface ReportRdyOptions {
  * `fixLocation` places each fix either in the recap or in its check's reason block. The count line
  * tallies every result in `report`, including those `reportOn` and `quiet` omit from the tree, and it
  * closes the block: the last line a reader meets before the blank parting one block from the next.
+ *
+ * Reports whether the tree rendered anything, so a caller placing the block in a sequence can decide
+ * whether a report that is nothing but its count line has earned its place there.
  */
-export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string {
+export function reportRdy(report: RdyReport, options?: ReportRdyOptions): RenderedReport {
   const fixLocation = options?.fixLocation ?? 'end';
   const reportOn = options?.reportOn ?? 'recommend';
 
@@ -43,9 +52,9 @@ export function reportRdy(report: RdyReport, options?: ReportRdyOptions): string
     }
   }
 
-  lines.push(getLayout().formatCountLine(countResults(report.results), report.durationMs));
+  const countLine = getLayout().formatCountLine(countResults(report.results), report.durationMs);
 
-  return lines.join('\n');
+  return { body: [...lines, countLine].join('\n'), hasVisibleResults: lines.length > 0 };
 }
 
 /** Returns counts with every field at zero and no worst severity. */


### PR DESCRIPTION
## What

A `rdy run` filtered with `--quiet` or `--report-on` no longer gives a block of its own to a checklist that has nothing left to report; the run's summary table accounts for it instead. An 11-checklist run that reported 11 blocks now reports 2. What remains reads the same way filtered or not. The total is now labeled to avoid visual confusion with checks.

## Why

Quiet mode was harder to read than the ordinary output it thins. Stripping the content away left the grouping mechanisms competing with each other -- two blank-line widths, two rule weights, and a bare closing rule -- and left most blocks saying nothing a reader could act on. The run-wide summary table (#238) had already made that redundant: every checklist's counts appear once more in an aligned column, so a block rendering only a heading and a tally states nothing the table does not state better.

## Details

### 🎉 Features

- A checklist whose every result is hidden renders no block; its summary-table row is the report. The drop is gated on the body being empty rather than on `--quiet` specifically, so a `--report-on` above a block's severities thins the same way and the two modes stay one grammar.
- A block is withheld only where a table will cover it. A run of one checklist tabulates nothing, so its block stands however little it has to say, and a run that withholds a block always ends with the table -- including when a single row is all that survives, every other kit having failed to load.
- Every count line is labelled `Total:` and closes its block, following any `Fixes` recap. The `|` verdict separator no longer appears in any output.
- The bare closing rule is gone. `━━` heads a kit block, `──` heads a section, and nothing else carries a rule.
- One blank line parts every block from the next, kit boundaries included, and none appears inside a block. The heading below a gap names the kit it opens, so the wider gap restated in whitespace what the next line already said in words.

### 🐛 Bug fixes

- 💊 now marks fix text under either `fixLocation`. A recapped fix previously carried the token on the check's name, so the same glyph pointed at the problem in one placement and at the remedy in the other. A recapped check also leads with its own severity token, so a reader scanning a long fix list sees which fixes answer errors and which answer recommendations.

### ♻️ Refactoring

- `reportRdy` returns `{ body, hasVisibleResults }` rather than a bare string, so a caller placing the block in a sequence decides whether it has earned its place without re-deriving the filter.
- `formatBlockRule` and `VERDICT_SEPARATOR` are deleted; `formatCountLine` loses its optional `label` parameter now that every count line carries the same one.
- `BlockWriter` narrows to `(text: string) => void`, its `startsKit` argument having no remaining meaning.

### 🧪 Tests

- Coverage for the drop and both its exemptions, the tally's position after the recap, the absence of any gap wider than one blank, and the recap and inline fix shapes compared by strict equality rather than as independent literals that could drift apart again.

### 📚 Documentation

- README's "Reading the output" states the grammar as a rule a reader can apply, and every worked listing matches what the CLI renders. No reference survives to the `|` separator, the bare closing rule, or the two-blank kit gap.


Closes #281
