### PR TITLE
#328 Memoize workspace discovery so one run walks the tree once

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1170,7 +1170,7 @@ const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
 
 `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs using YAML anchors, flow sequences, or negation patterns raise a clear error.
 
-Discovery is memoized per `cwd` for the life of the process: repeated calls in one run share a single directory walk, and `filter` is applied per call rather than being part of the key, so two checks filtering differently still pay for one walk. Entries are the same `Workspace` objects on every call -- treat them as read-only -- and a call made after the filesystem changes answers from the first walk. A discovery that throws is not memoized.
+Discovery is memoized per `cwd` for the life of the process: Repeated calls in one run share a single directory walk. `filter` is applied per call rather than being part of the key, so two checks filtering differently share that walk too. Entries are the same `Workspace` objects on every call, frozen along with their `packageJson`, so a write throws rather than reaching the next caller; a workspace added or removed after the first call does not appear in later results. A discovery that throws is not memoized.
 
 ### Kit packages
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1170,6 +1170,8 @@ const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
 
 `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs using YAML anchors, flow sequences, or negation patterns raise a clear error.
 
+Discovery is memoized per `cwd` for the life of the process: repeated calls in one run share a single directory walk, and `filter` is applied per call rather than being part of the key, so two checks filtering differently still pay for one walk. Entries are the same `Workspace` objects on every call -- treat them as read-only -- and a call made after the filesystem changes answers from the first walk. A discovery that throws is not memoized.
+
 ### Kit packages
 
 `discoverKitPackages(fromDir?)` names the installed dependencies that publish kits, sorted. It reads the `dependencies` and `devDependencies` a project declares rather than sweeping `node_modules`, so every name it returns is one the reader chose to depend on and can act on; a transitive package is not. `fromDir` defaults to `cwd`, which under `rdy run --from <other-repo>` is the project being checked rather than the repo the kit came from.

