### PR TITLE
#337 Adopt toolbelt's `silenceConsole` and retire the hand-rolled console spies

### DIFF
--- a/.config/readyup.config.ts
+++ b/.config/readyup.config.ts
@@ -13,6 +13,7 @@ export default defineRdyConfig({
     '@williamthorsen/nmr',
     '@williamthorsen/release-kit',
     '@williamthorsen/toolbelt.errors',
+    '@williamthorsen/toolbelt.vitest',
     '@williamthorsen/tsconfig',
     'codeassembly',
     'readyup',

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@williamthorsen/release-kit": "10.3.2",
     "@williamthorsen/strict-lint": "11.0.0",
     "@williamthorsen/toolbelt.errors": "catalog:",
+    "@williamthorsen/toolbelt.vitest": "catalog:",
     "@williamthorsen/tsconfig": "0.5.0",
     "codeassembly": "0.9.0",
     "esbuild": "catalog:",

--- a/packages/readyup/package.json
+++ b/packages/readyup/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@types/picomatch": "4.0.3",
     "@williamthorsen/toolbelt.testing": "catalog:",
+    "@williamthorsen/toolbelt.vitest": "catalog:",
     "ajv": "8.20.0",
     "esbuild": "catalog:"
   },

--- a/packages/readyup/src/init/__tests__/initCommand.scaffold.unit.test.ts
+++ b/packages/readyup/src/init/__tests__/initCommand.scaffold.unit.test.ts
@@ -33,7 +33,7 @@ describe('scaffolded kit', () => {
   });
 
   it('passes with NODE_ENV set, reporting the value it found', async () => {
-    using _silent = silenceConsole(['info']);
+    using _silent = silenceConsole(['error', 'info']);
 
     vi.stubEnv('NODE_ENV', 'production');
     initCommand({ dryRun: false, force: false });
@@ -44,7 +44,7 @@ describe('scaffolded kit', () => {
   });
 
   it('fails with NODE_ENV unset, reporting that the environment carries no value', async () => {
-    using _silent = silenceConsole(['info']);
+    using _silent = silenceConsole(['error', 'info']);
 
     vi.stubEnv('NODE_ENV', undefined);
     initCommand({ dryRun: false, force: false });

--- a/packages/readyup/src/init/__tests__/initCommand.scaffold.unit.test.ts
+++ b/packages/readyup/src/init/__tests__/initCommand.scaffold.unit.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { silenceConsole } from '@williamthorsen/toolbelt.vitest/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { loadRdyKit } from '../../kits/loadRdyKit.ts';
@@ -24,16 +25,16 @@ describe('scaffolded kit', () => {
     originalCwd = process.cwd();
     mkdirSync(TEST_DIR, { recursive: true });
     process.chdir(TEST_DIR);
-    vi.spyOn(console, 'info').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     process.chdir(originalCwd);
     rmSync(TEST_DIR, { recursive: true, force: true });
-    vi.restoreAllMocks();
   });
 
   it('passes with NODE_ENV set, reporting the value it found', async () => {
+    using _silent = silenceConsole(['info']);
+
     vi.stubEnv('NODE_ENV', 'production');
     initCommand({ dryRun: false, force: false });
 
@@ -43,6 +44,8 @@ describe('scaffolded kit', () => {
   });
 
   it('fails with NODE_ENV unset, reporting that the environment carries no value', async () => {
+    using _silent = silenceConsole(['info']);
+
     vi.stubEnv('NODE_ENV', undefined);
     initCommand({ dryRun: false, force: false });
 

--- a/packages/readyup/src/init/__tests__/initCommand.unit.test.ts
+++ b/packages/readyup/src/init/__tests__/initCommand.unit.test.ts
@@ -26,7 +26,7 @@ describe(initCommand, () => {
   });
 
   it('scaffolds both config and kit files and returns 0', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['error', 'info']);
 
     const exitCode = initCommand({ dryRun: false, force: false });
 
@@ -42,7 +42,7 @@ describe(initCommand, () => {
   });
 
   it('skips with a warning when both files already exist', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['error', 'info']);
 
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
@@ -57,7 +57,7 @@ describe(initCommand, () => {
   });
 
   it('overwrites existing files when force is true', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['error', 'info']);
 
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
@@ -72,7 +72,7 @@ describe(initCommand, () => {
   });
 
   it('previews without writing when dry-run is true', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['error', 'info']);
 
     const exitCode = initCommand({ dryRun: true, force: false });
 
@@ -82,7 +82,7 @@ describe(initCommand, () => {
   });
 
   it('reports up-to-date when both files match the templates', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['error', 'info']);
 
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
@@ -97,7 +97,7 @@ describe(initCommand, () => {
   });
 
   it('does not modify existing files during dry-run', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['error', 'info']);
 
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
@@ -112,7 +112,7 @@ describe(initCommand, () => {
   });
 
   it('does not overwrite during dry-run even with force', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['error', 'info']);
 
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
@@ -127,7 +127,7 @@ describe(initCommand, () => {
   });
 
   it('does not print next steps during dry-run', () => {
-    using silent = silenceConsole(['error', 'info', 'warn']);
+    using silent = silenceConsole(['error', 'info']);
 
     const exitCode = initCommand({ dryRun: true, force: false });
 
@@ -137,7 +137,7 @@ describe(initCommand, () => {
   });
 
   it('prints next steps after successful scaffolding', () => {
-    using silent = silenceConsole(['error', 'info', 'warn']);
+    using silent = silenceConsole(['error', 'info']);
 
     const exitCode = initCommand({ dryRun: false, force: false });
 

--- a/packages/readyup/src/init/__tests__/initCommand.unit.test.ts
+++ b/packages/readyup/src/init/__tests__/initCommand.unit.test.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { silenceConsole } from '@williamthorsen/toolbelt.vitest/candidate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { initCommand } from '../initCommand.ts';
 import { rdyConfigTemplate, rdyKitTemplate } from '../templates.ts';
@@ -17,18 +18,16 @@ describe(initCommand, () => {
     originalCwd = process.cwd();
     mkdirSync(TEST_DIR, { recursive: true });
     process.chdir(TEST_DIR);
-    vi.spyOn(console, 'info').mockImplementation(() => undefined);
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     process.chdir(originalCwd);
     rmSync(TEST_DIR, { recursive: true, force: true });
-    vi.restoreAllMocks();
   });
 
   it('scaffolds both config and kit files and returns 0', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     const exitCode = initCommand({ dryRun: false, force: false });
 
     expect(exitCode).toBe(0);
@@ -43,6 +42,8 @@ describe(initCommand, () => {
   });
 
   it('skips with a warning when both files already exist', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
     writeFileSync(join(TEST_DIR, CONFIG_PATH), 'existing config', 'utf8');
@@ -56,6 +57,8 @@ describe(initCommand, () => {
   });
 
   it('overwrites existing files when force is true', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
     writeFileSync(join(TEST_DIR, CONFIG_PATH), 'old config', 'utf8');
@@ -69,6 +72,8 @@ describe(initCommand, () => {
   });
 
   it('previews without writing when dry-run is true', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     const exitCode = initCommand({ dryRun: true, force: false });
 
     expect(exitCode).toBe(0);
@@ -77,6 +82,8 @@ describe(initCommand, () => {
   });
 
   it('reports up-to-date when both files match the templates', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
     writeFileSync(join(TEST_DIR, CONFIG_PATH), rdyConfigTemplate, 'utf8');
@@ -90,6 +97,8 @@ describe(initCommand, () => {
   });
 
   it('does not modify existing files during dry-run', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
     writeFileSync(join(TEST_DIR, CONFIG_PATH), 'existing config', 'utf8');
@@ -103,6 +112,8 @@ describe(initCommand, () => {
   });
 
   it('does not overwrite during dry-run even with force', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     mkdirSync(join(TEST_DIR, '.config'), { recursive: true });
     mkdirSync(join(TEST_DIR, '.readyup/kits'), { recursive: true });
     writeFileSync(join(TEST_DIR, CONFIG_PATH), 'existing config', 'utf8');
@@ -116,18 +127,22 @@ describe(initCommand, () => {
   });
 
   it('does not print next steps during dry-run', () => {
+    using silent = silenceConsole(['error', 'info', 'warn']);
+
     const exitCode = initCommand({ dryRun: true, force: false });
 
     expect(exitCode).toBe(0);
-    const infoMessages = vi.mocked(console.info).mock.calls.map((c) => String(c[0]));
+    const infoMessages = silent.info.mock.calls.map((c) => String(c[0]));
     expect(infoMessages.some((m) => m.includes('Next steps'))).toBe(false);
   });
 
   it('prints next steps after successful scaffolding', () => {
+    using silent = silenceConsole(['error', 'info', 'warn']);
+
     const exitCode = initCommand({ dryRun: false, force: false });
 
     expect(exitCode).toBe(0);
-    const infoMessages = vi.mocked(console.info).mock.calls.map((c) => String(c[0]));
+    const infoMessages = silent.info.mock.calls.map((c) => String(c[0]));
     expect(infoMessages.some((m) => m.includes('Next steps'))).toBe(true);
   });
 });

--- a/packages/readyup/src/init/__tests__/initCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/init/__tests__/initCommand.wiring.unit.test.ts
@@ -47,7 +47,7 @@ describe(`${initCommand.name} error handling`, () => {
   });
 
   it('throws a config error when scaffoldConfig throws', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['info']);
 
     mockScaffoldConfig.mockImplementation(() => {
       throw new Error('disk full');
@@ -59,7 +59,7 @@ describe(`${initCommand.name} error handling`, () => {
   });
 
   it('throws a config error naming the file when the config result failed', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['info']);
 
     mockScaffoldConfig.mockReturnValue(makeScaffoldResult('failed'));
 
@@ -69,7 +69,7 @@ describe(`${initCommand.name} error handling`, () => {
   });
 
   it('throws a config error naming the file when the kit result failed', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['info']);
 
     mockScaffoldConfig.mockReturnValue({
       configResult: { filePath: '.config/readyup.config.ts', outcome: 'created' },
@@ -82,7 +82,7 @@ describe(`${initCommand.name} error handling`, () => {
   });
 
   it('returns exit code 0 when both results are created', () => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['info']);
 
     mockScaffoldConfig.mockReturnValue(makeScaffoldResult('created'));
 
@@ -99,7 +99,7 @@ describe(`${initCommand.name} error handling`, () => {
     { outcome: 'skipped', dryRun: false },
     { outcome: 'failed', dryRun: false },
   ])('calls reportWriteResult for both files with $outcome outcome (dryRun=$dryRun)', ({ outcome, dryRun }) => {
-    using _silent = silenceConsole(['error', 'info', 'warn']);
+    using _silent = silenceConsole(['info']);
 
     const result = makeScaffoldResult(outcome);
     mockScaffoldConfig.mockReturnValue(result);

--- a/packages/readyup/src/init/__tests__/initCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/init/__tests__/initCommand.wiring.unit.test.ts
@@ -1,3 +1,4 @@
+import { silenceConsole } from '@williamthorsen/toolbelt.vitest/candidate';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 
 const mockScaffoldConfig = vi.hoisted(() => vi.fn());
@@ -38,14 +39,7 @@ function makeScaffoldResult(outcome: string) {
 }
 
 describe(`${initCommand.name} error handling`, () => {
-  beforeEach(() => {
-    vi.spyOn(console, 'info').mockImplementation(() => undefined);
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-  });
-
   afterEach(() => {
-    vi.restoreAllMocks();
     mockScaffoldConfig.mockReset();
     mockReportWriteResult.mockReset();
     mockBuildInstallCommand.mockReset();
@@ -53,6 +47,8 @@ describe(`${initCommand.name} error handling`, () => {
   });
 
   it('throws a config error when scaffoldConfig throws', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     mockScaffoldConfig.mockImplementation(() => {
       throw new Error('disk full');
     });
@@ -63,6 +59,8 @@ describe(`${initCommand.name} error handling`, () => {
   });
 
   it('throws a config error naming the file when the config result failed', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     mockScaffoldConfig.mockReturnValue(makeScaffoldResult('failed'));
 
     expect(() => initCommand({ dryRun: false, force: false })).toThrow(
@@ -71,6 +69,8 @@ describe(`${initCommand.name} error handling`, () => {
   });
 
   it('throws a config error naming the file when the kit result failed', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     mockScaffoldConfig.mockReturnValue({
       configResult: { filePath: '.config/readyup.config.ts', outcome: 'created' },
       kitResult: { filePath: '.readyup/kits/default.ts', outcome: 'failed' },
@@ -82,6 +82,8 @@ describe(`${initCommand.name} error handling`, () => {
   });
 
   it('returns exit code 0 when both results are created', () => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     mockScaffoldConfig.mockReturnValue(makeScaffoldResult('created'));
 
     const exitCode = initCommand({ dryRun: false, force: false });
@@ -97,6 +99,8 @@ describe(`${initCommand.name} error handling`, () => {
     { outcome: 'skipped', dryRun: false },
     { outcome: 'failed', dryRun: false },
   ])('calls reportWriteResult for both files with $outcome outcome (dryRun=$dryRun)', ({ outcome, dryRun }) => {
+    using _silent = silenceConsole(['error', 'info', 'warn']);
+
     const result = makeScaffoldResult(outcome);
     mockScaffoldConfig.mockReturnValue(result);
 
@@ -113,54 +117,58 @@ describe(`${initCommand.name} error handling`, () => {
 });
 
 describe(`${initCommand.name} next steps`, () => {
-  let infoSpy: MockInstance;
-
   beforeEach(() => {
-    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     mockScaffoldConfig.mockReturnValue(makeScaffoldResult('created'));
     mockBuildInstallCommand.mockReturnValue('pnpm add --save-dev readyup');
     mockIsPackageInstalled.mockReturnValue(true);
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     mockScaffoldConfig.mockReset();
     mockBuildInstallCommand.mockReset();
     mockIsPackageInstalled.mockReset();
   });
 
   it('names only rdy commands, never npx readyup', () => {
+    using silent = silenceConsole(['info']);
+
     initCommand({ dryRun: false, force: false });
 
-    expect(printedSteps(infoSpy)).not.toContain('npx readyup');
-    expect(printedSteps(infoSpy)).toContain('rdy compile');
-    expect(printedSteps(infoSpy)).toContain('rdy run');
+    expect(printedSteps(silent.info)).not.toContain('npx readyup');
+    expect(printedSteps(silent.info)).toContain('rdy compile');
+    expect(printedSteps(silent.info)).toContain('rdy run');
   });
 
   it('omits the install step when readyup is already installed', () => {
+    using silent = silenceConsole(['info']);
+
     initCommand({ dryRun: false, force: false });
 
-    const steps = printedSteps(infoSpy);
+    const steps = printedSteps(silent.info);
     expect(steps).not.toContain('Install readyup');
     expect(steps).toContain('1. Customize .config/readyup.config.ts');
     expect(steps).toContain('5. Commit the generated files.');
   });
 
   it('leads with the install step when readyup is not installed', () => {
+    using silent = silenceConsole(['info']);
+
     mockIsPackageInstalled.mockReturnValue(false);
 
     initCommand({ dryRun: false, force: false });
 
-    const steps = printedSteps(infoSpy);
+    const steps = printedSteps(silent.info);
     expect(steps).toContain('1. Install readyup as a dev dependency: pnpm add --save-dev readyup');
     expect(steps).toContain('2. Customize .config/readyup.config.ts');
     expect(steps).toContain('6. Commit the generated files.');
   });
 
   it('prints no next steps in dry-run mode', () => {
+    using silent = silenceConsole(['info']);
+
     initCommand({ dryRun: true, force: false });
 
-    expect(printedSteps(infoSpy)).not.toContain('Customize');
+    expect(printedSteps(silent.info)).not.toContain('Customize');
   });
 });
 

--- a/packages/readyup/src/output/__tests__/terminal.unit.test.ts
+++ b/packages/readyup/src/output/__tests__/terminal.unit.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { silenceConsole } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, it } from 'vitest';
 
 import { richFormatter } from '../../layout/richFormatter.ts';
 import type { WriteResult } from '../../portable/writeFileWithCheck.ts';
@@ -16,42 +17,24 @@ function makeResult(overrides: Partial<WriteResult> = {}): WriteResult {
 }
 
 describe(printStep, () => {
-  let infoSpy: MockInstance;
-
-  beforeEach(() => {
-    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('renders a step label as a section heading, parted from what precedes it', () => {
+    using silent = silenceConsole(['info']);
+
     printStep('Scaffolding config');
 
-    expect(infoSpy).toHaveBeenCalledWith('\n\u{2500}\u{2500} Scaffolding config');
+    expect(silent.info).toHaveBeenCalledWith('\n\u{2500}\u{2500} Scaffolding config');
   });
 
   it('retires the arrow-prefixed step grammar', () => {
+    using silent = silenceConsole(['info']);
+
     printStep('Next steps');
 
-    expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining('> Next steps'));
+    expect(silent.info).not.toHaveBeenCalledWith(expect.stringContaining('> Next steps'));
   });
 });
 
 describe(reportWriteResult, () => {
-  let infoSpy: MockInstance;
-  let errorSpy: MockInstance;
-
-  beforeEach(() => {
-    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   describe.each([
     ['created', { outcome: 'created' as const }, `${PASSED} ${PATH} \u{00B7} created`],
     ['overwrote', { outcome: 'overwritten' as const }, `${PASSED} ${PATH} \u{00B7} overwrote`],
@@ -59,15 +42,19 @@ describe(reportWriteResult, () => {
     ['already exists', { outcome: 'skipped' as const }, `${SKIPPED} ${PATH} \u{00B7} already exists`],
   ])('%s', (_case, overrides, expected) => {
     it('renders the ratified token with the outcome as inline detail', () => {
+      using silent = silenceConsole(['error', 'info']);
+
       reportWriteResult(makeResult(overrides), false);
 
-      expect(infoSpy).toHaveBeenCalledWith(expected);
+      expect(silent.info).toHaveBeenCalledWith(expected);
     });
 
     it('writes to stdout', () => {
+      using silent = silenceConsole(['error', 'info']);
+
       reportWriteResult(makeResult(overrides), false);
 
-      expect(errorSpy).not.toHaveBeenCalled();
+      expect(silent.error).not.toHaveBeenCalled();
     });
   });
 
@@ -76,9 +63,11 @@ describe(reportWriteResult, () => {
     ['overwritten', { outcome: 'overwritten' as const }, 'would overwrite'],
   ])('%s under dry run', (_case, overrides, expected) => {
     it('states what would happen rather than what did', () => {
+      using silent = silenceConsole(['error', 'info']);
+
       reportWriteResult(makeResult(overrides), true);
 
-      expect(infoSpy).toHaveBeenCalledWith(`${PASSED} ${PATH} \u{00B7} ${expected}`);
+      expect(silent.info).toHaveBeenCalledWith(`${PASSED} ${PATH} \u{00B7} ${expected}`);
     });
   });
 
@@ -86,39 +75,51 @@ describe(reportWriteResult, () => {
     const result = makeResult({ outcome: 'skipped', error: 'EACCES' });
 
     it('warns rather than reporting a benign skip', () => {
+      using silent = silenceConsole(['error', 'info']);
+
       reportWriteResult(result, false);
 
-      expect(infoSpy).toHaveBeenCalledWith(`${WARNED} ${PATH}\n   could not read for comparison: EACCES`);
+      expect(silent.info).toHaveBeenCalledWith(`${WARNED} ${PATH}\n   could not read for comparison: EACCES`);
     });
 
     it('puts the reason in a block rather than inline', () => {
+      using silent = silenceConsole(['error', 'info']);
+
       reportWriteResult(result, false);
 
-      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining(`${PATH} \u{00B7}`));
+      expect(silent.info).not.toHaveBeenCalledWith(expect.stringContaining(`${PATH} \u{00B7}`));
     });
   });
 
   describe('failed', () => {
     it('renders a claim with the cause in a block beneath', () => {
+      using silent = silenceConsole(['error', 'info']);
+
       reportWriteResult(makeResult({ outcome: 'failed', error: 'ENOSPC' }), false);
 
-      expect(errorSpy).toHaveBeenCalledWith(`${FAILED} ${PATH}\n   failed to write: ENOSPC`);
+      expect(silent.error).toHaveBeenCalledWith(`${FAILED} ${PATH}\n   failed to write: ENOSPC`);
     });
 
     it('states the failure without a cause when none was captured', () => {
+      using silent = silenceConsole(['error', 'info']);
+
       reportWriteResult(makeResult({ outcome: 'failed' }), false);
 
-      expect(errorSpy).toHaveBeenCalledWith(`${FAILED} ${PATH}\n   failed to write`);
+      expect(silent.error).toHaveBeenCalledWith(`${FAILED} ${PATH}\n   failed to write`);
     });
 
     it('routes to stderr so a caller redirecting stdout still sees it', () => {
+      using silent = silenceConsole(['error', 'info']);
+
       reportWriteResult(makeResult({ outcome: 'failed', error: 'ENOSPC' }), false);
 
-      expect(infoSpy).not.toHaveBeenCalled();
+      expect(silent.info).not.toHaveBeenCalled();
     });
   });
 
   it.each(['\u{2705}', '\u{26A0}', '\u{274C}', '\u{FE0F}'])('renders no %s for any outcome', (retired) => {
+    using silent = silenceConsole(['error', 'info']);
+
     const outcomes: WriteResult[] = [
       makeResult({ outcome: 'created' }),
       makeResult({ outcome: 'overwritten' }),
@@ -132,7 +133,7 @@ describe(reportWriteResult, () => {
       reportWriteResult(result, false);
     }
 
-    const written = [...infoSpy.mock.calls, ...errorSpy.mock.calls].flat().join('\n');
+    const written = [...silent.info.mock.calls, ...silent.error.mock.calls].flat().join('\n');
     expect(written).not.toContain(retired);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@williamthorsen/toolbelt.testing':
       specifier: 0.2.0
       version: 0.2.0
+    '@williamthorsen/toolbelt.vitest':
+      specifier: 0.3.0
+      version: 0.3.0
     esbuild:
       specifier: 0.28.1
       version: 0.28.1
@@ -59,6 +62,9 @@ importers:
       '@williamthorsen/toolbelt.errors':
         specifier: 'catalog:'
         version: 0.5.0
+      '@williamthorsen/toolbelt.vitest':
+        specifier: 'catalog:'
+        version: 0.3.0(vitest@4.1.10)
       '@williamthorsen/tsconfig':
         specifier: 0.5.0
         version: 0.5.0
@@ -152,6 +158,9 @@ importers:
       '@williamthorsen/toolbelt.testing':
         specifier: 'catalog:'
         version: 0.2.0
+      '@williamthorsen/toolbelt.vitest':
+        specifier: 'catalog:'
+        version: 0.3.0(vitest@4.1.10)
       ajv:
         specifier: 8.20.0
         version: 8.20.0
@@ -850,6 +859,12 @@ packages:
   '@williamthorsen/toolbelt.testing@0.2.0':
     resolution: {integrity: sha512-QKAt2tUrmxtT3Qwrkfax+gnjEuZ9PLmwXUDeDfIVIhvh6dqV540hJBUwLV2eI6BsPGV33d4xxAAfnKCevRS9Bg==}
     engines: {node: '>=24.0.0'}
+
+  '@williamthorsen/toolbelt.vitest@0.3.0':
+    resolution: {integrity: sha512-dxb/X6WKfpx/l/CeNlxRuvU/VS4SDnyOJCLwSSZH2uLC7tRJZHjFA+B7aT/R9eAdfvl/fCvImxZKWHWWxLrXYg==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      vitest: ^4.0.0
 
   '@williamthorsen/tsconfig@0.5.0':
     resolution: {integrity: sha512-GNWk0qdf3jSsjXCTipOnvYgDFIdBxxPiuJwjc8MkroVq+9eIWFzOWohX3Nb4m6cCba0k90SaFOLiBvUikyiHWw==}
@@ -3251,6 +3266,10 @@ snapshots:
       '@williamthorsen/toolbelt.filesystem': 0.5.0
 
   '@williamthorsen/toolbelt.testing@0.2.0': {}
+
+  '@williamthorsen/toolbelt.vitest@0.3.0(vitest@4.1.10)':
+    dependencies:
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   '@williamthorsen/tsconfig@0.5.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
   '@williamthorsen/toolbelt.errors': 0.5.0
   '@williamthorsen/toolbelt.packaging': 0.4.0
   '@williamthorsen/toolbelt.testing': 0.2.0
+  '@williamthorsen/toolbelt.vitest': 0.3.0
   esbuild: 0.28.1
   zod: 4.4.3
 


### PR DESCRIPTION
## What

Adopts `silenceConsole` from `@williamthorsen/toolbelt.vitest` to replace every hand-rolled `vi.spyOn(console, …)` spy in the repo. The function returns a disposable, so a test binds it with `using` and the console methods it named are restored at the end of the test scope.

`@williamthorsen/toolbelt.vitest` is added to the ReadyUp configuration; `rdy run --packages` runs the kit bundled with the new package along with other kits.

## Why

Each of the four suites carried its own console-spy boilerplate, and each silenced the union of channels the file had ever needed rather than what a given test could reach. Unexpected output on an unwatched channel was swallowed instead of surfacing, and the hooks had to be kept in step with the assertions by hand. `@williamthorsen/toolbelt.vitest` publishes the utility these suites were reimplementing, and adopting it also brings the repo under the adoption kit that package ships.

## Details

### 🧪 Tests

- Converted `packages/readyup/src/output/__tests__/terminal.unit.test.ts`, `packages/readyup/src/init/__tests__/initCommand.unit.test.ts`, `packages/readyup/src/init/__tests__/initCommand.wiring.unit.test.ts`, and `packages/readyup/src/init/__tests__/initCommand.scaffold.unit.test.ts` to `silenceConsole`, imported from the package's `/candidate` subpath alongside the repo's existing `@williamthorsen/toolbelt.testing/candidate` usage.
- Each of the 31 call sites derives its method set from the declared console surface of the unit it exercises rather than from the channels a given input happens to reach, so a set survives the addition of a test case to its describe. `initCommand.wiring.unit.test.ts` mocks `output/terminal.ts` wholesale, leaving `initCommand`'s own two `console.info` calls as the entire surface, and silences `info` alone.
- `console.warn` leaves every call site: `packages/readyup` holds no `console.warn`.
- Every `vi.restoreAllMocks()` in these files is removed. In `@vitest/spy`, `restoreAllMocks()` iterates only the restore callbacks that `vi.spyOn` registers, so it never reached the `vi.hoisted(() => vi.fn())` module mocks in `initCommand.wiring.unit.test.ts`; that suite's explicit `mockReset()` calls stay. Console spies were the only spies these files created, so `silenceConsole`'s own disposal covers what the hooks covered.
- `initCommand.wiring.unit.test.ts` sheds a `beforeEach` outright, its whole content having been the three spies, and its two assertions on `vi.mocked(console.info).mock.calls` read `silent.info.mock.calls` instead.
- No test name, count, or assertion target moved: 136 files and 2472 tests, as before.

### 📦 Dependencies

- Adds `@williamthorsen/toolbelt.vitest` at `0.3.0` to the `catalog` block in `pnpm-workspace.yaml`, referenced as `catalog:` from both the root manifest and `packages/readyup`. Its `vitest: ^4.0.0` peer resolves against the workspace's `4.1.10`.
- The root declaration is load-bearing despite no root code importing the package: `expandConfiguredPackages` resolves a configured name by walking `node_modules` upward from the repo root, where a devDependency of `packages/readyup` alone is invisible under pnpm, and an unresolvable name fails the run rather than skipping it. `@williamthorsen/toolbelt.errors` carries a root declaration for the same reason.
- Adds the package to the `packages` list in `.config/readyup.config.ts`, which puts its `default` kit into `pnpm exec rdy run --packages`.


Closes #337

