### PR TITLE
#313 Record the compile's input closure in the manifest

### DIFF
--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -8,6 +8,13 @@
         "code-quality",
         "publishing-pipeline"
       ],
+      "inputs": [
+        {
+          "hash": "33b6ea59",
+          "kind": "module",
+          "path": "kits/demo.ts"
+        }
+      ],
       "name": "demo",
       "path": "kits/demo.js",
       "readyupVersion": "0.27.0",

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -853,6 +853,26 @@ A sweep that finds no kits writes a manifest only where one already exists, empt
 
 Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `failed`), and the reason it was skipped or failed.
 
+#### What a manifest entry records
+
+| Field            | Meaning                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| `checklists`     | The checklist names the kit declares, so `rdy list` reports them without running the bundle |
+| `description`    | The kit's own description, where it declares one                                            |
+| `inputs`         | Every file the compile read, each with the hash of what was consumed from it                |
+| `name`           | The kit's name, which is its compiled file's basename                                       |
+| `path`           | The compiled bundle, relative to the manifest                                               |
+| `readyupVersion` | The readyup that compiled the kit                                                           |
+| `source`         | The TypeScript the bundle was built from, relative to the manifest                          |
+| `sourceHash`     | Hash of that source, read back out of its own `inputs` record                               |
+| `targetHash`     | Hash of the compiled bundle                                                                 |
+
+`inputs` is the compile's input closure: every module the bundle inlined past the entry, and every JSON file [`pickJson`](#inlining-json-at-compile-time) projected. A module records the hash of its bytes. An inlined JSON file records the hash of the projection that was substituted, with the path specifier that produced it, so an edit to a field the kit did not pick is not staleness.
+
+The closure stops at `node_modules`. A dependency's contents are pinned by the lockfile and read exactly by [`rdy verify --rebuild`](#verifying-by-recompiling), while recording them would size a committed, per-compile-rewritten manifest to the dependency tree rather than to the kit: one `import zod` inlines 79 files.
+
+An entry compiled before readyup recorded the closure carries no `inputs`.
+
 ### Package-hosted kits
 
 A package can publish the kit that checks its own configuration, which keeps the check with the thing it describes. The consumer then runs it against the version they actually have, rather than naming a ref and hoping it matches.

--- a/packages/readyup/src/compile/CompiledInput.ts
+++ b/packages/readyup/src/compile/CompiledInput.ts
@@ -12,3 +12,13 @@ import type { JsonPathSpec } from './extractJsonPaths.ts';
  */
 export type CompiledInput =
   { hash: string; kind: 'inline'; path: string; paths: JsonPathSpec } | { hash: string; kind: 'module'; path: string };
+
+/**
+ * Returns a recorded input's identity, which is its path and its kind together.
+ *
+ * A JSON file a kit both imports and projects is two inputs, not one, because the two record different
+ * bytes about it.
+ */
+export function identifyInput(kind: CompiledInput['kind'], filePath: string): string {
+  return `${kind}\u{0}${filePath}`;
+}

--- a/packages/readyup/src/compile/CompiledInput.ts
+++ b/packages/readyup/src/compile/CompiledInput.ts
@@ -1,0 +1,14 @@
+import type { JsonPathSpec } from './extractJsonPaths.ts';
+
+/**
+ * One file a compile read, as recorded while the compile ran.
+ *
+ * `path` is absolute; `rdy compile` relativizes it against the manifest directory on the way out, as it
+ * already does for a kit's `path` and `source`. Kept distinct from the manifest's own record so that
+ * neither type means two different things about its own `path`.
+ *
+ * A `module` record's hash is over the file's bytes. An `inline` record's is over the projection that was
+ * substituted into the bundle, which is why it alone carries the specifier that produced it.
+ */
+export type CompiledInput =
+  { hash: string; kind: 'inline'; path: string; paths: JsonPathSpec } | { hash: string; kind: 'module'; path: string };

--- a/packages/readyup/src/compile/JsonProjectionError.ts
+++ b/packages/readyup/src/compile/JsonProjectionError.ts
@@ -1,0 +1,44 @@
+/**
+ * Why a JSON file could not be projected onto a path specifier.
+ *
+ * `unreadable` and `invalid-json` describe the file. `not-an-object` and `path-not-found` describe the
+ * projection, which is what lets a reader report a file that is present and well-formed while the fields
+ * a kit pinned to are gone.
+ */
+export type JsonProjectionFailure = 'invalid-json' | 'not-an-object' | 'path-not-found' | 'unreadable';
+
+/** Optional fields accepted by the `JsonProjectionError` constructor. */
+export interface JsonProjectionErrorOptions {
+  cause?: unknown;
+
+  /** What the failure found, where `reason` alone does not say it: the root's type for `not-an-object`. */
+  detail?: string | undefined;
+}
+
+/**
+ * A JSON file that could not be projected onto a path specifier.
+ *
+ * `reason` travels separately from `message` so a caller can report the failure in its own wording:
+ * `pickJson` names the path as the kit wrote it, while a verdict over a recorded input names the kind
+ * of staleness. Carrying the diagnosis as data is what keeps both from matching on message text.
+ */
+export class JsonProjectionError extends Error {
+  /** The JSON file, absolute. */
+  readonly filePath: string;
+
+  readonly detail: string | undefined;
+  readonly reason: JsonProjectionFailure;
+
+  constructor(
+    reason: JsonProjectionFailure,
+    filePath: string,
+    message: string,
+    options: JsonProjectionErrorOptions = {},
+  ) {
+    super(message, ...(options.cause === undefined ? [] : [{ cause: options.cause }]));
+    this.name = 'JsonProjectionError';
+    this.detail = options.detail;
+    this.filePath = filePath;
+    this.reason = reason;
+  }
+}

--- a/packages/readyup/src/compile/__tests__/buildBundle.closure.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.closure.tool.test.ts
@@ -1,0 +1,80 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { buildBundle } from '../buildBundle.ts';
+import type { CompiledInput } from '../CompiledInput.ts';
+
+const KIT_SOURCE = [
+  `import { pickJson } from '${path.resolve(import.meta.dirname, '../pickJson.ts')}';`,
+  `import { helper } from './helper.ts';`,
+  `import { tiny } from 'tiny-dep';`,
+  '',
+  `export const meta = pickJson('./data.json', ['version']);`,
+  'export const kit = { helper, meta, tiny };',
+].join('\n');
+
+const HELPER_SOURCE = "export const helper = 'helper';\n";
+
+const DATA_JSON = JSON.stringify({ name: 'fixture', version: '1.0.0' }, null, 2);
+
+describe('buildBundle input closure', () => {
+  let treeRoot: string;
+  let inputs: CompiledInput[];
+
+  beforeAll(async () => {
+    treeRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'closure-')));
+    writeFileSync(path.join(treeRoot, 'kit.ts'), KIT_SOURCE);
+    writeFileSync(path.join(treeRoot, 'helper.ts'), HELPER_SOURCE);
+    writeFileSync(path.join(treeRoot, 'data.json'), DATA_JSON);
+
+    const dependencyDir = path.join(treeRoot, 'node_modules', 'tiny-dep');
+    mkdirSync(dependencyDir, { recursive: true });
+    writeFileSync(path.join(dependencyDir, 'package.json'), JSON.stringify({ name: 'tiny-dep', version: '1.0.0' }));
+    writeFileSync(path.join(dependencyDir, 'index.js'), 'export const tiny = 1;\n');
+
+    ({ inputs } = await buildBundle(path.join(treeRoot, 'kit.ts')));
+  });
+
+  afterAll(() => {
+    rmSync(treeRoot, { recursive: true, force: true });
+  });
+
+  it('records the entry point as a module', () => {
+    expect(inputs).toContainEqual({ hash: expect.any(String), kind: 'module', path: path.join(treeRoot, 'kit.ts') });
+  });
+
+  it('records a relative module the bundle inlined', () => {
+    expect(inputs).toContainEqual({ hash: expect.any(String), kind: 'module', path: path.join(treeRoot, 'helper.ts') });
+  });
+
+  it('records a projected JSON file as an inline input carrying its path specifier', () => {
+    expect(inputs).toContainEqual({
+      hash: expect.any(String),
+      kind: 'inline',
+      path: path.join(treeRoot, 'data.json'),
+      paths: ['version'],
+    });
+  });
+
+  it('records nothing from node_modules', () => {
+    expect(inputs.filter((input) => input.path.includes('node_modules'))).toStrictEqual([]);
+  });
+
+  it('sorts the closure by path and then by kind', () => {
+    const sorted = inputs.toSorted((a, b) => a.path.localeCompare(b.path) || a.kind.localeCompare(b.kind));
+
+    expect(inputs).toStrictEqual(sorted);
+  });
+
+  it('hashes an inline input over the projection rather than over the file', async () => {
+    const before = inputs.find((input) => input.kind === 'inline');
+    writeFileSync(path.join(treeRoot, 'data.json'), JSON.stringify({ name: 'renamed', version: '1.0.0' }, null, 2));
+
+    const rebuilt = await buildBundle(path.join(treeRoot, 'kit.ts'));
+
+    expect(rebuilt.inputs.find((input) => input.kind === 'inline')).toStrictEqual(before);
+  });
+});

--- a/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
@@ -925,6 +925,60 @@ describe(compileCommand, () => {
     });
   });
 
