### PR TITLE
#314 Verify and warn on a stale compile input

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -591,7 +591,7 @@ Once a style is named explicitly, output is byte-identical to a terminal or a pi
 | `source-stale` | The kit's TypeScript changed since the compiled bundle was built from it |
 | `target-drift` | The compiled bundle no longer matches the manifest's recorded hash       |
 
-They are silent when the manifest is absent, when no entry describes the kit, when an entry records no hashes or no input closure, or when a file cannot be read. Only the local manifest is consulted, so a kit reached through `--from` is out of scope -- run `rdy verify` in that root instead. They also do not apply to `--url` or `--jit`.
+They are silent when the manifest is absent, when no entry describes the kit, when an entry records no hashes or no input closure, or when a file they would compare is gone or cannot be read. Only the local manifest is consulted, so a kit reached through `--from` is out of scope -- run `rdy verify` in that root instead. They also do not apply to `--url` or `--jit`.
 
 ### Kit import compatibility
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -396,7 +396,7 @@ Both arguments must be literals written in place. They are read out of the sourc
 Two consequences follow from the value being resolved at compile time:
 
 - `pickJson` throws if it is ever reached at runtime. A kit that hits it was not compiled.
-- Editing the JSON afterward leaves the bundle stale, and neither recorded hash changes -- the source did not move, and neither did the bundle. [`rdy verify --rebuild`](#verifying-by-recompiling) is what catches it.
+- Editing a picked field afterward leaves the bundle stale. Neither recorded hash changes -- the source did not move, and neither did the bundle -- but the compile records the projection it inlined, so [`rdy verify`](#verifying) names the file and [`rdy run`](#advisory-warnings) warns on it. [`rdy verify --rebuild`](#verifying-by-recompiling) is the exact answer, reading the file rather than a record of it.
 
 ### TypeScript settings
 
@@ -587,10 +587,11 @@ Once a style is named explicitly, output is byte-identical to a terminal or a pi
 
 | Code           | Raised when                                                              |
 | -------------- | ------------------------------------------------------------------------ |
+| `input-stale`  | A file the compile inlined changed since the bundle was built from it    |
 | `source-stale` | The kit's TypeScript changed since the compiled bundle was built from it |
 | `target-drift` | The compiled bundle no longer matches the manifest's recorded hash       |
 
-They are silent when the manifest is absent, when no entry describes the kit, when an entry records no hashes, or when a file cannot be read. Only the local manifest is consulted, so a kit reached through `--from` is out of scope -- run `rdy verify` in that root instead. They also do not apply to `--url` or `--jit`.
+They are silent when the manifest is absent, when no entry describes the kit, when an entry records no hashes or no input closure, or when a file cannot be read. Only the local manifest is consulted, so a kit reached through `--from` is out of scope -- run `rdy verify` in that root instead. They also do not apply to `--url` or `--jit`.
 
 ### Kit import compatibility
 
@@ -990,11 +991,19 @@ rdy verify --rebuild           Also recompile each kit and compare it to the com
 1 of 2 kits failed verification.
 ```
 
-Each kit carries two independent verdicts, because a kit is two artifacts. The compiled output is `ok`, `drift`, `missing`, or `unverified`; the source is `ok`, `stale`, `missing`, or `unverified`. `drift` means someone edited the bundle by hand; `stale` means the source moved on and nobody recompiled. A kit can be both at once.
+Each kit carries three independent verdicts. The compiled output is `ok`, `drift`, `missing`, or `unverified`; the source is `ok`, `stale`, `missing`, or `unverified`; the [recorded inputs](#what-a-manifest-entry-records) are `ok`, `stale`, or `unverified`. `drift` means someone edited the bundle by hand; a stale source means the TypeScript moved on and nobody recompiled; stale inputs mean the same of a module the bundle inlined or a JSON projection it substituted. A kit can be all three at once.
 
-Anything other than `ok` or `unverified` on either axis fails the run. `unverified` does not, since an entry with no recorded hash says nothing about whether the kit changed.
+The inputs verdict names every input that failed rather than the first, each on its own line, separating a changed module from a changed inline projection. A projected file that is still present while the fields the kit picked are gone is reported as `unprojectable`, which says something about the kit rather than about the file:
 
-Under `--json`, each kit reports `status` and `sourceStatus`. A `drift` verdict carries `expected` and `actual`; a `stale` verdict carries `sourceExpected` and `sourceActual`.
+```
+🔴 deploy
+   input stale: checks/shared.ts (module, expected 6f58905a, got eb104f57)
+   input unprojectable: ../../package.json (Path not found in JSON: version)
+```
+
+Anything other than `ok` or `unverified` on any axis fails the run. `unverified` does not, since an entry with no recorded hash -- or one compiled before readyup recorded the input closure -- says nothing about whether the kit changed.
+
+Under `--json`, each kit reports `status`, `sourceStatus`, and `inputsStatus`. A `drift` verdict carries `expected` and `actual`; a stale source carries `sourceExpected` and `sourceActual`; stale inputs carry `inputFailures`, one entry per input naming its `kind`, `path`, and `reason`, plus whichever of `expected`, `actual`, and `detail` that reason has.
 
 In CI:
 
@@ -1006,7 +1015,7 @@ In CI:
 
 #### Verifying by recompiling
 
-The two hashes record two of a bundle's inputs. A bundle is a function of many more: every module it inlines past the entry, every JSON file [`pickJson`](#inlining-json-at-compile-time) inlines at compile time, the bundler's version, and the compile options. None of those is recorded, so a bundle stale in any of them still hashes as `ok`.
+The three verdicts cover what the compile read and recorded. A bundle is a function of more than that: the bundler's version, the compile options, and the contents of every dependency, which the manifest records none of, since [the closure stops at `node_modules`](#what-a-manifest-entry-records). A bundle stale in any of them still hashes as `ok`.
 
 `--rebuild` answers the question exactly. It recompiles each kit in memory and compares the result to the committed bundle byte for byte:
 

--- a/packages/readyup/src/compile/createCompileRecorder.ts
+++ b/packages/readyup/src/compile/createCompileRecorder.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { hashBytes } from '../verify/targetHash.ts';
+import { hashBytes, hashProjection } from '../verify/targetHash.ts';
 import type { CompiledInput } from './CompiledInput.ts';
 import { identifyInput } from './CompiledInput.ts';
 import type { JsonPathSpec } from './extractJsonPaths.ts';
@@ -49,7 +49,7 @@ export function createCompileRecorder(): CompileRecorder {
     readProjection(filePath: string, paths: JsonPathSpec): string {
       const resolvedPath = path.resolve(filePath);
       const projection = projectJsonFile(resolvedPath, paths);
-      record(recorded, { hash: hashBytes(Buffer.from(projection, 'utf8')), kind: 'inline', path: resolvedPath, paths });
+      record(recorded, { hash: hashProjection(projection), kind: 'inline', path: resolvedPath, paths });
       return projection;
     },
   };

--- a/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
@@ -113,7 +113,7 @@ describe(warnOnKitStaleness, () => {
       ]);
     });
 
-    it('advises recompiling when a file the compile inlined no longer matches', () => {
+    it('advises recompiling when a file the compile inlined has changed', () => {
       arrangeInputStale();
 
       expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([
@@ -122,6 +122,20 @@ describe(warnOnKitStaleness, () => {
           message: 'kit "default" inlined files that no longer match the ones on disk.',
           remedy: 'Run `rdy compile` to rebuild it.',
         },
+      ]);
+    });
+
+    it('advises on a changed input sitting beside one that is merely gone', () => {
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [
+          { kind: 'module', path: 'kits/gone.ts', reason: 'missing' },
+          { kind: 'module', path: 'kits/shared.ts', reason: 'changed', expected: '7777dddd', actual: '8888eeee' },
+        ],
+      });
+
+      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking()).map((w) => w.code)).toStrictEqual([
+        'input-stale',
       ]);
     });
 
@@ -234,6 +248,31 @@ describe(warnOnKitStaleness, () => {
     it('stays silent when both artifacts match the manifest', () => {
       expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
       expect(stderrText()).toBe('');
+    });
+
+    it('stays silent for an input the compile read that is gone, as it is for a deleted source', () => {
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [{ kind: 'module', path: 'kits/shared.ts', reason: 'missing' }],
+      });
+
+      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
+    });
+
+    it('stays silent for a projection it can no longer reproduce', () => {
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [
+          {
+            kind: 'inline',
+            path: '../../package.json',
+            reason: 'unprojectable',
+            detail: 'Path not found in JSON: version',
+          },
+        ],
+      });
+
+      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
     });
 
     it('stays silent for an entry that predates the recorded closure', () => {

--- a/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
@@ -7,6 +7,7 @@ import type { RdyManifestKit } from '../../manifest/manifestSchema.ts';
 
 const mockReadManifest = vi.hoisted(() => vi.fn());
 const mockCheckDrift = vi.hoisted(() => vi.fn());
+const mockCheckInputDrift = vi.hoisted(() => vi.fn());
 const mockCheckSourceDrift = vi.hoisted(() => vi.fn());
 
 vi.mock(import('../../manifest/readManifest.ts'), () => ({
@@ -15,6 +16,10 @@ vi.mock(import('../../manifest/readManifest.ts'), () => ({
 
 vi.mock(import('../../verify/checkDrift.ts'), () => ({
   checkDrift: mockCheckDrift,
+}));
+
+vi.mock(import('../../verify/checkInputDrift.ts'), () => ({
+  checkInputDrift: mockCheckInputDrift,
 }));
 
 vi.mock(import('../../verify/checkSourceDrift.ts'), () => ({
@@ -72,12 +77,14 @@ describe(warnOnKitStaleness, () => {
   beforeEach(() => {
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
+    mockCheckInputDrift.mockReturnValue({ kind: 'ok' });
     mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555bbbb' });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     mockCheckDrift.mockReset();
+    mockCheckInputDrift.mockReset();
     mockCheckSourceDrift.mockReset();
   });
 
@@ -103,6 +110,30 @@ describe(warnOnKitStaleness, () => {
           message: 'kit "default" was compiled from an older source than the one on disk.',
           remedy: 'Run `rdy compile` to rebuild it.',
         },
+      ]);
+    });
+
+    it('advises recompiling when a file the compile inlined no longer matches', () => {
+      arrangeInputStale();
+
+      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([
+        {
+          code: 'input-stale',
+          message: 'kit "default" inlined files that no longer match the ones on disk.',
+          remedy: 'Run `rdy compile` to rebuild it.',
+        },
+      ]);
+    });
+
+    it('raises all three advisories when every axis has parted from the manifest', () => {
+      arrangeTargetDrift();
+      arrangeSourceStale();
+      arrangeInputStale();
+
+      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking()).map((w) => w.code)).toStrictEqual([
+        'target-drift',
+        'source-stale',
+        'input-stale',
       ]);
     });
 
@@ -205,8 +236,15 @@ describe(warnOnKitStaleness, () => {
       expect(stderrText()).toBe('');
     });
 
+    it('stays silent for an entry that predates the recorded closure', () => {
+      mockCheckInputDrift.mockReturnValue({ kind: 'unverified' });
+
+      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
+    });
+
     it('stays silent when the manifest entry records no hashes to compare', () => {
       mockCheckDrift.mockReturnValue({ kind: 'unverified' });
+      mockCheckInputDrift.mockReturnValue({ kind: 'unverified' });
       mockCheckSourceDrift.mockReturnValue({ kind: 'unverified' });
 
       expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
@@ -219,9 +257,12 @@ describe(warnOnKitStaleness, () => {
       expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
     });
 
-    it('stays silent when neither file can be hashed', () => {
+    it('stays silent when no file it would compare can be read', () => {
       mockCheckDrift.mockImplementation(() => {
         throw new Error('EACCES: permission denied, open /abs/default.js');
+      });
+      mockCheckInputDrift.mockImplementation(() => {
+        throw new Error('EACCES: permission denied, open /abs/shared.ts');
       });
       mockCheckSourceDrift.mockImplementation(() => {
         throw new Error('EACCES: permission denied, open /abs/default.ts');
@@ -232,6 +273,16 @@ describe(warnOnKitStaleness, () => {
   });
 
   // region | Helpers
+
+  /** Reports a file the compile inlined as edited without a recompile. */
+  function arrangeInputStale(): void {
+    mockCheckInputDrift.mockReturnValue({
+      kind: 'stale',
+      failures: [
+        { kind: 'module', path: 'kits/shared.ts', reason: 'changed', expected: '7777dddd', actual: '8888eeee' },
+      ],
+    });
+  }
 
   /** Reports the source as edited without a recompile. */
   function arrangeSourceStale(): void {

--- a/packages/readyup/src/run/kit-staleness.ts
+++ b/packages/readyup/src/run/kit-staleness.ts
@@ -6,6 +6,7 @@ import type { RdyManifest } from '../manifest/manifestSchema.ts';
 import { readManifest } from '../manifest/readManifest.ts';
 import type { RaisedWarning } from '../schemas/common.ts';
 import { checkDrift } from '../verify/checkDrift.ts';
+import { checkInputDrift } from '../verify/checkInputDrift.ts';
 import { checkSourceDrift } from '../verify/checkSourceDrift.ts';
 import type { KitSource } from './ResolvedKitEntry.ts';
 
@@ -39,11 +40,14 @@ export function readManifestTracking(isJit: boolean): ManifestTracking | undefin
  *
  * `target-drift` says the compiled bundle is not the one the manifest recorded, so someone edited
  * it by hand. `source-stale` says the TypeScript it was built from has moved on, so the run is
- * about to execute checks that no longer match their source. Both can hold at once.
+ * about to execute checks that no longer match their source. `input-stale` says the same of a file
+ * the compile read and inlined, which is the staleness neither hash can see. All three can hold at
+ * once.
  *
  * Advisory by design: `rdy verify` is the enforcing gate, and this never touches the exit code. A
- * kit no entry describes, an entry recording no hash, a remote or just-in-time source, and a file
- * that cannot be hashed are all silent, because none of them is evidence that anything is stale.
+ * kit no entry describes, an entry recording no hash or no closure, a remote or just-in-time
+ * source, and a file that cannot be read are all silent, because none of them is evidence that
+ * anything is stale.
  *
  * The stderr lines are written in both modes; the returned entries are what JSON mode captures into
  * the report, so a consumer that owns only stdout still learns the run was advised of something.
@@ -70,6 +74,13 @@ export function warnOnKitStaleness(
     warnings.push({
       code: 'source-stale',
       message: `kit "${kitName}" was compiled from an older source than the one on disk.`,
+      remedy: 'Run `rdy compile` to rebuild it.',
+    });
+  }
+  if (hasVerdict(() => checkInputDrift(entry, tracking.manifestDir), 'stale')) {
+    warnings.push({
+      code: 'input-stale',
+      message: `kit "${kitName}" inlined files that no longer match the ones on disk.`,
       remedy: 'Run `rdy compile` to rebuild it.',
     });
   }

--- a/packages/readyup/src/run/kit-staleness.ts
+++ b/packages/readyup/src/run/kit-staleness.ts
@@ -6,6 +6,7 @@ import type { RdyManifest } from '../manifest/manifestSchema.ts';
 import { readManifest } from '../manifest/readManifest.ts';
 import type { RaisedWarning } from '../schemas/common.ts';
 import { checkDrift } from '../verify/checkDrift.ts';
+import type { InputsStatus } from '../verify/checkInputDrift.ts';
 import { checkInputDrift } from '../verify/checkInputDrift.ts';
 import { checkSourceDrift } from '../verify/checkSourceDrift.ts';
 import type { KitSource } from './ResolvedKitEntry.ts';
@@ -44,10 +45,11 @@ export function readManifestTracking(isJit: boolean): ManifestTracking | undefin
  * the compile read and inlined, which is the staleness neither hash can see. All three can hold at
  * once.
  *
- * Advisory by design: `rdy verify` is the enforcing gate, and this never touches the exit code. A
+ * Advisory by design: `rdy verify` is the enforcing gate, and this never touches the exit code.
+ * Every axis speaks only where it compared a recorded hash against a file and the two differed. A
  * kit no entry describes, an entry recording no hash or no closure, a remote or just-in-time
- * source, and a file that cannot be read are all silent, because none of them is evidence that
- * anything is stale.
+ * source, and a file that is gone or cannot be read are all silent, because none of them is
+ * evidence that anything changed.
  *
  * The stderr lines are written in both modes; the returned entries are what JSON mode captures into
  * the report, so a consumer that owns only stdout still learns the run was advised of something.
@@ -63,21 +65,21 @@ export function warnOnKitStaleness(
   if (entry === undefined) return [];
 
   const warnings: RaisedWarning[] = [];
-  if (hasVerdict(() => checkDrift(entry, tracking.manifestDir), 'drift')) {
+  if (readVerdict(() => checkDrift(entry, tracking.manifestDir))?.kind === 'drift') {
     warnings.push({
       code: 'target-drift',
       message: `compiled kit "${kitName}" does not match the hash the manifest recorded for it.`,
       remedy: 'Run `rdy compile --force` to rebuild it from source.',
     });
   }
-  if (hasVerdict(() => checkSourceDrift(entry, tracking.manifestDir), 'stale')) {
+  if (readVerdict(() => checkSourceDrift(entry, tracking.manifestDir))?.kind === 'stale') {
     warnings.push({
       code: 'source-stale',
       message: `kit "${kitName}" was compiled from an older source than the one on disk.`,
       remedy: 'Run `rdy compile` to rebuild it.',
     });
   }
-  if (hasVerdict(() => checkInputDrift(entry, tracking.manifestDir), 'stale')) {
+  if (hasChangedInput(readVerdict(() => checkInputDrift(entry, tracking.manifestDir)))) {
     warnings.push({
       code: 'input-stale',
       message: `kit "${kitName}" inlined files that no longer match the ones on disk.`,
@@ -107,12 +109,23 @@ function findManifestEntry(kitPath: string, tracking: ManifestTracking): RdyMani
   );
 }
 
-/** Reports whether a staleness predicate reaches the given verdict, treating a file it cannot hash as no. */
-function hasVerdict<TStatus extends { kind: string }>(check: () => TStatus, kind: TStatus['kind']): boolean {
+/**
+ * Reports whether a closure verdict names an input whose content moved since the compile read it.
+ *
+ * An input that is gone, or that no longer yields the projection a kit picked, says nothing about
+ * whether the kit is stale -- a published kit legitimately ships without the sources it was built
+ * from -- so only a hash the check compared and found different raises the advisory.
+ */
+function hasChangedInput(status: InputsStatus | undefined): boolean {
+  return status?.kind === 'stale' && status.failures.some((failure) => failure.reason === 'changed');
+}
+
+/** Returns a staleness verdict, or nothing when reaching one needed a file that cannot be read. */
+function readVerdict<TStatus>(check: () => TStatus): TStatus | undefined {
   try {
-    return check().kind === kind;
+    return check();
   } catch {
-    return false;
+    return undefined;
   }
 }
 

--- a/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
@@ -65,7 +65,7 @@ describe('generated JSON Schemas', () => {
 
     it('publishes the warning vocabulary as an open set that still names its known codes', () => {
       expect(valueAt(report, '$defs', 'WarningCode', 'anyOf')).toStrictEqual([
-        { type: 'string', enum: ['source-stale', 'target-drift'] },
+        { type: 'string', enum: ['input-stale', 'source-stale', 'target-drift'] },
         { type: 'string' },
       ]);
     });

--- a/packages/readyup/src/schemas/__tests__/fixtures/payloadFixtures.ts
+++ b/packages/readyup/src/schemas/__tests__/fixtures/payloadFixtures.ts
@@ -139,9 +139,38 @@ export const verifyPayload = {
   schemaVersion: 1,
   passed: false,
   kits: [
-    { name: 'deploy', status: 'ok', sourceStatus: 'ok' },
-    { name: 'release', status: 'drift', expected: 'abc123', actual: 'def456', sourceStatus: 'unverified' },
-    { name: 'preflight', status: 'ok', sourceStatus: 'stale', sourceExpected: '111aaa', sourceActual: '222bbb' },
+    { name: 'deploy', status: 'ok', sourceStatus: 'ok', inputsStatus: 'ok' },
+    {
+      name: 'release',
+      status: 'drift',
+      expected: 'abc123',
+      actual: 'def456',
+      sourceStatus: 'unverified',
+      inputsStatus: 'unverified',
+    },
+    {
+      name: 'preflight',
+      status: 'ok',
+      sourceStatus: 'stale',
+      sourceExpected: '111aaa',
+      sourceActual: '222bbb',
+      inputsStatus: 'ok',
+    },
+    {
+      name: 'publish',
+      status: 'ok',
+      sourceStatus: 'ok',
+      inputsStatus: 'stale',
+      inputFailures: [
+        { kind: 'module', path: 'kits/shared.ts', reason: 'changed', expected: '333ccc', actual: '444ddd' },
+        {
+          kind: 'inline',
+          path: '../../package.json',
+          reason: 'unprojectable',
+          detail: 'Path not found in JSON: version',
+        },
+      ],
+    },
   ],
 };
 

--- a/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
@@ -5,12 +5,13 @@ import { ZodError } from 'zod';
 
 import type { RdyErrorCode } from '../../errors/RdyError.ts';
 import type { Severity } from '../../kits/types.ts';
+import type { InputFailure } from '../../verify/checkInputDrift.ts';
 import type { JsonErrorCode, JsonSeverity, JsonWarning, JsonWarningCode, RaisedWarning } from '../common.ts';
 import { CompileOutputSchema } from '../compileOutputSchema.ts';
 import { ErrorEnvelopeSchema } from '../errorEnvelopeSchema.ts';
 import { ListOutputSchema } from '../listOutputSchema.ts';
 import { ReportSchema } from '../reportSchema.ts';
-import { VerifyOutputSchema } from '../verifyOutputSchema.ts';
+import { type JsonInputFailure, VerifyOutputSchema } from '../verifyOutputSchema.ts';
 import {
   compilePayload,
   errorEnvelopePayload,
@@ -237,6 +238,10 @@ describe('JSON payload schemas', () => {
   describe('derived types', () => {
     it('keeps the wire severity vocabulary in step with the runner type', () => {
       expectTypeOf<JsonSeverity>().toEqualTypeOf<Severity>();
+    });
+
+    it('keeps the published input failure in step with the verdict that produces it', () => {
+      expectTypeOf<JsonInputFailure>().toEqualTypeOf<InputFailure>();
     });
 
     it('keeps the wire error taxonomy in step with RdyErrorCode', () => {

--- a/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
@@ -244,8 +244,8 @@ describe('JSON payload schemas', () => {
     });
 
     it('binds a producer to the vocabulary this version declares while the wire stays open', () => {
-      expectTypeOf<RaisedWarning['code']>().toEqualTypeOf<'source-stale' | 'target-drift'>();
-      expectTypeOf<JsonWarning['code']>().not.toEqualTypeOf<'source-stale' | 'target-drift'>();
+      expectTypeOf<RaisedWarning['code']>().toEqualTypeOf<'input-stale' | 'source-stale' | 'target-drift'>();
+      expectTypeOf<JsonWarning['code']>().not.toEqualTypeOf<'input-stale' | 'source-stale' | 'target-drift'>();
     });
 
     it('publishes the known warning codes as distinguishable members of an open set', () => {
@@ -254,6 +254,7 @@ describe('JSON payload schemas', () => {
       expectTypeOf<JsonWarningCode>().not.toEqualTypeOf<string>();
       expectTypeOf<'target-drift'>().toExtend<JsonWarningCode>();
       expectTypeOf<'source-stale'>().toExtend<JsonWarningCode>();
+      expectTypeOf<'input-stale'>().toExtend<JsonWarningCode>();
       expectTypeOf<'kit-deprecated'>().toExtend<JsonWarningCode>();
     });
   });

--- a/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
@@ -196,6 +196,25 @@ describe('JSON payload schemas', () => {
       expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: false, kits })).not.toThrow();
     });
 
+    it('accepts a payload from a readyup that predates the inputs verdict', () => {
+      const kits = [{ name: 'deploy', status: 'ok', sourceStatus: 'ok' }];
+
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).not.toThrow();
+    });
+
+    it('rejects an inputs verdict outside the vocabulary', () => {
+      const kits = [{ name: 'deploy', status: 'ok', inputsStatus: 'missing' }];
+
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).toThrow(ZodError);
+    });
+
+    it('rejects an input failure that names no cause the vocabulary knows', () => {
+      const inputFailures = [{ kind: 'module', path: 'kits/shared.ts', reason: 'drifted' }];
+      const kits = [{ name: 'deploy', status: 'ok', inputsStatus: 'stale', inputFailures }];
+
+      expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: false, kits })).toThrow(ZodError);
+    });
+
     it('rejects a rebuild verdict outside the vocabulary', () => {
       const kits = [{ name: 'deploy', status: 'ok', rebuildStatus: 'unverified' }];
 

--- a/packages/readyup/src/schemas/common.ts
+++ b/packages/readyup/src/schemas/common.ts
@@ -50,7 +50,7 @@ export const CountsSchema = z
   .meta({ id: 'Counts' });
 
 /** The advisory vocabulary this version raises. `RaisedWarning` binds producers to it. */
-export const WarningCodeSchema = z.enum(['source-stale', 'target-drift']);
+export const WarningCodeSchema = z.enum(['input-stale', 'source-stale', 'target-drift']);
 
 /**
  * The wire form of a warning code: a known value, or any other string.

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -33,19 +33,26 @@ export const InputsStatusSchema = z.enum(['ok', 'stale', 'unverified']).meta({ i
  * One recorded input that no longer matches what the compile read.
  *
  * `path` is the file as the manifest records it, relative to the manifest directory, and `kind`
- * separates a module the bundle inlined from a JSON projection `pickJson` substituted. `expected`
- * and `actual` appear on `changed` alone; `detail` appears on `unprojectable` alone, where the file
- * is present and the fields the kit pinned to are gone.
+ * separates a module the bundle inlined from a JSON projection `pickJson` substituted.
+ *
+ * Discriminated on `reason` so each cause carries exactly what it compared, as `ManifestInputSchema`
+ * discriminates the record this reads back: `changed` carries the hash pair, `missing` carries
+ * neither, and `unprojectable` carries a diagnosis instead and is inline-only, since only a
+ * projection can fail to be reproduced. A consumer generating types from this narrows by `reason`
+ * rather than by hand over three fields that are independently optional.
  */
 export const InputFailureSchema = z
-  .object({
-    kind: z.enum(['inline', 'module']),
-    path: z.string(),
-    reason: z.enum(['changed', 'missing', 'unprojectable']),
-    expected: z.string().optional(),
-    actual: z.string().optional(),
-    detail: z.string().optional(),
-  })
+  .discriminatedUnion('reason', [
+    z.object({
+      kind: z.enum(['inline', 'module']),
+      path: z.string(),
+      reason: z.literal('changed'),
+      expected: z.string(),
+      actual: z.string(),
+    }),
+    z.object({ kind: z.enum(['inline', 'module']), path: z.string(), reason: z.literal('missing') }),
+    z.object({ kind: z.literal('inline'), path: z.string(), reason: z.literal('unprojectable'), detail: z.string() }),
+  ])
   .meta({ id: 'InputFailure' });
 
 /**

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -21,16 +21,44 @@ export const DriftStatusSchema = z.enum(['drift', 'missing', 'ok', 'unverified']
 export const SourceStatusSchema = z.enum(['missing', 'ok', 'stale', 'unverified']).meta({ id: 'SourceStatus' });
 
 /**
+ * Outcome of reading one kit's recorded input closure back off disk.
+ *
+ * A vocabulary of its own rather than a widening of any above, for the reason `SourceStatus`
+ * records. One axis carries every kind of input, with `inputFailures` naming which inputs failed
+ * and why, so a consumer branches on the cause rather than on a status per kind of input.
+ */
+export const InputsStatusSchema = z.enum(['ok', 'stale', 'unverified']).meta({ id: 'InputsStatus' });
+
+/**
+ * One recorded input that no longer matches what the compile read.
+ *
+ * `path` is the file as the manifest records it, relative to the manifest directory, and `kind`
+ * separates a module the bundle inlined from a JSON projection `pickJson` substituted. `expected`
+ * and `actual` appear on `changed` alone; `detail` appears on `unprojectable` alone, where the file
+ * is present and the fields the kit pinned to are gone.
+ */
+export const InputFailureSchema = z
+  .object({
+    kind: z.enum(['inline', 'module']),
+    path: z.string(),
+    reason: z.enum(['changed', 'missing', 'unprojectable']),
+    expected: z.string().optional(),
+    actual: z.string().optional(),
+    detail: z.string().optional(),
+  })
+  .meta({ id: 'InputFailure' });
+
+/**
  * Outcome of recompiling one kit and comparing the result to the bundle on disk.
  *
- * A third vocabulary rather than a widening of either enum above, for the reason `SourceStatus`
+ * A fourth vocabulary rather than a widening of any enum above, for the reason `SourceStatus`
  * already records: the verdicts answer different questions, and widening a closed enum breaks a
  * consumer that switches exhaustively over it.
  *
- * It has no `unverified`. The other two axes admit one because a manifest with no recorded hash
- * says nothing about whether the kit changed; here there is no bookkeeping to be absent, only
- * inputs the check needs, and a kit exempted from an exactness check would make a passing run mean
- * less than it says. `missing` covers every such absence and fails.
+ * It has no `unverified`. The other axes admit one because a manifest with no recorded hash says
+ * nothing about whether the kit changed; here there is no bookkeeping to be absent, only inputs the
+ * check needs, and a kit exempted from an exactness check would make a passing run mean less than
+ * it says. `missing` covers every such absence and fails.
  */
 export const RebuildStatusSchema = z.enum(['failed', 'mismatch', 'missing', 'ok']).meta({ id: 'RebuildStatus' });
 
@@ -40,8 +68,10 @@ export const RebuildStatusSchema = z.enum(['failed', 'mismatch', 'missing', 'ok'
  * `expected` and `actual` are the manifest's hash and the on-disk hash of the compiled bundle; both
  * are present only on a `drift` verdict, since no other status has two hashes to compare.
  * `sourceExpected` and `sourceActual` are their counterparts for the source, present only on
- * `stale`. `sourceStatus` is optional so a consumer pinned to this schema still validates a payload
- * from the readyup that predates the source verdict.
+ * `stale`. `inputFailures` is the same idea for the recorded input closure, present only on a
+ * `stale` `inputsStatus` and carrying one entry per input rather than a pair of hashes, since a kit
+ * can be stale in several inputs at once. `sourceStatus` and `inputsStatus` are optional so a
+ * consumer pinned to this schema still validates a payload from a readyup that predates either.
  *
  * `rebuildStatus` and its fields appear only under `--rebuild`, so a run without the flag emits the
  * payload it always did. `rebuildExpected` is the hash of the recompiled bytes and `rebuildActual`
@@ -59,6 +89,8 @@ export const VerifyKitEntrySchema = z
     sourceStatus: SourceStatusSchema.optional(),
     sourceExpected: z.string().optional(),
     sourceActual: z.string().optional(),
+    inputsStatus: InputsStatusSchema.optional(),
+    inputFailures: z.array(InputFailureSchema).optional(),
     rebuildStatus: RebuildStatusSchema.optional(),
     rebuildExpected: z.string().optional(),
     rebuildActual: z.string().optional(),
@@ -70,8 +102,8 @@ export const VerifyKitEntrySchema = z
 /**
  * Top-level shape of `rdy verify --json`.
  *
- * `passed` is true when both of every kit's verdicts are `ok` or `unverified`, agreeing with exit
- * code 0. An unreadable manifest produces the error envelope instead of this payload.
+ * `passed` is true when every one of every kit's verdicts is `ok` or `unverified`, agreeing with
+ * exit code 0. An unreadable manifest produces the error envelope instead of this payload.
  */
 export const VerifyOutputSchema = z
   .object({
@@ -82,6 +114,8 @@ export const VerifyOutputSchema = z
   .meta({ id: 'VerifyOutput' });
 
 export type JsonDriftStatus = z.infer<typeof DriftStatusSchema>;
+export type JsonInputFailure = z.infer<typeof InputFailureSchema>;
+export type JsonInputsStatus = z.infer<typeof InputsStatusSchema>;
 export type JsonRebuildStatus = z.infer<typeof RebuildStatusSchema>;
 export type JsonSourceStatus = z.infer<typeof SourceStatusSchema>;
 export type JsonVerifyKitEntry = z.infer<typeof VerifyKitEntrySchema>;

--- a/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
@@ -1,0 +1,182 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { RdyManifestInput, RdyManifestKit } from '../../manifest/manifestSchema.ts';
+import { checkInputDrift } from '../checkInputDrift.ts';
+import { hashBytes, hashProjection } from '../targetHash.ts';
+
+const MODULE_SOURCE = 'export const shared = 1;\n';
+const PACKAGE_JSON = { name: 'demo', private: true, version: '3.1.0' };
+
+/** The module fixture as the compile recorded it. */
+const RECORDED_MODULE: RdyManifestInput = {
+  hash: hashBytes(Buffer.from(MODULE_SOURCE)),
+  kind: 'module',
+  path: 'kits/shared.ts',
+};
+
+/** The package fixture as the compile recorded it, projected onto the one field a kit picked. */
+const RECORDED_PICK: RdyManifestInput = {
+  hash: hashProjection(JSON.stringify({ version: PACKAGE_JSON.version })),
+  kind: 'inline',
+  path: 'package.json',
+  paths: ['version'],
+};
+
+describe(checkInputDrift, () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'input-drift-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns ok when every recorded input still matches', () => {
+    writeInput('kits/shared.ts', MODULE_SOURCE);
+    writeInput('package.json', JSON.stringify(PACKAGE_JSON));
+
+    expect(checkInputDrift(kitWith([RECORDED_MODULE, RECORDED_PICK]), tempDir)).toStrictEqual({ kind: 'ok' });
+  });
+
+  it('returns unverified for an entry that predates the closure', () => {
+    expect(checkInputDrift({ name: 'demo' }, tempDir)).toStrictEqual({ kind: 'unverified' });
+  });
+
+  describe('a module input', () => {
+    it('reports a changed module with both hashes and the file that carries them', () => {
+      writeInput('kits/shared.ts', 'export const shared = 2;\n');
+
+      expect(checkInputDrift(kitWith([RECORDED_MODULE]), tempDir)).toStrictEqual({
+        kind: 'stale',
+        failures: [
+          {
+            kind: 'module',
+            path: 'kits/shared.ts',
+            reason: 'changed',
+            expected: RECORDED_MODULE.hash,
+            actual: hashBytes(Buffer.from('export const shared = 2;\n')),
+          },
+        ],
+      });
+    });
+
+    it('reports a module the compile read that is no longer on disk', () => {
+      expect(checkInputDrift(kitWith([RECORDED_MODULE]), tempDir)).toStrictEqual({
+        kind: 'stale',
+        failures: [{ kind: 'module', path: 'kits/shared.ts', reason: 'missing' }],
+      });
+    });
+  });
+
+  describe('an inline input', () => {
+    it('reports a projection whose picked field has changed', () => {
+      writeInput('package.json', JSON.stringify({ ...PACKAGE_JSON, version: '4.0.0' }));
+
+      expect(checkInputDrift(kitWith([RECORDED_PICK]), tempDir)).toStrictEqual({
+        kind: 'stale',
+        failures: [
+          {
+            kind: 'inline',
+            path: 'package.json',
+            reason: 'changed',
+            expected: RECORDED_PICK.hash,
+            actual: hashProjection(JSON.stringify({ version: '4.0.0' })),
+          },
+        ],
+      });
+    });
+
+    it('leaves an edit to a field the kit did not pick as ok', () => {
+      writeInput('package.json', JSON.stringify({ ...PACKAGE_JSON, name: 'renamed' }));
+
+      expect(checkInputDrift(kitWith([RECORDED_PICK]), tempDir)).toStrictEqual({ kind: 'ok' });
+    });
+
+    it('reports a vanished picked field apart from a hash that moved', () => {
+      writeInput('package.json', JSON.stringify({ name: 'demo' }));
+
+      expect(checkInputDrift(kitWith([RECORDED_PICK]), tempDir)).toStrictEqual({
+        kind: 'stale',
+        failures: [
+          { kind: 'inline', path: 'package.json', reason: 'unprojectable', detail: 'Path not found in JSON: version' },
+        ],
+      });
+    });
+
+    it('reports a file that is no longer valid JSON without repeating its path', () => {
+      writeInput('package.json', '{ not json');
+
+      expect(checkInputDrift(kitWith([RECORDED_PICK]), tempDir)).toStrictEqual({
+        kind: 'stale',
+        failures: [{ kind: 'inline', path: 'package.json', reason: 'unprojectable', detail: 'invalid JSON' }],
+      });
+    });
+
+    it('reports a file whose root is no longer an object', () => {
+      writeInput('package.json', '42');
+
+      expect(checkInputDrift(kitWith([RECORDED_PICK]), tempDir)).toStrictEqual({
+        kind: 'stale',
+        failures: [
+          {
+            kind: 'inline',
+            path: 'package.json',
+            reason: 'unprojectable',
+            detail: 'expected a JSON object, got number',
+          },
+        ],
+      });
+    });
+
+    it('reports a projected file that is no longer on disk', () => {
+      expect(checkInputDrift(kitWith([RECORDED_PICK]), tempDir)).toStrictEqual({
+        kind: 'stale',
+        failures: [{ kind: 'inline', path: 'package.json', reason: 'missing' }],
+      });
+    });
+  });
+
+  it('reports every input that failed, so one pass names everything to fix', () => {
+    writeInput('kits/shared.ts', 'export const shared = 2;\n');
+    writeInput('package.json', JSON.stringify({ ...PACKAGE_JSON, version: '4.0.0' }));
+
+    const status = checkInputDrift(kitWith([RECORDED_MODULE, RECORDED_PICK]), tempDir);
+
+    expect(status.kind === 'stale' && status.failures.map((failure) => failure.path)).toStrictEqual([
+      'kits/shared.ts',
+      'package.json',
+    ]);
+  });
+
+  it('resolves each recorded path against the manifest directory', () => {
+    const manifestDir = path.join(tempDir, '.readyup');
+    mkdirSync(manifestDir, { recursive: true });
+    writeInput('kits/shared.ts', MODULE_SOURCE);
+
+    const status = checkInputDrift(kitWith([{ ...RECORDED_MODULE, path: '../kits/shared.ts' }]), manifestDir);
+
+    expect(status).toStrictEqual({ kind: 'ok' });
+  });
+
+  // region | Helpers
+
+  /** A manifest entry recording the given closure and nothing else this axis reads. */
+  function kitWith(inputs: RdyManifestInput[]): RdyManifestKit {
+    return { inputs, name: 'demo' };
+  }
+
+  /** Writes a fixture under the temp directory, creating any parent directories. */
+  function writeInput(relPath: string, contents: string): void {
+    const filePath = path.join(tempDir, relPath);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, contents);
+  }
+
+  // endregion | Helpers
+});

--- a/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
@@ -134,6 +134,15 @@ describe(checkInputDrift, () => {
       });
     });
 
+    it('reports a file that is present but cannot be read', () => {
+      mkdirSync(path.join(tempDir, 'package.json'), { recursive: true });
+
+      expect(checkInputDrift(kitWith([RECORDED_PICK]), tempDir)).toStrictEqual({
+        kind: 'stale',
+        failures: [{ kind: 'inline', path: 'package.json', reason: 'unprojectable', detail: 'unreadable' }],
+      });
+    });
+
     it('reports a projected file that is no longer on disk', () => {
       expect(checkInputDrift(kitWith([RECORDED_PICK]), tempDir)).toStrictEqual({
         kind: 'stale',

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 
 const mockReadManifest = vi.hoisted(() => vi.fn());
 const mockCheckDrift = vi.hoisted(() => vi.fn());
+const mockCheckInputDrift = vi.hoisted(() => vi.fn());
 const mockCheckSourceDrift = vi.hoisted(() => vi.fn());
 const mockCheckRebuild = vi.hoisted(() => vi.fn());
 const mockLoadEsbuild = vi.hoisted(() => vi.fn());
@@ -16,6 +17,10 @@ vi.mock(import('../../manifest/readManifest.ts'), async (importOriginal) => {
 
 vi.mock(import('../checkDrift.ts'), () => ({
   checkDrift: mockCheckDrift,
+}));
+
+vi.mock(import('../checkInputDrift.ts'), () => ({
+  checkInputDrift: mockCheckInputDrift,
 }));
 
 vi.mock(import('../checkSourceDrift.ts'), () => ({
@@ -45,6 +50,7 @@ describe(verifyCommand, () => {
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockCheckInputDrift.mockReturnValue({ kind: 'unverified' });
     mockCheckSourceDrift.mockReturnValue({ kind: 'unverified' });
     mockLoadEsbuild.mockResolvedValue({ build: vi.fn() });
   });
@@ -53,6 +59,7 @@ describe(verifyCommand, () => {
     vi.restoreAllMocks();
     mockReadManifest.mockReset();
     mockCheckDrift.mockReset();
+    mockCheckInputDrift.mockReset();
     mockCheckSourceDrift.mockReset();
     mockCheckRebuild.mockReset();
     mockLoadEsbuild.mockReset();
@@ -218,6 +225,139 @@ describe(verifyCommand, () => {
           `${FAILED} alpha\n   drift (expected aaaa1111, got aaaa9999)\n   source stale (expected 5555aaaa, got 6666bbbb)`,
         ),
       );
+    });
+  });
+
+  describe('inputs verdict', () => {
+    /** A manifest naming one kit whose two hash verdicts both pass, leaving the inputs axis alone to speak. */
+    function arrangeSingleKit(): void {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'alpha', path: 'alpha.js', source: 'alpha.ts', targetHash: 'aaaa1111' }],
+      });
+      mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
+      mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
+    }
+
+    it('fails a kit whose inlined module has changed, naming the file and its kind', async () => {
+      arrangeSingleKit();
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [
+          { kind: 'module', path: 'kits/shared.ts', reason: 'changed', expected: '1111aaaa', actual: '2222bbbb' },
+        ],
+      });
+
+      const exitCode = await verifyCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `${FAILED} alpha\n   input stale: kits/shared.ts (module, expected 1111aaaa, got 2222bbbb)`,
+        ),
+      );
+    });
+
+    it('names a changed inline projection as inline, apart from a changed module', async () => {
+      arrangeSingleKit();
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [
+          { kind: 'inline', path: '../../package.json', reason: 'changed', expected: '3333cccc', actual: '4444dddd' },
+        ],
+      });
+
+      await verifyCommand([]);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining('input stale: ../../package.json (inline, expected 3333cccc, got 4444dddd)'),
+      );
+    });
+
+    it('reports a picked field that has vanished with what went wrong rather than a pair of hashes', async () => {
+      arrangeSingleKit();
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [
+          {
+            kind: 'inline',
+            path: '../../package.json',
+            reason: 'unprojectable',
+            detail: 'Path not found in JSON: version',
+          },
+        ],
+      });
+
+      const exitCode = await verifyCommand([]);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining('input unprojectable: ../../package.json (Path not found in JSON: version)'),
+      );
+    });
+
+    it('reports an input the compile read that is gone', async () => {
+      arrangeSingleKit();
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [{ kind: 'module', path: 'kits/shared.ts', reason: 'missing' }],
+      });
+
+      await verifyCommand([]);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('input missing: kits/shared.ts (module)'));
+    });
+
+    it('gives every failed input its own line beneath the kit', async () => {
+      arrangeSingleKit();
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [
+          { kind: 'module', path: 'kits/shared.ts', reason: 'missing' },
+          { kind: 'inline', path: '../../package.json', reason: 'changed', expected: '3333cccc', actual: '4444dddd' },
+        ],
+      });
+
+      await verifyCommand([]);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `${FAILED} alpha\n   input missing: kits/shared.ts (module)\n` +
+            '   input stale: ../../package.json (inline, expected 3333cccc, got 4444dddd)',
+        ),
+      );
+    });
+
+    it('passes a kit whose inputs match, leaving the line unchanged', async () => {
+      arrangeSingleKit();
+      mockCheckInputDrift.mockReturnValue({ kind: 'ok' });
+
+      const exitCode = await verifyCommand([]);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+    });
+
+    it('passes an entry that predates the closure, leaving the line it produces today unchanged', async () => {
+      arrangeSingleKit();
+
+      const exitCode = await verifyCommand([]);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+    });
+
+    it('speaks a passing rebuild over a stale input, where it names the manifest as what went wrong', async () => {
+      arrangeSingleKit();
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [{ kind: 'module', path: 'kits/shared.ts', reason: 'missing' }],
+      });
+      mockCheckRebuild.mockResolvedValue({ kind: 'ok' });
+
+      await verifyCommand(['--rebuild']);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('rebuild ok'));
     });
   });
 

--- a/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
@@ -5,7 +5,8 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 import { richFormatter } from '../../layout/richFormatter.ts';
-import { hashBytes } from '../targetHash.ts';
+import { VerifyOutputSchema } from '../../schemas/verifyOutputSchema.ts';
+import { hashBytes, hashProjection } from '../targetHash.ts';
 import { verifyCommand } from '../verifyCommand.ts';
 
 /**
@@ -159,6 +160,121 @@ describe('verifyCommand wiring', () => {
     });
   });
 
+  describe('input staleness', () => {
+    const SHARED_MODULE = Buffer.from('export const shared = 1;\n');
+    const PACKAGE_JSON = { name: 'demo', version: '3.1.0' };
+
+    /**
+     * Writes a kit whose compile read a sibling module and a version out of `package.json`, and a
+     * manifest recording all of it.
+     *
+     * The two hash verdicts are arranged to pass, so whatever the run reports comes from the closure.
+     */
+    function writeRecordedClosure(): void {
+      const compiled = Buffer.from('export default { checklists: [] };\n');
+      const source = Buffer.from('export default defineRdyKit({ checklists: [] });\n');
+      writeFileSync(path.join(tempDir, 'demo.js'), compiled);
+      writeFileSync(path.join(tempDir, 'demo.ts'), source);
+      writeFileSync(path.join(tempDir, 'shared.ts'), SHARED_MODULE);
+      writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify(PACKAGE_JSON));
+      writeFileSync(
+        path.join(tempDir, 'manifest.json'),
+        JSON.stringify({
+          version: 1,
+          kits: [
+            {
+              name: 'demo',
+              path: 'demo.js',
+              source: 'demo.ts',
+              sourceHash: hashBytes(source),
+              targetHash: hashBytes(compiled),
+              inputs: [
+                { hash: hashBytes(SHARED_MODULE), kind: 'module', path: 'shared.ts' },
+                {
+                  hash: hashProjection(JSON.stringify({ version: PACKAGE_JSON.version })),
+                  kind: 'inline',
+                  path: 'package.json',
+                  paths: ['version'],
+                },
+              ],
+            },
+          ],
+        }),
+      );
+    }
+
+    it('returns 0 when every file the compile read still matches', async () => {
+      writeRecordedClosure();
+
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
+    });
+
+    it('returns 1 when a module the bundle inlined was edited without a recompile', async () => {
+      writeRecordedClosure();
+      writeFileSync(path.join(tempDir, 'shared.ts'), 'export const shared = 2;\n');
+
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`${FAILED} demo\n   input stale: shared.ts (module`),
+      );
+    });
+
+    it('returns 1 when the version the kit pinned to has moved', async () => {
+      writeRecordedClosure();
+      writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ ...PACKAGE_JSON, version: '4.0.0' }));
+
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+
+      expect(exitCode).toBe(1);
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`${FAILED} demo\n   input stale: package.json (inline`),
+      );
+    });
+
+    it('returns 0 when a field the kit did not pick was edited', async () => {
+      writeRecordedClosure();
+      writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ ...PACKAGE_JSON, name: 'renamed' }));
+
+      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+
+      expect(exitCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
+    });
+
+    it('carries the axis and every failure into the JSON entry, at the schema version it always emitted', async () => {
+      writeRecordedClosure();
+      writeFileSync(path.join(tempDir, 'shared.ts'), 'export const shared = 2;\n');
+      writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'demo' }));
+
+      await verifyCommand(['--manifest', 'manifest.json', '--json']);
+
+      expect(VerifyOutputSchema.parse(JSON.parse(stdout.join('')))).toMatchObject({
+        schemaVersion: 1,
+        passed: false,
+        kits: [
+          {
+            name: 'demo',
+            inputsStatus: 'stale',
+            inputFailures: [
+              { kind: 'module', path: 'shared.ts', reason: 'changed', expected: hashBytes(SHARED_MODULE) },
+              {
+                kind: 'inline',
+                path: 'package.json',
+                reason: 'unprojectable',
+                detail: 'Path not found in JSON: version',
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
   describe('--json', () => {
     /** Write a manifest naming one matching kit, one drifted kit, and one with no recorded hash. */
     function writeMixedManifest(): void {
@@ -189,16 +305,17 @@ describe('verifyCommand wiring', () => {
         schemaVersion: 1,
         passed: false,
         kits: [
-          { name: 'clean', status: 'ok', sourceStatus: 'unverified' },
+          { name: 'clean', status: 'ok', sourceStatus: 'unverified', inputsStatus: 'unverified' },
           {
             name: 'edited',
             status: 'drift',
             expected: 'deadbeef',
             actual: expect.any(String),
             sourceStatus: 'unverified',
+            inputsStatus: 'unverified',
           },
-          { name: 'gone', status: 'missing', sourceStatus: 'unverified' },
-          { name: 'unhashed', status: 'unverified', sourceStatus: 'unverified' },
+          { name: 'gone', status: 'missing', sourceStatus: 'unverified', inputsStatus: 'unverified' },
+          { name: 'unhashed', status: 'unverified', sourceStatus: 'unverified', inputsStatus: 'unverified' },
         ],
       });
     });

--- a/packages/readyup/src/verify/checkInputDrift.ts
+++ b/packages/readyup/src/verify/checkInputDrift.ts
@@ -1,0 +1,95 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { describeError } from '@williamthorsen/toolbelt.errors';
+
+import { JsonProjectionError } from '../compile/JsonProjectionError.ts';
+import { projectJsonFile } from '../compile/projectJsonFile.ts';
+import type { RdyManifestInput, RdyManifestKit } from '../manifest/manifestSchema.ts';
+import { hashFile, hashProjection } from './targetHash.ts';
+
+/**
+ * One recorded input that no longer matches what the compile read, and why.
+ *
+ * `changed` and `missing` describe either kind of input. `unprojectable` is inline-only: the file is
+ * present and the fields the kit pinned to are not, which says something different about the kit than a
+ * hash that moved and so is reported apart from one.
+ *
+ * `path` is the input as the manifest records it, relative to the manifest directory.
+ */
+export type InputFailure =
+  | { kind: 'inline' | 'module'; path: string; reason: 'changed'; expected: string; actual: string }
+  | { kind: 'inline' | 'module'; path: string; reason: 'missing' }
+  | { kind: 'inline'; path: string; reason: 'unprojectable'; detail: string };
+
+/** Outcome of a per-kit input-closure check. */
+export type InputsStatus = { kind: 'ok' } | { kind: 'stale'; failures: InputFailure[] } | { kind: 'unverified' };
+
+/**
+ * Determines whether everything a kit's compile read still matches what the manifest recorded for it.
+ *
+ * The axis the two hash verdicts leave uncovered: a bundle is a function of every module it inlined and
+ * every JSON projection `pickJson` substituted, none of which `sourceHash` or `targetHash` describes.
+ *
+ * Reports every input that failed rather than the first, so one pass names everything to fix. Returns
+ * `unverified` when the entry records no `inputs`, which means it predates the closure and says nothing
+ * about whether the kit is stale.
+ */
+export function checkInputDrift(kit: RdyManifestKit, manifestDir: string): InputsStatus {
+  if (kit.inputs === undefined) return { kind: 'unverified' };
+
+  const failures = kit.inputs
+    .map((input) => checkInput(input, manifestDir))
+    .filter((failure): failure is InputFailure => failure !== undefined);
+
+  return failures.length === 0 ? { kind: 'ok' } : { kind: 'stale', failures };
+}
+
+// region | Helpers
+
+/** Returns what is wrong with one recorded input, or nothing when it still matches. */
+function checkInput(input: RdyManifestInput, manifestDir: string): InputFailure | undefined {
+  const resolvedPath = path.resolve(manifestDir, input.path);
+  if (!existsSync(resolvedPath)) {
+    return { kind: input.kind, path: input.path, reason: 'missing' };
+  }
+
+  if (input.kind === 'module') {
+    const actual = hashFile(resolvedPath);
+    if (actual === input.hash) return undefined;
+    return { kind: 'module', path: input.path, reason: 'changed', expected: input.hash, actual };
+  }
+
+  let actual: string;
+  try {
+    actual = hashProjection(projectJsonFile(resolvedPath, input.paths));
+  } catch (error: unknown) {
+    return { kind: 'inline', path: input.path, reason: 'unprojectable', detail: describeProjectionFailure(error) };
+  }
+
+  if (actual === input.hash) return undefined;
+  return { kind: 'inline', path: input.path, reason: 'changed', expected: input.hash, actual };
+}
+
+/**
+ * Returns why a JSON file could not be projected, in a form that does not repeat the path beside it.
+ *
+ * The error's own message names the file absolutely, which the failure already names as the manifest
+ * records it. Reading the diagnosis off `reason` is what keeps the two from disagreeing about the path.
+ */
+function describeProjectionFailure(error: unknown): string {
+  if (!(error instanceof JsonProjectionError)) return describeError(error);
+
+  switch (error.reason) {
+    case 'invalid-json':
+      return 'invalid JSON';
+    case 'not-an-object':
+      return `expected a JSON object, got ${error.detail ?? 'something else'}`;
+    case 'path-not-found':
+      return error.message;
+    case 'unreadable':
+      return 'unreadable';
+  }
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/verify/targetHash.ts
+++ b/packages/readyup/src/verify/targetHash.ts
@@ -13,3 +13,13 @@ export function hashBytes(bytes: Buffer): string {
 export function hashFile(filePath: string): string {
   return hashBytes(readFileSync(filePath));
 }
+
+/**
+ * Return the hash of a serialized JSON projection, which is what a recorded inline input carries.
+ *
+ * The compile and every reader of a recorded input hash the projection through here, so neither can
+ * encode it differently and report a file neither changed as stale.
+ */
+export function hashProjection(projection: string): string {
+  return hashBytes(Buffer.from(projection, 'utf8'));
+}

--- a/packages/readyup/src/verify/targetHash.ts
+++ b/packages/readyup/src/verify/targetHash.ts
@@ -15,7 +15,7 @@ export function hashFile(filePath: string): string {
 }
 
 /**
- * Return the hash of a serialized JSON projection, which is what a recorded inline input carries.
+ * Returns the hash of a serialized JSON projection, which is what a recorded inline input carries.
  *
  * The compile and every reader of a recorded input hash the projection through here, so neither can
  * encode it differently and report a file neither changed as stale.

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -19,10 +19,20 @@ import { type JsonVerifyKitEntry, type JsonVerifyOutput, SCHEMA_VERSION } from '
 import { VERSION } from '../version.ts';
 import type { DriftStatus } from './checkDrift.ts';
 import { checkDrift } from './checkDrift.ts';
+import type { InputFailure, InputsStatus } from './checkInputDrift.ts';
+import { checkInputDrift } from './checkInputDrift.ts';
 import type { RebuildStatus } from './checkRebuild.ts';
 import { checkRebuild } from './checkRebuild.ts';
 import type { SourceStatus } from './checkSourceDrift.ts';
 import { checkSourceDrift } from './checkSourceDrift.ts';
+
+/** Every verdict one kit reached, gathered so each pass over a kit reads the same set. */
+interface KitVerdicts {
+  drift: DriftStatus;
+  inputs: InputsStatus;
+  rebuild: RebuildStatus | undefined;
+  source: SourceStatus;
+}
 
 const verifyOptions = {
   json: { type: 'boolean' },
@@ -36,7 +46,7 @@ const verifyOptions = {
  * Handles the `verify` subcommand: reads the manifest, hashes each kit's source and compiled
  * output, and reports what no longer matches.
  *
- * Each kit carries two independent verdicts, and a third under `--rebuild`. Returns 0 when every
+ * Each kit carries three independent verdicts, and a fourth under `--rebuild`. Returns 0 when every
  * verdict is `ok` or `unverified`; 1 when any kit has drifted, gone stale, lost a file, or failed
  * to reproduce. An unreadable manifest is a config failure and is thrown rather than reported as
  * drift, as is a `--rebuild` run with no esbuild to rebuild with.
@@ -88,12 +98,15 @@ export async function verifyCommand(args: string[]): Promise<number> {
   const entries: JsonVerifyKitEntry[] = [];
   let failed = 0;
   for (const kit of manifest.kits) {
-    const status = checkDrift(kit, manifestDir);
-    const sourceStatus = checkSourceDrift(kit, manifestDir);
-    const rebuildStatus = rebuild ? await checkRebuild(kit, manifestDir) : undefined;
-    writeHuman(formatStatusLine(kit, status, sourceStatus, rebuildStatus), json);
-    entries.push(buildVerifyEntry(kit.name, status, sourceStatus, rebuildStatus));
-    if (!isPassingVerdict(status, sourceStatus, rebuildStatus)) {
+    const verdicts: KitVerdicts = {
+      drift: checkDrift(kit, manifestDir),
+      inputs: checkInputDrift(kit, manifestDir),
+      rebuild: rebuild ? await checkRebuild(kit, manifestDir) : undefined,
+      source: checkSourceDrift(kit, manifestDir),
+    };
+    writeHuman(formatStatusLine(kit, verdicts), json);
+    entries.push(buildVerifyEntry(kit.name, verdicts));
+    if (!isPassingVerdict(verdicts)) {
       failed += 1;
     }
   }
@@ -139,45 +152,39 @@ function finishVerify(kits: JsonVerifyKitEntry[], passed: boolean, json: boolean
  * so every case is accounted for; the wire shape leaves `sourceStatus` optional for consumers that
  * predate it, and a verdict derived from an optional field has an absent case to get wrong.
  *
- * `unverified` passes on either hash axis: a manifest entry with no recorded hash predates the
- * feature or was written with `--skip-manifest`, which says nothing about whether the kit has
+ * `unverified` passes on every recorded-hash axis: a manifest entry with no recorded hash predates
+ * the feature or was written with `--skip-manifest`, which says nothing about whether the kit has
  * changed. The rebuild axis has no such case -- only `ok` passes there, and a kit the rebuild could
  * not reach an answer for fails rather than being waived.
  */
-function isPassingVerdict(
-  status: DriftStatus,
-  sourceStatus: SourceStatus,
-  rebuildStatus: RebuildStatus | undefined,
-): boolean {
-  const targetPasses = status.kind === 'ok' || status.kind === 'unverified';
-  const sourcePasses = sourceStatus.kind === 'ok' || sourceStatus.kind === 'unverified';
-  const rebuildPasses = rebuildStatus === undefined || rebuildStatus.kind === 'ok';
-  return targetPasses && sourcePasses && rebuildPasses;
+function isPassingVerdict({ drift, inputs, rebuild, source }: KitVerdicts): boolean {
+  const targetPasses = drift.kind === 'ok' || drift.kind === 'unverified';
+  const sourcePasses = source.kind === 'ok' || source.kind === 'unverified';
+  const inputsPass = inputs.kind === 'ok' || inputs.kind === 'unverified';
+  const rebuildPasses = rebuild === undefined || rebuild.kind === 'ok';
+  return targetPasses && sourcePasses && inputsPass && rebuildPasses;
 }
 
-/** Builds a kit's JSON entry, carrying a pair of hashes only on a verdict that compared them. */
-function buildVerifyEntry(
-  name: string,
-  status: DriftStatus,
-  sourceStatus: SourceStatus,
-  rebuildStatus: RebuildStatus | undefined,
-): JsonVerifyKitEntry {
+/** Builds a kit's JSON entry, carrying what a verdict compared only where it compared something. */
+function buildVerifyEntry(name: string, { drift, inputs, rebuild, source }: KitVerdicts): JsonVerifyKitEntry {
   return {
     name,
-    status: status.kind,
-    ...(status.kind === 'drift' && { expected: status.expected, actual: status.actual }),
-    sourceStatus: sourceStatus.kind,
-    ...(sourceStatus.kind === 'stale' && {
-      sourceExpected: sourceStatus.expected,
-      sourceActual: sourceStatus.actual,
+    status: drift.kind,
+    ...(drift.kind === 'drift' && { expected: drift.expected, actual: drift.actual }),
+    sourceStatus: source.kind,
+    ...(source.kind === 'stale' && {
+      sourceExpected: source.expected,
+      sourceActual: source.actual,
     }),
-    ...(rebuildStatus !== undefined && { rebuildStatus: rebuildStatus.kind }),
-    ...(rebuildStatus?.kind === 'mismatch' && {
-      rebuildExpected: rebuildStatus.expected,
-      rebuildActual: rebuildStatus.actual,
-      ...(rebuildStatus.compiledWith !== undefined && { rebuildCompiledWith: rebuildStatus.compiledWith }),
+    inputsStatus: inputs.kind,
+    ...(inputs.kind === 'stale' && { inputFailures: inputs.failures }),
+    ...(rebuild !== undefined && { rebuildStatus: rebuild.kind }),
+    ...(rebuild?.kind === 'mismatch' && {
+      rebuildExpected: rebuild.expected,
+      rebuildActual: rebuild.actual,
+      ...(rebuild.compiledWith !== undefined && { rebuildCompiledWith: rebuild.compiledWith }),
     }),
-    ...(rebuildStatus?.kind === 'failed' && { rebuildError: rebuildStatus.message }),
+    ...(rebuild?.kind === 'failed' && { rebuildError: rebuild.message }),
   };
 }
 
@@ -187,18 +194,15 @@ function buildVerifyEntry(
  * A failing kit carries each verdict on its own line beneath its name; any other kit carries them
  * inline. A kit that passes every verdict carries none, leaving its token to report the outcome.
  */
-function formatStatusLine(
-  kit: RdyManifestKit,
-  status: DriftStatus,
-  sourceStatus: SourceStatus,
-  rebuildStatus: RebuildStatus | undefined,
-): string {
-  const token = resolveToken(status, sourceStatus, rebuildStatus);
-  const hashesConfirmed = status.kind === 'ok' && sourceStatus.kind === 'ok';
+function formatStatusLine(kit: RdyManifestKit, verdicts: KitVerdicts): string {
+  const { drift, inputs, rebuild, source } = verdicts;
+  const token = resolveToken(verdicts);
+  const hashesConfirmed = drift.kind === 'ok' && source.kind === 'ok' && inputs.kind !== 'stale';
   const clauses = [
-    describeDriftStatus(kit, status),
-    describeSourceStatus(kit, sourceStatus),
-    describeRebuildStatus(rebuildStatus, hashesConfirmed),
+    describeDriftStatus(kit, drift),
+    describeSourceStatus(kit, source),
+    ...describeInputsStatus(inputs),
+    describeRebuildStatus(rebuild, hashesConfirmed),
   ].filter((clause): clause is string => clause !== undefined);
 
   if (token === 'failedError') {
@@ -217,14 +221,11 @@ function formatStatusLine(
  * target and no answer from the rebuild: a rebuild that reproduced the bundle has checked the kit
  * more exactly than the absent hash would have, so the kit passed rather than went unchecked.
  */
-function resolveToken(
-  status: DriftStatus,
-  sourceStatus: SourceStatus,
-  rebuildStatus: RebuildStatus | undefined,
-): TokenName {
-  const rebuildFailed = rebuildStatus !== undefined && rebuildStatus.kind !== 'ok';
-  if (hasTargetFailed(status) || hasSourceFailed(sourceStatus) || rebuildFailed) return 'failedError';
-  if (status.kind === 'unverified' && rebuildStatus?.kind !== 'ok') return 'skippedOptional';
+function resolveToken({ drift, inputs, rebuild, source }: KitVerdicts): TokenName {
+  const rebuildFailed = rebuild !== undefined && rebuild.kind !== 'ok';
+  const anyFailed = hasTargetFailed(drift) || hasSourceFailed(source) || inputs.kind === 'stale' || rebuildFailed;
+  if (anyFailed) return 'failedError';
+  if (drift.kind === 'unverified' && rebuild?.kind !== 'ok') return 'skippedOptional';
   return 'passed';
 }
 
@@ -265,10 +266,27 @@ function describeSourceStatus(kit: RdyManifestKit, status: SourceStatus): string
   }
 }
 
+/** Returns one clause per failed input, and none when the verdict is `ok` or `unverified`. */
+function describeInputsStatus(status: InputsStatus): string[] {
+  return status.kind === 'stale' ? status.failures.map(describeInputFailure) : [];
+}
+
+/** Returns a clause naming one input the compile read and what has happened to it since. */
+function describeInputFailure(failure: InputFailure): string {
+  switch (failure.reason) {
+    case 'changed':
+      return `input stale: ${failure.path} (${failure.kind}, expected ${failure.expected}, got ${failure.actual})`;
+    case 'missing':
+      return `input missing: ${failure.path} (${failure.kind})`;
+    case 'unprojectable':
+      return `input unprojectable: ${failure.path} (${failure.detail})`;
+  }
+}
+
 /**
  * Returns a clause describing the rebuild verdict, or nothing when there is nothing to add.
  *
- * A passing rebuild is silent only where both hash verdicts already reached `ok` and it would
+ * A passing rebuild is silent only where the hash verdicts already reached `ok` and it would
  * restate them. Anywhere else it speaks, because it then carries the line's strongest answer: over
  * a failing verdict it says the bundle reproduces and the manifest's record of it is what went
  * wrong, and over an unverified one it supplies the answer the absent hash could not.

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -197,6 +197,7 @@ function buildVerifyEntry(name: string, { drift, inputs, rebuild, source }: KitV
 function formatStatusLine(kit: RdyManifestKit, verdicts: KitVerdicts): string {
   const { drift, inputs, rebuild, source } = verdicts;
   const token = resolveToken(verdicts);
+  // An unverified closure counts as confirmed, so an entry predating it carries the line it always did.
   const hashesConfirmed = drift.kind === 'ok' && source.kind === 'ok' && inputs.kind !== 'stale';
   const clauses = [
     describeDriftStatus(kit, drift),


### PR DESCRIPTION
## What

Adds a third check to `rdy verify`. Alongside the kit's source and its compiled bundle, verify now re-reads every file the compile consumed -- helper modules the bundle inlined, and JSON values `pickJson` copied in -- and fails when any of them has changed since the build. Editing one of those files moves neither recorded hash, so until now verify reported `ok` on a bundle built from ingredients that no longer existed.

Verification names every input that failed, separating a changed file from one that is gone and from one whose picked field has vanished. `rdy run` gains a matching `input-stale` advisory, and both reach `--json` at `schemaVersion` 1.

## Why

A kit that pins consumers to its own package's version reads that version at compile time with `pickJson`, and the value is baked into the bundle. Bumping the version without recompiling left `rdy verify` reporting `ok` while the published kit still asserted the previous minimum, so a consumer sitting on the old version satisfied the very check meant to move them off it.

## Details

### 🎉 Features

- `checkInputDrift` reads a manifest entry's recorded `inputs` back off disk and returns `ok`, `stale`, or `unverified`. A `module` input is compared by the hash of its bytes; an `inline` input is reproduced through the same `projectJsonFile` and `hashProjection` the compile used, so an edit to a field the kit did not pick is not staleness.
- A `stale` verdict carries one `InputFailure` per input that failed, with a `reason` of `changed` (both hashes), `missing`, or `unprojectable` (inline only, carrying the diagnosis). `rdy verify` prints one clause per failure beneath the kit and exits 1.
- `rdy run` raises `input-stale` where the check compared a recorded hash against a file and the two differed. It is advisory: stderr in both modes, captured under `warnings` in JSON, no effect on the exit code.
- Under `--json`, each kit entry gains `inputsStatus` and, on a stale verdict, `inputFailures`. Both are optional, so `schemaVersion` stays 1 and a consumer pinned to it still validates a payload from a readyup that predates them.
- An entry that predates the closure verifies as `unverified`, producing the line and the exit code it does today.

### ♻️ Refactoring

- `verifyCommand`'s five per-kit functions take a single `KitVerdicts` record rather than three or four positional arguments, so each pass over a kit reads the same set by name.
- `hashProjection` is extracted into `targetHash.ts` and adopted by `createCompileRecorder`, so the compile and every reader of a recorded input encode a projection through one function and cannot report a file neither changed as stale.
- `warnOnKitStaleness`'s `hasVerdict` becomes `readVerdict`, which returns the verdict rather than matching a kind. Each axis names its own trigger at the call site, which is what makes the three comparable at a glance and lets the closure's trigger be a two-level test.

### 🧪 Tests

- A `checkInputDrift` suite covering each `reason` for each kind, including the two cases that carry the design: an edit to an unpicked field stays `ok`, and a vanished picked field reports `unprojectable` rather than a moved hash.
- Wiring coverage running `rdy verify` against real files and a real manifest, validating the JSON payload through `VerifyOutputSchema` rather than by shape-matching.
- Run-advisory coverage for the new warning, for a changed input sitting beside a merely absent one, and for the three conditions that stay silent.
- `expectTypeOf<JsonInputFailure>().toEqualTypeOf<InputFailure>()` binds the published failure shape to the verdict that produces it.

### 📚 Documentation

- The README documents the third verdict axis with sample failing output, the `input-stale` row in the warning-code table, and the `inputFailures` payload.
- The `pickJson` section no longer says `--rebuild` is the only thing that catches an edited pick, and the `--rebuild` section is narrowed to what genuinely remains outside the closure: the bundler's version, the compile options, and dependency contents.

Closes #314

