### PR TITLE
#231 Record the compile's toolchain so a rebuild mismatch names its cause

### DIFF
--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -8,6 +8,7 @@
         "code-quality",
         "publishing-pipeline"
       ],
+      "esbuildVersion": "0.28.1",
       "inputs": [
         {
           "hash": "33b6ea59",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,4 +48,4 @@ Releases run through the **Release** GitHub Actions workflow (`workflow_dispatch
 ## Gotchas
 
 - **Build caching**: `nmr build` skips a package whose sources are unchanged, keyed on a hash under `node_modules/.cache/nmr-compile/`. This is not the check-result cache, and `--no-cache` does not reach it; removing the output is what forces a rebuild (`nmr clean`, or deleting `dist` by any means).
-- **Kit freshness**: the tracked kit bundles embed the readyup version that compiled them, so a readyup version bump leaves them stale until `rdy compile` runs. `nmr ci` verifies them by recompiling, and does so before its build step, which would otherwise regenerate a stale bundle in place.
+- **Kit freshness**: the tracked kit bundles embed the readyup version that compiled them, and the manifest records the compile's toolchain (`esbuildVersion`, `bundledDependencies`), so a bump to readyup, to esbuild, or to a bundled dependency leaves them stale until `rdy compile` runs. `nmr ci` verifies them by recompiling, and does so before its build step, which would otherwise regenerate a stale bundle in place.

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -856,23 +856,27 @@ Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `fa
 
 #### What a manifest entry records
 
-| Field            | Meaning                                                                                     |
-| ---------------- | ------------------------------------------------------------------------------------------- |
-| `checklists`     | The checklist names the kit declares, so `rdy list` reports them without running the bundle |
-| `description`    | The kit's own description, where it declares one                                            |
-| `inputs`         | Every file the compile read, each with the hash of what was consumed from it                |
-| `name`           | The kit's name, which is its compiled file's basename                                       |
-| `path`           | The compiled bundle, relative to the manifest                                               |
-| `readyupVersion` | The readyup that compiled the kit                                                           |
-| `source`         | The TypeScript the bundle was built from, relative to the manifest                          |
-| `sourceHash`     | Hash of that source, read back out of its own `inputs` record                               |
-| `targetHash`     | Hash of the compiled bundle                                                                 |
+| Field                 | Meaning                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------- |
+| `bundledDependencies` | Each package the bundle inlined, by name, with the version its `package.json` declares      |
+| `checklists`          | The checklist names the kit declares, so `rdy list` reports them without running the bundle |
+| `description`         | The kit's own description, where it declares one                                            |
+| `esbuildVersion`      | The esbuild that produced the bundle                                                        |
+| `inputs`              | Every file the compile read, each with the hash of what was consumed from it                |
+| `name`                | The kit's name, which is its compiled file's basename                                       |
+| `path`                | The compiled bundle, relative to the manifest                                               |
+| `readyupVersion`      | The readyup that compiled the kit                                                           |
+| `source`              | The TypeScript the bundle was built from, relative to the manifest                          |
+| `sourceHash`          | Hash of that source, read back out of its own `inputs` record                               |
+| `targetHash`          | Hash of the compiled bundle                                                                 |
 
 `inputs` is the compile's input closure: every module the bundle inlined past the entry, and every JSON file [`pickJson`](#inlining-json-at-compile-time) projected. A module records the hash of its bytes. An inlined JSON file records the hash of the projection that was substituted, with the path specifier that produced it, so an edit to a field the kit did not pick is not staleness.
 
 The closure stops at `node_modules`. A dependency's contents are pinned by the lockfile and read exactly by [`rdy verify --rebuild`](#verifying-by-recompiling), while recording them would size a committed, per-compile-rewritten manifest to the dependency tree rather than to the kit: one `import zod` inlines 79 files.
 
-An entry compiled before readyup recorded the closure carries no `inputs`.
+What the closure leaves out is recorded as versions instead: `esbuildVersion` names the bundler and `bundledDependencies` each inlined package, one entry per package rather than one per file. A package a bundle inlines at two versions at once records both, sorted and comma-separated. `bundledDependencies` is absent for a kit that bundles nothing, so `esbuildVersion` is the marker that an entry carries the record at all.
+
+An entry compiled before readyup recorded the closure carries no `inputs`; one compiled before the version record carries no `esbuildVersion`.
 
 ### Package-hosted kits
 
@@ -1015,7 +1019,7 @@ In CI:
 
 #### Verifying by recompiling
 
-The three verdicts cover what the compile read and recorded. A bundle is a function of more than that: the bundler's version, the compile options, and the contents of every dependency, which the manifest records none of, since [the closure stops at `node_modules`](#what-a-manifest-entry-records). A bundle stale in any of them still hashes as `ok`.
+The three verdicts cover what the compile read and recorded as hashes. A bundle is a function of more than that: the bundler's version, the compile options, and the contents of every dependency, none of which the hash verdicts cover, since [the closure stops at `node_modules`](#what-a-manifest-entry-records). A bundle stale in any of them still hashes as `ok`.
 
 `--rebuild` answers the question exactly. It recompiles each kit in memory and compares the result to the committed bundle byte for byte:
 
@@ -1023,9 +1027,11 @@ The three verdicts cover what the compile read and recorded. A bundle is a funct
 ── Verifying kits against .readyup/manifest.json
 
 🔴 deploy
-   rebuild mismatch (rebuilt 8c31f0a2, on disk 6f58905a)
+   rebuild mismatch (rebuilt 8c31f0a2, on disk 6f58905a; esbuild 0.28.1 -> 0.29.0; zod 3.24.1 -> 4.0.0)
 🟢 smoke
 ```
+
+A mismatch names what moved, read from the versions the manifest records: the readyup that compiled the bundle, the esbuild, and each bundled package whose version the rebuild does not reproduce. When every recorded version matches, the mismatch says so, which leaves an edited bundle, a changed input, or dependency content changed without a version bump. The comparison reads the rebuild's own record on both sides, so nothing is resolved from the installed tree, and an entry compiled before the version record renders the bare hashes.
 
 The comparison is against the bundle on disk, never the recorded hash, so the verdict is independent of the manifest's bookkeeping and can contradict it. A bundle that reproduces exactly while its recorded hash does not match says the record is what went wrong, not the kit:
 
@@ -1037,9 +1043,9 @@ The comparison is against the bundle on disk, never the recorded hash, so the ve
 
 The verdict is `ok`, `mismatch`, `failed` (the source no longer compiles), or `missing` (nothing to recompile, or nothing to compare against). Only `ok` passes. There is no `unverified` here: an exactness check that waived the kits it could not reach would establish less than it appears to.
 
-Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`, plus `rebuildCompiledWith` when the bundle was built by a different readyup; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
+Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`, plus `rebuildCompiledWith` when the bundle was built by a different readyup, `rebuildEsbuild` (the recorded esbuild against the rebuild's) whenever the entry records one, and `rebuildDependencyChanges` when at least one bundled package's version moved; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
 
-Three things to know before wiring it into CI: It requires esbuild. The readyup version forms part of a bundle's hash, so a readyup upgrade makes every kit mismatch until recompiled. And it must not run after a step that recompiles kits, because recompilation would defeat the comparison.
+Three things to know before wiring it into CI: It requires esbuild, which a repository that compiles kits already has. The readyup version forms part of a bundle's hash, so a readyup upgrade makes every kit mismatch until recompiled. And it must not run after a step that recompiles kits, because recompilation would defeat the comparison.
 
 ```yaml
 - run: npx rdy verify --rebuild

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1031,7 +1031,7 @@ The three verdicts cover what the compile read and recorded as hashes. A bundle 
 🟢 smoke
 ```
 
-A mismatch names what moved, read from the versions the manifest records: the readyup that compiled the bundle, the esbuild, and each bundled package whose version the rebuild does not reproduce. When every recorded version matches, the mismatch says so, which leaves an edited bundle, a changed input, or dependency content changed without a version bump. The comparison reads the rebuild's own record on both sides, so nothing is resolved from the installed tree, and an entry compiled before the version record renders the bare hashes.
+A mismatch names which recorded versions changed, read from what the manifest records: the readyup that compiled the bundle, the esbuild, and each bundled package whose version the rebuild does not reproduce. When every recorded version matches, the mismatch says so, which leaves an edited bundle, a changed input, or dependency content changed without a version bump. The comparison reads the rebuild's own record on both sides, so nothing is resolved from the installed tree, and an entry compiled before the version record renders the bare hashes.
 
 The comparison is against the bundle on disk, never the recorded hash, so the verdict is independent of the manifest's bookkeeping and can contradict it. A bundle that reproduces exactly while its recorded hash does not match says the record is what went wrong, not the kit:
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1045,7 +1045,7 @@ The verdict is `ok`, `mismatch`, `failed` (the source no longer compiles), or `m
 
 Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`, plus `rebuildCompiledWith` when the bundle was built by a different readyup, `rebuildEsbuild` (the recorded esbuild against the rebuild's) whenever the entry records one, and `rebuildDependencyChanges` when at least one bundled package's version moved; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
 
-Three things to know before wiring it into CI: It requires esbuild, which a repository that compiles kits already has. The readyup version forms part of a bundle's hash, so a readyup upgrade makes every kit mismatch until recompiled. And it must not run after a step that recompiles kits, because recompilation would defeat the comparison.
+Three things to know before wiring it into CI: It requires esbuild, which a repository that compiles kits already has. The readyup version forms part of a bundle's hash, so a readyup upgrade makes every kit mismatch until recompiled; an esbuild or dependency upgrade mismatches wherever it changes a bundle's bytes, and the mismatch clause names it. And it must not run after a step that recompiles kits, because recompilation would defeat the comparison.
 
 ```yaml
 - run: npx rdy verify --rebuild

--- a/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
@@ -1,13 +1,14 @@
-import { version as installedEsbuildVersion } from 'esbuild';
 import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { version as installedEsbuildVersion } from 'esbuild';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { buildBundle } from '../buildBundle.ts';
+import { isRecord } from '../../portable/isRecord.ts';
 import type { BundleResult } from '../buildBundle.ts';
+import { buildBundle } from '../buildBundle.ts';
 
 const KIT_SOURCE = [
   `import { broken } from 'broken-dep';`,
@@ -105,8 +106,10 @@ describe('buildBundle bundled dependencies', () => {
 function readInstalledZodVersion(): string {
   const require = createRequire(import.meta.url);
   const parsed: unknown = JSON.parse(readFileSync(require.resolve('zod/package.json'), 'utf8'));
-  // Test-only assertion shortcut; the shape of an installed package.json is not under test.
-  return (parsed as { version: string }).version;
+  if (!isRecord(parsed) || typeof parsed['version'] !== 'string') {
+    throw new Error('zod/package.json declares no readable version');
+  }
+  return parsed['version'];
 }
 
 /** Writes a package directory with the given package.json body and files. */

--- a/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
@@ -1,0 +1,125 @@
+import { version as installedEsbuildVersion } from 'esbuild';
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { buildBundle } from '../buildBundle.ts';
+import type { BundleResult } from '../buildBundle.ts';
+
+const KIT_SOURCE = [
+  `import { broken } from 'broken-dep';`,
+  `import { outer } from 'outer';`,
+  `import { tiny } from 'tiny-dep';`,
+  '',
+  'export const kit = { broken, outer, tiny };',
+].join('\n');
+
+/** A repo module whose only import is `zod`, so bundling it reaches the pnpm store. */
+const PNPM_INSTALLED_MODULE = path.resolve(import.meta.dirname, '../../manifest/manifestSchema.ts');
+
+describe('buildBundle bundled dependencies', () => {
+  let treeRoot: string;
+  let result: BundleResult;
+
+  beforeAll(async () => {
+    treeRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'dependencies-')));
+    writeFileSync(path.join(treeRoot, 'kit.ts'), KIT_SOURCE);
+
+    writePackage(path.join(treeRoot, 'node_modules', 'tiny-dep'), { name: 'tiny-dep', version: '1.0.0' }, [
+      ['index.js', `import { util } from './util.js';\nexport const tiny = util;\n`],
+      ['util.js', `export const util = 'tiny@1';\n`],
+    ]);
+    writePackage(path.join(treeRoot, 'node_modules', 'outer'), { name: 'outer', version: '2.0.0' }, [
+      [
+        'index.js',
+        `import { inner } from 'inner';\nimport { tiny } from 'tiny-dep';\nexport const outer = { inner, tiny };\n`,
+      ],
+    ]);
+    writePackage(
+      path.join(treeRoot, 'node_modules', 'outer', 'node_modules', 'inner'),
+      { name: 'inner', version: '3.0.0' },
+      [['index.js', `export const inner = 'inner';\n`]],
+    );
+    writePackage(
+      path.join(treeRoot, 'node_modules', 'outer', 'node_modules', 'tiny-dep'),
+      { name: 'tiny-dep', version: '2.1.0' },
+      [['index.js', `export const tiny = 'tiny@2';\n`]],
+    );
+    writePackage(path.join(treeRoot, 'node_modules', 'broken-dep'), { name: 'broken-dep' }, [
+      ['index.js', `export const broken = 'broken';\n`],
+    ]);
+
+    result = await buildBundle(path.join(treeRoot, 'kit.ts'));
+  });
+
+  afterAll(() => {
+    rmSync(treeRoot, { recursive: true, force: true });
+  });
+
+  it('records each bundled package by name with its declared version', () => {
+    expect(result.bundledDependencies).toMatchObject({ inner: '3.0.0', outer: '2.0.0' });
+  });
+
+  it('joins the versions when the bundle inlines two versions of one package', () => {
+    expect(result.bundledDependencies['tiny-dep']).toBe('1.0.0, 2.1.0');
+  });
+
+  it('omits a package whose package.json declares no version', () => {
+    expect(result.bundledDependencies).not.toHaveProperty('broken-dep');
+  });
+
+  it('sorts the record by package name', () => {
+    expect(Object.keys(result.bundledDependencies)).toStrictEqual(['inner', 'outer', 'tiny-dep']);
+  });
+
+  it('records the running esbuild as esbuildVersion', () => {
+    expect(result.esbuildVersion).toBe(installedEsbuildVersion);
+  });
+
+  it('records nothing for a kit that bundles no packages', async () => {
+    writeFileSync(path.join(treeRoot, 'bare-kit.ts'), 'export const kit = {};\n');
+
+    const bare = await buildBundle(path.join(treeRoot, 'bare-kit.ts'));
+
+    expect(bare.bundledDependencies).toStrictEqual({});
+  });
+
+  it('identifies a package installed through the pnpm store', async () => {
+    writeFileSync(
+      path.join(treeRoot, 'pnpm-kit.ts'),
+      `export { ManifestSchema } from ${JSON.stringify(PNPM_INSTALLED_MODULE)};\n`,
+    );
+
+    const bundled = await buildBundle(path.join(treeRoot, 'pnpm-kit.ts'));
+
+    expect(bundled.bundledDependencies['zod']).toBe(readInstalledZodVersion());
+  });
+});
+
+// region | Helpers
+
+/** Reads the version of the zod this package resolves, which is the one bundling `manifestSchema.ts` inlines. */
+function readInstalledZodVersion(): string {
+  const require = createRequire(import.meta.url);
+  const parsed: unknown = JSON.parse(readFileSync(require.resolve('zod/package.json'), 'utf8'));
+  // Test-only assertion shortcut; the shape of an installed package.json is not under test.
+  return (parsed as { version: string }).version;
+}
+
+/** Writes a package directory with the given package.json body and files. */
+function writePackage(
+  packageDir: string,
+  packageJson: Record<string, string>,
+  files: Array<[name: string, content: string]>,
+): void {
+  mkdirSync(packageDir, { recursive: true });
+  writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify(packageJson));
+  for (const [name, content] of files) {
+    writeFileSync(path.join(packageDir, name), content);
+  }
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
@@ -1,12 +1,11 @@
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { version as installedEsbuildVersion } from 'esbuild';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { isRecord } from '../../portable/isRecord.ts';
+import { readInstalledPackageVersion } from '../../test-utils/readInstalledPackageVersion.ts';
 import type { BundleResult } from '../buildBundle.ts';
 import { buildBundle } from '../buildBundle.ts';
 
@@ -96,21 +95,11 @@ describe('buildBundle bundled dependencies', () => {
 
     const bundled = await buildBundle(path.join(treeRoot, 'pnpm-kit.ts'));
 
-    expect(bundled.bundledDependencies['zod']).toBe(readInstalledZodVersion());
+    expect(bundled.bundledDependencies['zod']).toBe(readInstalledPackageVersion('zod'));
   });
 });
 
 // region | Helpers
-
-/** Reads the version of the zod this package resolves, which is the one bundling `manifestSchema.ts` inlines. */
-function readInstalledZodVersion(): string {
-  const require = createRequire(import.meta.url);
-  const parsed: unknown = JSON.parse(readFileSync(require.resolve('zod/package.json'), 'utf8'));
-  if (!isRecord(parsed) || typeof parsed['version'] !== 'string') {
-    throw new Error('zod/package.json declares no readable version');
-  }
-  return parsed['version'];
-}
 
 /** Writes a package directory with the given package.json body and files. */
 function writePackage(

--- a/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
@@ -74,6 +74,9 @@ const SRC_DIR = '.readyup/kits';
 /** The hash a compile records for its entry point, which is where a manifest entry's `sourceHash` comes from. */
 const SOURCE_HASH = '5c0urce1';
 
+/** The esbuild version every mocked compile reports, which is where an entry's `esbuildVersion` comes from. */
+const ESBUILD_VERSION = '0.99.0-test';
+
 /** Returns the absolute path of a kit source in the directory a batch compile sweeps. */
 function kitSource(fileName: string): string {
   return path.resolve(process.cwd(), SRC_DIR, fileName);
@@ -90,7 +93,12 @@ function compileResult(
   result: { outputPath: string; changed: boolean; targetHash: string },
   hash: string = SOURCE_HASH,
 ): CompileResult {
-  return { ...result, inputs: [{ hash, kind: 'module', path: path.resolve(entry) }] };
+  return {
+    ...result,
+    bundledDependencies: {},
+    esbuildVersion: ESBUILD_VERSION,
+    inputs: [{ hash, kind: 'module', path: path.resolve(entry) }],
+  };
 }
 
 /** Returns the `inputs` an entry carries when its compile read only the entry point, stated against the manifest. */
@@ -643,6 +651,42 @@ describe(compileCommand, () => {
     });
   });
 
+  describe('manifest toolchain record', () => {
+    it('records bundled dependencies on the entry when the compile reports them', async () => {
+      mockCompileConfig.mockResolvedValue({
+        ...compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' }),
+        bundledDependencies: { picomatch: '4.0.2', zod: '4.0.5' },
+      });
+      mockReadManifest.mockImplementation(() => {
+        throw new ManifestNotFoundError('missing');
+      });
+
+      await compileCommand(['deploy.ts']);
+
+      expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
+        version: 1,
+        kits: [expect.objectContaining({ bundledDependencies: { picomatch: '4.0.2', zod: '4.0.5' } })],
+      });
+    });
+
+    it('omits the bundledDependencies field for a kit that bundles nothing', async () => {
+      mockCompileConfig.mockResolvedValue(
+        compileResult('deploy.ts', { outputPath: '/abs/deploy.js', changed: true, targetHash: 'aaaa1111' }),
+      );
+      mockReadManifest.mockImplementation(() => {
+        throw new ManifestNotFoundError('missing');
+      });
+
+      await compileCommand(['deploy.ts']);
+
+      const [call] = mockWriteManifest.mock.calls;
+      assert.ok(call);
+      const manifest: RdyManifest = call[1];
+
+      expect(manifest.kits[0]).not.toHaveProperty('bundledDependencies');
+    });
+  });
+
   describe('--json', () => {
     it('reports every kit status on stdout and keeps prose on stderr', async () => {
       mockLoadConfig.mockResolvedValue({
@@ -776,6 +820,7 @@ describe(compileCommand, () => {
       version: 1,
       kits: [
         {
+          esbuildVersion: ESBUILD_VERSION,
           inputs: recordedEntry('kits/alpha.ts'),
           name: 'alpha',
           description: 'Alpha checks',
@@ -786,6 +831,7 @@ describe(compileCommand, () => {
           targetHash: 'aaaa1111',
         },
         {
+          esbuildVersion: ESBUILD_VERSION,
           inputs: recordedEntry('kits/beta.ts'),
           name: 'beta',
           path: expect.stringContaining('beta.js'),
@@ -856,6 +902,7 @@ describe(compileCommand, () => {
       kits: [
         { name: 'default', description: 'Default checks' },
         {
+          esbuildVersion: ESBUILD_VERSION,
           inputs: recordedEntry('../deploy.ts'),
           name: 'deploy',
           description: 'Deploy checks',
@@ -884,6 +931,7 @@ describe(compileCommand, () => {
       version: 1,
       kits: [
         {
+          esbuildVersion: ESBUILD_VERSION,
           inputs: recordedEntry('../deploy.ts'),
           name: 'deploy',
           path: expect.stringContaining('deploy.js'),
@@ -912,6 +960,7 @@ describe(compileCommand, () => {
       version: 1,
       kits: [
         {
+          esbuildVersion: ESBUILD_VERSION,
           inputs: recordedEntry('../deploy.ts'),
           name: 'deploy',
           description: 'Updated',

--- a/packages/readyup/src/compile/__tests__/compileConfig.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileConfig.unit.test.ts
@@ -29,7 +29,7 @@ describe(compileConfig, () => {
   beforeEach(() => {
     // Default: The esbuild import succeeds and exposes the mocked `build`.
     // Failure-path tests override this with `mockRejectedValue`.
-    mockLoadEsbuild.mockResolvedValue({ build: mockBuild });
+    mockLoadEsbuild.mockResolvedValue({ build: mockBuild, version: '0.99.0-test' });
   });
 
   afterEach(() => {
@@ -74,6 +74,24 @@ describe(compileConfig, () => {
         banner: { js: expect.stringContaining(`export const __readyupVersion = ${JSON.stringify(VERSION)};`) },
       }),
     );
+  });
+
+  it('returns the loaded esbuild module version as esbuildVersion', async () => {
+    mockBuild.mockResolvedValue(buildResult('compiled'));
+    mockExistsSync.mockReturnValue(false);
+
+    const result = await compileConfig('config/readyup.config.ts');
+
+    expect(result.esbuildVersion).toBe('0.99.0-test');
+  });
+
+  it('returns no bundled dependencies when the metafile names no node_modules input', async () => {
+    mockBuild.mockResolvedValue(buildResult('compiled'));
+    mockExistsSync.mockReturnValue(false);
+
+    const result = await compileConfig('config/readyup.config.ts');
+
+    expect(result.bundledDependencies).toStrictEqual({});
   });
 
   it('returns the resolved output path', async () => {

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -70,7 +71,13 @@ const GENERATED_HEADER = [
 
 /** A kit's compiled bytes and the closure of files the compile read to produce them. */
 export interface BundleResult {
+  /** Every package the bundle inlined, by name, with the version its `package.json` declares. */
+  bundledDependencies: Record<string, string>;
+
   bytes: Buffer;
+
+  /** The esbuild that produced the bundle. */
+  esbuildVersion: string;
 
   /** Every file read outside `node_modules`, with absolute paths, sorted by path and then by kind. */
   inputs: CompiledInput[];
@@ -137,13 +144,46 @@ export async function buildBundle(inputPath: string): Promise<BundleResult> {
     throw new Error(`esbuild produced no output for ${resolvedInput}`);
   }
 
+  const metafileKeys = Object.keys(result.metafile.inputs);
+
   return {
+    bundledDependencies: collectBundledDependencies(metafileKeys, workingDir),
     bytes: Buffer.from(outputFile.contents),
-    inputs: collectInputs(recorder.inputs, Object.keys(result.metafile.inputs), workingDir),
+    esbuildVersion: esbuild.version,
+    inputs: collectInputs(recorder.inputs, metafileKeys, workingDir),
   };
 }
 
 // region | Helpers
+
+/**
+ * Returns the packages the bundle inlined, by name, from the metafile inputs the closure excludes.
+ *
+ * A tree can hold two versions of one package at once, and a bundle can inline both, so a name's value
+ * is every bundled version, sorted and comma-separated. A file whose package cannot be identified
+ * contributes nothing: the same derivation runs at compile time and at rebuild time, so an
+ * unidentifiable package cancels out of the comparison rather than producing a spurious difference.
+ */
+function collectBundledDependencies(metafileKeys: string[], workingDir: string): Record<string, string> {
+  const versionsByName = new Map<string, Set<string>>();
+  for (const key of metafileKeys) {
+    const resolvedPath = path.resolve(workingDir, key);
+    if (!isDependencyFile(resolvedPath)) continue;
+    const identity = identifyPackage(path.dirname(resolvedPath));
+    if (identity === undefined) continue;
+    const versions = versionsByName.get(identity.name) ?? new Set<string>();
+    versions.add(identity.version);
+    versionsByName.set(identity.name, versions);
+  }
+
+  return Object.fromEntries(
+    versionsByName
+      .entries()
+      .toArray()
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([name, versions]) => [name, versions.values().toArray().toSorted().join(', ')]),
+  );
+}
 
 /**
  * Returns the closure of a compile, merging what the recorder read with what esbuild resolved.
@@ -194,9 +234,41 @@ function hasUnresolvedSpecifier(error: unknown): boolean {
   );
 }
 
+/**
+ * Returns the name and version of the package holding `directory`, walking up to the nearest
+ * `package.json` that declares both.
+ *
+ * The walk never leaves `node_modules`: a store path with no identifiable package returns nothing
+ * rather than climbing on and attributing the file to the host project.
+ */
+function identifyPackage(directory: string): { name: string; version: string } | undefined {
+  for (let current = directory; isDependencyFile(current); current = path.dirname(current)) {
+    const manifestPath = path.join(current, 'package.json');
+    if (!existsSync(manifestPath)) continue;
+    const identity = readPackageIdentity(manifestPath);
+    if (identity !== undefined) return identity;
+  }
+  return undefined;
+}
+
 /** Reports whether a path lies under a dependency directory, whose contents the closure does not record. */
 function isDependencyFile(filePath: string): boolean {
   return filePath.split(path.sep).includes(EXCLUDED_DIRECTORY);
+}
+
+/** Returns a package.json's name and version, or nothing when the file does not declare both readably. */
+function readPackageIdentity(manifestPath: string): { name: string; version: string } | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+
+  if (!isRecord(parsed) || typeof parsed['name'] !== 'string' || typeof parsed['version'] !== 'string') {
+    return undefined;
+  }
+  return { name: parsed['name'], version: parsed['version'] };
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -143,6 +143,8 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
       const relSourcePath = path.relative(manifestDir, resolvedInputPath);
       const closure = deriveClosureFields(result.inputs, resolvedInputPath, manifestDir);
       upsertManifest(manifestPath, kitName, metadata, {
+        bundledDependencies: result.bundledDependencies,
+        esbuildVersion: result.esbuildVersion,
         inputs: closure.inputs,
         path: relOutputPath,
         source: relSourcePath,
@@ -266,6 +268,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
       const relSourcePath = path.relative(manifestDir, srcFile);
       const closure = deriveClosureFields(result.inputs, path.resolve(srcFile), manifestDir);
       kitEntries.push({
+        esbuildVersion: result.esbuildVersion,
         inputs: closure.inputs,
         name: kitName,
         path: relOutputPath,
@@ -273,6 +276,9 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
         source: relSourcePath,
         sourceHash: closure.sourceHash,
         targetHash: result.targetHash,
+        ...(Object.keys(result.bundledDependencies).length > 0 && {
+          bundledDependencies: result.bundledDependencies,
+        }),
         ...(metadata.checklists.length > 0 && { checklists: metadata.checklists }),
         ...(metadata.description !== undefined && { description: metadata.description }),
       });
@@ -352,8 +358,10 @@ function finishEmptySweep(args: FinishEmptySweepArgs): number {
   return finishCompile([], json);
 }
 
-/** Location fields for a manifest kit entry. */
-interface KitLocationFields {
+/** The fields a compile supplies to a manifest kit entry, with paths stated against the manifest. */
+interface KitCompileFields {
+  bundledDependencies: Record<string, string>;
+  esbuildVersion: string;
   inputs: RdyManifestInput[];
   path: string;
   source: string;
@@ -405,7 +413,7 @@ function upsertManifest(
   manifestPath: string,
   kitName: string,
   metadata: KitMetadata,
-  location: KitLocationFields,
+  compileFields: KitCompileFields,
 ): void {
   let existingKits: RdyManifestKit[] = [];
   try {
@@ -420,13 +428,17 @@ function upsertManifest(
   }
 
   const entry: RdyManifestKit = {
-    inputs: location.inputs,
+    esbuildVersion: compileFields.esbuildVersion,
+    inputs: compileFields.inputs,
     name: kitName,
-    path: location.path,
+    path: compileFields.path,
     readyupVersion: VERSION,
-    source: location.source,
-    sourceHash: location.sourceHash,
-    targetHash: location.targetHash,
+    source: compileFields.source,
+    sourceHash: compileFields.sourceHash,
+    targetHash: compileFields.targetHash,
+    ...(Object.keys(compileFields.bundledDependencies).length > 0 && {
+      bundledDependencies: compileFields.bundledDependencies,
+    }),
     ...(metadata.checklists.length > 0 && { checklists: metadata.checklists }),
     ...(metadata.description !== undefined && { description: metadata.description }),
   };

--- a/packages/readyup/src/compile/compileConfig.ts
+++ b/packages/readyup/src/compile/compileConfig.ts
@@ -8,7 +8,13 @@ import { deriveJsPath } from './deriveJsPath.ts';
 
 /** Result of a successful compilation. */
 export interface CompileResult {
+  /** Every package the bundle inlined, by name, with the version its `package.json` declares. */
+  bundledDependencies: Record<string, string>;
+
   changed: boolean;
+
+  /** The esbuild that produced the bundle. */
+  esbuildVersion: string;
 
   /** Every file the compile read outside `node_modules`, with absolute paths. */
   inputs: CompiledInput[];
@@ -27,7 +33,7 @@ export interface CompileResult {
 export async function compileConfig(inputPath: string, outputPath?: string): Promise<CompileResult> {
   const resolvedOutput = path.resolve(outputPath ?? deriveJsPath(inputPath));
 
-  const { bytes, inputs } = await buildBundle(inputPath);
+  const { bundledDependencies, bytes, esbuildVersion, inputs } = await buildBundle(inputPath);
   const existing = existsSync(resolvedOutput) ? readFileSync(resolvedOutput) : undefined;
   const changed = existing === undefined || !bytes.equals(existing);
 
@@ -36,5 +42,12 @@ export async function compileConfig(inputPath: string, outputPath?: string): Pro
     writeFileSync(resolvedOutput, bytes);
   }
 
-  return { changed, inputs, outputPath: resolvedOutput, targetHash: hashBytes(bytes) };
+  return {
+    bundledDependencies,
+    changed,
+    esbuildVersion,
+    inputs,
+    outputPath: resolvedOutput,
+    targetHash: hashBytes(bytes),
+  };
 }

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -36,7 +36,8 @@ const ManifestInputSchema = z.discriminatedUnion('kind', [
  *
  * `esbuildVersion` and `bundledDependencies` record the toolchain half of the compile: the esbuild
  * that produced the bundle, and each package the bundle inlined with the version its `package.json`
- * declares. Neither is covered by `inputs`, whose closure stops at `node_modules`; `rdy verify
+ * declares. A package inlined at two versions at once records both, sorted and comma-separated.
+ * Neither field is covered by `inputs`, whose closure stops at `node_modules`; `rdy verify
  * --rebuild` reads both to name what moved when a rebuild mismatches. Each is optional on the same
  * terms `checklists` is, and `bundledDependencies` is additionally absent when the kit bundles
  * nothing, so `esbuildVersion` is the marker that an entry carries the record at all.

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -38,9 +38,10 @@ const ManifestInputSchema = z.discriminatedUnion('kind', [
  * that produced the bundle, and each package the bundle inlined with the version its `package.json`
  * declares. A package inlined at two versions at once records both, sorted and comma-separated.
  * Neither field is covered by `inputs`, whose closure stops at `node_modules`; `rdy verify
- * --rebuild` reads both to name what moved when a rebuild mismatches. Each is optional on the same
- * terms `checklists` is, and `bundledDependencies` is additionally absent when the kit bundles
- * nothing, so `esbuildVersion` is the marker that an entry carries the record at all.
+ * --rebuild` reads both to name which versions changed when a rebuild mismatches. Each is
+ * optional on the same terms `checklists` is, and `bundledDependencies` is additionally absent
+ * when the kit bundles nothing, so `esbuildVersion` is the marker that an entry carries the
+ * record at all.
  */
 const ManifestKitSchema = z.object({
   bundledDependencies: z.record(z.string(), z.string()).optional(),

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -33,10 +33,19 @@ const ManifestInputSchema = z.discriminatedUnion('kind', [
  * `inputs` records everything else the compile read, which is every module the bundle inlined past the
  * entry and every JSON file `pickJson` projected. It is optional on the same terms `checklists` is: an
  * entry written before the closure was recorded has none.
+ *
+ * `esbuildVersion` and `bundledDependencies` record the toolchain half of the compile: the esbuild
+ * that produced the bundle, and each package the bundle inlined with the version its `package.json`
+ * declares. Neither is covered by `inputs`, whose closure stops at `node_modules`; `rdy verify
+ * --rebuild` reads both to name what moved when a rebuild mismatches. Each is optional on the same
+ * terms `checklists` is, and `bundledDependencies` is additionally absent when the kit bundles
+ * nothing, so `esbuildVersion` is the marker that an entry carries the record at all.
  */
 const ManifestKitSchema = z.object({
+  bundledDependencies: z.record(z.string(), z.string()).optional(),
   checklists: z.array(z.string()).optional(),
   description: z.string().optional(),
+  esbuildVersion: z.string().optional(),
   inputs: z.array(ManifestInputSchema).optional(),
   name: z.string().min(1),
   path: z.string().optional(),

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -78,7 +78,8 @@ export const RebuildEsbuildSchema = z
  * One bundled package whose recorded version the rebuild does not reproduce.
  *
  * `recorded` is the version the compile bundled and `rebuilt` the one the rebuild bundled; a side is
- * absent where the package was not bundled then or now.
+ * absent where the package was not bundled then or now. A side carrying several comma-separated
+ * versions is a package the bundle inlined at more than one version at once.
  */
 export const RebuildDependencyChangeSchema = z
   .object({ name: z.string(), recorded: z.string().optional(), rebuilt: z.string().optional() })

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -69,6 +69,21 @@ export const InputFailureSchema = z
  */
 export const RebuildStatusSchema = z.enum(['failed', 'mismatch', 'missing', 'ok']).meta({ id: 'RebuildStatus' });
 
+/** The esbuild version a mismatched bundle was compiled with against the one the rebuild ran. */
+export const RebuildEsbuildSchema = z
+  .object({ recorded: z.string(), rebuilt: z.string() })
+  .meta({ id: 'RebuildEsbuild' });
+
+/**
+ * One bundled package whose recorded version the rebuild does not reproduce.
+ *
+ * `recorded` is the version the compile bundled and `rebuilt` the one the rebuild bundled; a side is
+ * absent where the package was not bundled then or now.
+ */
+export const RebuildDependencyChangeSchema = z
+  .object({ name: z.string(), recorded: z.string().optional(), rebuilt: z.string().optional() })
+  .meta({ id: 'RebuildDependencyChange' });
+
 /**
  * One kit's verdicts.
  *
@@ -86,6 +101,12 @@ export const RebuildStatusSchema = z.enum(['failed', 'mismatch', 'missing', 'ok'
  * compile failure on `failed`. `rebuildCompiledWith` names the readyup a mismatched bundle was
  * built by, present only when it differs from the running one, which is what separates a mismatch
  * caused by a readyup upgrade from one caused by an edited bundle.
+ *
+ * `rebuildEsbuild` and `rebuildDependencyChanges` extend the same idea to the toolchain record: both
+ * appear only on `mismatch`, and only for a kit whose manifest entry records an `esbuildVersion`.
+ * `rebuildEsbuild` is present whenever that record exists, matching or not, so a consumer reads the
+ * comparison rather than reconstructing it from the manifest; `rebuildDependencyChanges` is present
+ * only when at least one bundled package's version moved.
  */
 export const VerifyKitEntrySchema = z
   .object({
@@ -102,6 +123,8 @@ export const VerifyKitEntrySchema = z
     rebuildExpected: z.string().optional(),
     rebuildActual: z.string().optional(),
     rebuildCompiledWith: z.string().optional(),
+    rebuildEsbuild: RebuildEsbuildSchema.optional(),
+    rebuildDependencyChanges: z.array(RebuildDependencyChangeSchema).optional(),
     rebuildError: z.string().optional(),
   })
   .meta({ id: 'VerifyKitEntry' });
@@ -123,6 +146,8 @@ export const VerifyOutputSchema = z
 export type JsonDriftStatus = z.infer<typeof DriftStatusSchema>;
 export type JsonInputFailure = z.infer<typeof InputFailureSchema>;
 export type JsonInputsStatus = z.infer<typeof InputsStatusSchema>;
+export type JsonRebuildDependencyChange = z.infer<typeof RebuildDependencyChangeSchema>;
+export type JsonRebuildEsbuild = z.infer<typeof RebuildEsbuildSchema>;
 export type JsonRebuildStatus = z.infer<typeof RebuildStatusSchema>;
 export type JsonSourceStatus = z.infer<typeof SourceStatusSchema>;
 export type JsonVerifyKitEntry = z.infer<typeof VerifyKitEntrySchema>;

--- a/packages/readyup/src/test-utils/readInstalledPackageVersion.ts
+++ b/packages/readyup/src/test-utils/readInstalledPackageVersion.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+import { isRecord } from '../portable/isRecord.ts';
+
+/** Reads the version of a package as this package resolves it, which is the one a compile here inlines. */
+export function readInstalledPackageVersion(name: string): string {
+  const require = createRequire(import.meta.url);
+  const parsed: unknown = JSON.parse(readFileSync(require.resolve(`${name}/package.json`), 'utf8'));
+  if (!isRecord(parsed) || typeof parsed['version'] !== 'string') {
+    throw new Error(`${name}/package.json declares no readable version`);
+  }
+  return parsed['version'];
+}

--- a/packages/readyup/src/verify/__tests__/checkRebuild.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkRebuild.unit.test.ts
@@ -79,6 +79,65 @@ describe(checkRebuild, () => {
     expect(status).not.toHaveProperty('compiledWith');
   });
 
+  it('compares the recorded esbuild version against the rebuild on a mismatch', async () => {
+    writeKitFiles(tempDir, Buffer.from('stale output'));
+    mockBuildBundle.mockResolvedValue(rebuildResult({ esbuildVersion: '0.29.0' }));
+
+    const status = await checkRebuild({ ...kit(), esbuildVersion: '0.28.1' }, tempDir);
+
+    expect(status).toMatchObject({ kind: 'mismatch', esbuild: { recorded: '0.28.1', rebuilt: '0.29.0' } });
+  });
+
+  it('carries the esbuild comparison even when the recorded version matches the rebuild', async () => {
+    writeKitFiles(tempDir, Buffer.from('stale output'));
+    mockBuildBundle.mockResolvedValue(rebuildResult({ esbuildVersion: '0.29.0' }));
+
+    const status = await checkRebuild({ ...kit(), esbuildVersion: '0.29.0' }, tempDir);
+
+    expect(status).toMatchObject({ kind: 'mismatch', esbuild: { recorded: '0.29.0', rebuilt: '0.29.0' } });
+  });
+
+  it('names each bundled package whose recorded version the rebuild does not reproduce', async () => {
+    writeKitFiles(tempDir, Buffer.from('stale output'));
+    mockBuildBundle.mockResolvedValue(rebuildResult({ bundledDependencies: { added: '2.0.0', zod: '4.0.0' } }));
+
+    const status = await checkRebuild(
+      { ...kit(), esbuildVersion: '0.29.0', bundledDependencies: { dropped: '1.0.0', zod: '3.24.1' } },
+      tempDir,
+    );
+
+    expect(status).toMatchObject({
+      kind: 'mismatch',
+      dependencyChanges: [
+        { name: 'added', rebuilt: '2.0.0' },
+        { name: 'dropped', recorded: '1.0.0' },
+        { name: 'zod', recorded: '3.24.1', rebuilt: '4.0.0' },
+      ],
+    });
+  });
+
+  it('omits dependencyChanges when the recorded versions match the rebuild', async () => {
+    writeKitFiles(tempDir, Buffer.from('stale output'));
+    mockBuildBundle.mockResolvedValue(rebuildResult({ bundledDependencies: { zod: '4.0.0' } }));
+
+    const status = await checkRebuild(
+      { ...kit(), esbuildVersion: '0.29.0', bundledDependencies: { zod: '4.0.0' } },
+      tempDir,
+    );
+
+    expect(status).not.toHaveProperty('dependencyChanges');
+  });
+
+  it('omits the toolchain comparison for an entry recording no esbuild version', async () => {
+    writeKitFiles(tempDir, Buffer.from('stale output'));
+    mockBuildBundle.mockResolvedValue(rebuildResult({ bundledDependencies: { zod: '4.0.0' } }));
+
+    const status = await checkRebuild(kit(), tempDir);
+
+    expect(status).not.toHaveProperty('esbuild');
+    expect(status).not.toHaveProperty('dependencyChanges');
+  });
+
   it('returns failed carrying the compile error when the source no longer compiles', async () => {
     writeKitFiles(tempDir, Buffer.from('compiled output'));
     mockBuildBundle.mockRejectedValue(new Error('Unexpected token'));
@@ -125,6 +184,17 @@ describe(checkRebuild, () => {
 /** Returns a manifest entry naming the source and bundle that `writeKitFiles` lays down. */
 function kit() {
   return { name: 'demo', path: 'demo.js', source: 'demo.ts' };
+}
+
+/** Returns a `buildBundle` result whose bytes mismatch the bundle `writeKitFiles` lays down. */
+function rebuildResult(overrides: { esbuildVersion?: string; bundledDependencies?: Record<string, string> } = {}) {
+  return {
+    bundledDependencies: {},
+    bytes: Buffer.from('fresh output'),
+    esbuildVersion: '0.29.0',
+    inputs: [],
+    ...overrides,
+  };
 }
 
 /** Writes a kit's source and its compiled bundle into `dir`. */

--- a/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { version as installedEsbuildVersion } from 'esbuild';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 import { compileConfig } from '../../compile/compileConfig.ts';
@@ -55,12 +56,16 @@ describe('verifyCommand --rebuild', () => {
         version: 1,
         kits: [
           {
+            esbuildVersion: result.esbuildVersion,
             name: 'demo',
             path: 'kit.js',
             readyupVersion: VERSION,
             source: 'kit.ts',
             sourceHash: hashFile(path.join(tempDir, 'kit.ts')),
             targetHash: result.targetHash,
+            ...(Object.keys(result.bundledDependencies).length > 0 && {
+              bundledDependencies: result.bundledDependencies,
+            }),
           },
         ],
       }),
@@ -116,6 +121,28 @@ describe('verifyCommand --rebuild', () => {
     expect(readPayload(stdoutSpy)).toMatchObject({
       passed: false,
       kits: [{ status: 'ok', sourceStatus: 'ok', rebuildStatus: 'mismatch', rebuildCompiledWith: PRIOR_VERSION }],
+    });
+  });
+
+  it('reports matching recorded versions on a mismatch the record cannot explain', async () => {
+    writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
+
+    await runVerify();
+
+    expect(readPayload(stdoutSpy).kits[0]).toMatchObject({
+      rebuildStatus: 'mismatch',
+      rebuildEsbuild: { recorded: installedEsbuildVersion, rebuilt: installedEsbuildVersion },
+    });
+  });
+
+  it('names a recorded esbuild that differs from the one rebuilding', async () => {
+    patchKits(path.join(tempDir, 'manifest.json'), { esbuildVersion: '0.0.1-old' });
+    writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
+
+    await runVerify();
+
+    expect(readPayload(stdoutSpy).kits[0]).toMatchObject({
+      rebuildEsbuild: { recorded: '0.0.1-old', rebuilt: installedEsbuildVersion },
     });
   });
 

--- a/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
@@ -1,15 +1,18 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { version as installedEsbuildVersion } from 'esbuild';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
+import type { CompileResult } from '../../compile/compileConfig.ts';
 import { compileConfig } from '../../compile/compileConfig.ts';
 import type { RdyManifestKit } from '../../manifest/manifestSchema.ts';
 import { ManifestSchema } from '../../manifest/manifestSchema.ts';
 import type { JsonVerifyOutput } from '../../schemas/verifyOutputSchema.ts';
 import { VerifyOutputSchema } from '../../schemas/verifyOutputSchema.ts';
+import { readInstalledPackageVersion } from '../../test-utils/readInstalledPackageVersion.ts';
 import { VERSION } from '../../version.ts';
 import { hashFile } from '../targetHash.ts';
 import { verifyCommand } from '../verifyCommand.ts';
@@ -17,9 +20,14 @@ import { verifyCommand } from '../verifyCommand.ts';
 /** Absolute specifier for the `pickJson` marker, so a kit written into a tempdir can import it. */
 const PICK_JSON_MODULE = path.resolve(import.meta.dirname, '../../compile/pickJson.ts');
 
-const KIT_SOURCE = `import { pickJson } from ${JSON.stringify(PICK_JSON_MODULE)};
+/** Absolute specifier for an installed package, so the fixture's compile records a bundled dependency. */
+const PICOMATCH_MODULE = createRequire(import.meta.url).resolve('picomatch');
+
+const KIT_SOURCE = `import picomatch from ${JSON.stringify(PICOMATCH_MODULE)};
+import { pickJson } from ${JSON.stringify(PICK_JSON_MODULE)};
 
 export const metadata = pickJson('./data.json', ['name', 'version']);
+export const matchesEverything = picomatch('*');
 
 export default { checklists: [] };
 `;
@@ -35,6 +43,7 @@ describe('verifyCommand --rebuild', () => {
   let tempDir: string;
   let stdoutSpy: MockInstance;
   let originalCwd: string;
+  let compiled: CompileResult;
 
   beforeEach(async () => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'verify-rebuild-'));
@@ -49,22 +58,22 @@ describe('verifyCommand --rebuild', () => {
     process.chdir(tempDir);
 
     // Record the manifest from a real compile, so its hashes are the ones the pipeline produces.
-    const result = await compileConfig(path.join(tempDir, 'kit.ts'), path.join(tempDir, 'kit.js'));
+    compiled = await compileConfig(path.join(tempDir, 'kit.ts'), path.join(tempDir, 'kit.js'));
     writeFileSync(
       path.join(tempDir, 'manifest.json'),
       JSON.stringify({
         version: 1,
         kits: [
           {
-            esbuildVersion: result.esbuildVersion,
+            esbuildVersion: compiled.esbuildVersion,
             name: 'demo',
             path: 'kit.js',
             readyupVersion: VERSION,
             source: 'kit.ts',
             sourceHash: hashFile(path.join(tempDir, 'kit.ts')),
-            targetHash: result.targetHash,
-            ...(Object.keys(result.bundledDependencies).length > 0 && {
-              bundledDependencies: result.bundledDependencies,
+            targetHash: compiled.targetHash,
+            ...(Object.keys(compiled.bundledDependencies).length > 0 && {
+              bundledDependencies: compiled.bundledDependencies,
             }),
           },
         ],
@@ -143,6 +152,22 @@ describe('verifyCommand --rebuild', () => {
 
     expect(readPayload(stdoutSpy).kits[0]).toMatchObject({
       rebuildEsbuild: { recorded: '0.0.1-old', rebuilt: installedEsbuildVersion },
+    });
+  });
+
+  it('names a dependency whose recorded version the rebuild does not reproduce', async () => {
+    patchKits(path.join(tempDir, 'manifest.json'), {
+      bundledDependencies: { ...compiled.bundledDependencies, picomatch: '0.0.1-old' },
+    });
+    writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
+
+    await runVerify();
+
+    expect(readPayload(stdoutSpy).kits[0]).toMatchObject({
+      rebuildStatus: 'mismatch',
+      rebuildDependencyChanges: [
+        { name: 'picomatch', recorded: '0.0.1-old', rebuilt: readInstalledPackageVersion('picomatch') },
+      ],
     });
   });
 

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -447,6 +447,91 @@ describe(verifyCommand, () => {
       );
     });
 
+    it('names the esbuild move on a mismatch whose recorded version differs', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({
+        kind: 'mismatch',
+        expected: '1111aaaa',
+        actual: '2222bbbb',
+        esbuild: { recorded: '0.28.1', rebuilt: '0.29.0' },
+      });
+
+      await verifyCommand(['--rebuild']);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('esbuild 0.28.1 -> 0.29.0'));
+    });
+
+    it('names each dependency change on a mismatch, one clause apiece', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({
+        kind: 'mismatch',
+        expected: '1111aaaa',
+        actual: '2222bbbb',
+        esbuild: { recorded: '0.29.0', rebuilt: '0.29.0' },
+        dependencyChanges: [
+          { name: 'glob', recorded: '10.0.0' },
+          { name: 'picomatch', rebuilt: '4.0.2' },
+          { name: 'zod', recorded: '3.24.1', rebuilt: '4.0.0' },
+        ],
+      });
+
+      await verifyCommand(['--rebuild']);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('glob 10.0.0 no longer bundled'));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('picomatch 4.0.2 newly bundled'));
+      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('zod 3.24.1 -> 4.0.0'));
+    });
+
+    it('says the recorded versions match when the toolchain record clears every named cause', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({
+        kind: 'mismatch',
+        expected: '1111aaaa',
+        actual: '2222bbbb',
+        esbuild: { recorded: '0.29.0', rebuilt: '0.29.0' },
+      });
+
+      await verifyCommand(['--rebuild']);
+
+      expect(stdoutSpy).toHaveBeenCalledWith(
+        expect.stringContaining('recorded esbuild and dependency versions match the rebuild'),
+      );
+    });
+
+    it('carries the esbuild comparison and dependency changes in the JSON payload', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({
+        kind: 'mismatch',
+        expected: '1111aaaa',
+        actual: '2222bbbb',
+        esbuild: { recorded: '0.28.1', rebuilt: '0.29.0' },
+        dependencyChanges: [{ name: 'zod', recorded: '3.24.1', rebuilt: '4.0.0' }],
+      });
+
+      await verifyCommand(['--rebuild', '--json']);
+
+      const payload: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({
+        kits: [
+          {
+            rebuildEsbuild: { recorded: '0.28.1', rebuilt: '0.29.0' },
+            rebuildDependencyChanges: [{ name: 'zod', recorded: '3.24.1', rebuilt: '4.0.0' }],
+          },
+        ],
+      });
+    });
+
+    it('omits the toolchain fields from the JSON payload for a mismatch predating the record', async () => {
+      arrangeSingleKit();
+      mockCheckRebuild.mockResolvedValue({ kind: 'mismatch', expected: '1111aaaa', actual: '2222bbbb' });
+
+      await verifyCommand(['--rebuild', '--json']);
+
+      const payload = String(stdoutSpy.mock.calls.at(-1)?.[0]);
+      expect(payload).not.toContain('rebuildEsbuild');
+      expect(payload).not.toContain('rebuildDependencyChanges');
+    });
+
     it('fails a kit whose source no longer compiles, carrying the compile error', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'failed', message: 'Unexpected token' });

--- a/packages/readyup/src/verify/checkRebuild.ts
+++ b/packages/readyup/src/verify/checkRebuild.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { describeError } from '@williamthorsen/toolbelt.errors';
 
+import type { BundleResult } from '../compile/buildBundle.ts';
 import { buildBundle } from '../compile/buildBundle.ts';
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
 import { VERSION } from '../version.ts';
@@ -11,17 +12,42 @@ import { hashBytes } from './targetHash.ts';
 /** Outcome of a per-kit rebuild check. */
 export type RebuildStatus =
   | { kind: 'ok' }
-  | { kind: 'mismatch'; expected: string; actual: string; compiledWith?: string }
+  | {
+      kind: 'mismatch';
+      expected: string;
+      actual: string;
+      compiledWith?: string;
+      dependencyChanges?: DependencyChange[];
+      esbuild?: EsbuildComparison;
+    }
   | { kind: 'failed'; message: string }
   | { kind: 'missing'; reason: string };
 
 /**
+ * A bundled package whose recorded version the rebuild does not reproduce.
+ *
+ * A side is absent where the package was not bundled then or now.
+ */
+export interface DependencyChange {
+  name: string;
+  recorded?: string;
+  rebuilt?: string;
+}
+
+/** The esbuild recorded at compile time against the one the rebuild ran. */
+export interface EsbuildComparison {
+  recorded: string;
+  rebuilt: string;
+}
+
+/**
  * Determines whether recompiling a kit's source reproduces the compiled bundle on disk.
  *
- * Answers exactly the question the two hash verdicts approximate. `targetHash` and `sourceHash`
- * record two of the bundle's inputs, but a bundle is a function of every module it inlines, every
- * JSON file `pickJson` reads, the esbuild version, and the compile options -- none of which the
- * manifest records. Recompiling reads all of them.
+ * Answers exactly the question the hash verdicts approximate. The recorded hashes cover what the
+ * compile read outside `node_modules`, but a bundle is also a function of every dependency module it
+ * inlines, the esbuild version, and the compile options. Recompiling reads all of them, and a
+ * mismatch compares the entry's recorded `esbuildVersion` and `bundledDependencies` against the
+ * rebuild's own record to name what moved.
  *
  * Compares against the on-disk bytes and never against `targetHash`, so the verdict is independent
  * of the manifest's bookkeeping and can contradict it. A kit whose recorded hash has gone wrong
@@ -51,9 +77,9 @@ export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Pr
     return { kind: 'missing', reason: `compiled file ${kit.path} is gone` };
   }
 
-  let rebuilt: Buffer;
+  let rebuild: BundleResult;
   try {
-    rebuilt = (await buildBundle(sourcePath)).bytes;
+    rebuild = await buildBundle(sourcePath);
   } catch (error: unknown) {
     // A source that no longer compiles is a finding about the kit, not a failure of the invocation,
     // so the sweep carries on to the kits after it.
@@ -61,7 +87,7 @@ export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Pr
   }
 
   const onDisk = readFileSync(targetPath);
-  if (rebuilt.equals(onDisk)) {
+  if (rebuild.bytes.equals(onDisk)) {
     return { kind: 'ok' };
   }
 
@@ -72,8 +98,54 @@ export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Pr
 
   return {
     kind: 'mismatch',
-    expected: hashBytes(rebuilt),
+    expected: hashBytes(rebuild.bytes),
     actual: hashBytes(onDisk),
     ...(compiledWith !== undefined && { compiledWith }),
+    ...compareToolchain(kit, rebuild),
   };
 }
+
+// region | Helpers
+
+/**
+ * Returns a mismatch's toolchain annotations: the recorded esbuild against the rebuild's, and every
+ * bundled package whose recorded version the rebuild does not reproduce.
+ *
+ * Empty for an entry recording no `esbuildVersion`, which predates the record. Both axes read the
+ * rebuild's own record, so no installed package is ever resolved outside a bundler run.
+ */
+function compareToolchain(
+  kit: RdyManifestKit,
+  rebuild: BundleResult,
+): Pick<Extract<RebuildStatus, { kind: 'mismatch' }>, 'dependencyChanges' | 'esbuild'> {
+  if (kit.esbuildVersion === undefined) return {};
+
+  const dependencyChanges = diffDependencies(kit.bundledDependencies ?? {}, rebuild.bundledDependencies);
+  return {
+    esbuild: { recorded: kit.esbuildVersion, rebuilt: rebuild.esbuildVersion },
+    ...(dependencyChanges.length > 0 && { dependencyChanges }),
+  };
+}
+
+/** Returns one change per package whose recorded and rebuilt versions differ, sorted by name. */
+function diffDependencies(recorded: Record<string, string>, rebuilt: Record<string, string>): DependencyChange[] {
+  const names = new Set([...Object.keys(recorded), ...Object.keys(rebuilt)])
+    .values()
+    .toArray()
+    .toSorted((a, b) => a.localeCompare(b));
+
+  const changes: DependencyChange[] = [];
+  for (const name of names) {
+    const recordedVersion = recorded[name];
+    const rebuiltVersion = rebuilt[name];
+    if (recordedVersion === rebuiltVersion) continue;
+    changes.push({
+      name,
+      ...(recordedVersion !== undefined && { recorded: recordedVersion }),
+      ...(rebuiltVersion !== undefined && { rebuilt: rebuiltVersion }),
+    });
+  }
+  return changes;
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/verify/checkRebuild.ts
+++ b/packages/readyup/src/verify/checkRebuild.ts
@@ -47,7 +47,7 @@ export interface EsbuildComparison {
  * compile read outside `node_modules`, but a bundle is also a function of every dependency module it
  * inlines, the esbuild version, and the compile options. Recompiling reads all of them, and a
  * mismatch compares the entry's recorded `esbuildVersion` and `bundledDependencies` against the
- * rebuild's own record to name what moved.
+ * rebuild's own record to name which versions changed.
  *
  * Compares against the on-disk bytes and never against `targetHash`, so the verdict is independent
  * of the manifest's bookkeeping and can contradict it. A kit whose recorded hash has gone wrong

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -21,7 +21,7 @@ import type { DriftStatus } from './checkDrift.ts';
 import { checkDrift } from './checkDrift.ts';
 import type { InputFailure, InputsStatus } from './checkInputDrift.ts';
 import { checkInputDrift } from './checkInputDrift.ts';
-import type { RebuildStatus } from './checkRebuild.ts';
+import type { DependencyChange, RebuildStatus } from './checkRebuild.ts';
 import { checkRebuild } from './checkRebuild.ts';
 import type { SourceStatus } from './checkSourceDrift.ts';
 import { checkSourceDrift } from './checkSourceDrift.ts';
@@ -183,6 +183,8 @@ function buildVerifyEntry(name: string, { drift, inputs, rebuild, source }: KitV
       rebuildExpected: rebuild.expected,
       rebuildActual: rebuild.actual,
       ...(rebuild.compiledWith !== undefined && { rebuildCompiledWith: rebuild.compiledWith }),
+      ...(rebuild.esbuild !== undefined && { rebuildEsbuild: rebuild.esbuild }),
+      ...(rebuild.dependencyChanges !== undefined && { rebuildDependencyChanges: rebuild.dependencyChanges }),
     }),
     ...(rebuild?.kind === 'failed' && { rebuildError: rebuild.message }),
   };
@@ -299,13 +301,50 @@ function describeRebuildStatus(status: RebuildStatus | undefined, hashesConfirme
     case 'ok':
       return hashesConfirmed ? undefined : 'rebuild ok';
     case 'mismatch': {
-      const versions =
-        status.compiledWith === undefined ? '' : `; compiled by readyup ${status.compiledWith}, rebuilt by ${VERSION}`;
-      return `rebuild mismatch (rebuilt ${status.expected}, on disk ${status.actual}${versions})`;
+      const causes = describeMismatchCauses(status);
+      const detail = causes.length === 0 ? '' : `; ${causes.join('; ')}`;
+      return `rebuild mismatch (rebuilt ${status.expected}, on disk ${status.actual}${detail})`;
     }
     case 'failed':
       return `rebuild failed (${status.message})`;
     case 'missing':
       return `cannot rebuild (${status.reason})`;
   }
+}
+
+/**
+ * Returns the clauses naming what moved between the compile and the rebuild, one per cause.
+ *
+ * When the entry carries the toolchain record and nothing in it moved, the single clause says so and
+ * names what the record cannot see: an edited bundle, a changed input, or a dependency whose content
+ * changed without a version change.
+ */
+function describeMismatchCauses(status: Extract<RebuildStatus, { kind: 'mismatch' }>): string[] {
+  const causes: string[] = [];
+  if (status.compiledWith !== undefined) {
+    causes.push(`compiled by readyup ${status.compiledWith}, rebuilt by ${VERSION}`);
+  }
+  if (status.esbuild !== undefined && status.esbuild.recorded !== status.esbuild.rebuilt) {
+    causes.push(`esbuild ${status.esbuild.recorded} -> ${status.esbuild.rebuilt}`);
+  }
+  const dependencyChanges = status.dependencyChanges ?? [];
+  for (const change of dependencyChanges) {
+    causes.push(describeDependencyChange(change));
+  }
+
+  if (causes.length === 0 && status.esbuild !== undefined) {
+    causes.push(
+      'recorded esbuild and dependency versions match the rebuild; the cause is an edited bundle, a changed input, or dependency content changed without a version bump',
+    );
+  }
+  return causes;
+}
+
+/** Returns a clause naming one bundled package and how its version moved since the compile. */
+function describeDependencyChange(change: DependencyChange): string {
+  const { name, rebuilt, recorded } = change;
+  if (recorded !== undefined && rebuilt !== undefined) return `${name} ${recorded} -> ${rebuilt}`;
+  if (rebuilt !== undefined) return `${name} ${rebuilt} newly bundled`;
+  if (recorded !== undefined) return `${name} ${recorded} no longer bundled`;
+  return name;
 }

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -313,9 +313,9 @@ function describeRebuildStatus(status: RebuildStatus | undefined, hashesConfirme
 }
 
 /**
- * Returns the clauses naming what moved between the compile and the rebuild, one per cause.
+ * Returns one clause per cause, naming which versions changed between the compile and the rebuild.
  *
- * When the entry carries the toolchain record and nothing in it moved, the single clause says so and
+ * When the entry carries the toolchain record and nothing in it changed, the single clause says so and
  * names what the record cannot see: an edited bundle, a changed input, or a dependency whose content
  * changed without a version change.
  */


### PR DESCRIPTION
## What

Improves ReadyUp's ability to diagnose why a kit is reported stale. `rdy compile` now records the esbuild that built each kit and every package the bundle inlined, as `esbuildVersion` and `bundledDependencies` on the kit's manifest entry. On a mismatch, `rdy verify --rebuild` compares them to newly computed values and reports which versions changed, or that none did. Plain `rdy verify` works as before.

## Why

The manifest's recorded input closure stops at `node_modules`, so a bundle can go stale from an esbuild upgrade or a dependency bump while every recorded hash still matches. `--rebuild` already caught both exactly and could say nothing about either, leaving a reader two hashes and no way to tell whether the bundler moved, a dependency moved, or someone edited the bundle by hand. readyup already named one such cause -- `rebuildCompiledWith`, rendered as "compiled by readyup 0.27.0, rebuilt by 0.29.0" -- and this extends that treatment to the rest of the compile's inputs.

## Details

### 🎉 Features

- `buildBundle` derives both values from what it already holds: `esbuildVersion` from the loaded module, and `bundledDependencies` by walking each `node_modules` metafile input up to the nearest `package.json` declaring both a name and a version. Packages are recorded once each, by name, so a kit inlining `zod` records one entry rather than 79 file hashes; a package inlined at two versions at once records both, sorted and comma-separated. A kit that bundles nothing records no `bundledDependencies` field, which makes `esbuildVersion` the marker that an entry carries the record at all.
- `checkRebuild` keeps the whole `BundleResult` rather than just its bytes, and on a mismatch compares the entry's recorded versions against the rebuild's own. Both sides come from a bundler run, so nothing is ever resolved from the installed tree -- which is what keeps the comparison correct under pnpm's store layout and under `pnpm patch`.
- Under `--json`, a `mismatch` gains `rebuildEsbuild` (both sides, whenever the entry records one) and `rebuildDependencyChanges` (one entry per package whose version moved, with a side absent where the package was not bundled then or now). Both are optional additions to an open schema, so `schemaVersion` stays at 1.
- An entry compiled before the record renders exactly as it did before, with neither JSON field present.

### 🧪 Tests

- A tool-tier suite compiles against a synthetic `node_modules` tree covering the walk's hard cases: a nested `outer/node_modules/inner`, two versions of one package inlined at once, and a `package.json` carrying a name but no version. A companion case compiles a module that inlines this repo's pnpm-installed `zod`, so the walk is exercised against a real store layout and not only a fixture.
- The `--rebuild` tool fixture now inlines `picomatch`, so its manifest carries `bundledDependencies` across a real `ManifestSchema` parse and a patched version proves the change reaches `rebuildDependencyChanges` end to end.
- Rendering is asserted through `verifyCommand` rather than against the clause helper, covering an esbuild move, each dependency-change shape, the matching-versions fallback, and the JSON payload's absence of both fields for an entry predating the record.

### 📚 Documentation

- The README's manifest table gains both fields, the closure paragraph explains why dependency identity is recorded as versions rather than files, and the `--rebuild` section documents the mismatch explanation, the JSON fields, and the standing limit that plain `rdy verify` still passes a bundle whose toolchain moved.
- `AGENTS.md`'s kit-freshness gotcha now names every input that can leave a tracked bundle stale, not readyup alone.


Closes #231