+  // esbuild reports the path it resolved a module to, so a symlink above the kit leaves the closure keyed
+  // on a path the command was never handed.
+  it('finds the entry point record under the real path of the source it was given', async () => {
+    const realEntryPath = path.resolve('/real/kits/deploy.ts');
+    mockRealpathSync.mockReturnValue(realEntryPath);
+    mockCompileConfig.mockResolvedValue(
+      compileResult(realEntryPath, { outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' }, 'r34lp47h'),
+    );
+    mockReadManifest.mockImplementation(() => {
+      throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
+    });
+
+    await compileCommand(['deploy.ts']);
+
+    expect(mockWriteManifest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ kits: [expect.objectContaining({ sourceHash: 'r34lp47h' })] }),
+    );
+  });
+
+  it('records an inlined JSON file with the specifier that produced its projection', async () => {
+    const result = compileResult('deploy.ts', {
+      outputPath: '/abs/deploy.js',
+      changed: true,
+      targetHash: 'deadbeef',
+    });
+    result.inputs.push({
+      hash: '1nl1n3d0',
+      kind: 'inline',
+      path: path.resolve('package.json'),
+      paths: ['version', ['engines', 'node']],
+    });
+    mockCompileConfig.mockResolvedValue(result);
+    mockReadManifest.mockImplementation(() => {
+      throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
+    });
+
+    await compileCommand(['deploy.ts']);
+
+    expect(mockWriteManifest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        kits: [
+          expect.objectContaining({
+            inputs: [
+              { hash: SOURCE_HASH, kind: 'module', path: '../deploy.ts' },
+              { hash: '1nl1n3d0', kind: 'inline', path: '../package.json', paths: ['version', ['engines', 'node']] },
+            ],
+          }),
+        ],
+      }),
+    );
+  });
+
   it('takes the source hash of a single-file compile from the entry point record', async () => {
     const result = compileResult(
       'deploy.ts',

--- a/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
@@ -11,11 +11,11 @@ const mockValidateCompiledOutput = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn());
 const mockReaddirSync = vi.hoisted(() => vi.fn());
+const mockRealpathSync = vi.hoisted(() => Object.assign(vi.fn(), { native: vi.fn() }));
 const mockPicomatch = vi.hoisted(() => vi.fn());
 const mockWriteManifest = vi.hoisted(() => vi.fn());
 const mockReadManifest = vi.hoisted(() => vi.fn());
 const mockCheckDrift = vi.hoisted(() => vi.fn());
-const mockHashFile = vi.hoisted(() => vi.fn());
 
 vi.mock(import('../compileConfig.ts'), () => ({
   compileConfig: mockCompileConfig,
@@ -32,6 +32,7 @@ vi.mock(import('../../config/loadConfig.ts'), () => ({
 vi.mock(import('node:fs'), () => ({
   existsSync: mockExistsSync,
   readdirSync: mockReaddirSync,
+  realpathSync: mockRealpathSync,
 }));
 
 vi.mock('picomatch', () => ({
@@ -54,21 +55,48 @@ vi.mock(import('../../verify/checkDrift.ts'), () => ({
   checkDrift: mockCheckDrift,
 }));
 
-vi.mock(import('../../verify/targetHash.ts'), () => ({
-  hashFile: mockHashFile,
-}));
-
 import { richFormatter } from '../../layout/richFormatter.ts';
 import { ManifestNotFoundError } from '../../manifest/readManifest.ts';
 import { captureRdyError } from '../../test-utils/captureRdyError.ts';
 import { VERSION } from '../../version.ts';
 import { compileCommand } from '../compileCommand.ts';
+import type { CompileResult } from '../compileConfig.ts';
 import type { KitMetadata } from '../validateCompiledOutput.ts';
 
 const ICON_NO_CHANGES = richFormatter.tokens.skippedOptional.glyph;
 const ICON_COMPILED = richFormatter.tokens.passed.glyph;
 const ICON_DRIFT = richFormatter.tokens.failedWarn.glyph;
 const GLYPH_OUTPUT = richFormatter.tokens.kit.glyph;
+
+/** Directory the batch tests sweep, matching the `srcDir` the config they mock declares. */
+const SRC_DIR = '.readyup/kits';
+
+/** The hash a compile records for its entry point, which is where a manifest entry's `sourceHash` comes from. */
+const SOURCE_HASH = '5c0urce1';
+
+/** Absolute path of a kit source in the directory a batch compile sweeps. */
+function kitSource(fileName: string): string {
+  return path.resolve(process.cwd(), SRC_DIR, fileName);
+}
+
+/**
+ * Builds a `compileConfig` result whose closure records `entry` as the module the bundle was built from.
+ *
+ * A test that cares which file supplied `sourceHash` says so by naming the entry, because the command
+ * reads the hash back out of the closure rather than hashing the source itself.
+ */
+function compileResult(
+  entry: string,
+  result: { outputPath: string; changed: boolean; targetHash: string },
+  hash: string = SOURCE_HASH,
+): CompileResult {
+  return { ...result, inputs: [{ hash, kind: 'module', path: path.resolve(entry) }] };
+}
+
+/** The `inputs` a manifest entry carries when its compile read only the entry point, stated against the manifest. */
+function recordedEntry(relativePath: string, hash: string = SOURCE_HASH) {
+  return [{ hash, kind: 'module', path: relativePath }];
+}
 
 /** Metadata as `validateCompiledOutput` returns it, defaulting to a kit with no checklists to record. */
 function kitMetadata(overrides: Partial<KitMetadata> = {}): KitMetadata {
@@ -84,7 +112,8 @@ describe(compileCommand, () => {
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockCheckDrift.mockReturnValue({ kind: 'unverified' });
-    mockHashFile.mockReturnValue('5c0urce1');
+    // No path these tests name holds a symlink, so a real path is the path itself.
+    mockRealpathSync.mockImplementation((target: string) => target);
   });
 
   afterEach(() => {
@@ -94,16 +123,18 @@ describe(compileCommand, () => {
     mockLoadConfig.mockReset();
     mockExistsSync.mockReset();
     mockReaddirSync.mockReset();
+    mockRealpathSync.mockReset();
     mockPicomatch.mockReset();
     mockWriteManifest.mockReset();
     mockReadManifest.mockReset();
     mockCheckDrift.mockReset();
-    mockHashFile.mockReset();
   });
 
   // Explicit input file tests
   it('returns 0 and writes a section heading for single file', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('input.ts', { outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     const exitCode = await compileCommand(['input.ts']);
 
@@ -113,7 +144,9 @@ describe(compileCommand, () => {
   });
 
   it('shows compiled indicator for a changed single file', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('input.ts', { outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand(['input.ts']);
 
@@ -122,7 +155,9 @@ describe(compileCommand, () => {
   });
 
   it('shows no-changes indicator for an unchanged single file', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: false, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('input.ts', { outputPath: '/abs/out.js', changed: false, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand(['input.ts']);
 
@@ -131,7 +166,9 @@ describe(compileCommand, () => {
   });
 
   it('passes --output value to compileConfig', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('input.ts', { outputPath: '/abs/custom.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     const exitCode = await compileCommand(['input.ts', '--output', 'custom.js']);
 
@@ -140,7 +177,9 @@ describe(compileCommand, () => {
   });
 
   it('passes --output=value inline form to compileConfig', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('input.ts', { outputPath: '/abs/custom.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     const exitCode = await compileCommand(['input.ts', '--output=custom.js']);
 
@@ -149,7 +188,9 @@ describe(compileCommand, () => {
   });
 
   it('passes -o value short form to compileConfig', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/custom.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('input.ts', { outputPath: '/abs/custom.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     const exitCode = await compileCommand(['input.ts', '-o', 'custom.js']);
 
@@ -214,7 +255,9 @@ describe(compileCommand, () => {
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand([]);
 
@@ -234,7 +277,9 @@ describe(compileCommand, () => {
       return !target.endsWith('.git');
     });
     mockReaddirSync.mockReturnValue(['a.ts']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand([]);
 
@@ -253,7 +298,9 @@ describe(compileCommand, () => {
     );
     mockReaddirSync.mockReturnValue(['a.ts']);
 
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand([]);
 
@@ -266,7 +313,9 @@ describe(compileCommand, () => {
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand([]);
 
@@ -281,8 +330,12 @@ describe(compileCommand, () => {
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts', 'b.ts', 'readme.md']);
     mockCompileConfig
-      .mockResolvedValueOnce({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' })
-      .mockResolvedValueOnce({ outputPath: '/abs/b.js', changed: false, targetHash: 'bbbb2222' });
+      .mockResolvedValueOnce(
+        compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+      )
+      .mockResolvedValueOnce(
+        compileResult(kitSource('b.ts'), { outputPath: '/abs/b.js', changed: false, targetHash: 'bbbb2222' }),
+      );
 
     const exitCode = await compileCommand([]);
 
@@ -316,7 +369,21 @@ describe(compileCommand, () => {
     mockReaddirSync.mockReturnValue(['shared/deploy.ts', 'shared/infra.ts', 'other.ts']);
     const matchFn = vi.fn((name: string) => name.startsWith('shared/'));
     mockPicomatch.mockReturnValue(matchFn);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig
+      .mockResolvedValueOnce(
+        compileResult(kitSource('shared/deploy.ts'), {
+          outputPath: '/abs/deploy.js',
+          changed: true,
+          targetHash: 'aaaa1111',
+        }),
+      )
+      .mockResolvedValueOnce(
+        compileResult(kitSource('shared/infra.ts'), {
+          outputPath: '/abs/infra.js',
+          changed: true,
+          targetHash: 'bbbb2222',
+        }),
+      );
 
     const exitCode = await compileCommand([]);
 
@@ -418,7 +485,9 @@ describe(compileCommand, () => {
 
   // Post-compile validation tests
   it('returns 1 when post-compile validation fails for explicit input', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('input.ts', { outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' }),
+    );
     mockValidateCompiledOutput.mockRejectedValue(new Error('Suite name(s) collide with checklist name(s): deploy'));
 
     const exitCode = await compileCommand(['input.ts']);
@@ -433,7 +502,9 @@ describe(compileCommand, () => {
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+    );
     mockValidateCompiledOutput.mockRejectedValue(new Error('suite "ci" references unknown checklist "missing"'));
 
     const exitCode = await compileCommand([]);
@@ -452,7 +523,9 @@ describe(compileCommand, () => {
       mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
       mockCompileConfig
         .mockRejectedValueOnce(new Error('alpha is not valid TypeScript'))
-        .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
+        .mockResolvedValueOnce(
+          compileResult(kitSource('beta.ts'), { outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' }),
+        );
     }
 
     it('compiles the kits after a failed one instead of abandoning the sweep', async () => {
@@ -536,7 +609,9 @@ describe(compileCommand, () => {
 
   describe('manifest checklist names', () => {
     it('records the checklist names the compiled kit declares', async () => {
-      mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' });
+      mockCompileConfig.mockResolvedValue(
+        compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' }),
+      );
       mockValidateCompiledOutput.mockResolvedValue(kitMetadata({ checklists: ['preflight', 'deploy'] }));
       mockReadManifest.mockImplementation(() => {
         throw new ManifestNotFoundError('missing');
@@ -551,7 +626,9 @@ describe(compileCommand, () => {
     });
 
     it('omits the field for a kit with no checklists to record', async () => {
-      mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' });
+      mockCompileConfig.mockResolvedValue(
+        compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' }),
+      );
       mockReadManifest.mockImplementation(() => {
         throw new ManifestNotFoundError('missing');
       });
@@ -575,7 +652,9 @@ describe(compileCommand, () => {
       mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
       mockCompileConfig
         .mockRejectedValueOnce(new Error('alpha is not valid TypeScript'))
-        .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
+        .mockResolvedValueOnce(
+          compileResult(kitSource('beta.ts'), { outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' }),
+        );
 
       const exitCode = await compileCommand(['--json']);
 
@@ -594,7 +673,9 @@ describe(compileCommand, () => {
     });
 
     it('reports a clean single-file compile as passed', async () => {
-      mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' });
+      mockCompileConfig.mockResolvedValue(
+        compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' }),
+      );
       mockReadManifest.mockImplementation(() => {
         throw new ManifestNotFoundError('missing');
       });
@@ -665,15 +746,21 @@ describe(compileCommand, () => {
   });
 
   /** A two-kit batch in which both kits compile successfully. */
-  function arrangeTwoKitBatch(): void {
+  function arrangeTwoKitBatch(hashes: { alphaHash?: string; betaHash?: string } = {}): void {
     mockLoadConfig.mockResolvedValue({
-      compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
+      compile: { srcDir: SRC_DIR, outDir: SRC_DIR, include: undefined },
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
-    mockCompileConfig
-      .mockResolvedValueOnce({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' })
-      .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
+    // Keyed by the source rather than queued, so a kit the sweep skips does not hand its result to the next one.
+    mockCompileConfig.mockImplementation((inputPath: string) => {
+      const isAlpha = path.basename(inputPath) === 'alpha.ts';
+      const result = isAlpha
+        ? { outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' }
+        : { outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' };
+
+      return Promise.resolve(compileResult(inputPath, result, isAlpha ? hashes.alphaHash : hashes.betaHash));
+    });
   }
 
   // Manifest generation tests
@@ -689,6 +776,7 @@ describe(compileCommand, () => {
       version: 1,
       kits: [
         {
+          inputs: recordedEntry('kits/alpha.ts'),
           name: 'alpha',
           description: 'Alpha checks',
           path: expect.stringContaining('alpha.js'),
@@ -698,6 +786,7 @@ describe(compileCommand, () => {
           targetHash: 'aaaa1111',
         },
         {
+          inputs: recordedEntry('kits/beta.ts'),
           name: 'beta',
           path: expect.stringContaining('beta.js'),
           readyupVersion: VERSION,
@@ -726,7 +815,9 @@ describe(compileCommand, () => {
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand(['--skip-manifest']);
 
@@ -739,7 +830,9 @@ describe(compileCommand, () => {
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand(['--manifest=custom/manifest.json']);
 
@@ -747,7 +840,9 @@ describe(compileCommand, () => {
   });
 
   it('upserts manifest entry for single-file compile with location fields', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' }),
+    );
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata({ description: 'Deploy checks' }));
     mockReadManifest.mockReturnValue({
       version: 1,
@@ -761,6 +856,7 @@ describe(compileCommand, () => {
       kits: [
         { name: 'default', description: 'Default checks' },
         {
+          inputs: recordedEntry('../deploy.ts'),
           name: 'deploy',
           description: 'Deploy checks',
           path: expect.stringContaining('deploy.js'),
@@ -774,7 +870,9 @@ describe(compileCommand, () => {
   });
 
   it('creates new manifest for single-file compile when no manifest exists', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' }),
+    );
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockImplementation(() => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
@@ -786,6 +884,7 @@ describe(compileCommand, () => {
       version: 1,
       kits: [
         {
+          inputs: recordedEntry('../deploy.ts'),
           name: 'deploy',
           path: expect.stringContaining('deploy.js'),
           readyupVersion: VERSION,
@@ -798,7 +897,9 @@ describe(compileCommand, () => {
   });
 
   it('replaces existing entry when upserting for single-file compile', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' }),
+    );
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata({ description: 'Updated' }));
     mockReadManifest.mockReturnValue({
       version: 1,
@@ -811,6 +912,7 @@ describe(compileCommand, () => {
       version: 1,
       kits: [
         {
+          inputs: recordedEntry('../deploy.ts'),
           name: 'deploy',
           description: 'Updated',
           path: expect.stringContaining('deploy.js'),
@@ -823,20 +925,27 @@ describe(compileCommand, () => {
     });
   });
 
-  it('hashes the source that a single-file compile was given', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
+  it('takes the source hash of a single-file compile from the entry point record', async () => {
+    const result = compileResult(
+      'deploy.ts',
+      { outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' },
+      'e47r1e50',
+    );
+    mockCompileConfig.mockResolvedValue(result);
     mockReadManifest.mockImplementation(() => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
 
     await compileCommand(['deploy.ts']);
 
-    expect(mockHashFile).toHaveBeenCalledWith(expect.stringContaining('deploy.ts'));
+    expect(mockWriteManifest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ kits: [expect.objectContaining({ sourceHash: 'e47r1e50' })] }),
+    );
   });
 
   it('records a distinct source hash per kit in a batch compile', async () => {
-    arrangeTwoKitBatch();
-    mockHashFile.mockReturnValueOnce('a1a1a1a1').mockReturnValueOnce('b2b2b2b2');
+    arrangeTwoKitBatch({ alphaHash: 'a1a1a1a1', betaHash: 'b2b2b2b2' });
 
     await compileCommand([]);
 
@@ -872,7 +981,9 @@ describe(compileCommand, () => {
   });
 
   it('skips manifest for single-file compile when --skip-manifest is set', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('input.ts', { outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand(['input.ts', '--skip-manifest']);
 
@@ -886,7 +997,9 @@ describe(compileCommand, () => {
     });
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts']);
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+    );
     mockWriteManifest.mockImplementation(() => {
       throw new Error('EACCES: permission denied');
     });
@@ -899,7 +1012,9 @@ describe(compileCommand, () => {
   });
 
   it('writes warning to stderr when upsert encounters non-missing-file error', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' }),
+    );
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockImplementation(() => {
       throw new Error('Invalid manifest schema in .readyup/manifest.json: bad data');
@@ -914,7 +1029,9 @@ describe(compileCommand, () => {
   });
 
   it('uses custom manifest path from --manifest flag for single-file compile', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' }),
+    );
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockImplementation(() => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
@@ -933,8 +1050,12 @@ describe(compileCommand, () => {
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
     mockCompileConfig
-      .mockResolvedValueOnce({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' })
-      .mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
+      .mockResolvedValueOnce(
+        compileResult(kitSource('alpha.ts'), { outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' }),
+      )
+      .mockResolvedValueOnce(
+        compileResult(kitSource('beta.ts'), { outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' }),
+      );
 
     await compileCommand([]);
 
@@ -947,7 +1068,9 @@ describe(compileCommand, () => {
   });
 
   it('populates readyupVersion when upserting a single-file compile entry', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'deadbeef' }),
+    );
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockImplementation(() => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
@@ -964,7 +1087,9 @@ describe(compileCommand, () => {
   });
 
   it('maintains alphabetical order when upserting manifest entries', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('alpha.ts', { outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' }),
+    );
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockReturnValue({
       version: 1,
@@ -1004,7 +1129,9 @@ describe(compileCommand, () => {
   });
 
   it('bypasses drift gate with --force on single-file compile', async () => {
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/deploy.js', changed: true, targetHash: 'bbbb2222' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'bbbb2222' }),
+    );
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockReadManifest.mockReturnValue({
       version: 1,
@@ -1047,7 +1174,9 @@ describe(compileCommand, () => {
         resolvedPath: '/abs/alpha.js',
       })
       .mockReturnValueOnce({ kind: 'ok', targetHash: 'bbbb0000' });
-    mockCompileConfig.mockResolvedValueOnce({ outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' });
+    mockCompileConfig.mockResolvedValueOnce(
+      compileResult(kitSource('beta.ts'), { outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' }),
+    );
 
     const exitCode = await compileCommand([]);
 
@@ -1083,7 +1212,9 @@ describe(compileCommand, () => {
       actual: 'aaaa9999',
       resolvedPath: '/abs/alpha.js',
     });
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa9999' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('alpha.ts'), { outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa9999' }),
+    );
 
     const exitCode = await compileCommand(['--force']);
 
@@ -1100,7 +1231,9 @@ describe(compileCommand, () => {
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['a.ts']);
     mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand([]);
 
@@ -1116,7 +1249,9 @@ describe(compileCommand, () => {
     mockReadManifest.mockImplementation(() => {
       throw new Error('Unexpected token in JSON at position 0');
     });
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('alpha.ts'), { outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand([]);
 
@@ -1133,7 +1268,9 @@ describe(compileCommand, () => {
     mockReadManifest.mockImplementation(() => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
-    mockCompileConfig.mockResolvedValue({ outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' });
+    mockCompileConfig.mockResolvedValue(
+      compileResult(kitSource('alpha.ts'), { outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' }),
+    );
 
     await compileCommand([]);
 

--- a/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
@@ -74,7 +74,7 @@ const SRC_DIR = '.readyup/kits';
 /** The hash a compile records for its entry point, which is where a manifest entry's `sourceHash` comes from. */
 const SOURCE_HASH = '5c0urce1';
 
-/** Absolute path of a kit source in the directory a batch compile sweeps. */
+/** Returns the absolute path of a kit source in the directory a batch compile sweeps. */
 function kitSource(fileName: string): string {
   return path.resolve(process.cwd(), SRC_DIR, fileName);
 }
@@ -93,7 +93,7 @@ function compileResult(
   return { ...result, inputs: [{ hash, kind: 'module', path: path.resolve(entry) }] };
 }
 
-/** The `inputs` a manifest entry carries when its compile read only the entry point, stated against the manifest. */
+/** Returns the `inputs` an entry carries when its compile read only the entry point, stated against the manifest. */
 function recordedEntry(relativePath: string, hash: string = SOURCE_HASH) {
   return [{ hash, kind: 'module', path: relativePath }];
 }

--- a/packages/readyup/src/compile/__tests__/compileConfig.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileConfig.unit.test.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -48,6 +49,7 @@ describe(compileConfig, () => {
 
     expect(mockBuild).toHaveBeenCalledWith({
       entryPoints: [path.resolve('config/readyup.config.ts')],
+      absWorkingDir: process.cwd(),
       bundle: true,
       format: 'esm',
       platform: 'node',
@@ -56,6 +58,7 @@ describe(compileConfig, () => {
       external: ['node:*', 'readyup', 'readyup/*'],
       plugins: [expect.objectContaining({ name: 'pick-json' })],
       banner: { js: expect.stringContaining('@generated') },
+      metafile: true,
       write: false,
     });
   });
@@ -160,7 +163,7 @@ describe(compileConfig, () => {
   });
 });
 
-/** Builds a mock esbuild result with the given output text. */
+/** Builds a mock esbuild result with the given output text and no resolved modules. */
 function buildResult(text: string) {
-  return { outputFiles: [{ contents: new TextEncoder().encode(text) }] };
+  return { metafile: { inputs: {} }, outputFiles: [{ contents: new TextEncoder().encode(text) }] };
 }

--- a/packages/readyup/src/compile/__tests__/createCompileRecorder.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/createCompileRecorder.unit.test.ts
@@ -1,0 +1,102 @@
+import path from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+import { hashBytes } from '../../verify/targetHash.ts';
+import { createCompileRecorder } from '../createCompileRecorder.ts';
+
+describe(createCompileRecorder, () => {
+  it('starts with an empty closure', () => {
+    expect(createCompileRecorder().inputs).toStrictEqual([]);
+  });
+
+  it('records a module read as its bytes and returns its contents', () => {
+    const source = 'export const kit = 1;\n';
+    mockReadFileSync.mockReturnValueOnce(Buffer.from(source));
+    const recorder = createCompileRecorder();
+
+    const contents = recorder.readModule('/project/src/kit.ts');
+
+    expect(contents).toBe(source);
+    expect(recorder.inputs).toStrictEqual([
+      { hash: hashBytes(Buffer.from(source)), kind: 'module', path: '/project/src/kit.ts' },
+    ]);
+  });
+
+  it('records a projection read with its path specifier and returns the serialized projection', () => {
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify({ name: 'my-pkg', version: '1.0.0' }));
+    const recorder = createCompileRecorder();
+
+    const projection = recorder.readProjection('/project/package.json', ['version']);
+
+    expect(projection).toBe(JSON.stringify({ version: '1.0.0' }));
+    expect(recorder.inputs).toStrictEqual([
+      {
+        hash: hashBytes(Buffer.from(projection, 'utf8')),
+        kind: 'inline',
+        path: '/project/package.json',
+        paths: ['version'],
+      },
+    ]);
+  });
+
+  it('hashes a projection over what was picked, not over the file', () => {
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify({ name: 'my-pkg', scripts: { build: 'tsc' } }));
+    const before = createCompileRecorder();
+    before.readProjection('/project/package.json', ['name']);
+
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify({ name: 'my-pkg', scripts: { build: 'esbuild' } }));
+    const after = createCompileRecorder();
+    after.readProjection('/project/package.json', ['name']);
+
+    expect(after.inputs).toStrictEqual(before.inputs);
+  });
+
+  it('resolves a relative path against the working directory', () => {
+    mockReadFileSync.mockReturnValueOnce(Buffer.from('export const kit = 1;\n'));
+    const recorder = createCompileRecorder();
+
+    recorder.readModule('src/kit.ts');
+
+    expect(recorder.inputs[0]?.path).toBe(path.resolve('src/kit.ts'));
+  });
+
+  it('collapses two reads of the same path and kind into one record', () => {
+    const source = Buffer.from('export const kit = 1;\n');
+    mockReadFileSync.mockReturnValue(source);
+    const recorder = createCompileRecorder();
+
+    recorder.readModule('/project/src/kit.ts');
+    recorder.readModule('/project/src/kit.ts');
+
+    expect(recorder.inputs).toHaveLength(1);
+  });
+
+  it('keeps the same path read as both kinds as two records', () => {
+    mockReadFileSync
+      .mockReturnValueOnce(Buffer.from(JSON.stringify({ name: 'my-pkg' })))
+      .mockReturnValueOnce(JSON.stringify({ name: 'my-pkg' }));
+    const recorder = createCompileRecorder();
+
+    recorder.readModule('/project/data.json');
+    recorder.readProjection('/project/data.json', ['name']);
+
+    expect(recorder.inputs.map((input) => input.kind)).toStrictEqual(['module', 'inline']);
+  });
+
+  it('leaves the closure alone when a read fails', () => {
+    mockReadFileSync.mockImplementationOnce(() => {
+      throw new Error('ENOENT');
+    });
+    const recorder = createCompileRecorder();
+
+    expect(() => recorder.readModule('/project/src/gone.ts')).toThrow('ENOENT');
+    expect(recorder.inputs).toStrictEqual([]);
+  });
+});

--- a/packages/readyup/src/compile/__tests__/pickJsonPlugin.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/pickJsonPlugin.unit.test.ts
@@ -10,6 +10,8 @@ vi.mock(import('node:fs'), () => ({
   writeFileSync: vi.fn(),
 }));
 
+import type { CompileRecorder } from '../createCompileRecorder.ts';
+import { createCompileRecorder } from '../createCompileRecorder.ts';
 import { pickJsonPlugin } from '../pickJsonPlugin.ts';
 
 type OnLoadCallback = Parameters<esbuild.PluginBuild['onLoad']>[1];
@@ -28,10 +30,10 @@ function stubBuild(onLoad: esbuild.PluginBuild['onLoad']): esbuild.PluginBuild {
   };
 }
 
-/** Capture the onLoad callback registered by the plugin. */
-function captureOnLoad(): OnLoadCallback {
+/** Capture the onLoad callback registered by the plugin, reading through a real recorder. */
+function captureOnLoad(recorder: CompileRecorder = createCompileRecorder()): OnLoadCallback {
   let captured: OnLoadCallback | undefined;
-  const plugin = pickJsonPlugin();
+  const plugin = pickJsonPlugin(recorder);
   void plugin.setup(
     stubBuild((_options, callback) => {
       captured = callback;
@@ -54,7 +56,7 @@ function runOnLoad(onLoad: OnLoadCallback, path: string): esbuild.OnLoadResult |
 
 describe(pickJsonPlugin, () => {
   it('returns a plugin with the name "pick-json"', () => {
-    const plugin = pickJsonPlugin();
+    const plugin = pickJsonPlugin(createCompileRecorder());
 
     expect(plugin.name).toBe('pick-json');
   });
@@ -212,9 +214,23 @@ describe(pickJsonPlugin, () => {
     expect(result?.contents).toContain('"name":"my-pkg"');
   });
 
+  it('records the module it loaded and the JSON file it projected', () => {
+    const recorder = createCompileRecorder();
+    const onLoad = captureOnLoad(recorder);
+    const sourceCode = `const meta = pickJson('./package.json', ['name']);`;
+    mockReadFileSync.mockReturnValueOnce(sourceCode).mockReturnValueOnce(JSON.stringify({ name: 'my-pkg', x: 1 }));
+
+    runOnLoad(onLoad, '/project/src/kit.ts');
+
+    expect(recorder.inputs).toStrictEqual([
+      { hash: expect.any(String), kind: 'module', path: '/project/src/kit.ts' },
+      { hash: expect.any(String), kind: 'inline', path: '/project/src/package.json', paths: ['name'] },
+    ]);
+  });
+
   it('registers onLoad filter for TypeScript extensions only', () => {
     let capturedFilter: RegExp | undefined;
-    const plugin = pickJsonPlugin();
+    const plugin = pickJsonPlugin(createCompileRecorder());
     void plugin.setup(
       stubBuild((options, _callback) => {
         capturedFilter = options.filter;

--- a/packages/readyup/src/compile/__tests__/pluginFsIsolation.app.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/pluginFsIsolation.app.unit.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/** Modules registered as esbuild plugins, which read files through a `CompileRecorder` instead of `node:fs`. */
+const PLUGIN_MODULES = ['pickJsonPlugin.ts'];
+
+/** Specifiers that reach the filesystem directly. A plugin reaching one of these can read outside the closure. */
+const FILESYSTEM_SPECIFIERS = new Set(['fs', 'fs/promises', 'node:fs', 'node:fs/promises']);
+
+const COMPILE_DIR = path.join(import.meta.dirname, '..');
+
+/** A filesystem import found in a module a plugin reaches at run time. */
+interface Offender {
+  module: string;
+  specifier: string;
+}
+
+describe('esbuild plugins are isolated from the filesystem', () => {
+  it.each(PLUGIN_MODULES)('%s reaches no filesystem API', (fileName) => {
+    const offenders = findFilesystemImports(path.join(COMPILE_DIR, fileName));
+    const formatted = offenders.map((offender) => `  ${offender.module} imports ${offender.specifier}`).join('\n');
+
+    expect(offenders, `Found filesystem imports reachable from the plugin:\n${formatted}`).toStrictEqual([]);
+  });
+
+  // The walk has to reach past the entry, or a plugin could regain a filesystem API through any import.
+  it('reports a filesystem import reached through another module', () => {
+    const offenders = findFilesystemImports(path.join(COMPILE_DIR, 'createCompileRecorder.ts'));
+
+    expect(offenders).toContainEqual({ module: 'projectJsonFile.ts', specifier: 'node:fs' });
+  });
+});
+
+// region | Helpers
+
+/** Walks a module's value imports transitively and returns every filesystem import reachable from it. */
+function findFilesystemImports(entryPath: string): Offender[] {
+  const offenders: Offender[] = [];
+  const visited = new Set<string>();
+  const queue = [entryPath];
+
+  while (queue.length > 0) {
+    const modulePath = queue.pop();
+    if (modulePath === undefined || visited.has(modulePath)) continue;
+    visited.add(modulePath);
+
+    for (const specifier of readValueImports(modulePath)) {
+      if (FILESYSTEM_SPECIFIERS.has(specifier)) {
+        offenders.push({ module: path.relative(COMPILE_DIR, modulePath), specifier });
+      } else if (specifier.startsWith('.')) {
+        queue.push(path.resolve(path.dirname(modulePath), specifier));
+      }
+    }
+  }
+
+  return offenders.toSorted((a, b) => a.module.localeCompare(b.module) || a.specifier.localeCompare(b.specifier));
+}
+
+/**
+ * Returns the specifiers a module imports for their values, in source order.
+ *
+ * Type-only imports are left out because they are erased: a type reaching a module that reads files says
+ * nothing about what the importer can do at run time.
+ */
+function readValueImports(modulePath: string): string[] {
+  const text = readFileSync(modulePath, 'utf8');
+  const source = ts.createSourceFile(modulePath, text, ts.ScriptTarget.Latest, true);
+  const specifiers: string[] = [];
+
+  for (const statement of source.statements) {
+    if (ts.isImportDeclaration(statement)) {
+      if (!importsValues(statement.importClause)) continue;
+      if (ts.isStringLiteral(statement.moduleSpecifier)) specifiers.push(statement.moduleSpecifier.text);
+    } else if (ts.isExportDeclaration(statement) && statement.moduleSpecifier !== undefined) {
+      if (statement.isTypeOnly) continue;
+      if (ts.isStringLiteral(statement.moduleSpecifier)) specifiers.push(statement.moduleSpecifier.text);
+    }
+  }
+
+  return specifiers;
+}
+
+/** Reports whether an import clause binds anything that survives to run time. */
+function importsValues(importClause: ts.ImportClause | undefined): boolean {
+  // A bare `import './x.ts'` has no clause and is evaluated for its side effects alone.
+  if (importClause === undefined) return true;
+  if (importClause.phaseModifier === ts.SyntaxKind.TypeKeyword) return false;
+  if (importClause.name !== undefined) return true;
+
+  const bindings = importClause.namedBindings;
+  if (bindings === undefined) return false;
+  if (ts.isNamespaceImport(bindings)) return true;
+
+  return bindings.elements.some((element) => !element.isTypeOnly);
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/compile/__tests__/pluginFsIsolation.app.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/pluginFsIsolation.app.unit.test.ts
@@ -4,9 +4,6 @@ import path from 'node:path';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-/** Modules registered as esbuild plugins, which read files through a `CompileRecorder` instead of `node:fs`. */
-const PLUGIN_MODULES = ['pickJsonPlugin.ts'];
-
 /** Specifiers that reach the filesystem directly. A plugin reaching one of these can read outside the closure. */
 const FILESYSTEM_SPECIFIERS = new Set(['fs', 'fs/promises', 'node:fs', 'node:fs/promises']);
 
@@ -18,7 +15,14 @@ interface Offender {
   specifier: string;
 }
 
+const PLUGIN_MODULES = findPluginModules();
+
 describe('esbuild plugins are isolated from the filesystem', () => {
+  // Derived rather than listed, so a plugin added to the build is covered without anyone extending a set here.
+  it('reads every plugin the build registers', () => {
+    expect(PLUGIN_MODULES).not.toStrictEqual([]);
+  });
+
   it.each(PLUGIN_MODULES)('%s reaches no filesystem API', (fileName) => {
     const offenders = findFilesystemImports(path.join(COMPILE_DIR, fileName));
     const formatted = offenders.map((offender) => `  ${offender.module} imports ${offender.specifier}`).join('\n');
@@ -35,6 +39,29 @@ describe('esbuild plugins are isolated from the filesystem', () => {
 });
 
 // region | Helpers
+
+/** Returns the names of the factories called inside an esbuild `plugins` array. */
+function collectPluginFactoryNames(source: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isPropertyAssignment(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'plugins' &&
+      ts.isArrayLiteralExpression(node.initializer)
+    ) {
+      for (const element of node.initializer.elements) {
+        if (ts.isCallExpression(element) && ts.isIdentifier(element.expression)) names.add(element.expression.text);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+
+  return names;
+}
 
 /** Walks a module's value imports transitively and returns every filesystem import reachable from it. */
 function findFilesystemImports(entryPath: string): Offender[] {
@@ -59,28 +86,22 @@ function findFilesystemImports(entryPath: string): Offender[] {
   return offenders.toSorted((a, b) => a.module.localeCompare(b.module) || a.specifier.localeCompare(b.specifier));
 }
 
-/**
- * Returns the specifiers a module imports for their values, in source order.
- *
- * Type-only imports are left out because they are erased: a type reaching a module that reads files says
- * nothing about what the importer can do at run time.
- */
-function readValueImports(modulePath: string): string[] {
-  const text = readFileSync(modulePath, 'utf8');
-  const source = ts.createSourceFile(modulePath, text, ts.ScriptTarget.Latest, true);
-  const specifiers: string[] = [];
+/** Returns the modules `buildBundle` registers as esbuild plugins, named by their file. */
+function findPluginModules(): string[] {
+  const source = parseModule(path.join(COMPILE_DIR, 'buildBundle.ts'));
+  const factoryNames = collectPluginFactoryNames(source);
+  const fileNames: string[] = [];
 
   for (const statement of source.statements) {
-    if (ts.isImportDeclaration(statement)) {
-      if (!importsValues(statement.importClause)) continue;
-      if (ts.isStringLiteral(statement.moduleSpecifier)) specifiers.push(statement.moduleSpecifier.text);
-    } else if (ts.isExportDeclaration(statement) && statement.moduleSpecifier !== undefined) {
-      if (statement.isTypeOnly) continue;
-      if (ts.isStringLiteral(statement.moduleSpecifier)) specifiers.push(statement.moduleSpecifier.text);
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings === undefined || !ts.isNamedImports(bindings)) continue;
+    if (bindings.elements.some((element) => factoryNames.has(element.name.text))) {
+      fileNames.push(path.basename(statement.moduleSpecifier.text));
     }
   }
 
-  return specifiers;
+  return fileNames.toSorted((a, b) => a.localeCompare(b));
 }
 
 /** Reports whether an import clause binds anything that survives to run time. */
@@ -95,6 +116,34 @@ function importsValues(importClause: ts.ImportClause | undefined): boolean {
   if (ts.isNamespaceImport(bindings)) return true;
 
   return bindings.elements.some((element) => !element.isTypeOnly);
+}
+
+/** Parses a TypeScript module into a syntax tree. */
+function parseModule(modulePath: string): ts.SourceFile {
+  return ts.createSourceFile(modulePath, readFileSync(modulePath, 'utf8'), ts.ScriptTarget.Latest, true);
+}
+
+/**
+ * Returns the specifiers a module imports for their values, in source order.
+ *
+ * Type-only imports are left out because they are erased: a type reaching a module that reads files says
+ * nothing about what the importer can do at run time.
+ */
+function readValueImports(modulePath: string): string[] {
+  const source = parseModule(modulePath);
+  const specifiers: string[] = [];
+
+  for (const statement of source.statements) {
+    if (ts.isImportDeclaration(statement)) {
+      if (!importsValues(statement.importClause)) continue;
+      if (ts.isStringLiteral(statement.moduleSpecifier)) specifiers.push(statement.moduleSpecifier.text);
+    } else if (ts.isExportDeclaration(statement) && statement.moduleSpecifier !== undefined) {
+      if (statement.isTypeOnly) continue;
+      if (ts.isStringLiteral(statement.moduleSpecifier)) specifiers.push(statement.moduleSpecifier.text);
+    }
+  }
+
+  return specifiers;
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
@@ -11,7 +11,7 @@ vi.mock(import('node:fs'), () => ({
 import { JsonProjectionError } from '../JsonProjectionError.ts';
 import { projectJsonFile } from '../projectJsonFile.ts';
 
-/** Run the projection and return the `JsonProjectionError` it raised. */
+/** Runs the projection over a file with the given contents and returns the `JsonProjectionError` it raised. */
 function captureProjectionError(fileContents: string | Error, paths: string[] = ['name']): JsonProjectionError {
   if (fileContents instanceof Error) {
     mockReadFileSync.mockImplementationOnce(() => {

--- a/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert';
+
+import { describe, expect, it, vi } from 'vitest';
+
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock(import('node:fs'), () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+import { JsonProjectionError } from '../JsonProjectionError.ts';
+import { projectJsonFile } from '../projectJsonFile.ts';
+
+/** Run the projection and return the `JsonProjectionError` it raised. */
+function captureProjectionError(fileContents: string | Error, paths: string[] = ['name']): JsonProjectionError {
+  if (fileContents instanceof Error) {
+    mockReadFileSync.mockImplementationOnce(() => {
+      throw fileContents;
+    });
+  } else {
+    mockReadFileSync.mockReturnValueOnce(fileContents);
+  }
+
+  try {
+    projectJsonFile('/project/data.json', paths);
+  } catch (error: unknown) {
+    assert.ok(error instanceof JsonProjectionError);
+    return error;
+  }
+  throw new Error('projectJsonFile did not throw');
+}
+
+describe(projectJsonFile, () => {
+  it('returns the projection serialized', () => {
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify({ license: 'ISC', name: 'my-pkg', version: '1.0.0' }));
+
+    const projection = projectJsonFile('/project/package.json', ['name', 'version']);
+
+    expect(projection).toBe(JSON.stringify({ name: 'my-pkg', version: '1.0.0' }));
+  });
+
+  it('preserves the nesting of a nested path', () => {
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify({ engines: { node: '>=24', pnpm: '10' } }));
+
+    const projection = projectJsonFile('/project/package.json', [['engines', 'node']]);
+
+    expect(projection).toBe(JSON.stringify({ engines: { node: '>=24' } }));
+  });
+
+  it('yields the same projection when an unpicked field changes', () => {
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify({ name: 'my-pkg', scripts: { build: 'tsc' } }));
+    const before = projectJsonFile('/project/package.json', ['name']);
+
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify({ name: 'my-pkg', scripts: { build: 'esbuild' } }));
+    const after = projectJsonFile('/project/package.json', ['name']);
+
+    expect(after).toBe(before);
+  });
+
+  it('reports an unreadable file as unreadable, naming it', () => {
+    const error = captureProjectionError(new Error('ENOENT'));
+
+    expect(error.reason).toBe('unreadable');
+    expect(error.filePath).toBe('/project/data.json');
+    expect(error.message).toContain('/project/data.json');
+  });
+
+  it('reports malformed JSON as invalid-json', () => {
+    const error = captureProjectionError('{broken');
+
+    expect(error.reason).toBe('invalid-json');
+  });
+
+  it('reports a non-object root as not-an-object, carrying the type it found', () => {
+    const error = captureProjectionError('[1,2,3]');
+
+    expect(error.reason).toBe('not-an-object');
+    expect(error.detail).toBe('object');
+  });
+
+  it('reports a picked path the file does not have as path-not-found, naming the path', () => {
+    const error = captureProjectionError(JSON.stringify({ name: 'my-pkg' }), ['version']);
+
+    expect(error.reason).toBe('path-not-found');
+    expect(error.message).toBe('Path not found in JSON: version');
+  });
+});

--- a/packages/readyup/src/compile/__tests__/tsconfigIsolation.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/tsconfigIsolation.tool.test.ts
@@ -44,12 +44,12 @@ describe(buildBundle, () => {
     writeHostTsconfig(entryPath);
     const withHostConfig = await buildBundle(entryPath);
 
-    expect(withHostConfig.equals(withoutHostConfig)).toBe(true);
+    expect(withHostConfig.bytes.equals(withoutHostConfig.bytes)).toBe(true);
   });
 
   it('compiles class fields and decorators under the declared settings', async () => {
-    const fieldBundle = (await buildBundle(writeKitTree(FIELD_SOURCE))).toString('utf8');
-    const decoratorBundle = (await buildBundle(writeKitTree(KIT_SOURCE))).toString('utf8');
+    const fieldBundle = (await buildBundle(writeKitTree(FIELD_SOURCE))).bytes.toString('utf8');
+    const decoratorBundle = (await buildBundle(writeKitTree(KIT_SOURCE))).bytes.toString('utf8');
 
     // esbuild names no setting in its output, so the declared values are read back from the lowering
     // they produce: a defined field stays in the class body where an assigned one moves into the

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -4,6 +4,7 @@ import { describeError } from '@williamthorsen/toolbelt.errors';
 
 import { isRecord } from '../portable/isRecord.ts';
 import { VERSION } from '../version.ts';
+import { createCompileRecorder } from './createCompileRecorder.ts';
 import { loadEsbuild } from './loadEsbuild.ts';
 import { pickJsonPlugin } from './pickJsonPlugin.ts';
 
@@ -82,6 +83,8 @@ export async function buildBundle(inputPath: string): Promise<Buffer> {
     });
   }
 
+  const recorder = createCompileRecorder();
+
   let result;
   try {
     result = await esbuild.build({
@@ -92,7 +95,7 @@ export async function buildBundle(inputPath: string): Promise<Buffer> {
       target: KIT_COMPILE_TARGET,
       tsconfigRaw: KIT_TSCONFIG,
       external: ['node:*', 'readyup', 'readyup/*'],
-      plugins: [pickJsonPlugin()],
+      plugins: [pickJsonPlugin(recorder)],
       banner: { js: GENERATED_HEADER },
       write: false,
     });

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -89,8 +89,9 @@ export interface BundleResult {
  * compile would have produced -- a property that holds by construction rather than by two option
  * objects being kept in agreement.
  *
- * Takes no output path, because none can reach the result: esbuild is invoked without `outfile`, so
- * the bytes are a function of the entry point and the plugin alone.
+ * Takes no output path, because none can reach the result: esbuild is invoked without `outfile`. The bytes
+ * are a function of the entry point, the plugin, and the working directory, against which esbuild renders
+ * each bundled module's path into the output.
  *
  * The one place a compile's input closure is known, which is why it returns the closure alongside the
  * bytes rather than leaving a later reader to reconstruct it.
@@ -156,11 +157,14 @@ export async function buildBundle(inputPath: string): Promise<BundleResult> {
 function collectInputs(recorded: CompiledInput[], metafileKeys: string[], workingDir: string): CompiledInput[] {
   const byIdentity = new Map<string, CompiledInput>();
   for (const input of recorded) {
+    if (isDependencyFile(input.path)) continue;
     byIdentity.set(identifyInput(input.kind, input.path), input);
   }
 
   for (const key of metafileKeys) {
     const resolvedPath = path.resolve(workingDir, key);
+    // Excluded before the hash, so a dependency tree is never read from disk: one `import zod` inlines 79 files.
+    if (isDependencyFile(resolvedPath)) continue;
     const identity = identifyInput('module', resolvedPath);
     if (byIdentity.has(identity)) continue;
     byIdentity.set(identity, { hash: hashFile(resolvedPath), kind: 'module', path: resolvedPath });
@@ -168,7 +172,6 @@ function collectInputs(recorded: CompiledInput[], metafileKeys: string[], workin
 
   return byIdentity
     .values()
-    .filter((input) => !input.path.split(path.sep).includes(EXCLUDED_DIRECTORY))
     .toArray()
     .toSorted((a, b) => a.path.localeCompare(b.path) || a.kind.localeCompare(b.kind));
 }
@@ -189,6 +192,11 @@ function hasUnresolvedSpecifier(error: unknown): boolean {
         isRecord(message) && typeof message['text'] === 'string' && message['text'].startsWith('Could not resolve '),
     )
   );
+}
+
+/** Reports whether a path lies under a dependency directory, whose contents the closure does not record. */
+function isDependencyFile(filePath: string): boolean {
+  return filePath.split(path.sep).includes(EXCLUDED_DIRECTORY);
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -1,12 +1,25 @@
 import path from 'node:path';
+import process from 'node:process';
 
 import { describeError } from '@williamthorsen/toolbelt.errors';
 
 import { isRecord } from '../portable/isRecord.ts';
+import { hashFile } from '../verify/targetHash.ts';
 import { VERSION } from '../version.ts';
+import type { CompiledInput } from './CompiledInput.ts';
+import { identifyInput } from './CompiledInput.ts';
 import { createCompileRecorder } from './createCompileRecorder.ts';
 import { loadEsbuild } from './loadEsbuild.ts';
 import { pickJsonPlugin } from './pickJsonPlugin.ts';
+
+/**
+ * Directory whose contents stay out of a kit's recorded closure.
+ *
+ * Dependency contents are pinned by the lockfile and read exactly by `rdy verify --rebuild`, while
+ * recording them would size a committed, per-compile-rewritten manifest to the dependency tree rather
+ * than to the kit: one `import zod` inlines 79 files.
+ */
+const EXCLUDED_DIRECTORY = 'node_modules';
 
 /** esbuild target for compiled kits. Matches the Node floor of the `rdy` runner that executes them. */
 export const KIT_COMPILE_TARGET = 'es2025';
@@ -55,6 +68,14 @@ const GENERATED_HEADER = [
   '',
 ].join('\n');
 
+/** A kit's compiled bytes and the closure of files the compile read to produce them. */
+export interface BundleResult {
+  bytes: Buffer;
+
+  /** Every file read outside `node_modules`, with absolute paths, sorted by path and then by kind. */
+  inputs: CompiledInput[];
+}
+
 /**
  * Bundles a TypeScript checklist file into a self-contained ESM bundle and returns its bytes.
  *
@@ -70,9 +91,13 @@ const GENERATED_HEADER = [
  *
  * Takes no output path, because none can reach the result: esbuild is invoked without `outfile`, so
  * the bytes are a function of the entry point and the plugin alone.
+ *
+ * The one place a compile's input closure is known, which is why it returns the closure alongside the
+ * bytes rather than leaving a later reader to reconstruct it.
  */
-export async function buildBundle(inputPath: string): Promise<Buffer> {
+export async function buildBundle(inputPath: string): Promise<BundleResult> {
   const resolvedInput = path.resolve(inputPath);
+  const workingDir = process.cwd();
 
   let esbuild: typeof import('esbuild');
   try {
@@ -89,6 +114,7 @@ export async function buildBundle(inputPath: string): Promise<Buffer> {
   try {
     result = await esbuild.build({
       entryPoints: [resolvedInput],
+      absWorkingDir: workingDir,
       bundle: true,
       format: 'esm',
       platform: 'node',
@@ -97,6 +123,7 @@ export async function buildBundle(inputPath: string): Promise<Buffer> {
       external: ['node:*', 'readyup', 'readyup/*'],
       plugins: [pickJsonPlugin(recorder)],
       banner: { js: GENERATED_HEADER },
+      metafile: true,
       write: false,
     });
   } catch (error: unknown) {
@@ -109,10 +136,42 @@ export async function buildBundle(inputPath: string): Promise<Buffer> {
     throw new Error(`esbuild produced no output for ${resolvedInput}`);
   }
 
-  return Buffer.from(outputFile.contents);
+  return {
+    bytes: Buffer.from(outputFile.contents),
+    inputs: collectInputs(recorder.inputs, Object.keys(result.metafile.inputs), workingDir),
+  };
 }
 
 // region | Helpers
+
+/**
+ * Returns the closure of a compile, merging what the recorder read with what esbuild resolved.
+ *
+ * A recorded read wins over the metafile's account of the same file, because only the recorder knows an
+ * inline input's path specifier. The metafile keys are relative to the working directory esbuild ran
+ * under, which is pinned rather than defaulted so that resolving them cannot drift.
+ *
+ * Sorted so that recompiling a kit whose inputs have not moved rewrites the manifest identically.
+ */
+function collectInputs(recorded: CompiledInput[], metafileKeys: string[], workingDir: string): CompiledInput[] {
+  const byIdentity = new Map<string, CompiledInput>();
+  for (const input of recorded) {
+    byIdentity.set(identifyInput(input.kind, input.path), input);
+  }
+
+  for (const key of metafileKeys) {
+    const resolvedPath = path.resolve(workingDir, key);
+    const identity = identifyInput('module', resolvedPath);
+    if (byIdentity.has(identity)) continue;
+    byIdentity.set(identity, { hash: hashFile(resolvedPath), kind: 'module', path: resolvedPath });
+  }
+
+  return byIdentity
+    .values()
+    .filter((input) => !input.path.split(path.sep).includes(EXCLUDED_DIRECTORY))
+    .toArray()
+    .toSorted((a, b) => a.path.localeCompare(b.path) || a.kind.localeCompare(b.kind));
+}
 
 /**
  * Reports whether an esbuild failure carries an import esbuild could not resolve.

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { parseArgs as nodeParseArgs } from 'node:util';
@@ -9,10 +9,10 @@ import { EXIT_OK, EXIT_PROBLEMS_FOUND } from '../bin/exitCodes.ts';
 import { loadConfig } from '../config/loadConfig.ts';
 import { extractHint } from '../errors/error-handling.ts';
 import { translateParseArgsError } from '../errors/parse-args-error.ts';
-import { configError, usageError } from '../errors/RdyError.ts';
+import { configError, internalError, usageError } from '../errors/RdyError.ts';
 import { getLayout } from '../layout/engine.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
-import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
+import type { RdyManifestInput, RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { writeManifest } from '../manifest/writeManifest.ts';
 import { writeHuman } from '../output/writeHuman.ts';
@@ -20,10 +20,10 @@ import { pluralizeWithCount } from '../portable/pluralize.ts';
 import { type JsonCompileKitEntry, type JsonCompileOutput, SCHEMA_VERSION } from '../schemas/compileOutputSchema.ts';
 import type { DriftStatus } from '../verify/checkDrift.ts';
 import { checkDrift } from '../verify/checkDrift.ts';
-import { hashFile } from '../verify/targetHash.ts';
 import { VERSION } from '../version.ts';
 import { collectSourceFiles } from './collectSourceFiles.ts';
 import { compileConfig } from './compileConfig.ts';
+import type { CompiledInput } from './CompiledInput.ts';
 import { deriveJsPath } from './deriveJsPath.ts';
 import type { KitMetadata } from './validateCompiledOutput.ts';
 import { validateCompiledOutput } from './validateCompiledOutput.ts';
@@ -141,10 +141,12 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
     try {
       const relOutputPath = path.relative(manifestDir, path.resolve(result.outputPath));
       const relSourcePath = path.relative(manifestDir, resolvedInputPath);
+      const closure = deriveClosureFields(result.inputs, resolvedInputPath, manifestDir);
       upsertManifest(manifestPath, kitName, metadata, {
+        inputs: closure.inputs,
         path: relOutputPath,
         source: relSourcePath,
-        sourceHash: hashFile(resolvedInputPath),
+        sourceHash: closure.sourceHash,
         targetHash: result.targetHash,
       });
     } catch (error: unknown) {
@@ -262,12 +264,14 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
 
       const relOutputPath = path.relative(manifestDir, path.resolve(result.outputPath));
       const relSourcePath = path.relative(manifestDir, srcFile);
+      const closure = deriveClosureFields(result.inputs, path.resolve(srcFile), manifestDir);
       kitEntries.push({
+        inputs: closure.inputs,
         name: kitName,
         path: relOutputPath,
         readyupVersion: VERSION,
         source: relSourcePath,
-        sourceHash: hashFile(srcFile),
+        sourceHash: closure.sourceHash,
         targetHash: result.targetHash,
         ...(metadata.checklists.length > 0 && { checklists: metadata.checklists }),
         ...(metadata.description !== undefined && { description: metadata.description }),
@@ -350,10 +354,50 @@ function finishEmptySweep(args: FinishEmptySweepArgs): number {
 
 /** Location fields for a manifest kit entry. */
 interface KitLocationFields {
+  inputs: RdyManifestInput[];
   path: string;
   source: string;
   sourceHash: string;
   targetHash: string;
+}
+
+/** The manifest fields a compile's input closure supplies. */
+interface ClosureFields {
+  inputs: RdyManifestInput[];
+  sourceHash: string;
+}
+
+/**
+ * Returns the manifest fields a compile's closure supplies, with paths stated against the manifest.
+ *
+ * `sourceHash` is the entry's own record rather than a second reading of the file, so the two cannot
+ * disagree. A closure holding no record of the entry is a defect in rdy rather than an occasion to hash
+ * the file again: deriving is the point, and hashing separately would restore exactly the disagreement
+ * deriving prevents.
+ *
+ * The entry is matched by its real path, because esbuild reports the path it resolved a module to, which
+ * differs from the path a compile was handed wherever a directory above it is a symlink.
+ */
+function deriveClosureFields(inputs: CompiledInput[], entryPath: string, manifestDir: string): ClosureFields {
+  const realEntryPath = realpathSync(entryPath);
+  const entry = inputs.find((input) => input.kind === 'module' && input.path === realEntryPath);
+  if (entry === undefined) {
+    throw internalError(`Compile recorded no input for its entry point ${entryPath}`);
+  }
+
+  return {
+    inputs: inputs.map((input) => relativizeInput(input, manifestDir)),
+    sourceHash: entry.hash,
+  };
+}
+
+/** Returns a recorded input with its path stated relative to the manifest directory, as `path` and `source` are. */
+function relativizeInput(input: CompiledInput, manifestDir: string): RdyManifestInput {
+  const relativePath = path.relative(manifestDir, input.path);
+
+  return input.kind === 'inline'
+    ? { hash: input.hash, kind: 'inline', path: relativePath, paths: input.paths }
+    : { hash: input.hash, kind: 'module', path: relativePath };
 }
 
 /** Read an existing manifest (if any), upsert a kit entry, and write back. */
@@ -376,6 +420,7 @@ function upsertManifest(
   }
 
   const entry: RdyManifestKit = {
+    inputs: location.inputs,
     name: kitName,
     path: location.path,
     readyupVersion: VERSION,

--- a/packages/readyup/src/compile/compileConfig.ts
+++ b/packages/readyup/src/compile/compileConfig.ts
@@ -3,12 +3,17 @@ import path from 'node:path';
 
 import { hashBytes } from '../verify/targetHash.ts';
 import { buildBundle } from './buildBundle.ts';
+import type { CompiledInput } from './CompiledInput.ts';
 import { deriveJsPath } from './deriveJsPath.ts';
 
 /** Result of a successful compilation. */
 export interface CompileResult {
-  outputPath: string;
   changed: boolean;
+
+  /** Every file the compile read outside `node_modules`, with absolute paths. */
+  inputs: CompiledInput[];
+
+  outputPath: string;
   targetHash: string;
 }
 
@@ -22,14 +27,14 @@ export interface CompileResult {
 export async function compileConfig(inputPath: string, outputPath?: string): Promise<CompileResult> {
   const resolvedOutput = path.resolve(outputPath ?? deriveJsPath(inputPath));
 
-  const compiled = await buildBundle(inputPath);
+  const { bytes, inputs } = await buildBundle(inputPath);
   const existing = existsSync(resolvedOutput) ? readFileSync(resolvedOutput) : undefined;
-  const changed = existing === undefined || !compiled.equals(existing);
+  const changed = existing === undefined || !bytes.equals(existing);
 
   if (changed) {
     mkdirSync(path.dirname(resolvedOutput), { recursive: true });
-    writeFileSync(resolvedOutput, compiled);
+    writeFileSync(resolvedOutput, bytes);
   }
 
-  return { outputPath: resolvedOutput, changed, targetHash: hashBytes(compiled) };
+  return { changed, inputs, outputPath: resolvedOutput, targetHash: hashBytes(bytes) };
 }

--- a/packages/readyup/src/compile/createCompileRecorder.ts
+++ b/packages/readyup/src/compile/createCompileRecorder.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { hashBytes } from '../verify/targetHash.ts';
+import type { CompiledInput } from './CompiledInput.ts';
+import type { JsonPathSpec } from './extractJsonPaths.ts';
+import { projectJsonFile } from './projectJsonFile.ts';
+
+/**
+ * The two doors a compile plugin reads files through.
+ *
+ * Both record, so a file a plugin reads out of band cannot escape the compile's input closure. A plugin
+ * holds a recorder rather than importing `node:fs`, which is what keeps that property true of the next
+ * plugin as well as this one.
+ */
+export interface CompileRecorder {
+  /** Every file read so far, one record per path and kind, in the order the reads happened. */
+  readonly inputs: CompiledInput[];
+
+  /** Reads a module and records its bytes. */
+  readModule(filePath: string): string;
+
+  /**
+   * Reads a JSON file and records the projection of `paths` over it, returning that projection serialized.
+   *
+   * Recording the projection rather than the file is what keeps an edit to a field the kit did not pick
+   * from reading as staleness.
+   */
+  readProjection(filePath: string, paths: JsonPathSpec): string;
+}
+
+/** Builds a recorder that accumulates the closure of everything read through it. */
+export function createCompileRecorder(): CompileRecorder {
+  const recorded = new Map<string, CompiledInput>();
+
+  return {
+    get inputs(): CompiledInput[] {
+      return recorded.values().toArray();
+    },
+
+    readModule(filePath: string): string {
+      const resolvedPath = path.resolve(filePath);
+      const bytes = readFileSync(resolvedPath);
+      record(recorded, { hash: hashBytes(bytes), kind: 'module', path: resolvedPath });
+      return bytes.toString('utf8');
+    },
+
+    readProjection(filePath: string, paths: JsonPathSpec): string {
+      const resolvedPath = path.resolve(filePath);
+      const projection = projectJsonFile(resolvedPath, paths);
+      record(recorded, { hash: hashBytes(Buffer.from(projection, 'utf8')), kind: 'inline', path: resolvedPath, paths });
+      return projection;
+    },
+  };
+}
+
+// region | Helpers
+
+/** Files a compile reads more than once, and the same file read as two kinds, collapse to one record each. */
+function record(recorded: Map<string, CompiledInput>, input: CompiledInput): void {
+  const key = `${input.kind}\0${input.path}`;
+  if (!recorded.has(key)) recorded.set(key, input);
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/compile/createCompileRecorder.ts
+++ b/packages/readyup/src/compile/createCompileRecorder.ts
@@ -57,7 +57,7 @@ export function createCompileRecorder(): CompileRecorder {
 
 // region | Helpers
 
-/** Files a compile reads more than once collapse to one record each. */
+/** Records an input, leaving a repeat read of the same path and kind with the record it already has. */
 function record(recorded: Map<string, CompiledInput>, input: CompiledInput): void {
   const key = identifyInput(input.kind, input.path);
   if (!recorded.has(key)) recorded.set(key, input);

--- a/packages/readyup/src/compile/createCompileRecorder.ts
+++ b/packages/readyup/src/compile/createCompileRecorder.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { hashBytes } from '../verify/targetHash.ts';
 import type { CompiledInput } from './CompiledInput.ts';
+import { identifyInput } from './CompiledInput.ts';
 import type { JsonPathSpec } from './extractJsonPaths.ts';
 import { projectJsonFile } from './projectJsonFile.ts';
 
@@ -56,9 +57,9 @@ export function createCompileRecorder(): CompileRecorder {
 
 // region | Helpers
 
-/** Files a compile reads more than once, and the same file read as two kinds, collapse to one record each. */
+/** Files a compile reads more than once collapse to one record each. */
 function record(recorded: Map<string, CompiledInput>, input: CompiledInput): void {
-  const key = `${input.kind}\0${input.path}`;
+  const key = identifyInput(input.kind, input.path);
   if (!recorded.has(key)) recorded.set(key, input);
 }
 

--- a/packages/readyup/src/compile/extractJsonPaths.ts
+++ b/packages/readyup/src/compile/extractJsonPaths.ts
@@ -3,15 +3,20 @@ import assert from 'node:assert';
 import { isRecord } from '../portable/isRecord.ts';
 
 /**
+ * A `pickJson` path specifier list: a top-level key as a string, a nested one as an array of keys.
+ *
+ * Mirrors `pickJson`'s second argument, and is the form a recorded inline input carries so a later reader
+ * can reproduce the projection the compile inlined.
+ */
+export type JsonPathSpec = Array<string | Array<string>>;
+
+/**
  * Extract selected paths from a parsed JSON object, preserving original nesting structure.
  *
  * Each path is either a single string (top-level key) or an array of strings (nested key path).
  * Throws if any requested path does not exist in the source object.
  */
-export function extractJsonPaths(
-  obj: Record<string, unknown>,
-  paths: Array<string | Array<string>>,
-): Record<string, unknown> {
+export function extractJsonPaths(obj: Record<string, unknown>, paths: JsonPathSpec): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
   for (const raw of paths) {

--- a/packages/readyup/src/compile/pickJsonPlugin.ts
+++ b/packages/readyup/src/compile/pickJsonPlugin.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert';
-import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import type { Plugin } from 'esbuild';
 
-import { isRecord } from '../portable/isRecord.ts';
-import { extractJsonPaths } from './extractJsonPaths.ts';
+import type { CompileRecorder } from './createCompileRecorder.ts';
+import type { JsonPathSpec } from './extractJsonPaths.ts';
+import { JsonProjectionError } from './JsonProjectionError.ts';
 
 /**
  * Regex that matches a `pickJson(...)` call expression in source text.
@@ -18,6 +18,77 @@ import { extractJsonPaths } from './extractJsonPaths.ts';
  */
 const PICK_JSON_RE = /\bpickJson\s*\((?<args>[^)]+)\)/g;
 
+/**
+ * Create an esbuild plugin that replaces `pickJson(...)` calls with inlined object literals.
+ *
+ * The plugin intercepts TypeScript file loads, scans for `pickJson` calls, resolves
+ * the referenced JSON file relative to the source file, extracts the requested paths,
+ * and substitutes the call with a static object expression.
+ *
+ * Every read goes through `recorder`, which is what puts the module and the JSON file it projected into
+ * the compile's input closure. This module imports no filesystem API of its own, so a read it performs
+ * cannot escape that closure.
+ */
+export function pickJsonPlugin(recorder: CompileRecorder): Plugin {
+  return {
+    name: 'pick-json',
+    setup(build) {
+      build.onLoad({ filter: /\.[cm]?ts$/ }, (args) => {
+        let source: string;
+        try {
+          source = recorder.readModule(args.path);
+        } catch {
+          throw new Error(`pickJson: Cannot read source file "${args.path}"`);
+        }
+
+        // Fast bail: skip files that don't reference pickJson.
+        if (!source.includes('pickJson')) return null;
+
+        // Replace each pickJson(...) call with an inlined object literal.
+        const replaced = source.replace(PICK_JSON_RE, (_fullMatch, argsText: string) => {
+          const { relativePath, paths } = parsePickJsonArgs(argsText);
+          const jsonFilePath = path.resolve(path.dirname(args.path), relativePath);
+
+          try {
+            return recorder.readProjection(jsonFilePath, paths);
+          } catch (error: unknown) {
+            throw describeProjectionFailure(error, relativePath, jsonFilePath);
+          }
+        });
+
+        if (replaced === source) return null;
+
+        return { contents: replaced, loader: 'ts' };
+      });
+    },
+  };
+}
+
+// region | Helpers
+
+/**
+ * Returns the failure to raise for a projection that did not complete, worded as `pickJson` reports it.
+ *
+ * Names the path as the kit wrote it, which the projection cannot: by the time it reads the file, only
+ * the resolved path survives.
+ */
+function describeProjectionFailure(error: unknown, relativePath: string, jsonFilePath: string): unknown {
+  if (!(error instanceof JsonProjectionError)) return error;
+
+  switch (error.reason) {
+    case 'invalid-json':
+      return new Error(`pickJson: Invalid JSON in "${relativePath}" (resolved to ${jsonFilePath})`, { cause: error });
+    case 'not-an-object':
+      return new Error(`pickJson: Expected a JSON object in "${relativePath}", got ${error.detail}`, { cause: error });
+    case 'path-not-found':
+      return error;
+    case 'unreadable':
+      return new Error(`pickJson: Cannot read JSON file "${relativePath}" (resolved to ${jsonFilePath})`, {
+        cause: error,
+      });
+  }
+}
+
 /** Narrows a parsed JSON value to the nested-path form a path specifier may take. */
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === 'string');
@@ -29,7 +100,7 @@ function isStringArray(value: unknown): value is string[] {
  * Expects a JSON file path string and an array of path specifiers (strings or string arrays).
  * Only static literals are supported; expressions or template literals produce an error.
  */
-function parsePickJsonArgs(argsText: string): { relativePath: string; paths: Array<string | Array<string>> } {
+function parsePickJsonArgs(argsText: string): { relativePath: string; paths: JsonPathSpec } {
   // Trim and strip potential trailing comma.
   const trimmed = argsText.trim().replace(/,\s*$/, '');
 
@@ -63,7 +134,7 @@ function parsePickJsonArgs(argsText: string): { relativePath: string; paths: Arr
     throw new TypeError(`pickJson paths argument must be an array. Got: ${rest}`);
   }
 
-  const paths: Array<string | Array<string>> = [];
+  const paths: JsonPathSpec = [];
   for (const item of parsed) {
     if (typeof item !== 'string' && !isStringArray(item)) {
       throw new Error(`Invalid path in pickJson paths array: ${JSON.stringify(item)}`);
@@ -74,59 +145,4 @@ function parsePickJsonArgs(argsText: string): { relativePath: string; paths: Arr
   return { relativePath, paths };
 }
 
-/**
- * Create an esbuild plugin that replaces `pickJson(...)` calls with inlined object literals.
- *
- * The plugin intercepts TypeScript file loads, scans for `pickJson` calls, resolves
- * the referenced JSON file relative to the source file, extracts the requested paths,
- * and substitutes the call with a static object expression.
- */
-export function pickJsonPlugin(): Plugin {
-  return {
-    name: 'pick-json',
-    setup(build) {
-      build.onLoad({ filter: /\.[cm]?ts$/ }, (args) => {
-        let source: string;
-        try {
-          source = readFileSync(args.path, 'utf8');
-        } catch {
-          throw new Error(`pickJson: Cannot read source file "${args.path}"`);
-        }
-
-        // Fast bail: skip files that don't reference pickJson.
-        if (!source.includes('pickJson')) return null;
-
-        // Replace each pickJson(...) call with an inlined object literal.
-        const replaced = source.replace(PICK_JSON_RE, (_fullMatch, argsText: string) => {
-          const { relativePath, paths } = parsePickJsonArgs(argsText);
-          const jsonFilePath = path.resolve(path.dirname(args.path), relativePath);
-
-          let jsonContent: string;
-          try {
-            jsonContent = readFileSync(jsonFilePath, 'utf8');
-          } catch {
-            throw new Error(`pickJson: Cannot read JSON file "${relativePath}" (resolved to ${jsonFilePath})`);
-          }
-
-          let parsed: unknown;
-          try {
-            parsed = JSON.parse(jsonContent);
-          } catch {
-            throw new Error(`pickJson: Invalid JSON in "${relativePath}" (resolved to ${jsonFilePath})`);
-          }
-
-          if (!isRecord(parsed)) {
-            throw new Error(`pickJson: Expected a JSON object in "${relativePath}", got ${typeof parsed}`);
-          }
-
-          const extracted = extractJsonPaths(parsed, paths);
-          return JSON.stringify(extracted);
-        });
-
-        if (replaced === source) return null;
-
-        return { contents: replaced, loader: 'ts' };
-      });
-    },
-  };
-}
+// endregion | Helpers

--- a/packages/readyup/src/compile/projectJsonFile.ts
+++ b/packages/readyup/src/compile/projectJsonFile.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+
+import { describeError } from '@williamthorsen/toolbelt.errors';
+
+import { isRecord } from '../portable/isRecord.ts';
+import type { JsonPathSpec } from './extractJsonPaths.ts';
+import { extractJsonPaths } from './extractJsonPaths.ts';
+import { JsonProjectionError } from './JsonProjectionError.ts';
+
+/**
+ * Reads a JSON file, projects `paths` out of it, and returns that projection serialized.
+ *
+ * The one implementation of the projection every reader of a recorded input decides by. Once a
+ * projection's serialization is hashed it is a format, so a second implementation of it would drift and
+ * the two would disagree about a file neither had changed.
+ *
+ * Returns the serialized form rather than the projected object, which is what makes the bytes a compile
+ * hashes the bytes it substitutes.
+ */
+export function projectJsonFile(filePath: string, paths: JsonPathSpec): string {
+  let contents: string;
+  try {
+    contents = readFileSync(filePath, 'utf8');
+  } catch (error: unknown) {
+    throw new JsonProjectionError('unreadable', filePath, `Cannot read JSON file ${filePath}`, { cause: error });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (error: unknown) {
+    throw new JsonProjectionError('invalid-json', filePath, `Invalid JSON in ${filePath}`, { cause: error });
+  }
+
+  if (!isRecord(parsed)) {
+    const detail = typeof parsed;
+    throw new JsonProjectionError('not-an-object', filePath, `Expected a JSON object in ${filePath}, got ${detail}`, {
+      detail,
+    });
+  }
+
+  try {
+    return JSON.stringify(extractJsonPaths(parsed, paths));
+  } catch (error: unknown) {
+    throw new JsonProjectionError('path-not-found', filePath, describeError(error), { cause: error });
+  }
+}

--- a/packages/readyup/src/manifest/__tests__/manifestSchema.unit.test.ts
+++ b/packages/readyup/src/manifest/__tests__/manifestSchema.unit.test.ts
@@ -171,6 +171,59 @@ describe('ManifestSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('round-trips an entry carrying recorded inputs', () => {
+    const inputs = [
+      { hash: 'a1b2c3d4', kind: 'inline', path: '../package.json', paths: ['version', ['engines', 'node']] },
+      { hash: 'e5f6a7b8', kind: 'module', path: 'kits/checks/shared.ts' },
+    ];
+    const input = { version: 1, kits: [{ inputs, name: 'deploy' }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+    assert.ok(result.success);
+    expect(result.data.kits[0]?.inputs).toStrictEqual(inputs);
+  });
+
+  it('accepts an entry that records no inputs', () => {
+    const input = { version: 1, kits: [{ name: 'deploy', sourceHash: 'a1b2c3d4', targetHash: 'e5f6a7b8' }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+    assert.ok(result.success);
+    expect(result.data.kits[0]?.inputs).toBeUndefined();
+  });
+
+  it('rejects an inline input that records no paths', () => {
+    const input = {
+      version: 1,
+      kits: [{ inputs: [{ hash: 'a1b2c3d4', kind: 'inline', path: 'pkg.json' }], name: 'deploy' }],
+    };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a module input that records paths', () => {
+    const inputs = [{ hash: 'a1b2c3d4', kind: 'module', path: 'kits/shared.ts', paths: ['version'] }];
+    const input = { version: 1, kits: [{ inputs, name: 'deploy' }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an input of an unrecognized kind', () => {
+    const inputs = [{ hash: 'a1b2c3d4', kind: 'asset', path: 'logo.png' }];
+    const input = { version: 1, kits: [{ inputs, name: 'deploy' }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
   it('rejects a kit with an empty name', () => {
     const input = { version: 1, kits: [{ name: '' }] };
 

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -1,5 +1,23 @@
 import { z } from 'zod';
 
+/** Schema for a `pickJson` path specifier list, mirroring the function's second argument. */
+const JsonPathSpecSchema = z.array(z.union([z.string(), z.array(z.string())]));
+
+/**
+ * Schema for one file the compile read to produce a kit's bundle.
+ *
+ * `kind` decides what the hash covers. A `module` records the file's bytes; an `inline` records the
+ * projection `pickJson` substituted, so an edit to a field the kit did not pick is not staleness. Only
+ * an inline record carries `paths`, which is the specifier that produced the projection and so what a
+ * reader needs to reproduce it.
+ *
+ * Paths are relative to the manifest directory, as `path` and `source` are.
+ */
+const ManifestInputSchema = z.discriminatedUnion('kind', [
+  z.object({ hash: z.string(), kind: z.literal('inline'), path: z.string(), paths: JsonPathSpecSchema }),
+  z.object({ hash: z.string(), kind: z.literal('module'), path: z.string(), paths: z.undefined().optional() }),
+]);
+
 /**
  * Schema for a single kit entry in the manifest.
  *
@@ -11,10 +29,15 @@ import { z } from 'zod';
  * `sourceHash` and `targetHash` are the two ends of the compile: the hash of the `.ts` the kit was
  * built from and the hash of the `.js` it produced. Comparing each against the file on disk is what
  * separates a source edited without recompiling from a compiled bundle edited by hand.
+ *
+ * `inputs` records everything else the compile read, which is every module the bundle inlined past the
+ * entry and every JSON file `pickJson` projected. It is optional on the same terms `checklists` is: an
+ * entry written before the closure was recorded has none.
  */
 const ManifestKitSchema = z.object({
   checklists: z.array(z.string()).optional(),
   description: z.string().optional(),
+  inputs: z.array(ManifestInputSchema).optional(),
   name: z.string().min(1),
   path: z.string().optional(),
   readyupVersion: z.string().optional(),
@@ -31,6 +54,9 @@ export const ManifestSchema = z.object({
 
 /** Typed manifest produced by parsing with `ManifestSchema`. */
 export type RdyManifest = z.infer<typeof ManifestSchema>;
+
+/** Typed record of one file a kit's compile read. */
+export type RdyManifestInput = z.infer<typeof ManifestInputSchema>;
 
 /** Typed manifest kit entry. */
 export type RdyManifestKit = z.infer<typeof ManifestKitSchema>;

--- a/packages/readyup/src/verify/__tests__/checkRebuild.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkRebuild.unit.test.ts
@@ -29,7 +29,7 @@ describe(checkRebuild, () => {
   it('returns ok when the recompiled bytes match the bundle on disk', async () => {
     const bundle = Buffer.from('compiled output');
     writeKitFiles(tempDir, bundle);
-    mockBuildBundle.mockResolvedValue(bundle);
+    mockBuildBundle.mockResolvedValue({ bytes: bundle, inputs: [] });
 
     const status = await checkRebuild(kit(), tempDir);
 
@@ -40,7 +40,7 @@ describe(checkRebuild, () => {
     const onDisk = Buffer.from('stale output');
     const rebuilt = Buffer.from('fresh output');
     writeKitFiles(tempDir, onDisk);
-    mockBuildBundle.mockResolvedValue(rebuilt);
+    mockBuildBundle.mockResolvedValue({ bytes: rebuilt, inputs: [] });
 
     const status = await checkRebuild(kit(), tempDir);
 
@@ -54,7 +54,7 @@ describe(checkRebuild, () => {
   it('compares against the on-disk bytes rather than the recorded targetHash', async () => {
     const bundle = Buffer.from('compiled output');
     writeKitFiles(tempDir, bundle);
-    mockBuildBundle.mockResolvedValue(bundle);
+    mockBuildBundle.mockResolvedValue({ bytes: bundle, inputs: [] });
 
     const status = await checkRebuild({ ...kit(), targetHash: 'deadbeef' }, tempDir);
 
@@ -63,7 +63,7 @@ describe(checkRebuild, () => {
 
   it('names the compiling version on a mismatch when it differs from the runner', async () => {
     writeKitFiles(tempDir, Buffer.from('stale output'));
-    mockBuildBundle.mockResolvedValue(Buffer.from('fresh output'));
+    mockBuildBundle.mockResolvedValue({ bytes: Buffer.from('fresh output'), inputs: [] });
 
     const status = await checkRebuild({ ...kit(), readyupVersion: '0.0.1-old' }, tempDir);
 
@@ -72,7 +72,7 @@ describe(checkRebuild, () => {
 
   it('omits the compiling version on a mismatch when it matches the runner', async () => {
     writeKitFiles(tempDir, Buffer.from('stale output'));
-    mockBuildBundle.mockResolvedValue(Buffer.from('fresh output'));
+    mockBuildBundle.mockResolvedValue({ bytes: Buffer.from('fresh output'), inputs: [] });
 
     const status = await checkRebuild({ ...kit(), readyupVersion: VERSION }, tempDir);
 

--- a/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
@@ -40,6 +40,13 @@ describe('verifyCommand --rebuild', () => {
     writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '1.0.0' }));
     writeFileSync(path.join(tempDir, 'kit.ts'), KIT_SOURCE);
 
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    originalCwd = process.cwd();
+    // esbuild renders each module's path against the working directory, so the fixture is compiled from
+    // the directory it is verified from, as a real project is.
+    process.chdir(tempDir);
+
     // Record the manifest from a real compile, so its hashes are the ones the pipeline produces.
     const result = await compileConfig(path.join(tempDir, 'kit.ts'), path.join(tempDir, 'kit.js'));
     writeFileSync(
@@ -58,11 +65,6 @@ describe('verifyCommand --rebuild', () => {
         ],
       }),
     );
-
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    originalCwd = process.cwd();
-    process.chdir(tempDir);
   });
 
   afterEach(() => {

--- a/packages/readyup/src/verify/checkRebuild.ts
+++ b/packages/readyup/src/verify/checkRebuild.ts
@@ -53,7 +53,7 @@ export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Pr
 
   let rebuilt: Buffer;
   try {
-    rebuilt = await buildBundle(sourcePath);
+    rebuilt = (await buildBundle(sourcePath)).bytes;
   } catch (error: unknown) {
     // A source that no longer compiles is a finding about the kit, not a failure of the invocation,
     // so the sweep carries on to the kits after it.


### PR DESCRIPTION
## What

`rdy compile` now records every file it read into a kit's bundle -- each module the kit imports, and each JSON file `pickJson` drew from -- with a hash of each, on the kit's manifest entry. Only the entry `.ts` and the emitted `.js` were hashed before, so an edit to an inlined module or a picked JSON value left a stale bundle with both recorded hashes still matching. Nothing reads the new record yet; turning it into a staleness verdict comes next.

A `pickJson` input hashes only the values the kit drew, so an unrelated edit to the same file -- another `package.json` script, say -- does not read as staleness. The record stops at `node_modules`, whose contents the lockfile already pins.

## Why

A kit whose bundle was built from code the repo no longer holds still reports a pass -- a verdict about something that is not there, which is worse than no verdict at all. Nothing could catch it, because a compile left no record of what went into the bundle.

## Details

### 🎉 Features

- A manifest kit entry carries `inputs`, optional on the same terms as `checklists`, so a manifest written before this change still parses. Each record holds `hash`, `kind` (`module` or `inline`), and `path` relative to the manifest; an `inline` record also holds the `paths` specifier that produced its projection, so a later reader can re-project and compare.
- `sourceHash` is derived from the closure's record for the entry rather than computed by a second reading of the file. The entry is matched by its real path, since esbuild reports the path it resolved a module to.
- The closure stops at `node_modules`. Dependency contents are pinned by the lockfile and read exactly by `rdy verify --rebuild`, while recording them would size a committed, per-compile-rewritten manifest to the dependency tree rather than to the kit: one `import zod` inlines 79 files.

### ♻️ Refactoring

- Compile plugins read through a `CompileRecorder` -- `readModule` for a module's bytes, `readProjection` for a `pickJson` projection -- rather than importing `node:fs`, so a read cannot escape the closure. `pickJsonPlugin` takes a recorder and imports no filesystem API of its own.
- `projectJsonFile` becomes the single implementation of a `pickJson` projection, raising a typed `JsonProjectionError` whose `reason` (`invalid-json`, `not-an-object`, `path-not-found`, `unreadable`) lets each caller word the failure in its own terms. `pickJson`'s existing messages are unchanged.
- `buildBundle` returns the closure alongside the bytes, turns on esbuild's `metafile` to learn the modules it resolved, and pins `absWorkingDir` so those keys resolve against a known directory. Dependency files are excluded before they are read or hashed.

### 🧪 Tests

- Closure coverage against real esbuild over a fixture tree carrying a relative import, a projected JSON file, and a dependency: the recorded kinds, the `node_modules` exclusion, the sort order, and an unpicked field's edit leaving the inline hash unmoved.
- A structural test asserting that no module reachable from a registered esbuild plugin imports a filesystem API. The plugin set is read out of `buildBundle`'s own `plugins` array rather than listed, with a guard that fails if that derivation yields nothing.
- Manifest-writing coverage for the real-path entry match and for an inline record reaching a written entry with its path relativized and its specifier intact, plus schema coverage for both discriminated-union rejections.

### 📚 Documentation

- The README gains "What a manifest entry records": a table of the entry's fields, what `inputs` holds and what each kind's hash covers, the `node_modules` boundary and its rationale, and the note that an entry compiled before this change carries none.
- `buildBundle`'s description names the working directory among the bundle's inputs, since esbuild renders each bundled module's path into the output.

Closes #313

