### PR TITLE
#309 Catalog esbuild and declare the peer in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@williamthorsen/strict-lint": "10.0.0",
     "@williamthorsen/tsconfig": "0.5.0",
     "codeassembly": "0.8.0",
-    "esbuild": "0.28.1",
+    "esbuild": "catalog:",
     "eslint": "10.8.0",
     "lefthook": "2.1.10",
     "prettier": "3.9.6",

--- a/packages/readyup/package.json
+++ b/packages/readyup/package.json
@@ -64,7 +64,8 @@
   },
   "devDependencies": {
     "@types/picomatch": "4.0.3",
-    "ajv": "8.20.0"
+    "ajv": "8.20.0",
+    "esbuild": "catalog:"
   },
   "peerDependencies": {
     "esbuild": ">=0.28.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@williamthorsen/toolbelt.packaging':
       specifier: 0.3.0
       version: 0.3.0
+    esbuild:
+      specifier: 0.28.1
+      version: 0.28.1
     zod:
       specifier: 4.4.3
       version: 4.4.3
@@ -57,7 +60,7 @@ importers:
         specifier: 0.8.0
         version: 0.8.0
       esbuild:
-        specifier: 0.28.1
+        specifier: 'catalog:'
         version: 0.28.1
       eslint:
         specifier: 10.8.0
@@ -116,9 +119,6 @@ importers:
       es-module-lexer:
         specifier: 2.3.1
         version: 2.3.1
-      esbuild:
-        specifier: '>=0.28.1'
-        version: 0.28.1
       jiti:
         specifier: 2.7.0
         version: 2.7.0
@@ -138,6 +138,9 @@ importers:
       ajv:
         specifier: 8.20.0
         version: 8.20.0
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.28.1
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ allowBuilds:
 catalog:
   '@williamthorsen/toolbelt.errors': 0.3.0
   '@williamthorsen/toolbelt.packaging': 0.3.0
+  esbuild: 0.28.1
   zod: 4.4.3
 
 savePrefix: ''


### PR DESCRIPTION
## What

Declares `esbuild` as a dev dependency of `readyup`, making the peer dependency explicit. Moves the version specification of `esbuild` (also used by the root) to a pnpm catalog.

## Why

The latest `eslint-plugin-package-json` brought `package-json/specify-peers-locally` into the shared config, and it fails `packages/readyup/package.json` on every lint run. Satisfying it introduces a second `esbuild` version alongside root's, which the catalog is what keeps aligned.

## Details

### 📦 Dependencies

- `pnpm-workspace.yaml` gains a `catalog:` entry pinning `esbuild` to `0.28.1`, joining `@williamthorsen/toolbelt.errors`, `@williamthorsen/toolbelt.packaging`, and `zod`.
- Root's `package.json` and `packages/readyup/package.json` each declare `esbuild` as `catalog:`; `esbuild` was the last dependency declared in more than one manifest without a catalog entry.
- Root retains a declaration of its own because `vite` takes `esbuild` as an optional peer and resolves it from the root importer.
- The lockfile records `esbuild` under readyup's `devDependencies` rather than as a resolved peer, at `0.28.1` for both importers.

Closes #309
