### PR TITLE
#315 Check recorded inputs in ReadyUp's own freshness checklist

### DIFF
--- a/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
@@ -257,7 +257,7 @@ describe('default kit', () => {
 
       expect(pickResult(results, 'Everything it inlined')).toMatchObject({
         status: 'failed',
-        detail: 'package.json is missing',
+        detail: expect.stringContaining('package.json is missing'),
       });
     });
 
@@ -272,19 +272,20 @@ describe('default kit', () => {
 
       expect(pickResult(results, 'Everything it inlined')).toMatchObject({
         status: 'failed',
-        detail: 'package.json records no paths to project it by',
+        detail: expect.stringContaining('records no paths'),
       });
     });
 
-    it('reports an input recording no path, kind, or hash', async () => {
+    it('names only the fields an incomplete input record is missing', async () => {
       const entry = writeKit(projectRoot, 'default');
-      writeRawKitManifest(projectRoot, [{ ...entry, inputs: [{ kind: 'module' }] }]);
+      const input = { path: path.join('kits', 'demo.ts'), hash: '0badcafe' };
+      writeRawKitManifest(projectRoot, [{ ...entry, inputs: [input] }]);
 
       const results = await runFreshness();
 
       expect(pickResult(results, 'Everything it inlined')).toMatchObject({
         status: 'failed',
-        detail: 'The manifest records an input with no path, kind, or hash',
+        detail: expect.stringContaining('.readyup/kits/demo.ts records no kind'),
       });
     });
 

--- a/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
@@ -8,7 +8,22 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { RdyResult } from '../../../src/kits/types.ts';
 import { pickResult, runChecklist } from '../test-utils/checklist-results.ts';
 import { loadOwnKit } from '../test-utils/loadOwnKit.ts';
-import { FIXTURE_KITS_DIR, writeKit, writeKitManifest, writeRdyConfig } from '../test-utils/project-fixture.ts';
+import type { FixtureManifestEntry, FixtureManifestInput } from '../test-utils/project-fixture.ts';
+import {
+  FIXTURE_KITS_DIR,
+  writeInlineInput,
+  writeKit,
+  writeKitManifest,
+  writeModuleInput,
+  writePackageJson,
+  writeRdyConfig,
+} from '../test-utils/project-fixture.ts';
+
+/** Module a fixture kit inlines, as the manifest records it: relative to the manifest's own directory. */
+const INLINED_MODULE_PATH = path.join('kits', 'checks', 'helper.ts');
+
+/** JSON file a fixture kit projects. It sits above the manifest directory, as the canonical `../package.json` does. */
+const PROJECTED_JSON_PATH = path.join('..', 'package.json');
 
 /**
  * Covers the `default` kit readyup publishes, against fixture projects in a temp directory.
@@ -154,6 +169,84 @@ describe('default kit', () => {
       expect(pickResult(results, 'Its bundle')).toMatchObject({ status: 'skipped' });
     });
 
+    it('reports a module it inlined that has since changed', async () => {
+      writeKitManifest(projectRoot, [withInputs(writeKit(projectRoot, 'default'), inlineHelper(projectRoot, '1'))]);
+      inlineHelper(projectRoot, '2');
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({
+        status: 'failed',
+        detail: expect.stringContaining(path.join('.readyup', INLINED_MODULE_PATH)),
+      });
+    });
+
+    it('reports a projection it inlined that has since changed', async () => {
+      writeKitManifest(projectRoot, [
+        withInputs(writeKit(projectRoot, 'default'), projectVersion(projectRoot, '1.0.0')),
+      ]);
+      writePackageJson(projectRoot, { version: '2.0.0' });
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({
+        status: 'failed',
+        detail: expect.stringContaining('package.json'),
+      });
+    });
+
+    // The recorded hash is over the projection rather than the file, so a field the kit never picked up
+    // is not something the bundle could have inlined.
+    it('accepts an edit to a field the projection does not pick', async () => {
+      writeKitManifest(projectRoot, [
+        withInputs(writeKit(projectRoot, 'default'), projectVersion(projectRoot, '1.0.0')),
+      ]);
+      writePackageJson(projectRoot, { description: 'edited since the kit was compiled', version: '1.0.0' });
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({ status: 'passed' });
+    });
+
+    it('reports a projected file whose picked field is gone', async () => {
+      writeKitManifest(projectRoot, [
+        withInputs(writeKit(projectRoot, 'default'), projectVersion(projectRoot, '1.0.0')),
+      ]);
+      writePackageJson(projectRoot, {});
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({
+        status: 'failed',
+        detail: expect.stringContaining('no longer projects'),
+      });
+    });
+
+    it('reports an inlined module that is no longer there', async () => {
+      writeKitManifest(projectRoot, [withInputs(writeKit(projectRoot, 'default'), inlineHelper(projectRoot, '1'))]);
+      rmSync(path.join(projectRoot, '.readyup', INLINED_MODULE_PATH));
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({
+        status: 'failed',
+        detail: expect.stringContaining('is missing'),
+      });
+    });
+
+    // An entry compiled before readyup recorded the closure says nothing about whether the kit is stale.
+    it('stands down for an entry recording no inputs', async () => {
+      const { inputs, ...entry } = writeKit(projectRoot, 'default');
+      writeKitManifest(projectRoot, [entry]);
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({
+        status: 'skipped',
+        detail: 'The manifest records no inputs for it',
+      });
+    });
+
     it('stands down when the project compiles nothing', async () => {
       mkdirSync(path.join(projectRoot, FIXTURE_KITS_DIR), { recursive: true });
 
@@ -186,6 +279,16 @@ describe('default kit', () => {
 
 // region | Helpers
 
+/** Writes the module a fixture kit inlines, and returns the record of it. */
+function inlineHelper(projectRoot: string, value: string): FixtureManifestInput {
+  return writeModuleInput(projectRoot, INLINED_MODULE_PATH, `export const helper = ${value};\n`);
+}
+
+/** Writes the JSON file a fixture kit projects, and returns the record of the projection over `version`. */
+function projectVersion(projectRoot: string, version: string): FixtureManifestInput {
+  return writeInlineInput(projectRoot, PROJECTED_JSON_PATH, { name: 'fixture', version }, ['version']);
+}
+
 /** Runs the `freshness` checklist against the fixture as it now stands. */
 async function runFreshness(): Promise<RdyResult[]> {
   return runChecklist(await loadOwnKit('default'), 'freshness');
@@ -194,6 +297,11 @@ async function runFreshness(): Promise<RdyResult[]> {
 /** Runs the `setup` checklist against the fixture as it now stands. */
 async function runSetup(): Promise<RdyResult[]> {
   return runChecklist(await loadOwnKit('default'), 'setup');
+}
+
+/** Adds recorded inputs to a fixture entry, beside the entry module `writeKit` already records. */
+function withInputs(entry: FixtureManifestEntry, ...inputs: FixtureManifestInput[]): FixtureManifestEntry {
+  return { ...entry, inputs: [...entry.inputs, ...inputs] };
 }
 
 // endregion | Helpers

--- a/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
@@ -163,7 +163,7 @@ describe('default kit', () => {
 
       expect(pickResult(results, 'recorded with a source and a bundle hash')).toMatchObject({
         status: 'failed',
-        detail: 'The manifest records no source or bundle hash',
+        detail: expect.stringContaining('records no source or bundle hash'),
       });
       expect(pickResult(results, 'Its source')).toMatchObject({ status: 'skipped' });
       expect(pickResult(results, 'Its bundle')).toMatchObject({ status: 'skipped' });
@@ -286,6 +286,19 @@ describe('default kit', () => {
       expect(pickResult(results, 'Everything it inlined')).toMatchObject({
         status: 'failed',
         detail: expect.stringContaining('.readyup/kits/demo.ts records no kind'),
+      });
+    });
+
+    // A record with no path has nothing to lead with, so the message names the input instead.
+    it('names every absent field of an input record that has no path to lead with', async () => {
+      const entry = writeKit(projectRoot, 'default');
+      writeRawKitManifest(projectRoot, [{ ...entry, inputs: [{ kind: 'module' }] }]);
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({
+        status: 'failed',
+        detail: expect.stringContaining('records an input with no path or hash'),
       });
     });
 

--- a/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
@@ -8,19 +8,19 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { RdyResult } from '../../../src/kits/types.ts';
 import { pickResult, runChecklist } from '../test-utils/checklist-results.ts';
 import { loadOwnKit } from '../test-utils/loadOwnKit.ts';
-import type { FixtureManifestEntry, FixtureManifestInput } from '../test-utils/project-fixture.ts';
+import type { FixtureManifestInput } from '../test-utils/project-fixture.ts';
 import {
+  FIXTURE_INLINED_MODULE_PATH,
   FIXTURE_KITS_DIR,
+  withInputs,
   writeInlineInput,
   writeKit,
   writeKitManifest,
   writeModuleInput,
   writePackageJson,
+  writeRawKitManifest,
   writeRdyConfig,
 } from '../test-utils/project-fixture.ts';
-
-/** Module a fixture kit inlines, as the manifest records it: relative to the manifest's own directory. */
-const INLINED_MODULE_PATH = path.join('kits', 'checks', 'helper.ts');
 
 /** JSON file a fixture kit projects. It sits above the manifest directory, as the canonical `../package.json` does. */
 const PROJECTED_JSON_PATH = path.join('..', 'package.json');
@@ -177,7 +177,7 @@ describe('default kit', () => {
 
       expect(pickResult(results, 'Everything it inlined')).toMatchObject({
         status: 'failed',
-        detail: expect.stringContaining(path.join('.readyup', INLINED_MODULE_PATH)),
+        detail: expect.stringContaining(path.join('.readyup', FIXTURE_INLINED_MODULE_PATH)),
       });
     });
 
@@ -224,7 +224,7 @@ describe('default kit', () => {
 
     it('reports an inlined module that is no longer there', async () => {
       writeKitManifest(projectRoot, [withInputs(writeKit(projectRoot, 'default'), inlineHelper(projectRoot, '1'))]);
-      rmSync(path.join(projectRoot, '.readyup', INLINED_MODULE_PATH));
+      rmSync(path.join(projectRoot, '.readyup', FIXTURE_INLINED_MODULE_PATH));
 
       const results = await runFreshness();
 
@@ -244,6 +244,47 @@ describe('default kit', () => {
       expect(pickResult(results, 'Everything it inlined')).toMatchObject({
         status: 'skipped',
         detail: 'The manifest records no inputs for it',
+      });
+    });
+
+    it('reports an inlined JSON file that is no longer there', async () => {
+      writeKitManifest(projectRoot, [
+        withInputs(writeKit(projectRoot, 'default'), projectVersion(projectRoot, '1.0.0')),
+      ]);
+      rmSync(path.join(projectRoot, 'package.json'));
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({
+        status: 'failed',
+        detail: 'package.json is missing',
+      });
+    });
+
+    // The kit reads raw JSON rather than the manifest schema, so a record no compile would have written
+    // reaches these two guards instead of failing validation.
+    it('reports an inline record whose path specifier is not one', async () => {
+      const entry = writeKit(projectRoot, 'default');
+      const input = { hash: '0badcafe', kind: 'inline', path: PROJECTED_JSON_PATH, paths: [42] };
+      writeRawKitManifest(projectRoot, [{ ...entry, inputs: [input] }]);
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({
+        status: 'failed',
+        detail: 'package.json records no paths to project it by',
+      });
+    });
+
+    it('reports an input recording no path, kind, or hash', async () => {
+      const entry = writeKit(projectRoot, 'default');
+      writeRawKitManifest(projectRoot, [{ ...entry, inputs: [{ kind: 'module' }] }]);
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Everything it inlined')).toMatchObject({
+        status: 'failed',
+        detail: 'The manifest records an input with no path, kind, or hash',
       });
     });
 
@@ -281,7 +322,7 @@ describe('default kit', () => {
 
 /** Writes the module a fixture kit inlines, and returns the record of it. */
 function inlineHelper(projectRoot: string, value: string): FixtureManifestInput {
-  return writeModuleInput(projectRoot, INLINED_MODULE_PATH, `export const helper = ${value};\n`);
+  return writeModuleInput(projectRoot, FIXTURE_INLINED_MODULE_PATH, `export const helper = ${value};\n`);
 }
 
 /** Writes the JSON file a fixture kit projects, and returns the record of the projection over `version`. */
@@ -297,11 +338,6 @@ async function runFreshness(): Promise<RdyResult[]> {
 /** Runs the `setup` checklist against the fixture as it now stands. */
 async function runSetup(): Promise<RdyResult[]> {
   return runChecklist(await loadOwnKit('default'), 'setup');
-}
-
-/** Adds recorded inputs to a fixture entry, beside the entry module `writeKit` already records. */
-function withInputs(entry: FixtureManifestEntry, ...inputs: FixtureManifestInput[]): FixtureManifestEntry {
-  return { ...entry, inputs: [...entry.inputs, ...inputs] };
 }
 
 // endregion | Helpers

--- a/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
@@ -8,7 +8,16 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { RdyResult } from '../../../src/kits/types.ts';
 import { pickResult, runChecklist } from '../test-utils/checklist-results.ts';
 import { loadOwnKit } from '../test-utils/loadOwnKit.ts';
-import { FIXTURE_KITS_DIR, writeKit, writeKitManifest, writePackageJson } from '../test-utils/project-fixture.ts';
+import {
+  FIXTURE_KITS_DIR,
+  writeKit,
+  writeKitManifest,
+  writeModuleInput,
+  writePackageJson,
+} from '../test-utils/project-fixture.ts';
+
+/** Module a fixture kit inlines, as the manifest records it: relative to the manifest's own directory. */
+const INLINED_MODULE_PATH = path.join('kits', 'checks', 'helper.ts');
 
 /** Bundle reaching for a package that only the publishing project has installed. */
 const LEAKY_BUNDLE = 'import picomatch from "picomatch";\nexport default { checklists: [] };\n';
@@ -183,6 +192,20 @@ describe('publishing kit', () => {
     const results = await runChecklist(await loadOwnKit('publishing'), 'freshness');
 
     expect(pickResult(results, 'Its source')).toMatchObject({ status: 'failed', severity: 'error' });
+  });
+
+  // A module the bundle inlined is as much a part of what a consumer runs as the kit source is, and
+  // neither recorded hash describes it.
+  it('blocks on a kit whose inlined module has since moved on', async () => {
+    writePackageJson(projectRoot, { files: ['.readyup'] });
+    const entry = writeKit(projectRoot, 'default');
+    const helper = writeModuleInput(projectRoot, INLINED_MODULE_PATH, 'export const helper = 1;\n');
+    writeKitManifest(projectRoot, [{ ...entry, inputs: [...entry.inputs, helper] }]);
+    writeModuleInput(projectRoot, INLINED_MODULE_PATH, 'export const helper = 2;\n');
+
+    const results = await runChecklist(await loadOwnKit('publishing'), 'freshness');
+
+    expect(pickResult(results, 'Everything it inlined')).toMatchObject({ status: 'failed', severity: 'error' });
   });
 });
 

--- a/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/publishing.unit.test.ts
@@ -9,15 +9,14 @@ import type { RdyResult } from '../../../src/kits/types.ts';
 import { pickResult, runChecklist } from '../test-utils/checklist-results.ts';
 import { loadOwnKit } from '../test-utils/loadOwnKit.ts';
 import {
+  FIXTURE_INLINED_MODULE_PATH,
   FIXTURE_KITS_DIR,
+  withInputs,
   writeKit,
   writeKitManifest,
   writeModuleInput,
   writePackageJson,
 } from '../test-utils/project-fixture.ts';
-
-/** Module a fixture kit inlines, as the manifest records it: relative to the manifest's own directory. */
-const INLINED_MODULE_PATH = path.join('kits', 'checks', 'helper.ts');
 
 /** Bundle reaching for a package that only the publishing project has installed. */
 const LEAKY_BUNDLE = 'import picomatch from "picomatch";\nexport default { checklists: [] };\n';
@@ -199,9 +198,9 @@ describe('publishing kit', () => {
   it('blocks on a kit whose inlined module has since moved on', async () => {
     writePackageJson(projectRoot, { files: ['.readyup'] });
     const entry = writeKit(projectRoot, 'default');
-    const helper = writeModuleInput(projectRoot, INLINED_MODULE_PATH, 'export const helper = 1;\n');
-    writeKitManifest(projectRoot, [{ ...entry, inputs: [...entry.inputs, helper] }]);
-    writeModuleInput(projectRoot, INLINED_MODULE_PATH, 'export const helper = 2;\n');
+    const helper = writeModuleInput(projectRoot, FIXTURE_INLINED_MODULE_PATH, 'export const helper = 1;\n');
+    writeKitManifest(projectRoot, [withInputs(entry, helper)]);
+    writeModuleInput(projectRoot, FIXTURE_INLINED_MODULE_PATH, 'export const helper = 2;\n');
 
     const results = await runChecklist(await loadOwnKit('publishing'), 'freshness');
 

--- a/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
@@ -119,6 +119,23 @@ function describeHashDrift(filePath: string, hashed: string, expected: string, v
 }
 
 /**
+ * Reports which of a recorded input's three required fields are absent.
+ *
+ * Leads with the path where the record carries one, so several incomplete records stay distinguishable
+ * in a detail that joins them.
+ */
+function describeIncompleteInput(input: ManifestInput): string {
+  const unrecorded: string[] = [];
+  if (input.path === undefined) unrecorded.push('path');
+  if (input.kind === undefined) unrecorded.push('kind');
+  if (input.hash === undefined) unrecorded.push('hash');
+
+  const absent = unrecorded.join(' or ');
+  if (input.path === undefined) return `The manifest records an input with no ${absent}`;
+  return `${resolveRecordedPath(input.path)} records no ${absent}`;
+}
+
+/**
  * Reports how one recorded input differs from what the compile read, or nothing when it still matches.
  *
  * An inline input is decided by the projection `rdy compile` recorded rather than by the file holding
@@ -129,7 +146,7 @@ function describeHashDrift(filePath: string, hashed: string, expected: string, v
 function describeInputDrift(input: ManifestInput): string | undefined {
   const { hash, kind, path: recordedPath, paths } = input;
   if (hash === undefined || kind === undefined || recordedPath === undefined) {
-    return 'The manifest records an input with no path, kind, or hash';
+    return describeIncompleteInput(input);
   }
 
   const filePath = resolveRecordedPath(recordedPath);
@@ -146,7 +163,7 @@ function describeInputDrift(input: ManifestInput): string | undefined {
   try {
     projection = projectJsonFile(filePath, paths);
   } catch (error: unknown) {
-    return `${filePath} no longer projects: ${describeJsonProjectionFailure(error)}`;
+    return `${filePath} no longer projects (${describeJsonProjectionFailure(error)})`;
   }
 
   return describeHashDrift(filePath, projection, hash, 'projects to');

--- a/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
@@ -1,12 +1,15 @@
 import { DEFAULT_MANIFEST_PATH } from 'readyup';
-import type { CheckOutcome, RdyCheck } from 'readyup';
-import { computeHash, readFile } from 'readyup/check-utils';
+import type { CheckOutcome, FractionProgress, RdyCheck } from 'readyup';
+import { computeHash, projectJsonFile, readFile } from 'readyup/check-utils';
 
-import type { ManifestEntry } from './kit-layout.ts';
+import type { ManifestEntry, ManifestInput } from './kit-layout.ts';
 import { readManifestEntries, resolveRecordedPath, skipWithoutBundles } from './kit-layout.ts';
 
+/** Detail reported by a check that stands down for an entry compiled before readyup recorded a closure. */
+const NO_INPUTS_REASON = 'The manifest records no inputs for it';
+
 /**
- * Checks asserting that every kit the manifest records still matches the hashes recorded for it.
+ * Checks asserting that every kit the manifest records still matches what was recorded for it.
  *
  * The checks are built when the kit module is evaluated, so a drifted kit is named on its own line
  * rather than buried in one check's detail. Severity is left to the kit: freshness is advisory while
@@ -36,6 +39,14 @@ function buildEntryCheck(entry: ManifestEntry): RdyCheck {
         name: 'Its bundle is unchanged since it was compiled',
         check: () => compareToRecordedHash(entry.path, entry.targetHash),
         fix: `Move the edits into the source and run 'rdy compile --force'`,
+      },
+      {
+        // The axis the two hashes leave uncovered: a bundle is a function of every module it inlined
+        // and every JSON projection substituted into it, and neither hash describes any of them.
+        name: 'Everything it inlined is unchanged since it was compiled',
+        skip: () => (entry.inputs === undefined ? NO_INPUTS_REASON : false),
+        check: () => compareToRecordedInputs(entry.inputs ?? []),
+        fix: `Run 'rdy compile' to rebuild ${entry.name} from the files it now reads`,
       },
     ],
   };
@@ -71,12 +82,68 @@ function compareToRecordedHash(recordedPath: string | undefined, expected: strin
   const content = readFile(filePath);
   if (content === undefined) return { ok: false, detail: `${filePath} is missing` };
 
-  const actual = computeHash(content).slice(0, expected.length);
-  if (actual !== expected) {
-    return { ok: false, detail: `${filePath} hashes to ${actual}, not the recorded ${expected}` };
-  }
+  const drift = describeHashDrift(filePath, content, expected);
+  if (drift !== undefined) return { ok: false, detail: drift };
 
   return { ok: true, detail: `${filePath} matches the recorded hash` };
+}
+
+/**
+ * Compares everything a kit's compile read against what was recorded for it.
+ *
+ * Names every input that no longer matches rather than the first, so one pass names everything to fix.
+ * The count stands as the evidence on a pass, since a kit records one input per file its compile read.
+ */
+function compareToRecordedInputs(inputs: ManifestInput[]): CheckOutcome {
+  const failures = inputs.map(describeInputDrift).filter((failure) => failure !== undefined);
+  const progress: FractionProgress = {
+    type: 'fraction',
+    passedCount: inputs.length - failures.length,
+    count: inputs.length,
+  };
+
+  if (failures.length === 0) return { ok: true, progress };
+  return { ok: false, detail: failures.join('; '), progress };
+}
+
+/** Compares content against the hash recorded for it, and reports how it differs. */
+function describeHashDrift(filePath: string, content: string, expected: string): string | undefined {
+  const actual = computeHash(content).slice(0, expected.length);
+  if (actual === expected) return undefined;
+  return `${filePath} hashes to ${actual}, not the recorded ${expected}`;
+}
+
+/**
+ * Reports how one recorded input differs from what the compile read, or nothing when it still matches.
+ *
+ * An inline input is decided by the projection `rdy compile` recorded rather than by the file holding
+ * it, which is what keeps an edit to a field the kit did not pick from reading as staleness. That
+ * projection comes from readyup itself: once its serialization is hashed it is a format, and a second
+ * implementation of it would drift from the one that wrote the hash.
+ */
+function describeInputDrift(input: ManifestInput): string | undefined {
+  const { hash, kind, path: recordedPath, paths } = input;
+  if (hash === undefined || kind === undefined || recordedPath === undefined) {
+    return 'The manifest records an input with no path, kind, or hash';
+  }
+
+  const filePath = resolveRecordedPath(recordedPath);
+  if (kind === 'module') {
+    const content = readFile(filePath);
+    if (content === undefined) return `${filePath} is missing`;
+    return describeHashDrift(filePath, content, hash);
+  }
+
+  if (paths === undefined) return `${filePath} records no paths to project it by`;
+
+  let projection: string;
+  try {
+    projection = projectJsonFile(filePath, paths);
+  } catch (error: unknown) {
+    return `${filePath} no longer projects: ${error instanceof Error ? error.message : String(error)}`;
+  }
+
+  return describeHashDrift(filePath, projection, hash);
 }
 
 /** Reports which of a manifest entry's two hash records are absent. */

--- a/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_MANIFEST_PATH } from 'readyup';
 import type { CheckOutcome, FractionProgress, RdyCheck } from 'readyup';
-import { computeHash, projectJsonFile, readFile } from 'readyup/check-utils';
+import { computeHash, describeJsonProjectionFailure, fileExists, projectJsonFile, readFile } from 'readyup/check-utils';
 
 import type { ManifestEntry, ManifestInput } from './kit-layout.ts';
 import { readManifestEntries, resolveRecordedPath, skipWithoutBundles } from './kit-layout.ts';
@@ -82,7 +82,7 @@ function compareToRecordedHash(recordedPath: string | undefined, expected: strin
   const content = readFile(filePath);
   if (content === undefined) return { ok: false, detail: `${filePath} is missing` };
 
-  const drift = describeHashDrift(filePath, content, expected);
+  const drift = describeHashDrift(filePath, content, expected, 'hashes to');
   if (drift !== undefined) return { ok: false, detail: drift };
 
   return { ok: true, detail: `${filePath} matches the recorded hash` };
@@ -106,11 +106,16 @@ function compareToRecordedInputs(inputs: ManifestInput[]): CheckOutcome {
   return { ok: false, detail: failures.join('; '), progress };
 }
 
-/** Compares content against the hash recorded for it, and reports how it differs. */
-function describeHashDrift(filePath: string, content: string, expected: string): string | undefined {
-  const actual = computeHash(content).slice(0, expected.length);
+/**
+ * Compares what was hashed against the hash recorded for it, and reports how it differs.
+ *
+ * `verb` names what the digest covers: an inline input's is over the projection substituted into the
+ * bundle, not over the bytes of the file holding it.
+ */
+function describeHashDrift(filePath: string, hashed: string, expected: string, verb: string): string | undefined {
+  const actual = computeHash(hashed).slice(0, expected.length);
   if (actual === expected) return undefined;
-  return `${filePath} hashes to ${actual}, not the recorded ${expected}`;
+  return `${filePath} ${verb} ${actual}, not the recorded ${expected}`;
 }
 
 /**
@@ -131,19 +136,20 @@ function describeInputDrift(input: ManifestInput): string | undefined {
   if (kind === 'module') {
     const content = readFile(filePath);
     if (content === undefined) return `${filePath} is missing`;
-    return describeHashDrift(filePath, content, hash);
+    return describeHashDrift(filePath, content, hash, 'hashes to');
   }
 
   if (paths === undefined) return `${filePath} records no paths to project it by`;
+  if (!fileExists(filePath)) return `${filePath} is missing`;
 
   let projection: string;
   try {
     projection = projectJsonFile(filePath, paths);
   } catch (error: unknown) {
-    return `${filePath} no longer projects: ${error instanceof Error ? error.message : String(error)}`;
+    return `${filePath} no longer projects: ${describeJsonProjectionFailure(error)}`;
   }
 
-  return describeHashDrift(filePath, projection, hash);
+  return describeHashDrift(filePath, projection, hash, 'projects to');
 }
 
 /** Reports which of a manifest entry's two hash records are absent. */

--- a/packages/readyup/.readyup/kits/checks/kit-layout.ts
+++ b/packages/readyup/.readyup/kits/checks/kit-layout.ts
@@ -41,20 +41,6 @@ export function listCompiledBundlePaths(): string[] {
 }
 
 /**
- * One file a kit's compile read, narrowed to the fields these kits read.
- *
- * Every field may be absent, because the record comes out of raw JSON rather than the manifest schema: a
- * kit reporting on a manifest cannot fail to load over the manifest it is reporting on. Only an inline
- * record carries `paths`, which is the specifier that produced the projection whose hash it holds.
- */
-export interface ManifestInput {
-  hash: string | undefined;
-  kind: 'inline' | 'module' | undefined;
-  path: string | undefined;
-  paths: JsonPathSpec | undefined;
-}
-
-/**
  * A manifest kit entry, narrowed to the fields these kits read.
  *
  * `inputs` is absent on an entry compiled before readyup recorded the closure, which is why it is
@@ -68,6 +54,20 @@ export interface ManifestEntry {
   source: string | undefined;
   sourceHash: string | undefined;
   targetHash: string | undefined;
+}
+
+/**
+ * One file a kit's compile read, narrowed to the fields these kits read.
+ *
+ * Every field may be absent, because the record comes out of raw JSON rather than the manifest schema: a
+ * kit reporting on a manifest cannot fail to load over the manifest it is reporting on. Only an inline
+ * record carries `paths`, which is the specifier that produced the projection whose hash it holds.
+ */
+export interface ManifestInput {
+  hash: string | undefined;
+  kind: 'inline' | 'module' | undefined;
+  path: string | undefined;
+  paths: JsonPathSpec | undefined;
 }
 
 /**

--- a/packages/readyup/.readyup/kits/checks/kit-layout.ts
+++ b/packages/readyup/.readyup/kits/checks/kit-layout.ts
@@ -4,6 +4,7 @@ import process from 'node:process';
 
 import { DEFAULT_MANIFEST_PATH } from 'readyup';
 import type { SkipResult } from 'readyup';
+import type { JsonPathSpec } from 'readyup/check-utils';
 import { fileExists, isRecord, readJsonFile } from 'readyup/check-utils';
 
 // -- Paths --
@@ -39,8 +40,29 @@ export function listCompiledBundlePaths(): string[] {
     .toSorted();
 }
 
-/** A manifest kit entry, narrowed to the fields these kits read. */
+/**
+ * One file a kit's compile read, narrowed to the fields these kits read.
+ *
+ * Every field may be absent, because the record comes out of raw JSON rather than the manifest schema: a
+ * kit reporting on a manifest cannot fail to load over the manifest it is reporting on. Only an inline
+ * record carries `paths`, which is the specifier that produced the projection whose hash it holds.
+ */
+export interface ManifestInput {
+  hash: string | undefined;
+  kind: 'inline' | 'module' | undefined;
+  path: string | undefined;
+  paths: JsonPathSpec | undefined;
+}
+
+/**
+ * A manifest kit entry, narrowed to the fields these kits read.
+ *
+ * `inputs` is absent on an entry compiled before readyup recorded the closure, which is why it is
+ * narrowed to `undefined` rather than to an empty list: recording nothing and recording no closure at
+ * all are different claims about a kit.
+ */
 export interface ManifestEntry {
+  inputs: ManifestInput[] | undefined;
   name: string;
   path: string | undefined;
   source: string | undefined;
@@ -88,20 +110,61 @@ export function skipWithoutKits(): SkipResult {
 
 // region | Helpers
 
+/**
+ * Narrows a value to a `pickJson` path specifier, or `undefined` when it is anything else.
+ *
+ * A specifier holding anything but a key or a key path is rejected whole rather than in part, since a
+ * projection taken over some of the paths recorded is not the projection whose hash was recorded.
+ */
+function asJsonPathSpec(value: unknown): JsonPathSpec | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  const spec: JsonPathSpec = [];
+  for (const item of value) {
+    if (typeof item !== 'string' && !isStringArray(item)) return undefined;
+    spec.push(item);
+  }
+
+  return spec;
+}
+
 /** Narrows a value to a string, or `undefined` when it is anything else. */
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
+/** Narrows a value to the nested-key form a path specifier may take. */
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
 /** Projects a raw manifest kit record onto the fields these kits read. */
 function toManifestEntry(kit: Record<string, unknown>): ManifestEntry {
   return {
+    inputs: toManifestInputs(kit['inputs']),
     name: asString(kit['name']) ?? '(unnamed)',
     path: asString(kit['path']),
     source: asString(kit['source']),
     sourceHash: asString(kit['sourceHash']),
     targetHash: asString(kit['targetHash']),
   };
+}
+
+/** Projects a raw recorded input onto the fields these kits read. */
+function toManifestInput(input: Record<string, unknown>): ManifestInput {
+  const kind = input['kind'];
+  return {
+    hash: asString(input['hash']),
+    kind: kind === 'inline' || kind === 'module' ? kind : undefined,
+    path: asString(input['path']),
+    paths: asJsonPathSpec(input['paths']),
+  };
+}
+
+/** Projects a raw entry's recorded closure, or `undefined` when the entry records none. */
+function toManifestInputs(value: unknown): ManifestInput[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter(isRecord).map(toManifestInput);
 }
 
 // endregion | Helpers

--- a/packages/readyup/.readyup/kits/test-utils/project-fixture.ts
+++ b/packages/readyup/.readyup/kits/test-utils/project-fixture.ts
@@ -1,7 +1,9 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { hashFile } from '../../../src/verify/targetHash.ts';
+import type { JsonPathSpec } from '../../../src/compile/extractJsonPaths.ts';
+import { projectJsonFile } from '../../../src/compile/projectJsonFile.ts';
+import { hashFile, hashProjection } from '../../../src/verify/targetHash.ts';
 
 /** Kit directory a fixture project holds, relative to its root. */
 export const FIXTURE_KITS_DIR = path.join('.readyup', 'kits');
@@ -11,11 +13,20 @@ export const FIXTURE_MANIFEST_PATH = path.join('.readyup', 'manifest.json');
 
 /** A manifest kit entry, as `rdy compile` records one. */
 export interface FixtureManifestEntry {
+  inputs: FixtureManifestInput[];
   name: string;
   path: string;
   source: string;
   sourceHash: string;
   targetHash: string;
+}
+
+/** A recorded input, as `rdy compile` writes one. */
+export interface FixtureManifestInput {
+  hash: string;
+  kind: 'inline' | 'module';
+  path: string;
+  paths?: JsonPathSpec;
 }
 
 /** Text of a bundle importing nothing beyond what the runner supplies. */
@@ -24,6 +35,22 @@ export const SELF_CONTAINED_BUNDLE = [
   'export default { checklists: [{ name: "demo", checks: [{ name: "ok", check: () => fileExists(".") }] }] };',
   '',
 ].join('\n');
+
+/**
+ * Writes a JSON file a compile would have projected, and returns the record of that projection.
+ *
+ * The projection and its hash come from the same helpers `rdy compile` records through, so a test says a
+ * projection has moved by editing a picked field rather than by writing a hash of its own.
+ */
+export function writeInlineInput(
+  projectRoot: string,
+  recordedPath: string,
+  data: Record<string, unknown>,
+  paths: JsonPathSpec,
+): FixtureManifestInput {
+  const filePath = writeInputFile(projectRoot, recordedPath, `${JSON.stringify(data, undefined, 2)}\n`);
+  return { hash: hashProjection(projectJsonFile(filePath, paths)), kind: 'inline', path: recordedPath, paths };
+}
 
 /**
  * Writes a kit source and the bundle compiled from it, and returns the entry recording both.
@@ -41,11 +68,16 @@ export function writeKit(projectRoot: string, name: string, options: WriteKitOpt
   writeFileSync(sourcePath, source);
   writeFileSync(bundlePath, bundle);
 
+  const recordedSource = path.join('kits', `${name}.ts`);
+  const sourceHash = hashFile(sourcePath);
+
   return {
+    // A compile records the entry module in its closure and reads `sourceHash` back out of that record.
+    inputs: [{ hash: sourceHash, kind: 'module', path: recordedSource }],
     name,
     path: path.join('kits', `${name}.js`),
-    source: path.join('kits', `${name}.ts`),
-    sourceHash: hashFile(sourcePath),
+    source: recordedSource,
+    sourceHash,
     targetHash: hashFile(bundlePath),
   };
 }
@@ -55,6 +87,12 @@ export function writeKitManifest(projectRoot: string, entries: Array<Partial<Fix
   const manifestPath = path.join(projectRoot, FIXTURE_MANIFEST_PATH);
   mkdirSync(path.dirname(manifestPath), { recursive: true });
   writeFileSync(manifestPath, JSON.stringify({ version: 1, kits: entries }));
+}
+
+/** Writes a module a compile would have inlined, and returns the record of it. */
+export function writeModuleInput(projectRoot: string, recordedPath: string, contents: string): FixtureManifestInput {
+  const filePath = writeInputFile(projectRoot, recordedPath, contents);
+  return { hash: hashFile(filePath), kind: 'module', path: recordedPath };
 }
 
 /** Writes the fixture project's manifest of record, which the publishing kit reads for its `files` list. */
@@ -78,6 +116,14 @@ const DEFAULT_SOURCE = [
   'export default defineRdyKit({ checklists: [] });',
   '',
 ].join('\n');
+
+/** Writes a file at a path the manifest would record, relative to the manifest's own directory. */
+function writeInputFile(projectRoot: string, recordedPath: string, contents: string): string {
+  const filePath = path.join(projectRoot, path.dirname(FIXTURE_MANIFEST_PATH), recordedPath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents);
+  return filePath;
+}
 
 /** Overrides for the two files `writeKit` lays down. */
 interface WriteKitOptions {

--- a/packages/readyup/.readyup/kits/test-utils/project-fixture.ts
+++ b/packages/readyup/.readyup/kits/test-utils/project-fixture.ts
@@ -5,6 +5,9 @@ import type { JsonPathSpec } from '../../../src/compile/extractJsonPaths.ts';
 import { projectJsonFile } from '../../../src/compile/projectJsonFile.ts';
 import { hashFile, hashProjection } from '../../../src/verify/targetHash.ts';
 
+/** Path a fixture kit's inlined module is recorded at, relative to the manifest's own directory. */
+export const FIXTURE_INLINED_MODULE_PATH = path.join('kits', 'checks', 'helper.ts');
+
 /** Kit directory a fixture project holds, relative to its root. */
 export const FIXTURE_KITS_DIR = path.join('.readyup', 'kits');
 
@@ -35,6 +38,11 @@ export const SELF_CONTAINED_BUNDLE = [
   'export default { checklists: [{ name: "demo", checks: [{ name: "ok", check: () => fileExists(".") }] }] };',
   '',
 ].join('\n');
+
+/** Adds recorded inputs to a fixture entry, beside the entry module `writeKit` already records. */
+export function withInputs(entry: FixtureManifestEntry, ...inputs: FixtureManifestInput[]): FixtureManifestEntry {
+  return { ...entry, inputs: [...entry.inputs, ...inputs] };
+}
 
 /**
  * Writes a JSON file a compile would have projected, and returns the record of that projection.
@@ -84,9 +92,7 @@ export function writeKit(projectRoot: string, name: string, options: WriteKitOpt
 
 /** Writes the manifest recording the given entries, each of which may be edited to describe drift. */
 export function writeKitManifest(projectRoot: string, entries: Array<Partial<FixtureManifestEntry>>): void {
-  const manifestPath = path.join(projectRoot, FIXTURE_MANIFEST_PATH);
-  mkdirSync(path.dirname(manifestPath), { recursive: true });
-  writeFileSync(manifestPath, JSON.stringify({ version: 1, kits: entries }));
+  writeRawKitManifest(projectRoot, entries);
 }
 
 /** Writes a module a compile would have inlined, and returns the record of it. */
@@ -98,6 +104,18 @@ export function writeModuleInput(projectRoot: string, recordedPath: string, cont
 /** Writes the fixture project's manifest of record, which the publishing kit reads for its `files` list. */
 export function writePackageJson(projectRoot: string, packageJson: Record<string, unknown>): void {
   writeFileSync(path.join(projectRoot, 'package.json'), JSON.stringify({ name: 'fixture', ...packageJson }));
+}
+
+/**
+ * Writes the manifest recording the given kits exactly as given, records no schema would produce included.
+ *
+ * The door for a manifest a hand edit or a foreign tool wrote, which is what the kits' defensive narrowing
+ * exists for and what a schema-typed entry cannot express.
+ */
+export function writeRawKitManifest(projectRoot: string, kits: Array<Record<string, unknown>>): void {
+  const manifestPath = path.join(projectRoot, FIXTURE_MANIFEST_PATH);
+  mkdirSync(path.dirname(manifestPath), { recursive: true });
+  writeFileSync(manifestPath, JSON.stringify({ version: 1, kits }));
 }
 
 /** Writes a readyup config at the one path `loadConfig` looks in. */

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1074,18 +1074,19 @@ import { fileExists, hasPackageJsonField } from 'readyup/check-utils';
 
 ### JSON
 
-| Function                            | Returns                                   |
-| ----------------------------------- | ----------------------------------------- |
-| `readJsonFile(path)`                | Parsed object, or `undefined`             |
-| `readJsonValue(path, ...keys)`      | Value at a key path within a file         |
-| `hasJsonField(path, field, value?)` | Field exists, optionally matching a value |
-| `hasJsonFields(path, fields)`       | `CheckOutcome` over several fields        |
-| `projectJsonFile(path, paths)`      | Serialized projection of a JSON file      |
-| `getJsonValue(obj, ...keys)`        | Value at a key path within an object      |
-| `hasJsonValue(obj, ...keys)`        | Key path is present                       |
-| `isRecord(value)`                   | Type guard for `Record<string, unknown>`  |
+| Function                               | Returns                                   |
+| -------------------------------------- | ----------------------------------------- |
+| `readJsonFile(path)`                   | Parsed object, or `undefined`             |
+| `readJsonValue(path, ...keys)`         | Value at a key path within a file         |
+| `hasJsonField(path, field, value?)`    | Field exists, optionally matching a value |
+| `hasJsonFields(path, fields)`          | `CheckOutcome` over several fields        |
+| `projectJsonFile(path, paths)`         | Serialized projection of a JSON file      |
+| `describeJsonProjectionFailure(error)` | Why a projection failed, without the path |
+| `getJsonValue(obj, ...keys)`           | Value at a key path within an object      |
+| `hasJsonValue(obj, ...keys)`           | Key path is present                       |
+| `isRecord(value)`                      | Type guard for `Record<string, unknown>`  |
 
-`projectJsonFile` returns what [`pickJson`](#inlining-json-at-compile-time) inlines: the paths it names projected out of the file, serialized. It is the one implementation of that projection, so a check reading an entry's [recorded inputs](#what-a-manifest-entry-records) decides an inlined JSON file the same way the compile that recorded it did. It throws when the file is unreadable, holds invalid JSON, holds something other than an object, or no longer holds a path the specifier names.
+`projectJsonFile` returns what [`pickJson`](#inlining-json-at-compile-time) inlines: the paths it names projected out of the file, serialized. It is the one implementation of that projection, so a check reading an entry's [recorded inputs](#what-a-manifest-entry-records) decides an inlined JSON file the same way the compile that recorded it did. It throws when the file is unreadable, holds invalid JSON, holds something other than an object, or no longer holds a path the specifier names. `describeJsonProjectionFailure` words any of those four for a report, and words them without the file path, so a check that already names the file does not name it twice.
 
 ### Package manifests
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -939,12 +939,12 @@ rdy list --from npm:readyup           # both, with the checklists each one carri
 
 `default` reports at `warn` and below, so it is safe to run mid-edit:
 
-| Checklist   | What it asserts                                                                                                  |
-| ----------- | ---------------------------------------------------------------------------------------------------------------- |
-| `setup`     | A config file is present (at `recommend`), and a manifest records what has been compiled.                        |
-| `freshness` | Every kit the manifest records still matches the hashes recorded for it, on the source side and the bundle side. |
+| Checklist   | What it asserts                                                                                                                    |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `setup`     | A config file is present (at `recommend`), and a manifest records what has been compiled.                                          |
+| `freshness` | Every kit the manifest records still matches what was recorded for it: its source, its bundle, and everything the compile inlined. |
 
-Both `setup` checks stand down for a project that defines no kits of its own: a monorepo root that lists `packages` rather than authoring kits is not expected to keep any at its root, and a project is judged to define kits once it holds either `.readyup/kits` or `.readyup/manifest.json`. The manifest check stands down for a second reason, when nothing is compiled, since a project running its kits with `--jit` has nothing to record. So does `freshness`, which otherwise names one check per recorded kit.
+Both `setup` checks stand down for a project that defines no kits of its own: a monorepo root that lists `packages` rather than authoring kits is not expected to keep any at its root, and a project is judged to define kits once it holds either `.readyup/kits` or `.readyup/manifest.json`. The manifest check stands down for a second reason, when nothing is compiled, since a project running its kits with `--jit` has nothing to record. So does `freshness`, which otherwise names one check per recorded kit. Beneath each kit, the comparison over what it inlined stands down for an entry compiled before readyup [recorded its inputs](#what-a-manifest-entry-records); an inlined JSON file is decided by the projection that was substituted rather than by the file holding it, through the same `projectJsonFile` the compile recorded through.
 
 `publishing` reports at `error`, for a package that distributes its kits:
 
@@ -1080,9 +1080,12 @@ import { fileExists, hasPackageJsonField } from 'readyup/check-utils';
 | `readJsonValue(path, ...keys)`      | Value at a key path within a file         |
 | `hasJsonField(path, field, value?)` | Field exists, optionally matching a value |
 | `hasJsonFields(path, fields)`       | `CheckOutcome` over several fields        |
+| `projectJsonFile(path, paths)`      | Serialized projection of a JSON file      |
 | `getJsonValue(obj, ...keys)`        | Value at a key path within an object      |
 | `hasJsonValue(obj, ...keys)`        | Key path is present                       |
 | `isRecord(value)`                   | Type guard for `Record<string, unknown>`  |
+
+`projectJsonFile` returns what [`pickJson`](#inlining-json-at-compile-time) inlines: the paths it names projected out of the file, serialized. It is the one implementation of that projection, so a check reading an entry's [recorded inputs](#what-a-manifest-entry-records) decides an inlined JSON file the same way the compile that recorded it did. It throws when the file is unreadable, holds invalid JSON, holds something other than an object, or no longer holds a path the specifier names.
 
 ### Package manifests
 

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -1,4 +1,5 @@
 export type { JsonPathSpec } from '../compile/extractJsonPaths.ts';
+export { describeJsonProjectionFailure } from '../compile/JsonProjectionError.ts';
 export { projectJsonFile } from '../compile/projectJsonFile.ts';
 export { isRecord } from '../portable/isRecord.ts';
 export { discoverKitPackages } from './discoverKitPackages.ts';

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -1,3 +1,5 @@
+export type { JsonPathSpec } from '../compile/extractJsonPaths.ts';
+export { projectJsonFile } from '../compile/projectJsonFile.ts';
 export { isRecord } from '../portable/isRecord.ts';
 export { discoverKitPackages } from './discoverKitPackages.ts';
 export type { EnginesNodeFloor } from './engines.ts';

--- a/packages/readyup/src/compile/JsonProjectionError.ts
+++ b/packages/readyup/src/compile/JsonProjectionError.ts
@@ -13,7 +13,7 @@ export type JsonProjectionFailure = 'invalid-json' | 'not-an-object' | 'path-not
 export interface JsonProjectionErrorOptions {
   cause?: unknown;
 
-  /** What the failure found, where `reason` alone does not say it: the root's type for `not-an-object`. */
+  /** What the failure found, where `reason` alone does not say it: the root's type, or the key path. */
   detail?: string | undefined;
 }
 
@@ -61,7 +61,7 @@ export function describeJsonProjectionFailure(error: unknown): string {
     case 'not-an-object':
       return `expected a JSON object, got ${error.detail ?? 'something else'}`;
     case 'path-not-found':
-      return error.message;
+      return `path not found: ${error.detail ?? 'unknown path'}`;
     case 'unreadable':
       return 'unreadable';
   }

--- a/packages/readyup/src/compile/JsonProjectionError.ts
+++ b/packages/readyup/src/compile/JsonProjectionError.ts
@@ -1,3 +1,5 @@
+import { describeError } from '@williamthorsen/toolbelt.errors';
+
 /**
  * Why a JSON file could not be projected onto a path specifier.
  *
@@ -40,5 +42,27 @@ export class JsonProjectionError extends Error {
     this.detail = options.detail;
     this.filePath = filePath;
     this.reason = reason;
+  }
+}
+
+/**
+ * Returns why a JSON file could not be projected, in a form that does not repeat the path beside it.
+ *
+ * A `JsonProjectionError`'s own message names the file absolutely, which a caller reporting the failure
+ * has usually already named as it knows it. Reading the diagnosis off `reason` is what keeps the two
+ * from disagreeing about the path.
+ */
+export function describeJsonProjectionFailure(error: unknown): string {
+  if (!(error instanceof JsonProjectionError)) return describeError(error);
+
+  switch (error.reason) {
+    case 'invalid-json':
+      return 'invalid JSON';
+    case 'not-an-object':
+      return `expected a JSON object, got ${error.detail ?? 'something else'}`;
+    case 'path-not-found':
+      return error.message;
+    case 'unreadable':
+      return 'unreadable';
   }
 }

--- a/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
@@ -90,6 +90,7 @@ describe(projectJsonFile, () => {
     const error = captureProjectionError(JSON.stringify({ name: 'my-pkg' }), ['version']);
 
     expect(error.reason).toBe('path-not-found');
+    expect(error.detail).toBe('version');
     expect(error.message).toBe('Path not found in JSON: version');
   });
 });

--- a/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
@@ -71,11 +71,19 @@ describe(projectJsonFile, () => {
     expect(error.reason).toBe('invalid-json');
   });
 
+  // The detail names the root as JSON sees it, so an array and a null are distinguishable from an object.
   it('reports a non-object root as not-an-object, carrying the type it found', () => {
     const error = captureProjectionError('[1,2,3]');
 
     expect(error.reason).toBe('not-an-object');
-    expect(error.detail).toBe('object');
+    expect(error.detail).toBe('array');
+  });
+
+  it('names a null root as null rather than as an object', () => {
+    const error = captureProjectionError('null');
+
+    expect(error.reason).toBe('not-an-object');
+    expect(error.detail).toBe('null');
   });
 
   it('reports a picked path the file does not have as path-not-found, naming the path', () => {

--- a/packages/readyup/src/compile/extractJsonPaths.ts
+++ b/packages/readyup/src/compile/extractJsonPaths.ts
@@ -10,6 +10,18 @@ import { isRecord } from '../portable/isRecord.ts';
  */
 export type JsonPathSpec = Array<string | Array<string>>;
 
+/** A key path a `pickJson` specifier named that the JSON object does not hold. */
+export class JsonPathNotFoundError extends Error {
+  /** The key path, dot-joined as `extractJsonPaths` walked it. */
+  readonly keyPath: string;
+
+  constructor(keyPath: string) {
+    super(`Path not found in JSON: ${keyPath}`);
+    this.name = 'JsonPathNotFoundError';
+    this.keyPath = keyPath;
+  }
+}
+
 /**
  * Extract selected paths from a parsed JSON object, preserving original nesting structure.
  *
@@ -27,7 +39,7 @@ export function extractJsonPaths(obj: Record<string, unknown>, paths: JsonPathSp
     let current: unknown = obj;
     for (const key of keys) {
       if (!isRecord(current) || !Object.hasOwn(current, key)) {
-        throw new Error(`Path not found in JSON: ${keys.join('.')}`);
+        throw new JsonPathNotFoundError(keys.join('.'));
       }
       current = current[key];
     }

--- a/packages/readyup/src/compile/projectJsonFile.ts
+++ b/packages/readyup/src/compile/projectJsonFile.ts
@@ -5,7 +5,7 @@ import { describeError } from '@williamthorsen/toolbelt.errors';
 import { describeType } from '../portable/describe-value.ts';
 import { isRecord } from '../portable/isRecord.ts';
 import type { JsonPathSpec } from './extractJsonPaths.ts';
-import { extractJsonPaths } from './extractJsonPaths.ts';
+import { extractJsonPaths, JsonPathNotFoundError } from './extractJsonPaths.ts';
 import { JsonProjectionError } from './JsonProjectionError.ts';
 
 /**
@@ -43,6 +43,7 @@ export function projectJsonFile(filePath: string, paths: JsonPathSpec): string {
   try {
     return JSON.stringify(extractJsonPaths(parsed, paths));
   } catch (error: unknown) {
-    throw new JsonProjectionError('path-not-found', filePath, describeError(error), { cause: error });
+    const detail = error instanceof JsonPathNotFoundError ? error.keyPath : undefined;
+    throw new JsonProjectionError('path-not-found', filePath, describeError(error), { cause: error, detail });
   }
 }

--- a/packages/readyup/src/compile/projectJsonFile.ts
+++ b/packages/readyup/src/compile/projectJsonFile.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 
 import { describeError } from '@williamthorsen/toolbelt.errors';
 
+import { describeType } from '../portable/describe-value.ts';
 import { isRecord } from '../portable/isRecord.ts';
 import type { JsonPathSpec } from './extractJsonPaths.ts';
 import { extractJsonPaths } from './extractJsonPaths.ts';
@@ -33,7 +34,7 @@ export function projectJsonFile(filePath: string, paths: JsonPathSpec): string {
   }
 
   if (!isRecord(parsed)) {
-    const detail = typeof parsed;
+    const detail = describeType(parsed);
     throw new JsonProjectionError('not-an-object', filePath, `Expected a JSON object in ${filePath}, got ${detail}`, {
       detail,
     });

--- a/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
@@ -267,7 +267,7 @@ describe(warnOnKitStaleness, () => {
             kind: 'inline',
             path: '../../package.json',
             reason: 'unprojectable',
-            detail: 'Path not found in JSON: version',
+            detail: 'path not found: version',
           },
         ],
       });

--- a/packages/readyup/src/schemas/__tests__/fixtures/payloadFixtures.ts
+++ b/packages/readyup/src/schemas/__tests__/fixtures/payloadFixtures.ts
@@ -167,7 +167,7 @@ export const verifyPayload = {
           kind: 'inline',
           path: '../../package.json',
           reason: 'unprojectable',
-          detail: 'Path not found in JSON: version',
+          detail: 'path not found: version',
         },
       ],
     },

--- a/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
@@ -104,7 +104,7 @@ describe(checkInputDrift, () => {
       expect(checkInputDrift(kitWith([RECORDED_PICK]), tempDir)).toStrictEqual({
         kind: 'stale',
         failures: [
-          { kind: 'inline', path: 'package.json', reason: 'unprojectable', detail: 'Path not found in JSON: version' },
+          { kind: 'inline', path: 'package.json', reason: 'unprojectable', detail: 'path not found: version' },
         ],
       });
     });

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -283,7 +283,7 @@ describe(verifyCommand, () => {
             kind: 'inline',
             path: '../../package.json',
             reason: 'unprojectable',
-            detail: 'Path not found in JSON: version',
+            detail: 'path not found: version',
           },
         ],
       });
@@ -292,7 +292,7 @@ describe(verifyCommand, () => {
 
       expect(exitCode).toBe(1);
       expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining('input unprojectable: ../../package.json (Path not found in JSON: version)'),
+        expect.stringContaining('input unprojectable: ../../package.json (path not found: version)'),
       );
     });
 

--- a/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
@@ -266,7 +266,7 @@ describe('verifyCommand wiring', () => {
                 kind: 'inline',
                 path: 'package.json',
                 reason: 'unprojectable',
-                detail: 'Path not found in JSON: version',
+                detail: 'path not found: version',
               },
             ],
           },

--- a/packages/readyup/src/verify/checkInputDrift.ts
+++ b/packages/readyup/src/verify/checkInputDrift.ts
@@ -1,9 +1,7 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
-import { describeError } from '@williamthorsen/toolbelt.errors';
-
-import { JsonProjectionError } from '../compile/JsonProjectionError.ts';
+import { describeJsonProjectionFailure } from '../compile/JsonProjectionError.ts';
 import { projectJsonFile } from '../compile/projectJsonFile.ts';
 import type { RdyManifestInput, RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { hashFile, hashProjection } from './targetHash.ts';
@@ -64,32 +62,11 @@ function checkInput(input: RdyManifestInput, manifestDir: string): InputFailure 
   try {
     actual = hashProjection(projectJsonFile(resolvedPath, input.paths));
   } catch (error: unknown) {
-    return { kind: 'inline', path: input.path, reason: 'unprojectable', detail: describeProjectionFailure(error) };
+    return { kind: 'inline', path: input.path, reason: 'unprojectable', detail: describeJsonProjectionFailure(error) };
   }
 
   if (actual === input.hash) return undefined;
   return { kind: 'inline', path: input.path, reason: 'changed', expected: input.hash, actual };
-}
-
-/**
- * Returns why a JSON file could not be projected, in a form that does not repeat the path beside it.
- *
- * The error's own message names the file absolutely, which the failure already names as the manifest
- * records it. Reading the diagnosis off `reason` is what keeps the two from disagreeing about the path.
- */
-function describeProjectionFailure(error: unknown): string {
-  if (!(error instanceof JsonProjectionError)) return describeError(error);
-
-  switch (error.reason) {
-    case 'invalid-json':
-      return 'invalid JSON';
-    case 'not-an-object':
-      return `expected a JSON object, got ${error.detail ?? 'something else'}`;
-    case 'path-not-found':
-      return error.message;
-    case 'unreadable':
-      return 'unreadable';
-  }
 }
 
 // endregion | Helpers


### PR DESCRIPTION
## What

The `freshness` checklist now checks all files bundled into a compiled kit to determine whether the compilation is fresh or stale. For a package that publishes its kits, a bundle stale in one of those files now fails the check.

`readyup/check-utils` gains `projectJsonFile` and `describeJsonProjectionFailure`, which a kit can use to read and report on the JSON values a compile inlined.

## Why

ReadyUp gates its own published bundles on the `freshness` checklist, which compared the kit source against its recorded hash and the compiled bundle against its own, and nothing else. A bundle is a function of every module it inlines past the entry and every JSON projection substituted into it, so editing one of those and publishing without recompiling shipped a stale bundle with the gate green -- and ReadyUp's `publishing` kit, which bundles five modules under `.readyup/kits/checks/`, was in exactly that state.

## Details

### 🎉 Features

- `freshness` builds a third comparison beneath each manifest entry, `Everything it inlined is unchanged since it was compiled`, reporting `[n of n]` on a pass and naming every input that moved rather than the first. A module input is read and hashed; an inline input is hashed over the projection `pickJson` substituted, so an edit to a field the kit never picked does not read as staleness.
- An entry recording no `inputs` stands the assertion down rather than failing it, since an entry compiled before ReadyUp recorded the closure says nothing about whether the kit is stale.
- `readyup/check-utils` publishes `projectJsonFile`, the `JsonPathSpec` type, and `describeJsonProjectionFailure`. The first is the one implementation of the projection a recorded inline input is decided by; the third words any of its four failures for a report, without the path, so a check that already names the file does not name it twice.
- README covers the inputs assertion in the `freshness` table and documents both new helpers in the check-utils JSON table.

### 🐛 Bug fixes

- `projectJsonFile` describes a non-object JSON root through the existing `describeType`, so a top-level array reports `got array` and `null` reports `got null` rather than the contradictory `got object` that `typeof` produced. The message reaches `pickJson`'s compile-time failure, `rdy verify`, and the kit alike.
- The `unprojectable` detail that `rdy verify` renders, and that the `input-stale` run warning carries, is now composed from the failure's `reason` and `detail` rather than from an inner message. Its text changed for the `path-not-found` case; the field is free-form in `verifyOutputSchema`, so no schema moved.

### ♻️ Refactoring

- `extractJsonPaths` throws `JsonPathNotFoundError`, which carries the dot-joined key path it failed to walk, and `projectJsonFile` copies that path onto `JsonProjectionError.detail` beside the root type `not-an-object` already recorded. The error's own message is unchanged, so the compile-time failure `pickJson` raises for a kit author reads as it did.
- `describeJsonProjectionFailure` moved out of `checkInputDrift.ts` to sit beside the error it reads, and `rdy verify` and the `freshness` kit now word a projection failure through the same function.
- `kit-layout.ts` narrows a manifest entry's `inputs` to a `ManifestInput` record, rejecting a partly-valid path specifier whole rather than in part, since a projection over a subset of the recorded paths is not the projection whose hash was recorded.

### 🧪 Tests

- Ten cases over the `default` kit cover a drifted module, a drifted projection, a projection insensitive to an unpicked field, a vanished module, a vanished inline file, a specifier that fails narrowing, both shapes of an incomplete record, and the stand-down. One case over `publishing` asserts the checklist blocks at `error`.
- `project-fixture.ts` gains `writeInlineInput` and `writeModuleInput`, which hash through the same helpers `rdy compile` records through, and `writeRawKitManifest`, the door for records a schema-typed fixture cannot express.

Closes #315