--- a/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
@@ -1,0 +1,93 @@
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTempDir } from '../../test-utils/tempDir.ts';
+import { discoverWorkspaces } from '../workspaces.ts';
+
+// Hoisted alongside the `vi.mock` factory below, which runs before this module's own bindings initialize.
+const { readDirectories } = vi.hoisted(() => {
+  const readDirectories: string[] = [];
+  return { readDirectories };
+});
+
+// The module under test binds `readdirSync` at import, so a spy on the `node:fs` namespace never reaches it.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => {
+      readDirectories.push(String(args[0]));
+      return actual.readdirSync(...args);
+    },
+  };
+});
+
+const temp = useTempDir({ prefix: 'rdy-ws-cache-', cwd: 'mock' });
+
+describe(`${discoverWorkspaces.name} memoization`, () => {
+  beforeEach(() => {
+    readDirectories.length = 0;
+  });
+
+  it('walks once across calls passing different filters, and filters each result correctly', () => {
+    writeMonorepo();
+
+    const packages = discoverWorkspaces({ filter: (workspace) => workspace.isPackage });
+    const walkedForFirstCall = readDirectories.length;
+    const privateWorkspaces = discoverWorkspaces({ filter: (workspace) => !workspace.isPackage });
+
+    expect(packages.map((workspace) => workspace.name)).toStrictEqual(['alpha']);
+    expect(privateWorkspaces.map((workspace) => workspace.name)).toStrictEqual(['internal']);
+    // Guards the equality below, which two zeroes would also satisfy.
+    expect(walkedForFirstCall).toBeGreaterThan(0);
+    expect(readDirectories).toHaveLength(walkedForFirstCall);
+  });
+
+  it('walks again for a second cwd', () => {
+    writeMonorepo();
+    discoverWorkspaces();
+    const walkedForFirstRoot = readDirectories.length;
+
+    const secondRoot = temp.mkdir('second-root');
+    temp.writeJson('second-root/package.json', { name: 'second', private: true, workspaces: ['packages/*'] });
+    temp.writeJson('second-root/packages/solo/package.json', { name: 'solo' });
+    vi.spyOn(process, 'cwd').mockReturnValue(secondRoot);
+
+    const workspaces = discoverWorkspaces();
+
+    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['solo']);
+    expect(readDirectories.length).toBeGreaterThan(walkedForFirstRoot);
+  });
+
+  it('answers a later call in full after a caller empties the array it returned', () => {
+    writeMonorepo();
+
+    discoverWorkspaces().length = 0;
+
+    expect(discoverWorkspaces().map((workspace) => workspace.dir)).toStrictEqual([
+      'packages/alpha',
+      'packages/internal',
+    ]);
+  });
+
+  it('caches nothing when discovery throws, so a repaired repo is discovered on the next call', () => {
+    expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
+    expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
+
+    temp.writeJson('package.json', { name: 'solo' });
+
+    expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['solo']);
+  });
+});
+
+// region | Helpers
+
+/** Writes a two-workspace monorepo whose members differ in `private`, so a filter can tell them apart. */
+function writeMonorepo(): void {
+  temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/*'] });
+  temp.writeJson(join('packages/alpha', 'package.json'), { name: 'alpha' });
+  temp.writeJson(join('packages/internal', 'package.json'), { name: 'internal', private: true });
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
@@ -235,6 +235,28 @@ describe(discoverWorkspaces, () => {
         packageJson: { name: 'alpha', version: '1.2.3' },
       });
     });
+
+    it('freezes the workspace and its `packageJson`', () => {
+      writeRootPackageJson({ name: 'root', version: '1.0.0' });
+
+      const [workspace] = discoverWorkspaces();
+
+      // `Object.isFrozen` answers true for `undefined`, so each subject is pinned before it is tested.
+      expect(workspace).toBeDefined();
+      expect(Object.isFrozen(workspace)).toBe(true);
+      expect(Object.isFrozen(workspace?.packageJson)).toBe(true);
+    });
+
+    it('freezes values nested inside `packageJson`, where an in-place sort would otherwise land', () => {
+      writeRootPackageJson({ name: 'root', files: ['dist', 'bin'], scripts: { build: 'tsc' } });
+
+      const [workspace] = discoverWorkspaces();
+
+      expect(workspace?.packageJson['files']).toStrictEqual(['dist', 'bin']);
+      expect(Object.isFrozen(workspace?.packageJson['files'])).toBe(true);
+      expect(workspace?.packageJson['scripts']).toStrictEqual({ build: 'tsc' });
+      expect(Object.isFrozen(workspace?.packageJson['scripts'])).toBe(true);
+    });
   });
 
   describe('negation patterns in npm workspaces', () => {

--- a/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
@@ -1,0 +1,64 @@
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { useTempDir } from '../../test-utils/tempDir.ts';
+import { discoverWorkspaces } from '../workspaces.ts';
+
+// Hoisted alongside the `vi.mock` factory below, which runs before this module's own bindings initialize.
+const { failures } = vi.hoisted(() => {
+  const failures = new Map<string, string>();
+  return { failures };
+});
+
+// The module under test binds `readdirSync` at import, so a spy on the `node:fs` namespace never reaches it.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => {
+      const code = failures.get(String(args[0]));
+      if (code !== undefined) throw Object.assign(new Error(`${code}: simulated`), { code });
+      return actual.readdirSync(...args);
+    },
+  };
+});
+
+const temp = useTempDir({ prefix: 'rdy-ws-walk-', cwd: 'mock', setup: () => failures.clear() });
+
+describe(`${discoverWorkspaces.name} directory walk`, () => {
+  it('reads every readable directory when none fails', () => {
+    writeMonorepo();
+
+    expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['alpha', 'locked', 'inner']);
+  });
+
+  it('skips the subtree under a directory it cannot read for a benign reason, keeping the rest', () => {
+    writeMonorepo();
+    failures.set(join(temp.dir, 'packages/locked'), 'EACCES');
+
+    expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['alpha', 'locked']);
+  });
+
+  it('propagates a systemic read failure rather than answering with a partial walk', () => {
+    writeMonorepo();
+    failures.set(join(temp.dir, 'packages/locked'), 'EMFILE');
+
+    expect(() => discoverWorkspaces()).toThrow(/EMFILE/);
+  });
+});
+
+// region | Helpers
+
+/**
+ * Writes a monorepo whose `packages/locked` holds a nested workspace, so a failed read of `locked`
+ * costs `inner` and nothing else. `locked` itself is matched from reading `packages/`, so it survives.
+ */
+function writeMonorepo(): void {
+  temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/**'] });
+  temp.writeJson(join('packages/alpha', 'package.json'), { name: 'alpha' });
+  temp.writeJson(join('packages/locked', 'package.json'), { name: 'locked' });
+  temp.writeJson(join('packages/locked/inner', 'package.json'), { name: 'inner' });
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -10,15 +10,15 @@ import { readPnpmWorkspacePackages } from './pnpmWorkspaceYaml.ts';
 /** A monorepo workspace, or the single workspace of a single-workspace repo. */
 export interface Workspace {
   /** Workspace directory, relative to `cwd`. `'.'` for a single-workspace repo. */
-  dir: string;
+  readonly dir: string;
   /** Absolute filesystem path to the workspace directory. */
-  absolutePath: string;
+  readonly absolutePath: string;
   /** `name` from the workspace's `package.json`; `undefined` if absent. */
-  name: string | undefined;
+  readonly name: string | undefined;
   /** True iff `package.json.private !== true`. (Equivalently: "this workspace is a package".) */
-  isPackage: boolean;
+  readonly isPackage: boolean;
   /** Parsed `package.json` contents, validated to be a record. */
-  packageJson: Record<string, unknown>;
+  readonly packageJson: Readonly<Record<string, unknown>>;
 }
 
 /** Options for `discoverWorkspaces`. */
@@ -50,7 +50,7 @@ const workspacesByCwd = new Map<string, Workspace[]>();
  * and falls back to a single-workspace repo using the root `package.json`.
  *
  * Memoized per `cwd` for the life of the process: repeated calls in one run share a single directory walk
- * and the `Workspace` objects it built, and none of them observes a filesystem change made since the first.
+ * and the frozen `Workspace` objects it built, and none of them observes a filesystem change made since the first.
  * `options.filter` applies per call, so it selects from the memoized list rather than being memoized with it.
  */
 export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspace[] {
@@ -238,7 +238,18 @@ function buildWorkspaceFromPackageJson(
   const nameValue = packageJson['name'];
   const name = typeof nameValue === 'string' ? nameValue : undefined;
   const isPackage = packageJson['private'] !== true;
-  return { dir: relDir, absolutePath, name, isPackage, packageJson };
+  // One call's mutation would otherwise reach every later call, which shares these objects.
+  deepFreeze(packageJson);
+  return Object.freeze({ dir: relDir, absolutePath, name, isPackage, packageJson });
+}
+
+/** Freezes a parsed JSON value and every value reachable from it. */
+function deepFreeze(value: unknown): void {
+  if (value === null || typeof value !== 'object') return;
+  Object.freeze(value);
+  for (const nested of Object.values(value)) {
+    deepFreeze(nested);
+  }
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -41,13 +41,41 @@ const PRUNED_NAMES = new Set(['node_modules']);
 /** Error codes a directory read may fail with benignly, leaving the rest of the walk sound. */
 const SKIPPABLE_READ_CODES = new Set(['EACCES', 'ENOENT', 'EPERM']);
 
+/** Discovered workspaces by the `cwd` they were resolved against, held for the life of the process. */
+const workspacesByCwd = new Map<string, Workspace[]>();
+
 /**
- * Discover the workspaces of the current repo.
+ * Discovers the workspaces of the current repo.
  * Detects pnpm (`pnpm-workspace.yaml`), then npm/yarn (`package.json.workspaces`),
  * and falls back to a single-workspace repo using the root `package.json`.
+ *
+ * Memoized per `cwd` for the life of the process: repeated calls in one run share a single directory walk
+ * and the `Workspace` objects it built, and none of them observes a filesystem change made since the first.
+ * `options.filter` applies per call, so it selects from the memoized list rather than being memoized with it.
  */
 export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspace[] {
   const cwd = process.cwd();
+
+  let workspaces = workspacesByCwd.get(cwd);
+  if (workspaces === undefined) {
+    // Build before storing, so a discovery that throws leaves nothing behind and the next call retries it.
+    workspaces = buildWorkspaces(cwd);
+    workspacesByCwd.set(cwd, workspaces);
+  }
+
+  return applyFilter(workspaces, options?.filter);
+}
+
+// region | Helpers
+
+/** Applies the optional filter to a workspace list, answering with an array the caller owns either way. */
+function applyFilter(workspaces: Workspace[], filter: DiscoverWorkspacesOptions['filter']): Workspace[] {
+  if (filter === undefined) return [...workspaces];
+  return workspaces.filter(filter);
+}
+
+/** Builds the unfiltered workspace list for the repo at `cwd`. */
+function buildWorkspaces(cwd: string): Workspace[] {
   const rootPackageJsonPath = join(cwd, 'package.json');
 
   const patternResult = resolveWorkspacePatterns(cwd);
@@ -58,8 +86,7 @@ export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspa
     if (rootPackageJson === undefined) {
       throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
     }
-    const workspace = buildWorkspaceFromPackageJson('.', cwd, rootPackageJson);
-    return applyFilter([workspace], options?.filter);
+    return [buildWorkspaceFromPackageJson('.', cwd, rootPackageJson)];
   }
 
   // Monorepo path: still require a root package.json (both pnpm and npm workspaces do).
@@ -78,19 +105,11 @@ export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspa
     }
   }
 
-  return applyFilter(workspaces, options?.filter);
-}
-
-// region | Helpers
-
-/** Apply the optional filter to a workspace list. */
-function applyFilter(workspaces: Workspace[], filter: DiscoverWorkspacesOptions['filter']): Workspace[] {
-  if (filter === undefined) return workspaces;
-  return workspaces.filter(filter);
+  return workspaces;
 }
 
 /**
- * Resolve the workspace pattern list for the repo at `cwd`.
+ * Resolves the workspace pattern list for the repo at `cwd`.
  * Returns `null` to signal single-workspace fallback, or `{ patterns, source }` for a monorepo.
  */
 function resolveWorkspacePatterns(cwd: string): { patterns: string[]; source: WorkspacePatternSource } | null {
@@ -115,7 +134,7 @@ function resolveWorkspacePatterns(cwd: string): { patterns: string[]; source: Wo
   return null;
 }
 
-/** Extract workspace patterns from the `workspaces` field of a root `package.json`. */
+/** Extracts workspace patterns from the `workspaces` field of a root `package.json`. */
 function extractNpmWorkspacePatterns(workspaces: unknown): string[] | null {
   if (Array.isArray(workspaces)) {
     const strings = workspaces.filter((entry): entry is string => typeof entry === 'string');
@@ -134,7 +153,7 @@ function extractNpmWorkspacePatterns(workspaces: unknown): string[] | null {
 }
 
 /**
- * Expand each pattern against a pruned recursive directory walk, returning relative
+ * Expands each pattern against a pruned recursive directory walk, returning relative
  * dir paths (forward-slash style) sorted and deduplicated.
  */
 function expandPatterns(cwd: string, patterns: string[], source: WorkspacePatternSource): string[] {
@@ -166,7 +185,7 @@ function expandPatterns(cwd: string, patterns: string[], source: WorkspacePatter
 }
 
 /**
- * Normalize a workspace pattern.
+ * Normalizes a workspace pattern.
  * Strips a trailing `/` because picomatch's `**` matches paths, not directories-with-slash.
  */
 function normalizePattern(pattern: string): string {
@@ -174,7 +193,7 @@ function normalizePattern(pattern: string): string {
   return pattern;
 }
 
-/** Recursively walk `cwd` starting at `relDir`, calling `visit` for each directory. */
+/** Walks `cwd` recursively from `relDir`, calling `visit` for each directory. */
 function walk(cwd: string, relDir: string, depth: number, visit: (relDir: string) => void): void {
   visit(relDir);
   if (depth >= MAX_WALK_DEPTH) return;
@@ -201,7 +220,7 @@ function walk(cwd: string, relDir: string, depth: number, visit: (relDir: string
   }
 }
 
-/** Build a `Workspace` for a relative directory; returns undefined if its `package.json` is missing or malformed. */
+/** Builds a `Workspace` for a relative directory; returns undefined if its `package.json` is missing or malformed. */
 function buildWorkspace(cwd: string, relDir: string): Workspace | undefined {
   const absoluteDir = resolve(cwd, relDir);
   const packageJsonRelativePath = relDir === '.' ? 'package.json' : `${relDir}/package.json`;
@@ -210,7 +229,7 @@ function buildWorkspace(cwd: string, relDir: string): Workspace | undefined {
   return buildWorkspaceFromPackageJson(relDir, absoluteDir, packageJson);
 }
 
-/** Build a `Workspace` from a relative dir, absolute path, and a parsed `package.json`. */
+/** Builds a `Workspace` from a relative dir, absolute path, and a parsed `package.json`. */
 function buildWorkspaceFromPackageJson(
   relDir: string,
   absolutePath: string,

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -3,7 +3,9 @@ import { join, resolve } from 'node:path';
 
 import picomatch from 'picomatch';
 
+import { deepFreeze } from '../portable/deepFreeze.ts';
 import { isRecord } from '../portable/isRecord.ts';
+import { isSkippableFilesystemError } from '../portable/isSkippableFilesystemError.ts';
 import { readJsonFile } from './json.ts';
 import { readPnpmWorkspacePackages } from './pnpmWorkspaceYaml.ts';
 
@@ -37,9 +39,6 @@ const MAX_WALK_DEPTH = 10;
  * dot-prefixed directories (including `.git`) are pruned separately in `walk`.
  */
 const PRUNED_NAMES = new Set(['node_modules']);
-
-/** Error codes a directory read may fail with benignly, leaving the rest of the walk sound. */
-const SKIPPABLE_READ_CODES = new Set(['EACCES', 'ENOENT', 'EPERM']);
 
 /** Discovered workspaces by the `cwd` they were resolved against, held for the life of the process. */
 const workspacesByCwd = new Map<string, Workspace[]>();
@@ -203,10 +202,8 @@ function walk(cwd: string, relDir: string, depth: number, visit: (relDir: string
   try {
     entries = readdirSync(absDir, { withFileTypes: true, encoding: 'utf8' });
   } catch (error) {
-    // Skip directories we can't read for benign reasons (missing, permission-denied).
-    // Rethrow systemic failures (e.g. EMFILE, EIO) so an incomplete walk isn't masked.
-    const code = isRecord(error) && typeof error['code'] === 'string' ? error['code'] : undefined;
-    if (code !== undefined && SKIPPABLE_READ_CODES.has(code)) return;
+    // A systemic failure (e.g. EMFILE, EIO) is rethrown, so an incomplete walk isn't masked.
+    if (isSkippableFilesystemError(error)) return;
     throw error;
   }
 
@@ -241,15 +238,6 @@ function buildWorkspaceFromPackageJson(
   // One call's mutation would otherwise reach every later call, which shares these objects.
   deepFreeze(packageJson);
   return Object.freeze({ dir: relDir, absolutePath, name, isPackage, packageJson });
-}
-
-/** Freezes a parsed JSON value and every value reachable from it. */
-function deepFreeze(value: unknown): void {
-  if (value === null || typeof value !== 'object') return;
-  Object.freeze(value);
-  for (const nested of Object.values(value)) {
-    deepFreeze(nested);
-  }
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/portable/__tests__/deepFreeze.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/deepFreeze.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { deepFreeze } from '../deepFreeze.ts';
+
+describe(deepFreeze, () => {
+  it('freezes an object and the objects and arrays nested inside it', () => {
+    const value = { scripts: { build: 'tsc' }, files: ['dist'] };
+
+    deepFreeze(value);
+
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.scripts)).toBe(true);
+    expect(Object.isFrozen(value.files)).toBe(true);
+  });
+
+  it('accepts a primitive without throwing', () => {
+    expect(() => deepFreeze('text')).not.toThrow();
+    expect(() => deepFreeze(undefined)).not.toThrow();
+    expect(() => deepFreeze(null)).not.toThrow();
+  });
+
+  it('terminates on a cyclic structure', () => {
+    const parent: Record<string, unknown> = { name: 'parent' };
+    const child = { parent };
+    parent['child'] = child;
+
+    deepFreeze(parent);
+
+    expect(Object.isFrozen(parent)).toBe(true);
+    expect(Object.isFrozen(child)).toBe(true);
+  });
+});

--- a/packages/readyup/src/portable/deepFreeze.ts
+++ b/packages/readyup/src/portable/deepFreeze.ts
@@ -1,0 +1,20 @@
+/** Freezes a value and every value reachable from it. */
+export function deepFreeze(value: unknown): void {
+  freezeReachable(value, new WeakSet());
+}
+
+// region | Helpers
+
+/** Freezes `value` and its reachable values, stopping at a value `seen` already holds. */
+function freezeReachable(value: unknown, seen: WeakSet<object>): void {
+  if (value === null || typeof value !== 'object') return;
+  // A cyclic input would otherwise recur forever, and a shared value would be walked once per holder.
+  if (seen.has(value)) return;
+  seen.add(value);
+  Object.freeze(value);
+  for (const nested of Object.values(value)) {
+    freezeReachable(nested, seen);
+  }
+}
+
+// endregion | Helpers


### PR DESCRIPTION
## What

`discoverWorkspaces` now scans a repository's workspace layout once per run and reuses the result, rather than rescanning for each check that calls it.

Kit authors should be aware that the `Workspace` values returned by the function are shared across a run, so a kit must treat them as read-only. A workspace added or removed mid-run is not reported in the results.

## Why

Kits call `discoverWorkspaces` from per-check `skip` predicates, so discovery ran once per check rather than once per run. Planned adoption kits add many more checks, each of which would have recomputed the same answer.

## Details

### ⚡ Performance

- `discoverWorkspaces` holds its unfiltered result in a module-level `Map` keyed on `process.cwd()`. Kit bundles keep `readyup` and `readyup/*` external, so one module instance serves every kit in a run and they share one walk rather than one apiece.
- A `Map` rather than a single slot: a caller alternating between two directories would evict on every call, where the `Map` costs one entry per distinct `cwd` -- one in a `rdy` run, one per test file under Vitest.
- The list is built before it is stored, so a discovery that throws leaves the `Map` untouched and the next call retries.
- `options.filter` applies per call against the cached list rather than entering the key, so the signature is unchanged; `applyFilter` returns a fresh array on both paths, so the cached list is unreachable through a result.

### 🧪 Tests

- `workspaces.caching.unit.test.ts` counts `readdirSync` calls through a `vi.mock('node:fs')` wrapper and pins four contracts: one walk across differently-filtered calls, a second walk for a second `cwd`, immunity to caller mutation of the returned array, and no memoization of a throw. A named import binds at module evaluation, so `vi.spyOn` on the `node:fs` namespace never reaches the module under test.
- Each test gets a unique temporary `cwd`, which is why no cache-reset export was added to `readyup/check-utils`.

### 📚 Documentation

- The README's Workspaces section states the memoization, the shared `Workspace` identity it implies, the staleness it accepts, and the un-memoized throw, without naming the mechanism.
- Every doc description in `workspaces.ts` moves from imperative to third-person indicative mood.

Closes #328
