### PR TITLE
#336 Move readyup's remaining stdio spies onto captureStdio

### DIFF
--- a/packages/readyup/src/bin/__tests__/route.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.unit.test.ts
@@ -78,16 +78,14 @@ describe(routeCommand, () => {
     const { exitCode, stdout } = await route([]);
 
     expect(exitCode).toBe(0);
-    const output = stdout;
-    expect(output).toContain('Usage: rdy');
+    expect(stdout).toContain('Usage: rdy');
   });
 
   it('shows help and returns 0 for --help', async () => {
     const { exitCode, stdout } = await route(['--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdout;
-    expect(output).toContain('Usage: rdy');
+    expect(stdout).toContain('Usage: rdy');
   });
 
   it('shows help and returns 0 for -h', async () => {
@@ -113,15 +111,14 @@ describe(routeCommand, () => {
   it('includes run options in top-level help', async () => {
     const { stdout } = await route(['--help']);
 
-    const output = stdout;
-    expect(output).toContain('--from');
-    expect(output).toContain('--file, -f');
-    expect(output).toContain('--url');
-    expect(output).toContain('--jit');
-    expect(output).toContain('--internal');
-    expect(output).toContain('--checklists, -c');
-    expect(output).toContain('--json');
-    expect(output).toContain('--version, -V');
+    expect(stdout).toContain('--from');
+    expect(stdout).toContain('--file, -f');
+    expect(stdout).toContain('--url');
+    expect(stdout).toContain('--jit');
+    expect(stdout).toContain('--internal');
+    expect(stdout).toContain('--checklists, -c');
+    expect(stdout).toContain('--json');
+    expect(stdout).toContain('--version, -V');
   });
 
   it.each([
@@ -131,24 +128,21 @@ describe(routeCommand, () => {
   ])('names no retired short flag in $label help', async ({ args }) => {
     const { stdout } = await route(args);
 
-    const output = stdout;
     for (const short of ['-J', '-F', '-R', '-i', '-u', '-j']) {
-      expect(output).not.toContain(`, ${short}`);
+      expect(stdout).not.toContain(`, ${short}`);
     }
   });
 
   it('marks run as the default command in top-level help', async () => {
     const { stdout } = await route(['--help']);
 
-    const output = stdout;
-    expect(output).toContain('(default)');
+    expect(stdout).toContain('(default)');
   });
 
   it('points at per-command help from top-level help', async () => {
     const { stdout } = await route(['--help']);
 
-    const output = stdout;
-    expect(output).toContain("Run 'rdy <command> --help' for command-specific options.");
+    expect(stdout).toContain("Run 'rdy <command> --help' for command-specific options.");
   });
 
   it.each([
@@ -161,8 +155,7 @@ describe(routeCommand, () => {
   ])('points at the documentation from $label help', async ({ args }) => {
     const { stdout } = await route(args);
 
-    const output = stdout;
-    expect(output).toContain(DOCS_POINTER);
+    expect(stdout).toContain(DOCS_POINTER);
   });
 
   it('points at the documented package homepage', () => {
@@ -175,8 +168,7 @@ describe(routeCommand, () => {
   ])('leaves $label to the documentation rather than top-level help', async ({ text }) => {
     const { stdout } = await route(['--help']);
 
-    const output = stdout;
-    expect(output).not.toContain(text);
+    expect(stdout).not.toContain(text);
   });
 
   it.each([
@@ -186,31 +178,27 @@ describe(routeCommand, () => {
   ])('shows examples in $label help', async ({ args }) => {
     const { stdout } = await route(args);
 
-    const output = stdout;
-    expect(output).toContain('Examples:');
+    expect(stdout).toContain('Examples:');
   });
 
   it('explains how to escape a positional starting with a dash in run help', async () => {
     const { stdout } = await route(['run', '--help']);
 
-    const output = stdout;
-    expect(output).toContain('rdy run -- "--odd-kit-name"');
+    expect(stdout).toContain('rdy run -- "--odd-kit-name"');
   });
 
   it('shows run help and returns 0 for run --help', async () => {
     const { exitCode, stdout } = await route(['run', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdout;
-    expect(output).toContain('Usage: rdy run');
+    expect(stdout).toContain('Usage: rdy run');
   });
 
   it('shows init help and returns 0 for init --help', async () => {
     const { exitCode, stdout } = await route(['init', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdout;
-    expect(output).toContain('Usage: rdy init');
+    expect(stdout).toContain('Usage: rdy init');
   });
 
   it('shows init help and returns 0 for init -h', async () => {
@@ -291,8 +279,7 @@ describe(routeCommand, () => {
   it('includes --json in run help text', async () => {
     const { stdout } = await route(['run', '--help']);
 
-    const output = stdout;
-    expect(output).toContain('--json');
+    expect(stdout).toContain('--json');
   });
 
   it('returns 2 and writes to stderr when parseRunArgs throws', async () => {
@@ -501,9 +488,8 @@ describe(routeCommand, () => {
     const { exitCode, stdout } = await route(['compile', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdout;
-    expect(output).toContain('Usage: rdy compile');
-    expect(output).toContain('If no file is given');
+    expect(stdout).toContain('Usage: rdy compile');
+    expect(stdout).toContain('If no file is given');
   });
 
   it('shows compile help and returns 0 for compile -h', async () => {
@@ -533,8 +519,7 @@ describe(routeCommand, () => {
   it('lists compile in top-level help', async () => {
     const { stdout } = await route([]);
 
-    const output = stdout;
-    expect(output).toContain('compile');
+    expect(stdout).toContain('compile');
   });
 
   it('delegates to initCommand for init subcommand', async () => {
@@ -582,8 +567,7 @@ describe(routeCommand, () => {
     const { exitCode, stdout } = await route(['list', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdout;
-    expect(output).toContain('Usage: rdy list');
+    expect(stdout).toContain('Usage: rdy list');
   });
 
   it('shows list help and returns 0 for list -h', async () => {
@@ -613,16 +597,10 @@ describe(routeCommand, () => {
   it('lists list in top-level help', async () => {
     const { stdout } = await route([]);
 
-    const output = stdout;
-    expect(output).toContain('list');
+    expect(stdout).toContain('list');
   });
 
   describe('error envelope and stdout purity', () => {
-    /** Reads everything the call wrote to stdout as a single JSON document. */
-    function parseStdout(stdout: string): unknown {
-      return JSON.parse(stdout);
-    }
-
     it('emits the error envelope on stdout and leaves stderr empty for a usage error under --json', async () => {
       mockParseRunArgs.mockImplementation(() => {
         throw usageError("Unknown option '--bogus'");
@@ -631,7 +609,7 @@ describe(routeCommand, () => {
       const { exitCode, stdout, stderr } = await route(['--json', '--bogus']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout(stdout)).toStrictEqual({
+      expect(JSON.parse(stdout)).toStrictEqual({
         schemaVersion: 1,
         error: { code: 'usage', message: "Unknown option '--bogus'" },
       });
@@ -646,7 +624,7 @@ describe(routeCommand, () => {
       const { exitCode, stdout } = await route(['--json', '--bogus']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout(stdout)).toStrictEqual({
+      expect(JSON.parse(stdout)).toStrictEqual({
         schemaVersion: 1,
         error: { code: 'usage', message: 'nothing found', hint: 'Set GITHUB_TOKEN.' },
       });
@@ -659,7 +637,7 @@ describe(routeCommand, () => {
       const { exitCode, stdout } = await route(['run', '--json']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout(stdout)).toMatchObject({ error: { code: 'config', message: 'bad config' } });
+      expect(JSON.parse(stdout)).toMatchObject({ error: { code: 'config', message: 'bad config' } });
     });
 
     it('classifies an undiagnosed failure as an internal error in the envelope', async () => {
@@ -670,14 +648,14 @@ describe(routeCommand, () => {
       const { exitCode, stdout } = await route(['--json']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout(stdout)).toMatchObject({ error: { code: 'internal', message: 'something unexpected' } });
+      expect(JSON.parse(stdout)).toMatchObject({ error: { code: 'internal', message: 'something unexpected' } });
     });
 
     it('emits an unknown-command error as an envelope rather than prose under --json', async () => {
       const { exitCode, stdout, stderr } = await route(['compil', '--json']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout(stdout)).toMatchObject({ error: { code: 'usage' } });
+      expect(JSON.parse(stdout)).toMatchObject({ error: { code: 'usage' } });
       expect(stderr).toBe('');
     });
 

--- a/packages/readyup/src/bin/__tests__/route.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.unit.test.ts
@@ -1,7 +1,8 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockRunCommand = vi.hoisted(() => vi.fn());
 const mockInitCommand = vi.hoisted(() => vi.fn());
@@ -51,12 +52,7 @@ import { DOCS_POINTER, routeCommand } from '../route.ts';
 const TYPO_TEST_DIR = join(import.meta.dirname, '../../../.test-tmp-route');
 
 describe(routeCommand, () => {
-  let stdoutSpy: MockInstance;
-  let stderrSpy: MockInstance;
-
   beforeEach(() => {
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
       internal: { dir: '.', infix: undefined },
@@ -79,45 +75,45 @@ describe(routeCommand, () => {
   });
 
   it('shows help and returns 0 when no arguments are given', async () => {
-    const exitCode = await routeCommand([]);
+    const { exitCode, stdout } = await route([]);
 
     expect(exitCode).toBe(0);
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('Usage: rdy');
   });
 
   it('shows help and returns 0 for --help', async () => {
-    const exitCode = await routeCommand(['--help']);
+    const { exitCode, stdout } = await route(['--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('Usage: rdy');
   });
 
   it('shows help and returns 0 for -h', async () => {
-    const exitCode = await routeCommand(['-h']);
+    const { exitCode } = await route(['-h']);
 
     expect(exitCode).toBe(0);
   });
 
   it('prints version and returns 0 for --version', async () => {
-    const exitCode = await routeCommand(['--version']);
+    const { exitCode, stdout } = await route(['--version']);
 
     expect(exitCode).toBe(0);
-    expect(stdoutSpy).toHaveBeenCalledWith('1.2.3\n');
+    expect(stdout).toBe('1.2.3\n');
   });
 
   it('prints version and returns 0 for -V', async () => {
-    const exitCode = await routeCommand(['-V']);
+    const { exitCode, stdout } = await route(['-V']);
 
     expect(exitCode).toBe(0);
-    expect(stdoutSpy).toHaveBeenCalledWith('1.2.3\n');
+    expect(stdout).toBe('1.2.3\n');
   });
 
   it('includes run options in top-level help', async () => {
-    await routeCommand(['--help']);
+    const { stdout } = await route(['--help']);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('--from');
     expect(output).toContain('--file, -f');
     expect(output).toContain('--url');
@@ -133,25 +129,25 @@ describe(routeCommand, () => {
     { label: 'run', args: ['run', '--help'] },
     { label: 'init', args: ['init', '--help'] },
   ])('names no retired short flag in $label help', async ({ args }) => {
-    await routeCommand(args);
+    const { stdout } = await route(args);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     for (const short of ['-J', '-F', '-R', '-i', '-u', '-j']) {
       expect(output).not.toContain(`, ${short}`);
     }
   });
 
   it('marks run as the default command in top-level help', async () => {
-    await routeCommand(['--help']);
+    const { stdout } = await route(['--help']);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('(default)');
   });
 
   it('points at per-command help from top-level help', async () => {
-    await routeCommand(['--help']);
+    const { stdout } = await route(['--help']);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain("Run 'rdy <command> --help' for command-specific options.");
   });
 
@@ -163,9 +159,9 @@ describe(routeCommand, () => {
     { label: 'list', args: ['list', '--help'] },
     { label: 'verify', args: ['verify', '--help'] },
   ])('points at the documentation from $label help', async ({ args }) => {
-    await routeCommand(args);
+    const { stdout } = await route(args);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain(DOCS_POINTER);
   });
 
@@ -177,9 +173,9 @@ describe(routeCommand, () => {
     { label: 'exit codes', text: 'Exit codes:' },
     { label: 'schema evolution', text: 'schemaVersion' },
   ])('leaves $label to the documentation rather than top-level help', async ({ text }) => {
-    await routeCommand(['--help']);
+    const { stdout } = await route(['--help']);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).not.toContain(text);
   });
 
@@ -188,37 +184,37 @@ describe(routeCommand, () => {
     { label: 'run', args: ['run', '--help'] },
     { label: 'list', args: ['list', '--help'] },
   ])('shows examples in $label help', async ({ args }) => {
-    await routeCommand(args);
+    const { stdout } = await route(args);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('Examples:');
   });
 
   it('explains how to escape a positional starting with a dash in run help', async () => {
-    await routeCommand(['run', '--help']);
+    const { stdout } = await route(['run', '--help']);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('rdy run -- "--odd-kit-name"');
   });
 
   it('shows run help and returns 0 for run --help', async () => {
-    const exitCode = await routeCommand(['run', '--help']);
+    const { exitCode, stdout } = await route(['run', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('Usage: rdy run');
   });
 
   it('shows init help and returns 0 for init --help', async () => {
-    const exitCode = await routeCommand(['init', '--help']);
+    const { exitCode, stdout } = await route(['init', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('Usage: rdy init');
   });
 
   it('shows init help and returns 0 for init -h', async () => {
-    const exitCode = await routeCommand(['init', '-h']);
+    const { exitCode } = await route(['init', '-h']);
 
     expect(exitCode).toBe(0);
   });
@@ -236,7 +232,7 @@ describe(routeCommand, () => {
     });
     mockRunCommand.mockResolvedValue(0);
 
-    const exitCode = await routeCommand(['run', 'deploy']);
+    const { exitCode } = await route(['run', 'deploy']);
 
     expect(mockParseRunArgs).toHaveBeenCalledWith(['deploy']);
     expect(mockRunCommand).toHaveBeenCalledWith(
@@ -262,7 +258,7 @@ describe(routeCommand, () => {
     });
     mockRunCommand.mockResolvedValue(0);
 
-    const exitCode = await routeCommand(['run', '--jit']);
+    const { exitCode } = await route(['run', '--jit']);
 
     expect(mockRunCommand).toHaveBeenCalledWith(expect.anything(), true);
     expect(exitCode).toBe(0);
@@ -281,7 +277,7 @@ describe(routeCommand, () => {
     });
     mockRunCommand.mockResolvedValue(0);
 
-    const exitCode = await routeCommand(['run', '--json']);
+    const { exitCode } = await route(['run', '--json']);
 
     expect(mockRunCommand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -293,9 +289,9 @@ describe(routeCommand, () => {
   });
 
   it('includes --json in run help text', async () => {
-    await routeCommand(['run', '--help']);
+    const { stdout } = await route(['run', '--help']);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('--json');
   });
 
@@ -304,10 +300,10 @@ describe(routeCommand, () => {
       throw new Error("unknown flag '--bad'");
     });
 
-    const exitCode = await routeCommand(['run', '--bad']);
+    const { exitCode, stderr } = await route(['run', '--bad']);
 
     expect(exitCode).toBe(2);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("unknown flag '--bad'"));
+    expect(stderr).toContain("unknown flag '--bad'");
   });
 
   it('returns 2 and writes to stderr when resolveKitSources throws', async () => {
@@ -325,10 +321,10 @@ describe(routeCommand, () => {
       throw new Error('resolution failed');
     });
 
-    const exitCode = await routeCommand(['run', '--file', 'path.ts']);
+    const { exitCode, stderr } = await route(['run', '--file', 'path.ts']);
 
     expect(exitCode).toBe(2);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('resolution failed'));
+    expect(stderr).toContain('resolution failed');
   });
 
   it('returns 2 and writes to stderr when loadConfig rejects', async () => {
@@ -344,10 +340,10 @@ describe(routeCommand, () => {
     });
     mockLoadConfig.mockRejectedValue(new Error('bad config'));
 
-    const exitCode = await routeCommand(['run']);
+    const { exitCode, stderr } = await route(['run']);
 
     expect(exitCode).toBe(2);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('bad config'));
+    expect(stderr).toContain('bad config');
   });
 
   it('writes a hint on a line of its own, under the style the invocation selected', async () => {
@@ -355,13 +351,10 @@ describe(routeCommand, () => {
       throw usageError('nothing found', { hint: 'Set GITHUB_TOKEN.' });
     });
 
-    const exitCode = await routeCommand(['--style', 'plain', 'run', '--bad']);
+    const { exitCode, stderrChunks } = await route(['--style', 'plain', 'run', '--bad']);
 
     expect(exitCode).toBe(2);
-    expect(stderrSpy.mock.calls.map((call: unknown[]) => String(call[0]))).toStrictEqual([
-      'Error: nothing found\n',
-      'Hint: Set GITHUB_TOKEN.\n',
-    ]);
+    expect(stderrChunks).toStrictEqual(['Error: nothing found\n', 'Hint: Set GITHUB_TOKEN.\n']);
   });
 
   it('renders the hint through the rich style by default', async () => {
@@ -369,9 +362,9 @@ describe(routeCommand, () => {
       throw usageError('nothing found', { hint: 'Set GITHUB_TOKEN.' });
     });
 
-    await routeCommand(['run', '--bad']);
+    const { stderr } = await route(['run', '--bad']);
 
-    expect(stderrSpy).toHaveBeenCalledWith('💡 Hint: Set GITHUB_TOKEN.\n');
+    expect(stderr).toContain('💡 Hint: Set GITHUB_TOKEN.\n');
   });
 
   it('forwards an install hint from a config file whose imports could not be resolved', async () => {
@@ -382,10 +375,10 @@ describe(routeCommand, () => {
       }),
     );
 
-    const exitCode = await routeCommand(['run', '--json']);
+    const { exitCode, stdout } = await route(['run', '--json']);
 
     expect(exitCode).toBe(2);
-    expect(JSON.parse(stdoutSpy.mock.calls.map((call: unknown[]) => String(call[0])).join(''))).toStrictEqual({
+    expect(JSON.parse(stdout)).toStrictEqual({
       schemaVersion: 1,
       error: {
         code: 'config',
@@ -400,9 +393,9 @@ describe(routeCommand, () => {
       throw usageError('nothing found');
     });
 
-    await routeCommand(['run', '--bad']);
+    const { stderrChunks } = await route(['run', '--bad']);
 
-    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    expect(stderrChunks).toHaveLength(1);
   });
 
   // -- Config loading: external sources skip loadConfig --
@@ -421,7 +414,7 @@ describe(routeCommand, () => {
     mockResolveKitSources.mockReturnValue([{ name: 'kit.ts', source: { path: 'kit.ts' }, checklists: [] }]);
     mockRunCommand.mockResolvedValue(0);
 
-    await routeCommand(['run', '--file', 'kit.ts']);
+    await route(['run', '--file', 'kit.ts']);
 
     expect(mockLoadConfig).not.toHaveBeenCalled();
   });
@@ -442,7 +435,7 @@ describe(routeCommand, () => {
     ]);
     mockRunCommand.mockResolvedValue(0);
 
-    await routeCommand(['run', '--from', 'github:org/repo', 'deploy']);
+    await route(['run', '--from', 'github:org/repo', 'deploy']);
 
     expect(mockLoadConfig).not.toHaveBeenCalled();
   });
@@ -463,7 +456,7 @@ describe(routeCommand, () => {
     ]);
     mockRunCommand.mockResolvedValue(0);
 
-    await routeCommand(['run', '--url', 'https://example.com/kit.js']);
+    await route(['run', '--url', 'https://example.com/kit.js']);
 
     expect(mockLoadConfig).not.toHaveBeenCalled();
   });
@@ -481,7 +474,7 @@ describe(routeCommand, () => {
     });
     mockRunCommand.mockResolvedValue(0);
 
-    await routeCommand(['run']);
+    await route(['run']);
 
     expect(mockLoadConfig).toHaveBeenCalled();
   });
@@ -499,22 +492,22 @@ describe(routeCommand, () => {
     });
     mockRunCommand.mockResolvedValue(0);
 
-    await routeCommand(['run', '--internal']);
+    await route(['run', '--internal']);
 
     expect(mockLoadConfig).toHaveBeenCalled();
   });
 
   it('shows compile help and returns 0 for compile --help', async () => {
-    const exitCode = await routeCommand(['compile', '--help']);
+    const { exitCode, stdout } = await route(['compile', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('Usage: rdy compile');
     expect(output).toContain('If no file is given');
   });
 
   it('shows compile help and returns 0 for compile -h', async () => {
-    const exitCode = await routeCommand(['compile', '-h']);
+    const { exitCode } = await route(['compile', '-h']);
 
     expect(exitCode).toBe(0);
   });
@@ -522,7 +515,7 @@ describe(routeCommand, () => {
   it('delegates to compileCommand for compile subcommand', async () => {
     mockCompileCommand.mockResolvedValue(0);
 
-    const exitCode = await routeCommand(['compile', 'input.ts']);
+    const { exitCode } = await route(['compile', 'input.ts']);
 
     expect(mockCompileCommand).toHaveBeenCalledWith(['input.ts']);
     expect(exitCode).toBe(0);
@@ -531,23 +524,23 @@ describe(routeCommand, () => {
   it('passes --output flag through to compileCommand', async () => {
     mockCompileCommand.mockResolvedValue(0);
 
-    const exitCode = await routeCommand(['compile', 'input.ts', '--output', 'out.js']);
+    const { exitCode } = await route(['compile', 'input.ts', '--output', 'out.js']);
 
     expect(mockCompileCommand).toHaveBeenCalledWith(['input.ts', '--output', 'out.js']);
     expect(exitCode).toBe(0);
   });
 
   it('lists compile in top-level help', async () => {
-    await routeCommand([]);
+    const { stdout } = await route([]);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('compile');
   });
 
   it('delegates to initCommand for init subcommand', async () => {
     mockInitCommand.mockReturnValue(0);
 
-    const exitCode = await routeCommand(['init']);
+    const { exitCode } = await route(['init']);
 
     expect(mockInitCommand).toHaveBeenCalledWith({ dryRun: false, force: false });
     expect(exitCode).toBe(0);
@@ -556,7 +549,7 @@ describe(routeCommand, () => {
   it('passes --dry-run and --force flags to initCommand', async () => {
     mockInitCommand.mockReturnValue(0);
 
-    const exitCode = await routeCommand(['init', '--dry-run', '--force']);
+    const { exitCode } = await route(['init', '--dry-run', '--force']);
 
     expect(mockInitCommand).toHaveBeenCalledWith({ dryRun: true, force: true });
     expect(exitCode).toBe(0);
@@ -565,36 +558,36 @@ describe(routeCommand, () => {
   it('passes the -n short flag to initCommand', async () => {
     mockInitCommand.mockReturnValue(0);
 
-    const exitCode = await routeCommand(['init', '-n']);
+    const { exitCode } = await route(['init', '-n']);
 
     expect(mockInitCommand).toHaveBeenCalledWith({ dryRun: true, force: false });
     expect(exitCode).toBe(0);
   });
 
   it('rejects the retired init -f short flag', async () => {
-    const exitCode = await routeCommand(['init', '-f']);
+    const { exitCode } = await route(['init', '-f']);
 
     expect(exitCode).toBe(2);
     expect(mockInitCommand).not.toHaveBeenCalled();
   });
 
   it('returns 2 for unknown init flags', async () => {
-    const exitCode = await routeCommand(['init', '--unknown']);
+    const { exitCode, stderr } = await route(['init', '--unknown']);
 
     expect(exitCode).toBe(2);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown option '--unknown'"));
+    expect(stderr).toContain("Unknown option '--unknown'");
   });
 
   it('shows list help and returns 0 for list --help', async () => {
-    const exitCode = await routeCommand(['list', '--help']);
+    const { exitCode, stdout } = await route(['list', '--help']);
 
     expect(exitCode).toBe(0);
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('Usage: rdy list');
   });
 
   it('shows list help and returns 0 for list -h', async () => {
-    const exitCode = await routeCommand(['list', '-h']);
+    const { exitCode } = await route(['list', '-h']);
 
     expect(exitCode).toBe(0);
   });
@@ -602,7 +595,7 @@ describe(routeCommand, () => {
   it('delegates to listCommand for list subcommand', async () => {
     mockListCommand.mockResolvedValue(0);
 
-    const exitCode = await routeCommand(['list']);
+    const { exitCode } = await route(['list']);
 
     expect(mockListCommand).toHaveBeenCalledWith([]);
     expect(exitCode).toBe(0);
@@ -611,24 +604,23 @@ describe(routeCommand, () => {
   it('passes --from flag through to listCommand', async () => {
     mockListCommand.mockResolvedValue(0);
 
-    const exitCode = await routeCommand(['list', '--from', '.']);
+    const { exitCode } = await route(['list', '--from', '.']);
 
     expect(mockListCommand).toHaveBeenCalledWith(['--from', '.']);
     expect(exitCode).toBe(0);
   });
 
   it('lists list in top-level help', async () => {
-    await routeCommand([]);
+    const { stdout } = await route([]);
 
-    const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    const output = stdout;
     expect(output).toContain('list');
   });
 
   describe('error envelope and stdout purity', () => {
-    /** Collects everything written to stdout during the call, parsed as a single JSON document. */
-    function parseStdout(): unknown {
-      const written = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-      return JSON.parse(written);
+    /** Reads everything the call wrote to stdout as a single JSON document. */
+    function parseStdout(stdout: string): unknown {
+      return JSON.parse(stdout);
     }
 
     it('emits the error envelope on stdout and leaves stderr empty for a usage error under --json', async () => {
@@ -636,14 +628,14 @@ describe(routeCommand, () => {
         throw usageError("Unknown option '--bogus'");
       });
 
-      const exitCode = await routeCommand(['--json', '--bogus']);
+      const { exitCode, stdout, stderr } = await route(['--json', '--bogus']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout()).toStrictEqual({
+      expect(parseStdout(stdout)).toStrictEqual({
         schemaVersion: 1,
         error: { code: 'usage', message: "Unknown option '--bogus'" },
       });
-      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(stderr).toBe('');
     });
 
     it('carries a hint as its own envelope field, leaving the message unchanged', async () => {
@@ -651,10 +643,10 @@ describe(routeCommand, () => {
         throw usageError('nothing found', { hint: 'Set GITHUB_TOKEN.' });
       });
 
-      const exitCode = await routeCommand(['--json', '--bogus']);
+      const { exitCode, stdout } = await route(['--json', '--bogus']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout()).toStrictEqual({
+      expect(parseStdout(stdout)).toStrictEqual({
         schemaVersion: 1,
         error: { code: 'usage', message: 'nothing found', hint: 'Set GITHUB_TOKEN.' },
       });
@@ -664,10 +656,10 @@ describe(routeCommand, () => {
       mockParseRunArgs.mockReturnValue(parsedRunArgs({ json: true }));
       mockLoadConfig.mockRejectedValue(new Error('bad config'));
 
-      const exitCode = await routeCommand(['run', '--json']);
+      const { exitCode, stdout } = await route(['run', '--json']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout()).toMatchObject({ error: { code: 'config', message: 'bad config' } });
+      expect(parseStdout(stdout)).toMatchObject({ error: { code: 'config', message: 'bad config' } });
     });
 
     it('classifies an undiagnosed failure as an internal error in the envelope', async () => {
@@ -675,26 +667,26 @@ describe(routeCommand, () => {
         throw new Error('something unexpected');
       });
 
-      const exitCode = await routeCommand(['--json']);
+      const { exitCode, stdout } = await route(['--json']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout()).toMatchObject({ error: { code: 'internal', message: 'something unexpected' } });
+      expect(parseStdout(stdout)).toMatchObject({ error: { code: 'internal', message: 'something unexpected' } });
     });
 
     it('emits an unknown-command error as an envelope rather than prose under --json', async () => {
-      const exitCode = await routeCommand(['compil', '--json']);
+      const { exitCode, stdout, stderr } = await route(['compil', '--json']);
 
       expect(exitCode).toBe(2);
-      expect(parseStdout()).toMatchObject({ error: { code: 'usage' } });
-      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(parseStdout(stdout)).toMatchObject({ error: { code: 'usage' } });
+      expect(stderr).toBe('');
     });
 
     it('diverts help text to stderr under --json so stdout stays free of prose', async () => {
-      const exitCode = await routeCommand(['--help', '--json']);
+      const { exitCode, stdout, stderr } = await route(['--help', '--json']);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).not.toHaveBeenCalled();
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Usage: rdy'));
+      expect(stdout).toBe('');
+      expect(stderr).toContain('Usage: rdy');
     });
 
     it('stops the --json scan at the `--` terminator', async () => {
@@ -702,11 +694,11 @@ describe(routeCommand, () => {
         throw usageError('nope');
       });
 
-      const exitCode = await routeCommand(['run', '--', '--json']);
+      const { exitCode, stdout, stderr } = await route(['run', '--', '--json']);
 
       expect(exitCode).toBe(2);
-      expect(stdoutSpy).not.toHaveBeenCalled();
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('nope'));
+      expect(stdout).toBe('');
+      expect(stderr).toContain('nope');
     });
   });
 
@@ -724,7 +716,7 @@ describe(routeCommand, () => {
       });
       mockRunCommand.mockResolvedValue(0);
 
-      const exitCode = await routeCommand(['--file', 'foo.ts']);
+      const { exitCode } = await route(['--file', 'foo.ts']);
 
       expect(mockParseRunArgs).toHaveBeenCalledWith(['--file', 'foo.ts']);
       expect(exitCode).toBe(0);
@@ -743,7 +735,7 @@ describe(routeCommand, () => {
       });
       mockRunCommand.mockResolvedValue(0);
 
-      const exitCode = await routeCommand(['onboarding']);
+      const { exitCode } = await route(['onboarding']);
 
       expect(mockParseRunArgs).toHaveBeenCalledWith(['onboarding']);
       expect(exitCode).toBe(0);
@@ -762,20 +754,20 @@ describe(routeCommand, () => {
       ['runn', 'run'],
       ['verfy', 'verify'],
     ])('suggests "%s" -> "%s"', async (input, expected) => {
-      const exitCode = await routeCommand([input]);
+      const { exitCode, stderr } = await route([input]);
 
       expect(exitCode).toBe(2);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`Did you mean 'rdy ${expected}'?`));
+      expect(stderr).toContain(`Did you mean 'rdy ${expected}'?`);
     });
 
     it('does not suggest for a word no command is close to', async () => {
       mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'onboarding', checklists: [] }] }));
       mockRunCommand.mockResolvedValue(0);
 
-      const exitCode = await routeCommand(['onboarding']);
+      const { exitCode, stderr } = await route(['onboarding']);
 
       expect(exitCode).toBe(0);
-      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(stderr).toBe('');
     });
 
     it('runs a bare word as a kit when a kit by that name exists', async () => {
@@ -785,7 +777,7 @@ describe(routeCommand, () => {
       mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'lst', checklists: [] }] }));
       mockRunCommand.mockResolvedValue(0);
 
-      const exitCode = await routeCommand(['lst']);
+      const { exitCode } = await route(['lst']);
 
       expect(exitCode).toBe(0);
       expect(mockParseRunArgs).toHaveBeenCalledWith(['lst']);
@@ -801,7 +793,7 @@ describe(routeCommand, () => {
       mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: args[0], checklists: [] }] }));
       mockRunCommand.mockResolvedValue(0);
 
-      const exitCode = await routeCommand(args);
+      const { exitCode } = await route(args);
 
       expect(exitCode).toBe(0);
       expect(mockParseRunArgs).toHaveBeenCalledWith(args);
@@ -811,24 +803,24 @@ describe(routeCommand, () => {
       mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'lis', checklists: ['t'] }] }));
       mockRunCommand.mockResolvedValue(0);
 
-      const exitCode = await routeCommand(['lis:t']);
+      const { exitCode } = await route(['lis:t']);
 
       expect(exitCode).toBe(0);
       expect(mockParseRunArgs).toHaveBeenCalledWith(['lis:t']);
     });
 
     it('still suggests a command when a source flag follows the -- terminator', async () => {
-      const exitCode = await routeCommand(['lst', '--', '--from']);
+      const { exitCode, stderr } = await route(['lst', '--', '--from']);
 
       expect(exitCode).toBe(2);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Did you mean 'rdy list'?"));
+      expect(stderr).toContain("Did you mean 'rdy list'?");
     });
 
     it('does not suggest after an explicit run subcommand', async () => {
       mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'lst', checklists: [] }] }));
       mockRunCommand.mockResolvedValue(0);
 
-      const exitCode = await routeCommand(['run', 'lst']);
+      const { exitCode } = await route(['run', 'lst']);
 
       expect(exitCode).toBe(0);
       expect(mockParseRunArgs).toHaveBeenCalledWith(['lst']);
@@ -840,12 +832,14 @@ describe(routeCommand, () => {
 
       // 'run' is handled before typo detection, so this verifies
       // the explicit subcommand path
-      const exitCode = await routeCommand(['run']);
+      const { exitCode } = await route(['run']);
 
       expect(exitCode).toBe(0);
     });
   });
 });
+
+// region | Helpers
 
 /** Builds a `parseRunArgs` return value with the no-flags defaults. */
 function parsedRunArgs(overrides?: Record<string, unknown>) {
@@ -861,3 +855,14 @@ function parsedRunArgs(overrides?: Record<string, unknown>) {
     ...overrides,
   };
 }
+
+/** Runs the CLI over the given arguments, returning its exit code alongside everything it wrote. */
+async function route(args: string[]) {
+  using io = captureStdio();
+
+  const exitCode = await routeCommand(args);
+
+  return { exitCode, stdout: io.stdout, stderr: io.stderr, stderrChunks: io.stderrChunks };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
@@ -3,7 +3,8 @@ import path from 'node:path';
 import process from 'node:process';
 
 import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RdyManifest } from '../../manifest/manifestSchema.ts';
 
@@ -113,12 +114,7 @@ function kitMetadata(overrides: Partial<KitMetadata> = {}): KitMetadata {
 }
 
 describe(compileCommand, () => {
-  let stdoutSpy: MockInstance;
-  let stderrSpy: MockInstance;
-
   beforeEach(() => {
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockValidateCompiledOutput.mockResolvedValue(kitMetadata());
     mockCheckDrift.mockReturnValue({ kind: 'unverified' });
     // No path these tests name holds a symlink, so a real path is the path itself.
@@ -145,11 +141,11 @@ describe(compileCommand, () => {
       compileResult('input.ts', { outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    const exitCode = await compileCommand(['input.ts']);
+    const { exitCode, stdout } = await compile(['input.ts']);
 
     expect(exitCode).toBe(0);
     expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', undefined);
-    expect(stdoutSpy).toHaveBeenCalledWith('\u{2500}\u{2500} Compiling kit\n');
+    expect(stdout).toContain('\u{2500}\u{2500} Compiling kit\n');
   });
 
   it('shows compiled indicator for a changed single file', async () => {
@@ -157,10 +153,10 @@ describe(compileCommand, () => {
       compileResult('input.ts', { outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand(['input.ts']);
+    const { stdout } = await compile(['input.ts']);
 
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_COMPILED} input.ts -> ${GLYPH_OUTPUT} `));
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('\u{2192}'));
+    expect(stdout).toContain(`${ICON_COMPILED} input.ts -> ${GLYPH_OUTPUT} `);
+    expect(stdout).not.toContain('\u{2192}');
   });
 
   it('shows no-changes indicator for an unchanged single file', async () => {
@@ -168,10 +164,10 @@ describe(compileCommand, () => {
       compileResult('input.ts', { outputPath: '/abs/out.js', changed: false, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand(['input.ts']);
+    const { stdout } = await compile(['input.ts']);
 
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(ICON_NO_CHANGES));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('no changes'));
+    expect(stdout).toContain(ICON_NO_CHANGES);
+    expect(stdout).toContain('no changes');
   });
 
   it('passes --output value to compileConfig', async () => {
@@ -179,7 +175,7 @@ describe(compileCommand, () => {
       compileResult('input.ts', { outputPath: '/abs/custom.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    const exitCode = await compileCommand(['input.ts', '--output', 'custom.js']);
+    const { exitCode } = await compile(['input.ts', '--output', 'custom.js']);
 
     expect(exitCode).toBe(0);
     expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', 'custom.js');
@@ -190,7 +186,7 @@ describe(compileCommand, () => {
       compileResult('input.ts', { outputPath: '/abs/custom.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    const exitCode = await compileCommand(['input.ts', '--output=custom.js']);
+    const { exitCode } = await compile(['input.ts', '--output=custom.js']);
 
     expect(exitCode).toBe(0);
     expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', 'custom.js');
@@ -201,28 +197,28 @@ describe(compileCommand, () => {
       compileResult('input.ts', { outputPath: '/abs/custom.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    const exitCode = await compileCommand(['input.ts', '-o', 'custom.js']);
+    const { exitCode } = await compile(['input.ts', '-o', 'custom.js']);
 
     expect(exitCode).toBe(0);
     expect(mockCompileConfig).toHaveBeenCalledWith('input.ts', 'custom.js');
   });
 
   it('reports a usage error when --output is provided without a value', async () => {
-    const error = await captureError(RdyError, () => compileCommand(['input.ts', '--output']));
+    const { error } = await compileRaising(['input.ts', '--output']);
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain('--output requires a path argument');
   });
 
   it('reports a usage error when --output is given an empty value', async () => {
-    const error = await captureError(RdyError, () => compileCommand(['input.ts', '--output=']));
+    const { error } = await compileRaising(['input.ts', '--output=']);
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain('--output requires a path argument');
   });
 
   it('reports a usage error for unknown flags', async () => {
-    const error = await captureError(RdyError, () => compileCommand(['input.ts', '--verbose']));
+    const { error } = await compileRaising(['input.ts', '--verbose']);
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain("Unknown option '--verbose'");
@@ -231,14 +227,14 @@ describe(compileCommand, () => {
   it('returns 1 when compileConfig throws', async () => {
     mockCompileConfig.mockRejectedValue(new Error('esbuild is required'));
 
-    const exitCode = await compileCommand(['input.ts']);
+    const { exitCode, stderr } = await compile(['input.ts']);
 
     expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('esbuild is required'));
+    expect(stderr).toContain('esbuild is required');
   });
 
   it('reports a usage error when multiple positional arguments are provided', async () => {
-    const error = await captureError(RdyError, () => compileCommand(['a.ts', 'b.ts']));
+    const { error } = await compileRaising(['a.ts', 'b.ts']);
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain('Too many arguments');
@@ -251,7 +247,7 @@ describe(compileCommand, () => {
       }),
     );
 
-    const error = await captureError(RdyError, () => compileCommand([]));
+    const { error } = await compileRaising([]);
 
     expect(error.code).toBe('config');
     expect(error.hint).toBe('Install it with: pnpm add --save-dev some-lib');
@@ -268,10 +264,10 @@ describe(compileCommand, () => {
       compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand([]);
+    const { stdout } = await compile([]);
 
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Compiling kits in'));
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining(' to '));
+    expect(stdout).toContain('Compiling kits in');
+    expect(stdout).not.toContain(' to ');
   });
 
   // `pnpm -r exec rdy compile` gives each workspace its own working directory, so a heading naming paths
@@ -290,10 +286,10 @@ describe(compileCommand, () => {
       compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand([]);
+    const { stdout } = await compile([]);
 
     const expected = path.relative(workspaceRoot, path.resolve(process.cwd(), '.readyup/kits'));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`Compiling kits in ${expected}`));
+    expect(stdout).toContain(`Compiling kits in ${expected}`);
   });
 
   // Readyup is published, so it runs in repositories that have no workspace file and in directories under
@@ -311,9 +307,9 @@ describe(compileCommand, () => {
       compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand([]);
+    const { stdout } = await compile([]);
 
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Compiling kits in .readyup/kits'));
+    expect(stdout).toContain('Compiling kits in .readyup/kits');
   });
 
   it('prints "from ... to ..." header when srcDir differs from outDir', async () => {
@@ -326,10 +322,10 @@ describe(compileCommand, () => {
       compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand([]);
+    const { stdout } = await compile([]);
 
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('from'));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('to'));
+    expect(stdout).toContain('from');
+    expect(stdout).toContain('to');
   });
 
   it('compiles all .ts files and shows per-file status lines', async () => {
@@ -346,25 +342,25 @@ describe(compileCommand, () => {
         compileResult(kitSource('b.ts'), { outputPath: '/abs/b.js', changed: false, targetHash: 'bbbb2222' }),
       );
 
-    const exitCode = await compileCommand([]);
+    const { exitCode, stdout, stdoutChunks } = await compile([]);
 
     expect(exitCode).toBe(0);
     expect(mockCompileConfig).toHaveBeenCalledTimes(2);
     // Header + 2 status lines
-    expect(stdoutSpy).toHaveBeenCalledTimes(3);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_COMPILED} a.ts -> ${GLYPH_OUTPUT} a.js`));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_NO_CHANGES} b.ts \u{00B7} no changes`));
+    expect(stdoutChunks).toHaveLength(3);
+    expect(stdout).toContain(`${ICON_COMPILED} a.ts -> ${GLYPH_OUTPUT} a.js`);
+    expect(stdout).toContain(`${ICON_NO_CHANGES} b.ts \u{00B7} no changes`);
   });
 
   it('reports a usage error when --output is given without an input file', async () => {
-    const error = await captureError(RdyError, () => compileCommand(['--output', 'out.js']));
+    const { error } = await compileRaising(['--output', 'out.js']);
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain('--output requires an input file');
   });
 
   it('reports a usage error for --all (removed flag)', async () => {
-    const error = await captureError(RdyError, () => compileCommand(['--all']));
+    const { error } = await compileRaising(['--all']);
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain("Unknown option '--all'");
@@ -394,7 +390,7 @@ describe(compileCommand, () => {
         }),
       );
 
-    const exitCode = await compileCommand([]);
+    const { exitCode } = await compile([]);
 
     expect(exitCode).toBe(0);
     expect(mockPicomatch).toHaveBeenCalledWith('shared/*.ts');
@@ -405,54 +401,50 @@ describe(compileCommand, () => {
     it('writes no manifest when the source directory is absent and no manifest exists', async () => {
       arrangeEmptySweep({ srcDirExists: false, manifestExists: false });
 
-      const exitCode = await compileCommand([]);
+      const { exitCode, stdout } = await compile([]);
 
       expect(exitCode).toBe(0);
       expect(mockReaddirSync).not.toHaveBeenCalled();
       expect(mockWriteManifest).not.toHaveBeenCalled();
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Source directory not found: .readyup/kits; manifest not written'),
-      );
+      expect(stdout).toContain('Source directory not found: .readyup/kits; manifest not written');
     });
 
     it('writes no manifest when the source directory holds no .ts files and no manifest exists', async () => {
       arrangeEmptySweep({ srcDirExists: true, manifestExists: false });
       mockReaddirSync.mockReturnValue(['readme.md']);
 
-      const exitCode = await compileCommand([]);
+      const { exitCode, stdout } = await compile([]);
 
       expect(exitCode).toBe(0);
       expect(mockWriteManifest).not.toHaveBeenCalled();
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining('No .ts files found in .readyup/kits; manifest not written'),
-      );
+      expect(stdout).toContain('No .ts files found in .readyup/kits; manifest not written');
     });
 
     it('empties an existing manifest when the source directory is absent', async () => {
       arrangeEmptySweep({ srcDirExists: false, manifestExists: true });
 
-      const exitCode = await compileCommand([]);
+      const { exitCode, stdout } = await compile([]);
 
       expect(exitCode).toBe(0);
       expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('manifest now lists no kits'));
+      expect(stdout).toContain('manifest now lists no kits');
     });
 
     it('empties an existing manifest when the source directory holds no .ts files', async () => {
       arrangeEmptySweep({ srcDirExists: true, manifestExists: true });
       mockReaddirSync.mockReturnValue(['readme.md']);
 
-      const exitCode = await compileCommand([]);
+      const { exitCode, stdout } = await compile([]);
 
       expect(exitCode).toBe(0);
       expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('manifest now lists no kits'));
+      expect(stdout).toContain('manifest now lists no kits');
     });
 
     it('gates on the path --manifest names rather than the default', async () => {
       arrangeEmptySweep({ srcDirExists: false, manifestExists: false });
 
-      await compileCommand(['--manifest', 'custom/manifest.json']);
+      await compile(['--manifest', 'custom/manifest.json']);
 
       expect(mockExistsSync).toHaveBeenCalledWith(path.resolve(process.cwd(), 'custom/manifest.json'));
       expect(mockWriteManifest).not.toHaveBeenCalled();
@@ -461,22 +453,22 @@ describe(compileCommand, () => {
     it('omits the manifest clause under --skip-manifest when the source directory is absent', async () => {
       arrangeEmptySweep({ srcDirExists: false, manifestExists: true });
 
-      const exitCode = await compileCommand(['--skip-manifest']);
+      const { exitCode, stdout } = await compile(['--skip-manifest']);
 
       expect(exitCode).toBe(0);
       expect(mockWriteManifest).not.toHaveBeenCalled();
-      expect(stdoutSpy).toHaveBeenCalledWith('Source directory not found: .readyup/kits\n');
+      expect(stdout).toBe('Source directory not found: .readyup/kits\n');
     });
 
     it('omits the manifest clause under --skip-manifest when the directory holds no .ts files', async () => {
       arrangeEmptySweep({ srcDirExists: true, manifestExists: true });
       mockReaddirSync.mockReturnValue(['readme.md']);
 
-      const exitCode = await compileCommand(['--skip-manifest']);
+      const { exitCode, stdout } = await compile(['--skip-manifest']);
 
       expect(exitCode).toBe(0);
       expect(mockWriteManifest).not.toHaveBeenCalled();
-      expect(stdoutSpy).toHaveBeenCalledWith('No .ts files found in .readyup/kits\n');
+      expect(stdout).toBe('No .ts files found in .readyup/kits\n');
     });
 
     // region | Helpers
@@ -499,10 +491,10 @@ describe(compileCommand, () => {
     );
     mockValidateCompiledOutput.mockRejectedValue(new Error('Suite name(s) collide with checklist name(s): deploy'));
 
-    const exitCode = await compileCommand(['input.ts']);
+    const { exitCode, stderr } = await compile(['input.ts']);
 
     expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Suite name(s) collide'));
+    expect(stderr).toContain('Suite name(s) collide');
   });
 
   it('returns 1 when post-compile validation fails during batch compile', async () => {
@@ -516,10 +508,10 @@ describe(compileCommand, () => {
     );
     mockValidateCompiledOutput.mockRejectedValue(new Error('suite "ci" references unknown checklist "missing"'));
 
-    const exitCode = await compileCommand([]);
+    const { exitCode, stderr } = await compile([]);
 
     expect(exitCode).toBe(1);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('references unknown checklist'));
+    expect(stderr).toContain('references unknown checklist');
   });
 
   describe('sweep completion', () => {
@@ -540,20 +532,20 @@ describe(compileCommand, () => {
     it('compiles the kits after a failed one instead of abandoning the sweep', async () => {
       arrangeMixedBatch();
 
-      const exitCode = await compileCommand([]);
+      const { exitCode, stdout, stderr } = await compile([]);
 
       expect(exitCode).toBe(1);
       expect(mockCompileConfig).toHaveBeenCalledTimes(2);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error compiling alpha.ts'));
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('beta.ts'));
+      expect(stderr).toContain('Error compiling alpha.ts');
+      expect(stdout).toContain('beta.ts');
     });
 
     it('reports how many kits failed once the sweep finishes', async () => {
       arrangeMixedBatch();
 
-      await compileCommand([]);
+      const { stdout } = await compile([]);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2 kits failed to compile.'));
+      expect(stdout).toContain('1 of 2 kits failed to compile.');
     });
 
     it('writes a manifest when sources are found but every one fails to compile', async () => {
@@ -564,7 +556,7 @@ describe(compileCommand, () => {
       mockReaddirSync.mockReturnValue(['alpha.ts', 'beta.ts']);
       mockCompileConfig.mockRejectedValue(new Error('not valid TypeScript'));
 
-      const exitCode = await compileCommand([]);
+      const { exitCode } = await compile([]);
 
       expect(exitCode).toBe(1);
       expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
@@ -573,7 +565,7 @@ describe(compileCommand, () => {
     it('leaves a failed kit out of the manifest rather than recording it as compiled', async () => {
       arrangeMixedBatch();
 
-      await compileCommand([]);
+      await compile([]);
 
       expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
         version: 1,
@@ -592,7 +584,7 @@ describe(compileCommand, () => {
       };
       mockReadManifest.mockReturnValue({ version: 1, kits: [recordedAlpha] });
 
-      await compileCommand([]);
+      await compile([]);
 
       expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
         version: 1,
@@ -609,10 +601,10 @@ describe(compileCommand, () => {
         ],
       });
 
-      const exitCode = await compileCommand([]);
+      const { exitCode, stderr } = await compile([]);
 
       expect(exitCode).toBe(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Error compiling alpha.ts'));
+      expect(stderr).toContain('Error compiling alpha.ts');
     });
   });
 
@@ -626,7 +618,7 @@ describe(compileCommand, () => {
         throw new ManifestNotFoundError('missing');
       });
 
-      await compileCommand(['deploy.ts']);
+      await compile(['deploy.ts']);
 
       expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
         version: 1,
@@ -642,7 +634,7 @@ describe(compileCommand, () => {
         throw new ManifestNotFoundError('missing');
       });
 
-      await compileCommand(['deploy.ts']);
+      await compile(['deploy.ts']);
 
       const [call] = mockWriteManifest.mock.calls;
       assert.ok(call);
@@ -662,7 +654,7 @@ describe(compileCommand, () => {
         throw new ManifestNotFoundError('missing');
       });
 
-      await compileCommand(['deploy.ts']);
+      await compile(['deploy.ts']);
 
       expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
         version: 1,
@@ -678,7 +670,7 @@ describe(compileCommand, () => {
         throw new ManifestNotFoundError('missing');
       });
 
-      await compileCommand(['deploy.ts']);
+      await compile(['deploy.ts']);
 
       const [call] = mockWriteManifest.mock.calls;
       assert.ok(call);
@@ -701,13 +693,11 @@ describe(compileCommand, () => {
           compileResult(kitSource('beta.ts'), { outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' }),
         );
 
-      const exitCode = await compileCommand(['--json']);
+      const { exitCode, stdout, stdoutChunks } = await compile(['--json']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledTimes(1);
-      const [jsonCall] = stdoutSpy.mock.calls;
-      assert.ok(jsonCall);
-      expect(JSON.parse(String(jsonCall[0]))).toStrictEqual({
+      expect(stdoutChunks).toHaveLength(1);
+      expect(JSON.parse(stdout)).toStrictEqual({
         schemaVersion: 1,
         passed: false,
         kits: [
@@ -725,12 +715,10 @@ describe(compileCommand, () => {
         throw new ManifestNotFoundError('missing');
       });
 
-      const exitCode = await compileCommand(['deploy.ts', '--json']);
+      const { exitCode, stdout } = await compile(['deploy.ts', '--json']);
 
       expect(exitCode).toBe(0);
-      const [jsonCall] = stdoutSpy.mock.calls;
-      assert.ok(jsonCall);
-      expect(JSON.parse(String(jsonCall[0]))).toMatchObject({
+      expect(JSON.parse(stdout)).toMatchObject({
         passed: true,
         kits: [{ name: 'deploy', status: 'compiled' }],
       });
@@ -748,12 +736,10 @@ describe(compileCommand, () => {
         resolvedPath: '/abs/deploy.js',
       });
 
-      const exitCode = await compileCommand(['deploy.ts', '--json']);
+      const { exitCode, stdout } = await compile(['deploy.ts', '--json']);
 
       expect(exitCode).toBe(1);
-      const [jsonCall] = stdoutSpy.mock.calls;
-      assert.ok(jsonCall);
-      expect(JSON.parse(String(jsonCall[0]))).toMatchObject({
+      expect(JSON.parse(stdout)).toMatchObject({
         passed: false,
         kits: [{ name: 'deploy', status: 'skipped', error: expect.stringContaining('drifted') }],
       });
@@ -769,7 +755,7 @@ describe(compileCommand, () => {
       throw new Error('EACCES: permission denied');
     });
 
-    const error = await captureError(RdyError, () => compileCommand([]));
+    const { error } = await compileRaising([]);
 
     expect(error.code).toBe('config');
     expect(error.message).toContain('Failed to read source directory');
@@ -784,7 +770,7 @@ describe(compileCommand, () => {
     mockReaddirSync.mockReturnValue(['data/readme.md', 'data/config.json']);
     mockPicomatch.mockReturnValue(() => true);
 
-    const exitCode = await compileCommand([]);
+    const { exitCode } = await compile([]);
 
     expect(exitCode).toBe(0);
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
@@ -815,7 +801,7 @@ describe(compileCommand, () => {
       .mockResolvedValueOnce(kitMetadata({ description: 'Alpha checks' }))
       .mockResolvedValueOnce(kitMetadata());
 
-    await compileCommand([]);
+    await compile([]);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
@@ -866,7 +852,7 @@ describe(compileCommand, () => {
       compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand(['--skip-manifest']);
+    await compile(['--skip-manifest']);
 
     expect(mockWriteManifest).not.toHaveBeenCalled();
   });
@@ -881,7 +867,7 @@ describe(compileCommand, () => {
       compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand(['--manifest=custom/manifest.json']);
+    await compile(['--manifest=custom/manifest.json']);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.stringContaining('custom/manifest.json'), expect.anything());
   });
@@ -896,7 +882,7 @@ describe(compileCommand, () => {
       kits: [{ name: 'default', description: 'Default checks' }],
     });
 
-    await compileCommand(['deploy.ts']);
+    await compile(['deploy.ts']);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
@@ -926,7 +912,7 @@ describe(compileCommand, () => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
 
-    await compileCommand(['deploy.ts']);
+    await compile(['deploy.ts']);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
@@ -955,7 +941,7 @@ describe(compileCommand, () => {
       kits: [{ name: 'deploy', description: 'Old' }],
     });
 
-    await compileCommand(['deploy.ts']);
+    await compile(['deploy.ts']);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
@@ -987,7 +973,7 @@ describe(compileCommand, () => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
 
-    await compileCommand(['deploy.ts']);
+    await compile(['deploy.ts']);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(
       expect.any(String),
@@ -1012,7 +998,7 @@ describe(compileCommand, () => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
 
-    await compileCommand(['deploy.ts']);
+    await compile(['deploy.ts']);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(
       expect.any(String),
@@ -1040,7 +1026,7 @@ describe(compileCommand, () => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
 
-    await compileCommand(['deploy.ts']);
+    await compile(['deploy.ts']);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(
       expect.any(String),
@@ -1051,7 +1037,7 @@ describe(compileCommand, () => {
   it('records a distinct source hash per kit in a batch compile', async () => {
     arrangeTwoKitBatch({ alphaHash: 'a1a1a1a1', betaHash: 'b2b2b2b2' });
 
-    await compileCommand([]);
+    await compile([]);
 
     const [writeManifestCall] = mockWriteManifest.mock.calls;
     assert.ok(writeManifestCall);
@@ -1076,7 +1062,7 @@ describe(compileCommand, () => {
         : { kind: 'unverified' },
     );
 
-    await compileCommand([]);
+    await compile([]);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
@@ -1089,7 +1075,7 @@ describe(compileCommand, () => {
       compileResult('input.ts', { outputPath: '/abs/out.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand(['input.ts', '--skip-manifest']);
+    await compile(['input.ts', '--skip-manifest']);
 
     expect(mockWriteManifest).not.toHaveBeenCalled();
     expect(mockReadManifest).not.toHaveBeenCalled();
@@ -1108,7 +1094,7 @@ describe(compileCommand, () => {
       throw new Error('EACCES: permission denied');
     });
 
-    const error = await captureError(RdyError, () => compileCommand([]));
+    const { error } = await compileRaising([]);
 
     expect(error.code).toBe('config');
     expect(error.message).toContain('Error writing manifest');
@@ -1124,10 +1110,10 @@ describe(compileCommand, () => {
       throw new Error('Invalid manifest schema in .readyup/manifest.json: bad data');
     });
 
-    await compileCommand(['deploy.ts']);
+    const { stderr } = await compile(['deploy.ts']);
 
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Warning:'));
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid manifest schema'));
+    expect(stderr).toContain('Warning:');
+    expect(stderr).toContain('Invalid manifest schema');
     // Still writes the manifest despite the warning
     expect(mockWriteManifest).toHaveBeenCalledTimes(1);
   });
@@ -1141,7 +1127,7 @@ describe(compileCommand, () => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
 
-    await compileCommand(['deploy.ts', '--manifest=custom/manifest.json']);
+    await compile(['deploy.ts', '--manifest=custom/manifest.json']);
 
     expect(mockWriteManifest).toHaveBeenCalledTimes(1);
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.stringContaining('custom/manifest.json'), expect.anything());
@@ -1161,7 +1147,7 @@ describe(compileCommand, () => {
         compileResult(kitSource('beta.ts'), { outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' }),
       );
 
-    await compileCommand([]);
+    await compile([]);
 
     const [writeManifestCall] = mockWriteManifest.mock.calls;
     assert.ok(writeManifestCall);
@@ -1180,7 +1166,7 @@ describe(compileCommand, () => {
       throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
     });
 
-    await compileCommand(['deploy.ts']);
+    await compile(['deploy.ts']);
 
     const [writeManifestCall] = mockWriteManifest.mock.calls;
     assert.ok(writeManifestCall);
@@ -1200,7 +1186,7 @@ describe(compileCommand, () => {
       kits: [{ name: 'charlie' }, { name: 'beta' }],
     });
 
-    await compileCommand(['alpha.ts']);
+    await compile(['alpha.ts']);
 
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), {
       version: 1,
@@ -1221,15 +1207,13 @@ describe(compileCommand, () => {
       resolvedPath: '/abs/deploy.js',
     });
 
-    const exitCode = await compileCommand(['deploy.ts']);
+    const { exitCode, stdout } = await compile(['deploy.ts']);
 
     expect(exitCode).toBe(1);
     expect(mockCompileConfig).not.toHaveBeenCalled();
     expect(mockWriteManifest).not.toHaveBeenCalled();
-    expect(stdoutSpy).toHaveBeenCalledWith(
-      `${ICON_DRIFT} deploy.ts\n   drift in deploy.js: expected aaaa1111, got bbbb2222\n`,
-    );
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Re-run with --force'));
+    expect(stdout).toContain(`${ICON_DRIFT} deploy.ts\n   drift in deploy.js: expected aaaa1111, got bbbb2222\n`);
+    expect(stdout).toContain('Re-run with --force');
   });
 
   it('bypasses drift gate with --force on single-file compile', async () => {
@@ -1248,7 +1232,7 @@ describe(compileCommand, () => {
       resolvedPath: '/abs/deploy.js',
     });
 
-    const exitCode = await compileCommand(['deploy.ts', '--force']);
+    const { exitCode } = await compile(['deploy.ts', '--force']);
 
     expect(exitCode).toBe(0);
     expect(mockCheckDrift).not.toHaveBeenCalled();
@@ -1282,12 +1266,12 @@ describe(compileCommand, () => {
       compileResult(kitSource('beta.ts'), { outputPath: '/abs/beta.js', changed: true, targetHash: 'bbbb2222' }),
     );
 
-    const exitCode = await compileCommand([]);
+    const { exitCode, stdout } = await compile([]);
 
     expect(exitCode).toBe(1);
     expect(mockCompileConfig).toHaveBeenCalledTimes(1); // only beta compiled
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${ICON_DRIFT} alpha.ts\n   drift in alpha.js:`));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2 kits skipped due to drift'));
+    expect(stdout).toContain(`${ICON_DRIFT} alpha.ts\n   drift in alpha.js:`);
+    expect(stdout).toContain('1 of 2 kits skipped due to drift');
 
     const [writeManifestCall] = mockWriteManifest.mock.calls;
     assert.ok(writeManifestCall);
@@ -1320,12 +1304,12 @@ describe(compileCommand, () => {
       compileResult(kitSource('alpha.ts'), { outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa9999' }),
     );
 
-    const exitCode = await compileCommand(['--force']);
+    const { exitCode, stdout } = await compile(['--force']);
 
     expect(exitCode).toBe(0);
     expect(mockCheckDrift).not.toHaveBeenCalled();
     expect(mockCompileConfig).toHaveBeenCalledTimes(1);
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('skipped due to drift'));
+    expect(stdout).not.toContain('skipped due to drift');
   });
 
   it('does not emit drift footer when no kits were skipped', async () => {
@@ -1339,9 +1323,9 @@ describe(compileCommand, () => {
       compileResult(kitSource('a.ts'), { outputPath: '/abs/a.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand([]);
+    const { stdout } = await compile([]);
 
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('skipped due to drift'));
+    expect(stdout).not.toContain('skipped due to drift');
   });
 
   it('warns on stderr when the existing manifest is unreadable during batch compile', async () => {
@@ -1357,10 +1341,10 @@ describe(compileCommand, () => {
       compileResult(kitSource('alpha.ts'), { outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand([]);
+    const { stderr } = await compile([]);
 
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Unexpected token in JSON'));
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('drift gate skipped'));
+    expect(stderr).toContain('Unexpected token in JSON');
+    expect(stderr).toContain('drift gate skipped');
   });
 
   it('is silent when the manifest is missing during batch compile', async () => {
@@ -1376,9 +1360,9 @@ describe(compileCommand, () => {
       compileResult(kitSource('alpha.ts'), { outputPath: '/abs/alpha.js', changed: true, targetHash: 'aaaa1111' }),
     );
 
-    await compileCommand([]);
+    const { stderr } = await compile([]);
 
-    expect(stderrSpy).not.toHaveBeenCalledWith(expect.stringContaining('drift gate skipped'));
+    expect(stderr).not.toContain('drift gate skipped');
   });
 
   // region | Helpers
@@ -1398,3 +1382,25 @@ describe(compileCommand, () => {
 
   // endregion | Helpers
 });
+
+// region | Helpers
+
+/** Runs the command over the given arguments, returning its exit code alongside everything it wrote. */
+async function compile(args: string[]) {
+  using io = captureStdio();
+
+  const exitCode = await compileCommand(args);
+
+  return { exitCode, stdout: io.stdout, stdoutChunks: io.stdoutChunks, stderr: io.stderr };
+}
+
+/** Runs the command expecting it to raise, returning the error alongside everything it wrote. */
+async function compileRaising(args: string[]) {
+  using io = captureStdio();
+
+  const error = await captureError(RdyError, () => compileCommand(args));
+
+  return { error, stdout: io.stdout, stderr: io.stderr };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
@@ -2,8 +2,7 @@ import assert from 'node:assert';
 import path from 'node:path';
 import process from 'node:process';
 
-import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { captureError, captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RdyManifest } from '../../manifest/manifestSchema.ts';

--- a/packages/readyup/src/list/__tests__/listCommand.from.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.from.unit.test.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert';
 import path from 'node:path';
 
 import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockEnumerateKits = vi.hoisted(() => vi.fn());
 const mockLoadConfig = vi.hoisted(() => vi.fn());
@@ -51,11 +52,7 @@ const validRemoteManifestBody = JSON.stringify({
 });
 
 describe(listCommand, () => {
-  let stdoutSpy: MockInstance;
-
   beforeEach(() => {
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
-    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     mockEnumerateKits.mockReturnValue([]);
     mockReadManifest.mockReturnValue({ version: 1, kits: [] });
     mockResolveBitbucketToken.mockReturnValue(undefined);
@@ -78,14 +75,14 @@ describe(listCommand, () => {
       kits: [{ name: 'default' }],
     });
 
-    const exitCode = await listCommand(['--from', 'global']);
+    const { exitCode, stdoutChunks } = await list(['--from', 'global']);
 
     expect(exitCode).toBe(0);
     const firstCall = mockReadManifest.mock.calls[0];
     assert.ok(firstCall, 'expected readManifest to have been called');
     const calledPath = String(firstCall[0]);
     expect(calledPath).toMatch(/\/.readyup\/manifest\.json$/);
-    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    expect(stdoutChunks).toHaveLength(1);
   });
 
   it('with --from dir:/some/path, reads manifest from the resolved directory', async () => {
@@ -94,7 +91,7 @@ describe(listCommand, () => {
       kits: [{ name: 'my-kit' }],
     });
 
-    const exitCode = await listCommand(['--from', 'dir:/some/path']);
+    const { exitCode } = await list(['--from', 'dir:/some/path']);
 
     expect(exitCode).toBe(0);
     const firstCall = mockReadManifest.mock.calls[0];
@@ -111,7 +108,7 @@ describe(listCommand, () => {
       kits: [{ name: 'default' }],
     });
 
-    const exitCode = await listCommand(['--from', '/some/repo']);
+    const { exitCode } = await list(['--from', '/some/repo']);
 
     expect(exitCode).toBe(0);
     const firstCall = mockReadManifest.mock.calls[0];
@@ -131,7 +128,7 @@ describe(listCommand, () => {
   it('with --from github:org/repo, fetches and renders the remote manifest', async () => {
     mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
 
-    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+    const { exitCode, stdout } = await list(['--from', 'github:williamthorsen/workshop']);
 
     expect(exitCode).toBe(0);
     expect(mockFetch).toHaveBeenCalledWith(
@@ -141,7 +138,7 @@ describe(listCommand, () => {
     expect(mockReadManifest).not.toHaveBeenCalled();
     expect(mockLoadConfig).not.toHaveBeenCalled();
 
-    const stdoutCalls = stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+    const stdoutCalls = stdout;
     expect(stdoutCalls).toContain(
       'Manifest: https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json',
     );
@@ -152,7 +149,7 @@ describe(listCommand, () => {
   it('with --from github:org/repo@ref, builds the URL using the supplied ref', async () => {
     mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
 
-    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop@develop']);
+    const { exitCode } = await list(['--from', 'github:williamthorsen/workshop@develop']);
 
     expect(exitCode).toBe(0);
     expect(mockFetch).toHaveBeenCalledWith(
@@ -165,7 +162,7 @@ describe(listCommand, () => {
     mockResolveGitHubToken.mockReturnValue('my-token');
     mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
 
-    const exitCode = await listCommand(['--from', 'github:williamthorsen/workshop']);
+    const { exitCode } = await list(['--from', 'github:williamthorsen/workshop']);
 
     expect(exitCode).toBe(0);
     expect(mockFetch).toHaveBeenCalledWith(
@@ -318,7 +315,7 @@ describe(listCommand, () => {
   it('with --from bitbucket:ws/repo, fetches and renders the remote manifest', async () => {
     mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
 
-    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+    const { exitCode, stdout } = await list(['--from', 'bitbucket:tutorials/markdowndemo']);
 
     expect(exitCode).toBe(0);
     expect(mockFetch).toHaveBeenCalledWith(
@@ -328,7 +325,7 @@ describe(listCommand, () => {
     expect(mockReadManifest).not.toHaveBeenCalled();
     expect(mockLoadConfig).not.toHaveBeenCalled();
 
-    const stdoutCalls = stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+    const stdoutCalls = stdout;
     expect(stdoutCalls).toContain(
       'Manifest: https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json',
     );
@@ -339,7 +336,7 @@ describe(listCommand, () => {
   it('with --from bitbucket:ws/repo@ref, builds the URL using the supplied ref', async () => {
     mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
 
-    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo@develop']);
+    const { exitCode } = await list(['--from', 'bitbucket:tutorials/markdowndemo@develop']);
 
     expect(exitCode).toBe(0);
     expect(mockFetch).toHaveBeenCalledWith(
@@ -352,7 +349,7 @@ describe(listCommand, () => {
     mockResolveBitbucketToken.mockReturnValue('bb-token');
     mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
 
-    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+    const { exitCode } = await list(['--from', 'bitbucket:tutorials/markdowndemo']);
 
     expect(exitCode).toBe(0);
     expect(mockFetch).toHaveBeenCalledWith(
@@ -365,7 +362,7 @@ describe(listCommand, () => {
     mockResolveBitbucketToken.mockReturnValue(undefined);
     mockFetch.mockResolvedValue(mockResponse(validRemoteManifestBody));
 
-    const exitCode = await listCommand(['--from', 'bitbucket:tutorials/markdowndemo']);
+    const { exitCode } = await list(['--from', 'bitbucket:tutorials/markdowndemo']);
 
     expect(exitCode).toBe(0);
     expect(mockFetch).toHaveBeenCalledWith(
@@ -432,3 +429,16 @@ describe(listCommand, () => {
     expect(error.message).toContain('ECONNREFUSED');
   });
 });
+
+// region | Helpers
+
+/** Runs the command over the given arguments, returning its exit code alongside everything it wrote. */
+async function list(args: string[]) {
+  using io = captureStdio();
+
+  const exitCode = await listCommand(args);
+
+  return { exitCode, stdout: io.stdout, stdoutChunks: io.stdoutChunks, stderr: io.stderr };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/list/__tests__/listCommand.from.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.from.unit.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert';
 import path from 'node:path';
 
-import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { captureError, captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockEnumerateKits = vi.hoisted(() => vi.fn());
@@ -138,12 +137,11 @@ describe(listCommand, () => {
     expect(mockReadManifest).not.toHaveBeenCalled();
     expect(mockLoadConfig).not.toHaveBeenCalled();
 
-    const stdoutCalls = stdout;
-    expect(stdoutCalls).toContain(
+    expect(stdout).toContain(
       'Manifest: https://raw.githubusercontent.com/williamthorsen/workshop/main/.readyup/manifest.json',
     );
-    expect(stdoutCalls).toContain('default \u{00B7} General project health checks');
-    expect(stdoutCalls).toContain('deploy');
+    expect(stdout).toContain('default \u{00B7} General project health checks');
+    expect(stdout).toContain('deploy');
   });
 
   it('with --from github:org/repo@ref, builds the URL using the supplied ref', async () => {
@@ -325,12 +323,11 @@ describe(listCommand, () => {
     expect(mockReadManifest).not.toHaveBeenCalled();
     expect(mockLoadConfig).not.toHaveBeenCalled();
 
-    const stdoutCalls = stdout;
-    expect(stdoutCalls).toContain(
+    expect(stdout).toContain(
       'Manifest: https://api.bitbucket.org/2.0/repositories/tutorials/markdowndemo/src/main/.readyup/manifest.json',
     );
-    expect(stdoutCalls).toContain('default \u{00B7} General project health checks');
-    expect(stdoutCalls).toContain('deploy');
+    expect(stdout).toContain('default \u{00B7} General project health checks');
+    expect(stdout).toContain('deploy');
   });
 
   it('with --from bitbucket:ws/repo@ref, builds the URL using the supplied ref', async () => {

--- a/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
@@ -1,5 +1,4 @@
-import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { captureError, captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockReaddirSync = vi.hoisted(() => vi.fn());
@@ -105,45 +104,40 @@ describe('list --recursive', () => {
   describe('rendering', () => {
     it('groups kits under the project holding them, the sweep root first', async () => {
       const { exitCode, stdout } = await list(['--recursive']);
-      const output = stdout;
 
       expect(exitCode).toBe(0);
-      expect(output).toContain('\u{2501}\u{2501} \u{1F4C1} ./');
-      expect(output).toContain('\u{2501}\u{2501} \u{1F4C1} packages/readyup/');
-      expect(output.indexOf('./')).toBeLessThan(output.indexOf('packages/readyup/'));
+      expect(stdout).toContain('\u{2501}\u{2501} \u{1F4C1} ./');
+      expect(stdout).toContain('\u{2501}\u{2501} \u{1F4C1} packages/readyup/');
+      expect(stdout.indexOf('./')).toBeLessThan(stdout.indexOf('packages/readyup/'));
     });
 
     it('names a command that runs each project\u{2019}s kits from the sweep root', async () => {
       const { stdout } = await list(['--recursive']);
-      const output = stdout;
 
-      expect(output).toContain('rdy run <name>');
-      expect(output).toContain('rdy run --from packages/readyup [<name>]');
+      expect(stdout).toContain('rdy run <name>');
+      expect(stdout).toContain('rdy run --from packages/readyup [<name>]');
     });
 
     it('carries the descriptions the manifest records, and renders a bare name without one', async () => {
       const { stdout } = await list(['--recursive']);
-      const output = stdout;
 
-      expect(output).toContain('\u{1F4D3} default \u{00B7} Authoring hygiene for a project that defines readyup kits');
-      expect(output).toContain('\u{1F4D3} demo');
-      expect(output).not.toContain('demo \u{00B7}');
+      expect(stdout).toContain('\u{1F4D3} default \u{00B7} Authoring hygiene for a project that defines readyup kits');
+      expect(stdout).toContain('\u{1F4D3} demo');
+      expect(stdout).not.toContain('demo \u{00B7}');
     });
 
     it('reaches a project on a relocated output directory by file path', async () => {
       const { stdout } = await list(['--recursive']);
-      const output = stdout;
 
-      expect(output).toContain('rdy run --file <file path>');
-      expect(output).toContain('\u{1F4D3} packages/tooling/dist/kits/lint.js');
+      expect(stdout).toContain('rdy run --file <file path>');
+      expect(stdout).toContain('\u{1F4D3} packages/tooling/dist/kits/lint.js');
     });
 
     it('omits a project with nothing compiled to show', async () => {
       const { stdout } = await list(['--recursive']);
-      const output = stdout;
 
-      expect(output).not.toContain('packages/authored');
-      expect(output).not.toContain('packages/emptied');
+      expect(stdout).not.toContain('packages/authored');
+      expect(stdout).not.toContain('packages/emptied');
     });
 
     // `--style` is consumed by the router before dispatch, so the style is bound here as the router binds it.
@@ -151,10 +145,9 @@ describe('list --recursive', () => {
       setStyle('plain');
 
       const { stdout } = await list(['--recursive']);
-      const output = stdout;
 
-      expect(output).toContain('== packages/readyup/');
-      expect(output).not.toContain('\u{1F4C1}');
+      expect(stdout).toContain('== packages/readyup/');
+      expect(stdout).not.toContain('\u{1F4C1}');
     });
   });
 
@@ -249,11 +242,10 @@ describe('list --recursive', () => {
       failReadOf('packages/blocked/dist/kits', 'EACCES');
 
       const { exitCode, stdout, stderr } = await list(['--recursive']);
-      const output = stdout;
 
       expect(exitCode).toBe(0);
-      expect(output).not.toContain('packages/blocked');
-      expect(output).toContain('packages/readyup/');
+      expect(stdout).not.toContain('packages/blocked');
+      expect(stdout).toContain('packages/readyup/');
       expect(stderr).toContain('Omitting packages/blocked from the listing');
     });
 
@@ -284,10 +276,9 @@ describe('list --recursive', () => {
 
   it('leaves a plain listing showing sections rather than project blocks', async () => {
     const { stdout } = await list([]);
-    const output = stdout;
 
-    expect(output).toContain('\u{2500}\u{2500} Compiled');
-    expect(output).not.toContain('\u{1F4C1}');
+    expect(stdout).toContain('\u{2500}\u{2500} Compiled');
+    expect(stdout).not.toContain('\u{1F4C1}');
   });
 
   // region | Helpers

--- a/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
@@ -1,5 +1,6 @@
 import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockReaddirSync = vi.hoisted(() => vi.fn());
 
@@ -92,12 +93,8 @@ const tempDir = useTempDir({
 const { failReadOf, passAllReads } = useFailingDirectoryRead(mockReaddirSync, () => tempDir.dir);
 
 describe('list --recursive', () => {
-  let stdoutSpy: MockInstance;
-
   beforeEach(() => {
     passAllReads();
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
-    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -107,8 +104,8 @@ describe('list --recursive', () => {
 
   describe('rendering', () => {
     it('groups kits under the project holding them, the sweep root first', async () => {
-      const exitCode = await listCommand(['--recursive']);
-      const output = readOutput();
+      const { exitCode, stdout } = await list(['--recursive']);
+      const output = stdout;
 
       expect(exitCode).toBe(0);
       expect(output).toContain('\u{2501}\u{2501} \u{1F4C1} ./');
@@ -117,16 +114,16 @@ describe('list --recursive', () => {
     });
 
     it('names a command that runs each project\u{2019}s kits from the sweep root', async () => {
-      await listCommand(['--recursive']);
-      const output = readOutput();
+      const { stdout } = await list(['--recursive']);
+      const output = stdout;
 
       expect(output).toContain('rdy run <name>');
       expect(output).toContain('rdy run --from packages/readyup [<name>]');
     });
 
     it('carries the descriptions the manifest records, and renders a bare name without one', async () => {
-      await listCommand(['--recursive']);
-      const output = readOutput();
+      const { stdout } = await list(['--recursive']);
+      const output = stdout;
 
       expect(output).toContain('\u{1F4D3} default \u{00B7} Authoring hygiene for a project that defines readyup kits');
       expect(output).toContain('\u{1F4D3} demo');
@@ -134,16 +131,16 @@ describe('list --recursive', () => {
     });
 
     it('reaches a project on a relocated output directory by file path', async () => {
-      await listCommand(['--recursive']);
-      const output = readOutput();
+      const { stdout } = await list(['--recursive']);
+      const output = stdout;
 
       expect(output).toContain('rdy run --file <file path>');
       expect(output).toContain('\u{1F4D3} packages/tooling/dist/kits/lint.js');
     });
 
     it('omits a project with nothing compiled to show', async () => {
-      await listCommand(['--recursive']);
-      const output = readOutput();
+      const { stdout } = await list(['--recursive']);
+      const output = stdout;
 
       expect(output).not.toContain('packages/authored');
       expect(output).not.toContain('packages/emptied');
@@ -153,8 +150,8 @@ describe('list --recursive', () => {
     it('degrades to ASCII in plain style', async () => {
       setStyle('plain');
 
-      await listCommand(['--recursive']);
-      const output = readOutput();
+      const { stdout } = await list(['--recursive']);
+      const output = stdout;
 
       expect(output).toContain('== packages/readyup/');
       expect(output).not.toContain('\u{1F4C1}');
@@ -213,8 +210,8 @@ describe('list --recursive', () => {
     it('emits an empty kit list under --json', async () => {
       vi.spyOn(process, 'cwd').mockReturnValue(`${tempDir.dir}/packages/authored`);
 
-      await listCommand(['--recursive', '--json']);
-      const payload = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      const { stdout } = await list(['--recursive', '--json']);
+      const payload = JSON.parse(stdout);
 
       expect(payload).toStrictEqual({ schemaVersion: 1, kits: [] });
     });
@@ -222,19 +219,19 @@ describe('list --recursive', () => {
     it('prints the empty-sweep message for a tree whose projects have nothing compiled', async () => {
       vi.spyOn(process, 'cwd').mockReturnValue(`${tempDir.dir}/packages/authored`);
 
-      await listCommand(['--recursive']);
+      const { stdout } = await list(['--recursive']);
 
-      expect(readOutput()).toContain('No kit projects found.');
+      expect(stdout).toContain('No kit projects found.');
     });
   });
 
   describe('a project the filesystem will not fully give up', () => {
     it('lists the kits beside a manifest that cannot be parsed, and warns', async () => {
-      await listCommand(['--recursive']);
+      const { stdout, stderr } = await list(['--recursive']);
 
-      expect(readOutput()).toContain('packages/corrupt/');
-      expect(readOutput()).toContain('audit');
-      expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('manifest'));
+      expect(stdout).toContain('packages/corrupt/');
+      expect(stdout).toContain('audit');
+      expect(stderr).toContain('manifest');
     });
 
     it('names the project of a kit read from disk past a broken manifest', async () => {
@@ -251,15 +248,13 @@ describe('list --recursive', () => {
     it('drops a project whose output directory it cannot read, and lists the rest', async () => {
       failReadOf('packages/blocked/dist/kits', 'EACCES');
 
-      const exitCode = await listCommand(['--recursive']);
-      const output = readOutput();
+      const { exitCode, stdout, stderr } = await list(['--recursive']);
+      const output = stdout;
 
       expect(exitCode).toBe(0);
       expect(output).not.toContain('packages/blocked');
       expect(output).toContain('packages/readyup/');
-      expect(process.stderr.write).toHaveBeenCalledWith(
-        expect.stringContaining('Omitting packages/blocked from the listing'),
-      );
+      expect(stderr).toContain('Omitting packages/blocked from the listing');
     });
 
     it('rethrows a filesystem failure that is not benign', async () => {
@@ -288,8 +283,8 @@ describe('list --recursive', () => {
   });
 
   it('leaves a plain listing showing sections rather than project blocks', async () => {
-    await listCommand([]);
-    const output = readOutput();
+    const { stdout } = await list([]);
+    const output = stdout;
 
     expect(output).toContain('\u{2500}\u{2500} Compiled');
     expect(output).not.toContain('\u{1F4C1}');
@@ -297,15 +292,19 @@ describe('list --recursive', () => {
 
   // region | Helpers
 
-  /** Returns everything the run wrote to stdout. */
-  function readOutput(): string {
-    return stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+  /** Runs the command over the given arguments, returning its exit code alongside everything it wrote. */
+  async function list(args: string[]) {
+    using io = captureStdio();
+
+    const exitCode = await listCommand(args);
+
+    return { exitCode, stdout: io.stdout, stderr: io.stderr };
   }
 
   /** Runs a recursive listing under `--json` and returns the payload it emitted. */
   async function runForPayload(): Promise<unknown> {
-    await listCommand(['--recursive', '--json']);
-    return JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+    const { stdout } = await list(['--recursive', '--json']);
+    return JSON.parse(stdout);
   }
 
   // endregion | Helpers

--- a/packages/readyup/src/list/__tests__/listCommand.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.unit.test.ts
@@ -1,5 +1,4 @@
-import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { captureError, captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockLoadConfig = vi.hoisted(() => vi.fn());
@@ -85,11 +84,10 @@ describe(listCommand, () => {
 
       const { exitCode, stdout } = await list([]);
 
-      const output = stdout;
       expect(exitCode).toBe(0);
-      expect(output).toContain('Packages');
-      expect(output).toContain('@acme/kits@2.1.0 / \u{1F4D3} drift');
-      expect(output).not.toContain('No kits found');
+      expect(stdout).toContain('Packages');
+      expect(stdout).toContain('@acme/kits@2.1.0 / \u{1F4D3} drift');
+      expect(stdout).not.toContain('No kits found');
     });
 
     it('names installed packages that publish kits the config omits', async () => {
@@ -98,11 +96,10 @@ describe(listCommand, () => {
 
       const { stdout } = await list([]);
 
-      const output = stdout;
-      expect(output).toContain('Available');
-      expect(output).toContain('plain-kit');
+      expect(stdout).toContain('Available');
+      expect(stdout).toContain('plain-kit');
       // Already configured, so it belongs under Packages rather than as a candidate to add.
-      expect(output.slice(output.indexOf('Available'))).not.toContain('@acme/kits');
+      expect(stdout.slice(stdout.indexOf('Available'))).not.toContain('@acme/kits');
     });
 
     it('carries package provenance into the JSON payload, apart from the kits it lists', async () => {
@@ -137,9 +134,8 @@ describe(listCommand, () => {
       expect(mockEnumerateKits).toHaveBeenCalledWith(
         expect.objectContaining({ dir: expect.stringContaining('.readyup/kits'), extension: '.ts' }),
       );
-      const output = stdout;
-      expect(output).toContain('\u{2500}\u{2500} Internal');
-      expect(output).toContain('\u{2500}\u{2500} Compiled');
+      expect(stdout).toContain('\u{2500}\u{2500} Internal');
+      expect(stdout).toContain('\u{2500}\u{2500} Compiled');
     });
 
     it('uses infix-based extension for internal kits when configured', async () => {
@@ -163,9 +159,8 @@ describe(listCommand, () => {
       const { exitCode, stdout } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdout;
-      expect(output).toContain('\u{2500}\u{2500} Internal');
-      expect(output).not.toContain('\u{2500}\u{2500} Compiled');
+      expect(stdout).toContain('\u{2500}\u{2500} Internal');
+      expect(stdout).not.toContain('\u{2500}\u{2500} Compiled');
     });
 
     it('uses custom-outDir style when outDir differs from default', async () => {
@@ -183,9 +178,8 @@ describe(listCommand, () => {
       const { exitCode, stdout } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdout;
-      expect(output).toContain('dist/kits/deploy.js');
-      expect(output).toContain('--file');
+      expect(stdout).toContain('dist/kits/deploy.js');
+      expect(stdout).toContain('--file');
     });
 
     it('prints empty-owner message when no kits exist', async () => {
@@ -196,8 +190,7 @@ describe(listCommand, () => {
       const { exitCode, stdout } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdout;
-      expect(output).toContain('No kits found.');
+      expect(stdout).toContain('No kits found.');
     });
 
     it('warns and lists with default settings when config load fails', async () => {
@@ -208,8 +201,7 @@ describe(listCommand, () => {
 
       expect(exitCode).toBe(0);
       expect(stderr).toBe('Warning: bad config. Listing with default settings.\n');
-      const output = stdout;
-      expect(output).toContain('default');
+      expect(stdout).toContain('default');
     });
 
     it('renders a hint the config failure carries, on a line of its own', async () => {
@@ -264,9 +256,8 @@ describe(listCommand, () => {
       const { exitCode, stdout, stderr } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdout;
-      expect(output).toContain('\u{2500}\u{2500} Internal');
-      expect(output).not.toContain('\u{2500}\u{2500} Compiled');
+      expect(stdout).toContain('\u{2500}\u{2500} Internal');
+      expect(stdout).not.toContain('\u{2500}\u{2500} Compiled');
       expect(stderr).toBe('');
     });
 
@@ -283,8 +274,7 @@ describe(listCommand, () => {
 
       const { stdout } = await list([]);
 
-      const output = stdout;
-      expect(output).toContain('\u{2500}\u{2500} Internal\n   rdy run --jit --internal [<name>]');
+      expect(stdout).toContain('\u{2500}\u{2500} Internal\n   rdy run --jit --internal [<name>]');
     });
 
     it('leaves --internal out of the internal hint under the default config', async () => {
@@ -292,8 +282,7 @@ describe(listCommand, () => {
 
       const { stdout } = await list([]);
 
-      const output = stdout;
-      expect(output).toContain('\u{2500}\u{2500} Internal\n   rdy run --jit [<name>]');
+      expect(stdout).toContain('\u{2500}\u{2500} Internal\n   rdy run --jit [<name>]');
     });
 
     it('writes warning to stderr when manifest read fails with non-missing-file error and internal kits exist', async () => {
@@ -305,9 +294,8 @@ describe(listCommand, () => {
       const { exitCode, stdout, stderr } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdout;
-      expect(output).toContain('\u{2500}\u{2500} Internal');
-      expect(output).not.toContain('\u{2500}\u{2500} Compiled');
+      expect(stdout).toContain('\u{2500}\u{2500} Internal');
+      expect(stdout).not.toContain('\u{2500}\u{2500} Compiled');
       expect(stderr).toContain('Warning:');
       expect(stderr).toContain('invalid JSON');
     });
@@ -333,9 +321,8 @@ describe(listCommand, () => {
 
       expect(exitCode).toBe(0);
       expect(mockReadManifest).toHaveBeenCalledWith(expect.stringContaining('.readyup/manifest.json'));
-      const output = stdout;
-      expect(output).toContain('\u{2500}\u{2500} Compiled');
-      expect(output).toContain('deploy');
+      expect(stdout).toContain('\u{2500}\u{2500} Compiled');
+      expect(stdout).toContain('deploy');
     });
 
     it('prints empty-consumer message when manifest contains no kits', async () => {
@@ -344,8 +331,7 @@ describe(listCommand, () => {
       const { exitCode, stdout } = await list(['--from', '.']);
 
       expect(exitCode).toBe(0);
-      const output = stdout;
-      expect(output).toContain('No compiled kits found');
+      expect(stdout).toContain('No compiled kits found');
     });
 
     it('reports a config error when the manifest is not found at the --from path', async () => {
@@ -371,11 +357,10 @@ describe(listCommand, () => {
 
       expect(exitCode).toBe(0);
       expect(mockLoadConfig).not.toHaveBeenCalled();
-      const output = stdout;
-      expect(output).toContain('\u{2500}\u{2500} Manifest:');
-      expect(output).toContain('default');
-      expect(output).toContain('Health checks');
-      expect(output).toContain('deploy');
+      expect(stdout).toContain('\u{2500}\u{2500} Manifest:');
+      expect(stdout).toContain('default');
+      expect(stdout).toContain('Health checks');
+      expect(stdout).toContain('deploy');
     });
 
     it('reports a config error when the manifest file cannot be read', async () => {
@@ -398,11 +383,6 @@ describe(listCommand, () => {
   });
 
   describe('--json', () => {
-    /** Reads the single JSON document the command wrote to stdout. */
-    function parseStdout(stdout: string): unknown {
-      return JSON.parse(stdout);
-    }
-
     it('distinguishes internal sources from compiled kits in owner mode', async () => {
       mockEnumerateKits.mockReturnValue(['draft']);
       mockReadManifest.mockReturnValue({
@@ -413,7 +393,7 @@ describe(listCommand, () => {
       const { exitCode, stdout } = await list(['--json']);
 
       expect(exitCode).toBe(0);
-      expect(parseStdout(stdout)).toMatchObject({
+      expect(JSON.parse(stdout)).toMatchObject({
         schemaVersion: 1,
         kits: [
           { name: 'draft', kind: 'internal', path: expect.stringContaining('draft.ts') },
@@ -440,7 +420,7 @@ describe(listCommand, () => {
 
       const { stdout, stderr } = await list(['--json']);
 
-      expect(parseStdout(stdout)).toStrictEqual({ schemaVersion: 1, kits: [] });
+      expect(JSON.parse(stdout)).toStrictEqual({ schemaVersion: 1, kits: [] });
       expect(stderr).toContain('No kits found.');
     });
 
@@ -452,7 +432,7 @@ describe(listCommand, () => {
 
       const { stdout } = await list(['--manifest', '.readyup/manifest.json', '--json']);
 
-      expect(parseStdout(stdout)).toStrictEqual({
+      expect(JSON.parse(stdout)).toStrictEqual({
         schemaVersion: 1,
         kits: [{ name: 'deploy', kind: 'compiled', description: 'Deploy checks', readyupVersion: '0.21.2' }],
       });

--- a/packages/readyup/src/list/__tests__/listCommand.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.unit.test.ts
@@ -1,5 +1,6 @@
 import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 const mockEnumerateKits = vi.hoisted(() => vi.fn());
@@ -40,12 +41,7 @@ import { ManifestNotFoundError } from '../../manifest/readManifest.ts';
 import { listCommand } from '../listCommand.ts';
 
 describe(listCommand, () => {
-  let stdoutSpy: MockInstance;
-  let stderrSpy: MockInstance;
-
   beforeEach(() => {
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
       internal: { dir: '.', infix: undefined },
@@ -87,9 +83,9 @@ describe(listCommand, () => {
         throw new ManifestNotFoundError('.readyup/manifest.json');
       });
 
-      const exitCode = await listCommand([]);
+      const { exitCode, stdout } = await list([]);
 
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(exitCode).toBe(0);
       expect(output).toContain('Packages');
       expect(output).toContain('@acme/kits@2.1.0 / \u{1F4D3} drift');
@@ -100,9 +96,9 @@ describe(listCommand, () => {
       mockDiscoverKitPackages.mockReturnValue(['@acme/kits', 'plain-kit']);
       configureOnePackage();
 
-      await listCommand([]);
+      const { stdout } = await list([]);
 
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('Available');
       expect(output).toContain('plain-kit');
       // Already configured, so it belongs under Packages rather than as a candidate to add.
@@ -113,9 +109,9 @@ describe(listCommand, () => {
       mockDiscoverKitPackages.mockReturnValue(['plain-kit']);
       configureOnePackage();
 
-      await listCommand(['--json']);
+      const { stdout } = await list(['--json']);
 
-      const payload: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      const payload: unknown = JSON.parse(stdout);
       expect(payload).toMatchObject({
         kits: [{ name: 'drift', kind: 'compiled', origin: { package: '@acme/kits', version: '2.1.0' } }],
         availablePackages: ['plain-kit'],
@@ -131,7 +127,7 @@ describe(listCommand, () => {
         kits: [{ name: 'deploy' }],
       });
 
-      const exitCode = await listCommand([]);
+      const { exitCode, stdout } = await list([]);
 
       expect(exitCode).toBe(0);
       expect(mockLoadConfig).toHaveBeenCalledWith();
@@ -141,7 +137,7 @@ describe(listCommand, () => {
       expect(mockEnumerateKits).toHaveBeenCalledWith(
         expect.objectContaining({ dir: expect.stringContaining('.readyup/kits'), extension: '.ts' }),
       );
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('\u{2500}\u{2500} Internal');
       expect(output).toContain('\u{2500}\u{2500} Compiled');
     });
@@ -154,7 +150,7 @@ describe(listCommand, () => {
       });
       mockEnumerateKits.mockReturnValue(['default']);
 
-      const exitCode = await listCommand([]);
+      const { exitCode } = await list([]);
 
       expect(exitCode).toBe(0);
       expect(mockEnumerateKits).toHaveBeenCalledWith(expect.objectContaining({ extension: '.int.ts' }));
@@ -164,10 +160,10 @@ describe(listCommand, () => {
       mockEnumerateKits.mockReturnValue(['default']);
       mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-      const exitCode = await listCommand([]);
+      const { exitCode, stdout } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('\u{2500}\u{2500} Internal');
       expect(output).not.toContain('\u{2500}\u{2500} Compiled');
     });
@@ -184,10 +180,10 @@ describe(listCommand, () => {
         kits: [{ name: 'deploy' }],
       });
 
-      const exitCode = await listCommand([]);
+      const { exitCode, stdout } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('dist/kits/deploy.js');
       expect(output).toContain('--file');
     });
@@ -197,10 +193,10 @@ describe(listCommand, () => {
         throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
       });
 
-      const exitCode = await listCommand([]);
+      const { exitCode, stdout } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('No kits found.');
     });
 
@@ -208,11 +204,11 @@ describe(listCommand, () => {
       mockLoadConfig.mockRejectedValue(new Error('bad config'));
       mockEnumerateKits.mockReturnValue(['default']);
 
-      const exitCode = await listCommand([]);
+      const { exitCode, stdout, stderr } = await list([]);
 
       expect(exitCode).toBe(0);
-      expect(stderrSpy).toHaveBeenCalledWith('Warning: bad config. Listing with default settings.\n');
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(stderr).toBe('Warning: bad config. Listing with default settings.\n');
+      const output = stdout;
       expect(output).toContain('default');
     });
 
@@ -223,9 +219,9 @@ describe(listCommand, () => {
         }),
       );
 
-      await listCommand([]);
+      const { stderrChunks } = await list([]);
 
-      expect(stderrSpy.mock.calls.map((call: unknown[]) => String(call[0]))).toStrictEqual([
+      expect(stderrChunks).toStrictEqual([
         "Warning: Cannot resolve 'some-lib' while evaluating config.ts. Listing with default settings.\n",
         '\u{1F4A1} Hint: Install it with: pnpm add --save-dev some-lib\n',
       ]);
@@ -234,17 +230,17 @@ describe(listCommand, () => {
     it('writes no hint line for a config failure that carries none', async () => {
       mockLoadConfig.mockRejectedValue(new Error('bad config'));
 
-      await listCommand([]);
+      const { stderrChunks } = await list([]);
 
-      expect(stderrSpy).toHaveBeenCalledTimes(1);
+      expect(stderrChunks).toHaveLength(1);
     });
 
     it('does not double the period when the config failure already ends in one', async () => {
       mockLoadConfig.mockRejectedValue(new Error('bad config.'));
 
-      await listCommand([]);
+      const { stderr } = await list([]);
 
-      expect(stderrSpy).toHaveBeenCalledWith('Warning: bad config. Listing with default settings.\n');
+      expect(stderr).toBe('Warning: bad config. Listing with default settings.\n');
     });
 
     it('reports a config error when enumerateKits throws', async () => {
@@ -253,7 +249,7 @@ describe(listCommand, () => {
         throw permError;
       });
 
-      const error = await captureError(RdyError, () => listCommand([]));
+      const { error } = await listRaising([]);
 
       expect(error.code).toBe('config');
       expect(error.message).toContain('permission denied');
@@ -265,13 +261,13 @@ describe(listCommand, () => {
         throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
       });
 
-      const exitCode = await listCommand([]);
+      const { exitCode, stdout, stderr } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('\u{2500}\u{2500} Internal');
       expect(output).not.toContain('\u{2500}\u{2500} Compiled');
-      expect(stderrSpy).not.toHaveBeenCalled();
+      expect(stderr).toBe('');
     });
 
     it.each([
@@ -285,18 +281,18 @@ describe(listCommand, () => {
       });
       mockEnumerateKits.mockReturnValue(['default']);
 
-      await listCommand([]);
+      const { stdout } = await list([]);
 
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('\u{2500}\u{2500} Internal\n   rdy run --jit --internal [<name>]');
     });
 
     it('leaves --internal out of the internal hint under the default config', async () => {
       mockEnumerateKits.mockReturnValue(['default']);
 
-      await listCommand([]);
+      const { stdout } = await list([]);
 
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('\u{2500}\u{2500} Internal\n   rdy run --jit [<name>]');
     });
 
@@ -306,14 +302,14 @@ describe(listCommand, () => {
         throw new Error('Manifest file contains invalid JSON: .readyup/manifest.json');
       });
 
-      const exitCode = await listCommand([]);
+      const { exitCode, stdout, stderr } = await list([]);
 
       expect(exitCode).toBe(0);
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('\u{2500}\u{2500} Internal');
       expect(output).not.toContain('\u{2500}\u{2500} Compiled');
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('Warning:'));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'));
+      expect(stderr).toContain('Warning:');
+      expect(stderr).toContain('invalid JSON');
     });
   });
 
@@ -321,7 +317,7 @@ describe(listCommand, () => {
     it('does not load config when --from is given', async () => {
       mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-      const exitCode = await listCommand(['--from', '.']);
+      const { exitCode } = await list(['--from', '.']);
 
       expect(exitCode).toBe(0);
       expect(mockLoadConfig).not.toHaveBeenCalled();
@@ -333,11 +329,11 @@ describe(listCommand, () => {
         kits: [{ name: 'deploy' }],
       });
 
-      const exitCode = await listCommand(['--from', '.']);
+      const { exitCode, stdout } = await list(['--from', '.']);
 
       expect(exitCode).toBe(0);
       expect(mockReadManifest).toHaveBeenCalledWith(expect.stringContaining('.readyup/manifest.json'));
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('\u{2500}\u{2500} Compiled');
       expect(output).toContain('deploy');
     });
@@ -345,10 +341,10 @@ describe(listCommand, () => {
     it('prints empty-consumer message when manifest contains no kits', async () => {
       mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-      const exitCode = await listCommand(['--from', '.']);
+      const { exitCode, stdout } = await list(['--from', '.']);
 
       expect(exitCode).toBe(0);
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('No compiled kits found');
     });
 
@@ -357,7 +353,7 @@ describe(listCommand, () => {
         throw new Error('Manifest file not found: /nonexistent/.readyup/manifest.json');
       });
 
-      const error = await captureError(RdyError, () => listCommand(['--from', '/nonexistent']));
+      const { error } = await listRaising(['--from', '/nonexistent']);
 
       expect(error.code).toBe('config');
       expect(error.message).toContain('Manifest file not found');
@@ -371,11 +367,11 @@ describe(listCommand, () => {
         kits: [{ name: 'default', description: 'Health checks' }, { name: 'deploy' }],
       });
 
-      const exitCode = await listCommand(['--manifest', '.readyup/manifest.json']);
+      const { exitCode, stdout } = await list(['--manifest', '.readyup/manifest.json']);
 
       expect(exitCode).toBe(0);
       expect(mockLoadConfig).not.toHaveBeenCalled();
-      const output = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+      const output = stdout;
       expect(output).toContain('\u{2500}\u{2500} Manifest:');
       expect(output).toContain('default');
       expect(output).toContain('Health checks');
@@ -387,16 +383,14 @@ describe(listCommand, () => {
         throw new Error('Manifest file not found: /missing/manifest.json');
       });
 
-      const error = await captureError(RdyError, () => listCommand(['--manifest', '/missing/manifest.json']));
+      const { error } = await listRaising(['--manifest', '/missing/manifest.json']);
 
       expect(error.code).toBe('config');
       expect(error.message).toContain('Manifest file not found');
     });
 
     it('reports a usage error when --from and --manifest are both provided', async () => {
-      const error = await captureError(RdyError, () =>
-        listCommand(['--from', '.', '--manifest', '.readyup/manifest.json']),
-      );
+      const { error } = await listRaising(['--from', '.', '--manifest', '.readyup/manifest.json']);
 
       expect(error.code).toBe('usage');
       expect(error.message).toContain('mutually exclusive');
@@ -404,9 +398,9 @@ describe(listCommand, () => {
   });
 
   describe('--json', () => {
-    /** Read the single JSON document the command wrote to stdout. */
-    function parseStdout(): unknown {
-      return JSON.parse(stdoutSpy.mock.calls.map((c) => String(c[0])).join(''));
+    /** Reads the single JSON document the command wrote to stdout. */
+    function parseStdout(stdout: string): unknown {
+      return JSON.parse(stdout);
     }
 
     it('distinguishes internal sources from compiled kits in owner mode', async () => {
@@ -416,10 +410,10 @@ describe(listCommand, () => {
         kits: [{ name: 'deploy', path: 'kits/deploy.js', checklists: ['preflight'] }],
       });
 
-      const exitCode = await listCommand(['--json']);
+      const { exitCode, stdout } = await list(['--json']);
 
       expect(exitCode).toBe(0);
-      expect(parseStdout()).toMatchObject({
+      expect(parseStdout(stdout)).toMatchObject({
         schemaVersion: 1,
         kits: [
           { name: 'draft', kind: 'internal', path: expect.stringContaining('draft.ts') },
@@ -432,10 +426,10 @@ describe(listCommand, () => {
       mockEnumerateKits.mockReturnValue(['draft']);
       mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-      await listCommand(['--json']);
+      const { stdoutChunks, stderr } = await list(['--json']);
 
-      expect(stdoutSpy).toHaveBeenCalledTimes(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('\u{2500}\u{2500} Internal'));
+      expect(stdoutChunks).toHaveLength(1);
+      expect(stderr).toContain('\u{2500}\u{2500} Internal');
     });
 
     it('reports an empty kit list rather than the empty-owner prose', async () => {
@@ -444,10 +438,10 @@ describe(listCommand, () => {
         throw new ManifestNotFoundError('/fake/.readyup/manifest.json');
       });
 
-      await listCommand(['--json']);
+      const { stdout, stderr } = await list(['--json']);
 
-      expect(parseStdout()).toStrictEqual({ schemaVersion: 1, kits: [] });
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('No kits found.'));
+      expect(parseStdout(stdout)).toStrictEqual({ schemaVersion: 1, kits: [] });
+      expect(stderr).toContain('No kits found.');
     });
 
     it('carries the manifest fields in manifest mode', async () => {
@@ -456,9 +450,9 @@ describe(listCommand, () => {
         kits: [{ name: 'deploy', description: 'Deploy checks', readyupVersion: '0.21.2' }],
       });
 
-      await listCommand(['--manifest', '.readyup/manifest.json', '--json']);
+      const { stdout } = await list(['--manifest', '.readyup/manifest.json', '--json']);
 
-      expect(parseStdout()).toStrictEqual({
+      expect(parseStdout(stdout)).toStrictEqual({
         schemaVersion: 1,
         kits: [{ name: 'deploy', kind: 'compiled', description: 'Deploy checks', readyupVersion: '0.21.2' }],
       });
@@ -466,9 +460,37 @@ describe(listCommand, () => {
   });
 
   it('reports a usage error for unknown flags', async () => {
-    const error = await captureError(RdyError, () => listCommand(['--unknown']));
+    const { error } = await listRaising(['--unknown']);
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain("Unknown option '--unknown'");
   });
 });
+
+// region | Helpers
+
+/** Runs the command over the given arguments, returning its exit code alongside everything it wrote. */
+async function list(args: string[]) {
+  using io = captureStdio();
+
+  const exitCode = await listCommand(args);
+
+  return {
+    exitCode,
+    stdout: io.stdout,
+    stdoutChunks: io.stdoutChunks,
+    stderr: io.stderr,
+    stderrChunks: io.stderrChunks,
+  };
+}
+
+/** Runs the command expecting it to raise, returning the error alongside everything it wrote. */
+async function listRaising(args: string[]) {
+  using io = captureStdio();
+
+  const error = await captureError(RdyError, () => listCommand(args));
+
+  return { error, stdout: io.stdout, stderr: io.stderr };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RdyError } from '../../errors/RdyError.ts';
 import { ListOutputSchema } from '../../schemas/listOutputSchema.ts';
@@ -16,19 +17,10 @@ import { listCommand } from '../listCommand.ts';
  */
 describe('listCommand wiring', () => {
   let tempDir: string;
-  let stdout: string[];
-  let stdoutSpy: MockInstance;
-  let stderrSpy: MockInstance;
   let originalCwd: string;
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'list-integ-'));
-    stdout = [];
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
-      stdout.push(String(chunk));
-      return true;
-    });
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     originalCwd = process.cwd();
     process.chdir(tempDir);
   });
@@ -53,20 +45,20 @@ describe('listCommand wiring', () => {
     it('lists the compiled kits on disk in human mode', async () => {
       writeKitsDir('kits', ['alpha', 'beta']);
 
-      const exitCode = await listCommand(['--from', 'dir:kits']);
+      const { exitCode, stdout } = await list(['--from', 'dir:kits']);
 
       expect(exitCode).toBe(0);
-      expect(stdout.join('')).toContain('alpha');
-      expect(stdout.join('')).toContain('beta');
+      expect(stdout).toContain('alpha');
+      expect(stdout).toContain('beta');
     });
 
     it('lists them in JSON mode with a name and a path and nothing the manifest would have added', async () => {
       writeKitsDir('kits', ['alpha']);
 
-      const exitCode = await listCommand(['--from', 'dir:kits', '--json']);
+      const { exitCode, stdout } = await list(['--from', 'dir:kits', '--json']);
 
       expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout.join(''))).toStrictEqual({
+      expect(JSON.parse(stdout)).toStrictEqual({
         schemaVersion: 1,
         kits: [{ name: 'alpha', kind: 'compiled', path: path.join('kits', 'alpha.js') }],
       });
@@ -75,9 +67,9 @@ describe('listCommand wiring', () => {
     it('resolves a local repo path to the same directory run --from would load from', async () => {
       writeKitsDir(path.join('repo', '.readyup', 'kits'), ['deploy']);
 
-      await listCommand(['--from', 'repo', '--json']);
+      const { stdout } = await list(['--from', 'repo', '--json']);
 
-      expect(JSON.parse(stdout.join(''))).toMatchObject({
+      expect(JSON.parse(stdout)).toMatchObject({
         kits: [{ name: 'deploy', path: path.join('repo', '.readyup', 'kits', 'deploy.js') }],
       });
     });
@@ -87,9 +79,9 @@ describe('listCommand wiring', () => {
       writeFileSync(path.join(dir, 'notes.md'), '# not a kit\n');
       writeFileSync(path.join(dir, 'alpha.ts'), 'export default {};\n');
 
-      await listCommand(['--from', 'dir:kits', '--json']);
+      const { stdout } = await list(['--from', 'dir:kits', '--json']);
 
-      expect(JSON.parse(stdout.join(''))).toMatchObject({ kits: [{ name: 'alpha' }] });
+      expect(JSON.parse(stdout)).toMatchObject({ kits: [{ name: 'alpha' }] });
     });
 
     it('reports a source with neither a manifest nor a kit directory as a config error', async () => {
@@ -119,9 +111,9 @@ describe('listCommand wiring', () => {
         }),
       );
 
-      await listCommand(['--from', 'dir:kits', '--json']);
+      const { stdout } = await list(['--from', 'dir:kits', '--json']);
 
-      expect(JSON.parse(stdout.join(''))).toStrictEqual({
+      expect(JSON.parse(stdout)).toStrictEqual({
         schemaVersion: 1,
         kits: [
           {
@@ -141,11 +133,24 @@ describe('listCommand wiring', () => {
     it('emits exactly one JSON document and sends the human view to stderr', async () => {
       writeKitsDir('kits', ['alpha']);
 
-      await listCommand(['--from', 'dir:kits', '--json']);
+      const { stdout, stdoutChunks, stderr } = await list(['--from', 'dir:kits', '--json']);
 
-      expect(stdoutSpy).toHaveBeenCalledTimes(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('alpha'));
-      expect(() => ListOutputSchema.parse(JSON.parse(stdout.join('')))).not.toThrow();
+      expect(stdoutChunks).toHaveLength(1);
+      expect(stderr).toContain('alpha');
+      expect(() => ListOutputSchema.parse(JSON.parse(stdout))).not.toThrow();
     });
   });
 });
+
+// region | Helpers
+
+/** Runs the command over the given arguments, returning its exit code alongside everything it wrote. */
+async function list(args: string[]) {
+  using io = captureStdio();
+
+  const exitCode = await listCommand(args);
+
+  return { exitCode, stdout: io.stdout, stdoutChunks: io.stdoutChunks, stderr: io.stderr };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
@@ -2,8 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { captureError, captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RdyError } from '../../errors/RdyError.ts';

--- a/packages/readyup/src/projects/__tests__/discoverKitProjects.unit.test.ts
+++ b/packages/readyup/src/projects/__tests__/discoverKitProjects.unit.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import process from 'node:process';
 
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockReaddirSync = vi.hoisted(() => vi.fn());
@@ -69,7 +70,6 @@ const { failReadOf, passAllReads } = useFailingDirectoryRead(mockReaddirSync, ()
 describe(discoverKitProjects, () => {
   beforeEach(() => {
     passAllReads();
-    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -114,7 +114,7 @@ describe(discoverKitProjects, () => {
   });
 
   it('reads each project under its own config', async () => {
-    const projects = await discoverKitProjects({ root: tempDir.dir });
+    const { projects } = await discover();
     const byDir = new Map(projects.map((project) => [project.dir, project]));
 
     expect(byDir.get('packages/custom')?.config.compile.srcDir).toBe('src/kits');
@@ -123,7 +123,7 @@ describe(discoverKitProjects, () => {
   });
 
   it('resolves each project against the sweep root, manifest path included', async () => {
-    const projects = await discoverKitProjects({ root: tempDir.dir });
+    const { projects } = await discover();
     const emptied = projects.find((project) => project.dir === 'packages/emptied');
 
     expect(emptied?.absolutePath).toBe(path.join(tempDir.dir, 'packages/emptied'));
@@ -132,11 +132,11 @@ describe(discoverKitProjects, () => {
 
   // Discovery is read-only, so a config nobody can evaluate costs that project its settings, not its place.
   it('reports a project whose config fails to evaluate, reading it with default settings', async () => {
-    const projects = await discoverKitProjects({ root: tempDir.dir });
+    const { projects, stderr } = await discover();
     const broken = projects.find((project) => project.dir === 'packages/broken');
 
     expect(broken?.config.compile.srcDir).toBe('.readyup/kits');
-    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('packages/broken'));
+    expect(stderr).toContain('packages/broken');
   });
 
   // Topology comes from the filesystem, so a repo declaring no workspaces is swept like any other.
@@ -145,12 +145,13 @@ describe(discoverKitProjects, () => {
   });
 
   it('reports nothing for a tree holding no kit project', async () => {
-    const projects = await discoverKitProjects({ root: path.join(tempDir.dir, 'packages/plain') });
+    const { projects } = await discover(path.join(tempDir.dir, 'packages/plain'));
 
     expect(projects).toStrictEqual([]);
   });
 
   it('sweeps the working directory when no root is named', async () => {
+    using _io = captureStdio();
     vi.spyOn(process, 'cwd').mockReturnValue(path.join(tempDir.dir, 'packages/emptied'));
 
     const projects = await discoverKitProjects();
@@ -161,11 +162,11 @@ describe(discoverKitProjects, () => {
   it.each(['EACCES', 'EPERM'])('omits a project whose kit directory it cannot read for a benign %s', async (code) => {
     failReadOf('packages/compiled-only/.readyup/kits', code);
 
-    const dirs = await discoverDirs();
+    const { dirs, stderr } = await discover();
 
     expect(dirs).not.toContain('packages/compiled-only');
     expect(dirs).toStrictEqual(expect.arrayContaining(['.', 'packages/authored', 'packages/tooling']));
-    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining('packages/compiled-only'));
+    expect(stderr).toContain('packages/compiled-only');
   });
 
   it('omits a project whose source directory it cannot read', async () => {
@@ -180,16 +181,25 @@ describe(discoverKitProjects, () => {
   it('rethrows a filesystem failure that is not benign', async () => {
     failReadOf('packages/compiled-only/.readyup/kits', 'EMFILE');
 
-    await expect(discoverKitProjects({ root: tempDir.dir })).rejects.toThrow('read failed: EMFILE');
+    await expect(discover()).rejects.toThrow('read failed: EMFILE');
   });
 });
 
 // region | Helpers
 
+/** Sweeps the fixture tree for kit projects, returning them alongside what the sweep wrote to stderr. */
+async function discover(root: string = tempDir.dir) {
+  using io = captureStdio();
+
+  const projects = await discoverKitProjects({ root });
+
+  return { dirs: projects.map((project) => project.dir), projects, stderr: io.stderr };
+}
+
 /** Returns the root-relative directories discovery reports for the fixture tree. */
 async function discoverDirs(): Promise<string[]> {
-  const projects = await discoverKitProjects({ root: tempDir.dir });
-  return projects.map((project) => project.dir);
+  const { dirs } = await discover();
+  return dirs;
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
 import process from 'node:process';
 
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RdyManifestKit } from '../../manifest/manifestSchema.ts';
 
@@ -72,10 +73,7 @@ describe(readManifestTracking, () => {
 });
 
 describe(warnOnKitStaleness, () => {
-  let stderrSpy: MockInstance;
-
   beforeEach(() => {
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
     mockCheckInputDrift.mockReturnValue({ kind: 'ok' });
     mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555bbbb' });
@@ -92,7 +90,7 @@ describe(warnOnKitStaleness, () => {
     it('advises recompiling when the compiled bundle no longer matches the manifest', () => {
       arrangeTargetDrift();
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings).toStrictEqual([
         {
           code: 'target-drift',
           message: 'compiled kit "default" does not match the hash the manifest recorded for it.',
@@ -104,7 +102,7 @@ describe(warnOnKitStaleness, () => {
     it('advises recompiling when the source has moved on since the kit was compiled', () => {
       arrangeSourceStale();
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings).toStrictEqual([
         {
           code: 'source-stale',
           message: 'kit "default" was compiled from an older source than the one on disk.',
@@ -116,7 +114,7 @@ describe(warnOnKitStaleness, () => {
     it('advises recompiling when a file the compile inlined has changed', () => {
       arrangeInputStale();
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings).toStrictEqual([
         {
           code: 'input-stale',
           message: 'kit "default" inlined files that no longer match the ones on disk.',
@@ -134,7 +132,7 @@ describe(warnOnKitStaleness, () => {
         ],
       });
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking()).map((w) => w.code)).toStrictEqual([
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings.map((w) => w.code)).toStrictEqual([
         'input-stale',
       ]);
     });
@@ -144,7 +142,7 @@ describe(warnOnKitStaleness, () => {
       arrangeSourceStale();
       arrangeInputStale();
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking()).map((w) => w.code)).toStrictEqual([
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings.map((w) => w.code)).toStrictEqual([
         'target-drift',
         'source-stale',
         'input-stale',
@@ -155,7 +153,7 @@ describe(warnOnKitStaleness, () => {
       arrangeTargetDrift();
       arrangeSourceStale();
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking()).map((w) => w.code)).toStrictEqual([
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings.map((w) => w.code)).toStrictEqual([
         'target-drift',
         'source-stale',
       ]);
@@ -164,9 +162,9 @@ describe(warnOnKitStaleness, () => {
     it('writes each advisory to stderr with the remedy beside it', () => {
       arrangeTargetDrift();
 
-      warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking());
+      const { stderr } = warn('default', { path: KIT_PATH }, defaultTracking());
 
-      expect(stderrText()).toBe(
+      expect(stderr).toBe(
         'Warning: compiled kit "default" does not match the hash the manifest recorded for it. ' +
           'Run `rdy compile --force` to rebuild it from source.\n',
       );
@@ -175,7 +173,7 @@ describe(warnOnKitStaleness, () => {
     it('names the kit it was called for, not the entry it matched', () => {
       arrangeTargetDrift();
 
-      const warnings = warnOnKitStaleness('alpha', { path: KIT_PATH }, defaultTracking());
+      const { warnings } = warn('alpha', { path: KIT_PATH }, defaultTracking());
 
       expect(warnings[0]?.message).toContain('compiled kit "alpha"');
     });
@@ -186,7 +184,7 @@ describe(warnOnKitStaleness, () => {
         throw new Error('EACCES: permission denied, open /abs/default.ts');
       });
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking()).map((w) => w.code)).toStrictEqual([
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings.map((w) => w.code)).toStrictEqual([
         'target-drift',
       ]);
     });
@@ -197,7 +195,7 @@ describe(warnOnKitStaleness, () => {
         throw new Error('EACCES: permission denied, open /abs/default.js');
       });
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking()).map((w) => w.code)).toStrictEqual([
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings.map((w) => w.code)).toStrictEqual([
         'source-stale',
       ]);
     });
@@ -207,16 +205,16 @@ describe(warnOnKitStaleness, () => {
     it('stays silent when the run read no manifest', () => {
       arrangeTargetDrift();
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, undefined)).toStrictEqual([]);
+      expect(warn('default', { path: KIT_PATH }, undefined).warnings).toStrictEqual([]);
       expect(mockCheckDrift).not.toHaveBeenCalled();
     });
 
     it('stays silent for a remote kit, which no local manifest describes', () => {
       arrangeTargetDrift();
 
-      expect(
-        warnOnKitStaleness('deploy', { url: 'https://example.com/kits/deploy.js' }, defaultTracking()),
-      ).toStrictEqual([]);
+      expect(warn('deploy', { url: 'https://example.com/kits/deploy.js' }, defaultTracking()).warnings).toStrictEqual(
+        [],
+      );
       expect(mockCheckDrift).not.toHaveBeenCalled();
     });
 
@@ -224,7 +222,7 @@ describe(warnOnKitStaleness, () => {
       arrangeTargetDrift();
       const tracking = trackingFor([{ name: 'other', path: 'kits/other.js', source: 'kits/other.ts' }]);
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, tracking)).toStrictEqual([]);
+      expect(warn('default', { path: KIT_PATH }, tracking).warnings).toStrictEqual([]);
       expect(mockCheckDrift).not.toHaveBeenCalled();
     });
 
@@ -233,7 +231,7 @@ describe(warnOnKitStaleness, () => {
       arrangeTargetDrift();
 
       expect(
-        warnOnKitStaleness('default', { path: '/elsewhere/.readyup/kits/default.js' }, defaultTracking()),
+        warn('default', { path: '/elsewhere/.readyup/kits/default.js' }, defaultTracking()).warnings,
       ).toStrictEqual([]);
       expect(mockCheckDrift).not.toHaveBeenCalled();
     });
@@ -242,12 +240,14 @@ describe(warnOnKitStaleness, () => {
       arrangeTargetDrift();
       const tracking = trackingFor([{ name: 'default', source: 'kits/default.ts' }]);
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, tracking)).toStrictEqual([]);
+      expect(warn('default', { path: KIT_PATH }, tracking).warnings).toStrictEqual([]);
     });
 
     it('stays silent when both artifacts match the manifest', () => {
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
-      expect(stderrText()).toBe('');
+      const { warnings, stderr } = warn('default', { path: KIT_PATH }, defaultTracking());
+
+      expect(warnings).toStrictEqual([]);
+      expect(stderr).toBe('');
     });
 
     it('stays silent for an input the compile read that is gone, as it is for a deleted source', () => {
@@ -256,7 +256,7 @@ describe(warnOnKitStaleness, () => {
         failures: [{ kind: 'module', path: 'kits/shared.ts', reason: 'missing' }],
       });
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings).toStrictEqual([]);
     });
 
     it('stays silent for a projection it can no longer reproduce', () => {
@@ -272,13 +272,13 @@ describe(warnOnKitStaleness, () => {
         ],
       });
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings).toStrictEqual([]);
     });
 
     it('stays silent for an entry that predates the recorded closure', () => {
       mockCheckInputDrift.mockReturnValue({ kind: 'unverified' });
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings).toStrictEqual([]);
     });
 
     it('stays silent when the manifest entry records no hashes to compare', () => {
@@ -286,14 +286,14 @@ describe(warnOnKitStaleness, () => {
       mockCheckInputDrift.mockReturnValue({ kind: 'unverified' });
       mockCheckSourceDrift.mockReturnValue({ kind: 'unverified' });
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings).toStrictEqual([]);
     });
 
     it('stays silent when a file the manifest names is gone', () => {
       mockCheckDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/default.js' });
       mockCheckSourceDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/default.ts' });
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings).toStrictEqual([]);
     });
 
     it('stays silent when no file it would compare can be read', () => {
@@ -307,7 +307,7 @@ describe(warnOnKitStaleness, () => {
         throw new Error('EACCES: permission denied, open /abs/default.ts');
       });
 
-      expect(warnOnKitStaleness('default', { path: KIT_PATH }, defaultTracking())).toStrictEqual([]);
+      expect(warn('default', { path: KIT_PATH }, defaultTracking()).warnings).toStrictEqual([]);
     });
   });
 
@@ -348,14 +348,18 @@ describe(warnOnKitStaleness, () => {
     return trackingFor([{ name: 'default', path: MANIFEST_KIT_PATH, source: 'kits/default.ts' }]);
   }
 
-  /** Every stderr write concatenated into one string. */
-  function stderrText(): string {
-    return stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-  }
-
   /** Tracking as `readManifestTracking` would have built it, holding the given entries. */
   function trackingFor(kits: RdyManifestKit[]): ManifestTracking {
     return { manifest: { version: 1, kits }, manifestDir: path.resolve(process.cwd(), '.readyup') };
+  }
+
+  /** Warns over the given kit, returning the warnings alongside what the call wrote to stderr. */
+  function warn(...args: Parameters<typeof warnOnKitStaleness>) {
+    using io = captureStdio();
+
+    const warnings = warnOnKitStaleness(...args);
+
+    return { warnings, stderr: io.stderr };
   }
 
   // endregion | Helpers

--- a/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ReportSchema } from '../../schemas/reportSchema.ts';
@@ -19,16 +20,9 @@ import { runCommand } from '../runCommand.ts';
 describe('--packages run path wiring', () => {
   let projectRoot: string;
   let originalCwd: string;
-  let stdout: string[];
 
   beforeEach(() => {
     projectRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'packages-run-')));
-    stdout = [];
-    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
-      stdout.push(String(chunk));
-      return true;
-    });
-    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     originalCwd = process.cwd();
     process.chdir(projectRoot);
   });
@@ -106,20 +100,20 @@ describe('--packages run path wiring', () => {
     installPackage('@acme/kits', ['drift']);
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
-    const exitCode = await runCommand({ kitEntries: entries, json: false });
+    const { exitCode, stdout } = await run({ kitEntries: entries, json: false });
 
     expect(exitCode).toBe(0);
-    expect(stdout.join('')).toBe('No kits to run.\n');
+    expect(stdout).toBe('No kits to run.\n');
   });
 
   it('carries the package and version into the JSON report', async () => {
     installPackage('@acme/kits', ['default'], { version: '2.1.0' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
-    const exitCode = await runCommand({ kitEntries: entries, json: true });
+    const { exitCode, stdout } = await run({ kitEntries: entries, json: true });
 
     expect(exitCode).toBe(0);
-    const report = ReportSchema.parse(JSON.parse(stdout.join('')));
+    const report = ReportSchema.parse(JSON.parse(stdout));
     expect(report.kits[0]).toMatchObject({ name: 'default', origin: { package: '@acme/kits', version: '2.1.0' } });
   });
 
@@ -127,9 +121,9 @@ describe('--packages run path wiring', () => {
     installPackage('@acme/kits', ['default']);
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
-    await runCommand({ kitEntries: entries, json: true });
+    const { stdout } = await run({ kitEntries: entries, json: true });
 
-    const report = ReportSchema.parse(JSON.parse(stdout.join('')));
+    const report = ReportSchema.parse(JSON.parse(stdout));
     expect(report.kits[0]).toMatchObject({ origin: { package: '@acme/kits' } });
     expect(report.kits[0]?.origin).not.toHaveProperty('version');
   });
@@ -138,9 +132,9 @@ describe('--packages run path wiring', () => {
     installPackage('@acme/kits', ['default'], { version: '2.1.0', readyupVersion: '0.19.2' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
-    await runCommand({ kitEntries: entries, json: true });
+    const { stdout } = await run({ kitEntries: entries, json: true });
 
-    const report = ReportSchema.parse(JSON.parse(stdout.join('')));
+    const report = ReportSchema.parse(JSON.parse(stdout));
     expect(report.kits[0]).toMatchObject({ compiledWith: '0.19.2', origin: { package: '@acme/kits' } });
     expect(report.kits[0]?.origin).not.toHaveProperty('compiledWith');
   });
@@ -150,9 +144,9 @@ describe('--packages run path wiring', () => {
     installPackage('@acme/kits', ['default'], { version: '2.1.0' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
-    await runCommand({ kitEntries: entries, json: false });
+    const { stdout } = await run({ kitEntries: entries, json: false });
 
-    expect(stdout.join('')).toContain('\u{1F4E6} @acme/kits@2.1.0 / \u{1F4D3} default');
+    expect(stdout).toContain('\u{1F4E6} @acme/kits@2.1.0 / \u{1F4D3} default');
   });
 
   // The defect #238 reports: every package kit here runs one checklist, so the run tallied nothing at all.
@@ -165,8 +159,8 @@ describe('--packages run path wiring', () => {
       configuredPackages: ['plain-kit', '@acme/kits'],
     });
 
-    await runCommand({ kitEntries: entries, json: false });
-    const lines = stdout.join('').trimEnd().split('\n');
+    const { stdout } = await run({ kitEntries: entries, json: false });
+    const lines = stdout.trimEnd().split('\n');
 
     // Heading, rule, one row per checklist, rule, total.
     expect(lines.at(-6)).toContain('Summary');
@@ -185,8 +179,8 @@ describe('--packages run path wiring', () => {
       configuredPackages: ['@acme/kits', 'plain-kit'],
     });
 
-    await runCommand({ kitEntries: entries, json: false });
-    const output = stdout.join('');
+    const { stdout } = await run({ kitEntries: entries, json: false });
+    const output = stdout;
     const headings = output
       .matchAll(/^\u{2501}\u{2501} \u{1F4E6} (?<crumb>.+)$/gmu)
       .map((match) => (match.groups?.['crumb'] ?? '').replaceAll(/\p{Emoji_Presentation} /gu, ''))
@@ -213,8 +207,8 @@ describe('--packages run path wiring', () => {
       configuredPackages: ['@acme/kits', 'broken-kit', 'plain-kit'],
     });
 
-    await runCommand({ kitEntries: entries, json: false });
-    const table = stdout.join('').split('\u{2501}\u{2501} Summary\n', 2)[1] ?? '';
+    const { stdout } = await run({ kitEntries: entries, json: false });
+    const table = stdout.split('\u{2501}\u{2501} Summary\n', 2)[1] ?? '';
 
     expect(table).toContain('@acme/kits@2.1.0 / default');
     expect(table).toContain('plain-kit@1.0.0 / default');
@@ -266,6 +260,15 @@ interface InstallPackageOptions {
   hasManifest?: boolean;
   readyupVersion?: string;
   version?: string;
+}
+
+/** Runs the command over the given options, returning its exit code alongside everything it wrote. */
+async function run(options: Parameters<typeof runCommand>[0]) {
+  using io = captureStdio();
+
+  const exitCode = await runCommand(options);
+
+  return { exitCode, stdout: io.stdout, stderr: io.stderr };
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
@@ -180,15 +180,14 @@ describe('--packages run path wiring', () => {
     });
 
     const { stdout } = await run({ kitEntries: entries, json: false });
-    const output = stdout;
-    const headings = output
+    const headings = stdout
       .matchAll(/^\u{2501}\u{2501} \u{1F4E6} (?<crumb>.+)$/gmu)
       .map((match) => (match.groups?.['crumb'] ?? '').replaceAll(/\p{Emoji_Presentation} /gu, ''))
       .toArray();
 
     expect(headings).toStrictEqual(['@acme/kits@2.1.0 / default', 'plain-kit@1.0.0 / default']);
     for (const heading of headings) {
-      expect(output).toContain(`\u{1F7E2} ${heading}`);
+      expect(stdout).toContain(`\u{1F7E2} ${heading}`);
     }
   });
 

--- a/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
@@ -1,6 +1,5 @@
-import process from 'node:process';
-
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { KitProvenance } from '../../kits/KitProvenance.ts';
 import type { FailedResult, PassedResult, Severity } from '../../kits/types.ts';
@@ -66,12 +65,7 @@ const BLOCK_GAP = '\n'.repeat(2);
 const WIDER_GAP = '\n'.repeat(3);
 
 describe(runHumanMode, () => {
-  let stdoutSpy: MockInstance;
-  let stderrSpy: MockInstance;
-
   beforeEach(() => {
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: true });
     mockFormatCombinedSummary.mockReturnValue('combined summary');
     mockReadManifestTracking.mockReturnValue(undefined);
@@ -90,21 +84,11 @@ describe(runHumanMode, () => {
     mockWarnOnKitStaleness.mockReset();
   });
 
-  /** Every stdout write concatenated into one string. */
-  function stdoutText(): string {
-    return stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-  }
-
-  /** Every stderr write concatenated into one string. */
-  function stderrText(): string {
-    return stderrSpy.mock.calls.map((c) => String(c[0])).join('');
-  }
-
   it('says the run selected no kits rather than printing nothing', async () => {
-    const exitCode = await runHuman([]);
+    const { exitCode, stdout } = await runHuman([]);
 
     expect(exitCode).toBe(0);
-    expect(stdoutText()).toBe('No kits to run.\n');
+    expect(stdout).toBe('No kits to run.\n');
     expect(mockLoadRdyKit).not.toHaveBeenCalled();
   });
 
@@ -113,7 +97,7 @@ describe(runHumanMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    const exitCode = await runHuman(singleKitEntry());
+    const { exitCode } = await runHuman(singleKitEntry());
 
     expect(mockRunRdy).toHaveBeenCalledTimes(2);
     expect(exitCode).toBe(0);
@@ -124,7 +108,7 @@ describe(runHumanMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    const exitCode = await runHuman(singleKitEntry(['deploy']));
+    const { exitCode } = await runHuman(singleKitEntry(['deploy']));
 
     expect(mockRunRdy).toHaveBeenCalledTimes(1);
     expect(mockRunRdy).toHaveBeenCalledWith(
@@ -138,10 +122,10 @@ describe(runHumanMode, () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
 
-    const exitCode = await runHuman(singleKitEntry(['nonexistent']));
+    const { exitCode, stderr } = await runHuman(singleKitEntry(['nonexistent']));
 
     expect(exitCode).toBe(2);
-    expect(stderrText()).toContain('Error: Unknown name(s): nonexistent');
+    expect(stderr).toContain('Error: Unknown name(s): nonexistent');
   });
 
   it('returns exit code 1 when any checklist fails', async () => {
@@ -151,7 +135,7 @@ describe(runHumanMode, () => {
       .mockResolvedValueOnce({ results: [], passed: true, durationMs: 0 })
       .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
 
-    const exitCode = await runHuman(singleKitEntry());
+    const { exitCode } = await runHuman(singleKitEntry());
 
     expect(exitCode).toBe(1);
   });
@@ -171,9 +155,8 @@ describe(runHumanMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runHuman(singleKitEntry());
+    const { stdout: allOutput } = await runHuman(singleKitEntry());
 
-    const allOutput = stdoutText();
     expect(allOutput).toContain('\u{2501}\u{2501} \u{1F4CB} deploy');
     expect(allOutput).toContain('\u{2501}\u{2501} \u{1F4CB} infra');
   });
@@ -184,9 +167,8 @@ describe(runHumanMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runHuman(singleKitEntry());
+    const { stdout: allOutput } = await runHuman(singleKitEntry());
 
-    const allOutput = stdoutText();
     expect(allOutput).not.toContain(WIDER_GAP);
     expect(allOutput).toContain(`${BLOCK_GAP}\u{2501}\u{2501} \u{1F4CB} infra`);
     expect(allOutput).toContain(`${BLOCK_GAP}combined summary`);
@@ -199,9 +181,8 @@ describe(runHumanMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runHuman(singleKitEntry(['deploy']));
+    const { stdout: allOutput } = await runHuman(singleKitEntry(['deploy']));
 
-    const allOutput = stdoutText();
     expect(allOutput).not.toContain('\u{2501}\u{2501}');
     expect(allOutput).not.toContain('\u{2500}\u{2500} ');
     expect(allOutput.startsWith('\n')).toBe(false);
@@ -214,12 +195,11 @@ describe(runHumanMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runHuman([
+    const { stdout: allOutput } = await runHuman([
       { name: 'kit1', source: { path: '.readyup/kits/kit1.js' }, checklists: [] },
       { name: 'kit2', source: { path: '.readyup/kits/kit2.js' }, checklists: [] },
     ]);
 
-    const allOutput = stdoutText();
     expect(allOutput).toContain('\u{2501}\u{2501} \u{1F4D3} kit1');
     expect(allOutput).toContain('\u{2501}\u{2501} \u{1F4D3} kit2');
   });
@@ -231,9 +211,11 @@ describe(runHumanMode, () => {
       mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-      await runHuman([{ name: 'deploy', source: { path: '.readyup/kits/deploy.js' }, checklists: [], provenance }]);
+      const { stdout } = await runHuman([
+        { name: 'deploy', source: { path: '.readyup/kits/deploy.js' }, checklists: [], provenance },
+      ]);
 
-      return stdoutText();
+      return stdout;
     }
 
     it('names a remote kit by the source it was fetched from', async () => {
@@ -280,12 +262,11 @@ describe(runHumanMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runHuman([
+    const { stdout: allOutput } = await runHuman([
       { name: 'kit1', source: { path: '.readyup/kits/kit1.js' }, checklists: [] },
       { name: 'kit2', source: { path: '.readyup/kits/kit2.js' }, checklists: [] },
     ]);
 
-    const allOutput = stdoutText();
     expect(allOutput.startsWith('\u{2501}\u{2501} \u{1F4D3} kit1')).toBe(true);
     expect(allOutput).toContain(`${BLOCK_GAP}\u{2501}\u{2501} \u{1F4D3} kit2`);
     expect(allOutput).not.toContain(WIDER_GAP);
@@ -297,9 +278,8 @@ describe(runHumanMode, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
     mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: false });
 
-    await runHuman(singleKitEntry());
+    const { stdout: allOutput } = await runHuman(singleKitEntry());
 
-    const allOutput = stdoutText();
     expect(allOutput).not.toContain('report output');
     expect(allOutput).toContain('combined summary');
   });
@@ -310,9 +290,8 @@ describe(runHumanMode, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
     mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: false });
 
-    await runHuman(singleKitEntry());
+    const { stdout: allOutput } = await runHuman(singleKitEntry());
 
-    const allOutput = stdoutText();
     expect(allOutput).toContain('report output');
     expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
   });
@@ -324,12 +303,11 @@ describe(runHumanMode, () => {
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
     mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: false });
 
-    await runHuman([
+    const { stdout: allOutput } = await runHuman([
       { name: 'kit1', source: { path: '.readyup/kits/kit1.js' }, checklists: [] },
       { name: 'kit2', source: { path: '.readyup/kits/kit2.js' }, checklists: [] },
     ]);
 
-    const allOutput = stdoutText();
     expect(allOutput).not.toContain('report output');
     expect(allOutput).toContain('combined summary');
   });
@@ -412,10 +390,10 @@ describe(runHumanMode, () => {
   it('reports an unloadable kit against its kit name and exits 2', async () => {
     mockLoadRdyKit.mockRejectedValue(new Error('Kit not found'));
 
-    const exitCode = await runHuman(singleKitEntry());
+    const { exitCode, stderr } = await runHuman(singleKitEntry());
 
     expect(exitCode).toBe(2);
-    expect(stderrText()).toBe('Error: Kit not found\n');
+    expect(stderr).toBe('Error: Kit not found\n');
   });
 
   it('keeps running the kits that are not at fault', async () => {
@@ -424,7 +402,7 @@ describe(runHumanMode, () => {
       .mockResolvedValueOnce({ kit: makeKit(), compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    const exitCode = await runHuman([
+    const { exitCode } = await runHuman([
       { name: 'broken', source: { path: '.readyup/kits/broken.js' }, checklists: ['deploy'] },
       { name: 'healthy', source: { path: '.readyup/kits/healthy.js' }, checklists: ['deploy'] },
     ]);
@@ -554,7 +532,7 @@ describe(runHumanMode, () => {
       mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-      const exitCode = await runHuman(singleKitEntry(['deploy']));
+      const { exitCode } = await runHuman(singleKitEntry(['deploy']));
 
       expect(exitCode).toBe(0);
     });
@@ -568,11 +546,9 @@ describe(runHumanMode, () => {
       mockResolveGitHubToken.mockReturnValue(undefined);
       mockLoadRemoteKit.mockRejectedValue(new RemoteFetchError(`Failed to fetch remote kit from ${GITHUB_URL}`, 404));
 
-      await runHuman([{ name: 'deploy', source: { url: GITHUB_URL }, checklists: [] }]);
+      const { stderr } = await runHuman([{ name: 'deploy', source: { url: GITHUB_URL }, checklists: [] }]);
 
-      expect(stderrText()).toBe(
-        `Error: Failed to fetch remote kit from ${GITHUB_URL}\n\u{1F4A1} Hint: ${GITHUB_HINT}\n`,
-      );
+      expect(stderr).toBe(`Error: Failed to fetch remote kit from ${GITHUB_URL}\n\u{1F4A1} Hint: ${GITHUB_HINT}\n`);
     });
   });
 });
@@ -621,12 +597,19 @@ interface HumanRunOptions {
   reportOn?: Severity;
 }
 
-/** Runs the mode over the given entries, filling in every setting the test did not name. */
-function runHuman(
+/**
+ * Runs the mode over the given entries, filling in every setting the test did not name, and returns its
+ * exit code alongside everything it wrote.
+ */
+async function runHuman(
   kitEntries: ResolvedKitEntry[],
   { failOn, isJit = false, quiet = false, reportOn }: HumanRunOptions = {},
-): Promise<number> {
-  return runHumanMode(kitEntries, { failOn, quiet, reportOn }, isJit);
+) {
+  using io = captureStdio();
+
+  const exitCode = await runHumanMode(kitEntries, { failOn, quiet, reportOn }, isJit);
+
+  return { exitCode, stdout: io.stdout, stderr: io.stderr };
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
@@ -1,6 +1,5 @@
-import process from 'node:process';
-
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Severity } from '../../kits/types.ts';
 import { RemoteFetchError } from '../../remote/RemoteFetchError.ts';
@@ -62,12 +61,7 @@ import { runJsonMode } from '../runJsonMode.ts';
 import { makeKit, singleKitEntry } from '../test-utils/kit-fixtures.ts';
 
 describe(runJsonMode, () => {
-  let stdoutSpy: MockInstance;
-  let stderrSpy: MockInstance;
-
   beforeEach(() => {
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockFormatJsonReport.mockReturnValue('{"worstSeverity":null}');
     mockReadManifestTracking.mockReturnValue(undefined);
     mockWarnOnKitStaleness.mockReturnValue([]);
@@ -91,12 +85,12 @@ describe(runJsonMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    const exitCode = await runJson(singleKitEntry());
+    const { exitCode, stdout } = await runJson(singleKitEntry());
 
     expect(mockFormatJsonReport).toHaveBeenCalledTimes(1);
     expect(mockReportRdy).not.toHaveBeenCalled();
     expect(mockFormatCombinedSummary).not.toHaveBeenCalled();
-    expect(stdoutSpy).toHaveBeenCalledWith('{"worstSeverity":null}\n');
+    expect(stdout).toBe('{"worstSeverity":null}\n');
     expect(exitCode).toBe(0);
   });
 
@@ -107,7 +101,7 @@ describe(runJsonMode, () => {
       .mockResolvedValueOnce({ results: [], passed: true, durationMs: 0 })
       .mockResolvedValueOnce({ results: [], passed: false, durationMs: 0 });
 
-    const exitCode = await runJson(singleKitEntry());
+    const { exitCode } = await runJson(singleKitEntry());
 
     expect(exitCode).toBe(1);
   });
@@ -116,14 +110,14 @@ describe(runJsonMode, () => {
     mockLoadRdyKit.mockRejectedValue(new Error('Kit not found'));
     mockFormatJsonReport.mockReturnValue('{}');
 
-    const exitCode = await runJson(singleKitEntry());
+    const { exitCode, stderr } = await runJson(singleKitEntry());
 
     expect(exitCode).toBe(2);
     expect(mockFormatJsonReport).toHaveBeenCalledWith(
       [{ name: 'default', error: { code: 'kit-load', message: 'Kit not found' } }],
       expect.anything(),
     );
-    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(stderr).toBe('');
   });
 
   it('records an unknown checklist name as an error entry, leaving stderr clean', async () => {
@@ -131,14 +125,14 @@ describe(runJsonMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockFormatJsonReport.mockReturnValue('{}');
 
-    const exitCode = await runJson(singleKitEntry(['nonexistent']));
+    const { exitCode, stderr } = await runJson(singleKitEntry(['nonexistent']));
 
     expect(exitCode).toBe(2);
     expect(mockFormatJsonReport).toHaveBeenCalledWith(
       [{ name: 'default', error: { code: 'usage', message: expect.stringContaining('nonexistent') } }],
       expect.anything(),
     );
-    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(stderr).toBe('');
   });
 
   it('passes kit-grouped entries to formatJsonReport', async () => {
@@ -200,7 +194,7 @@ describe(runJsonMode, () => {
     mockRunRdy.mockRejectedValue(new Error('runner crashed'));
     mockFormatJsonReport.mockReturnValue('{}');
 
-    const exitCode = await runJson(singleKitEntry(['deploy']));
+    const { exitCode } = await runJson(singleKitEntry(['deploy']));
 
     expect(exitCode).toBe(2);
     expect(mockFormatJsonReport).toHaveBeenCalledWith(
@@ -214,10 +208,8 @@ describe(runJsonMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    await runJson(singleKitEntry());
-
-    const allOutput = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(allOutput).not.toContain('---');
+    const { stdout } = await runJson(singleKitEntry());
+    expect(stdout).not.toContain('---');
   });
 
   it('produces JSON output with multiple kit entries', async () => {
@@ -227,7 +219,7 @@ describe(runJsonMode, () => {
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 
-    const exitCode = await runJson([
+    const { exitCode } = await runJson([
       { name: 'kit1', source: { path: '.readyup/kits/kit1.js' }, checklists: [] },
       { name: 'kit2', source: { path: '.readyup/kits/kit2.js' }, checklists: [] },
     ]);
@@ -284,7 +276,7 @@ describe(runJsonMode, () => {
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
       mockFormatJsonReport.mockReturnValue('{"kits":[]}');
 
-      const exitCode = await runJson(twoKitEntries());
+      const { exitCode } = await runJson(twoKitEntries());
 
       expect(mockWarnOnKitStaleness).toHaveBeenNthCalledWith(1, 'alpha', { path: '.readyup/kits/alpha.js' }, tracking);
       expect(mockWarnOnKitStaleness).toHaveBeenNthCalledWith(2, 'beta', { path: '.readyup/kits/beta.js' }, tracking);
@@ -338,12 +330,19 @@ interface JsonRunOptions {
   reportOn?: Severity;
 }
 
-/** Runs the mode over the given entries, filling in every setting the test did not name. */
-function runJson(
+/**
+ * Runs the mode over the given entries, filling in every setting the test did not name, and returns its
+ * exit code alongside everything it wrote.
+ */
+async function runJson(
   kitEntries: ResolvedKitEntry[],
   { detail = 'full', failOn, isJit = false, reportOn }: JsonRunOptions = {},
-): Promise<number> {
-  return runJsonMode(kitEntries, { detail, failOn, reportOn }, isJit);
+) {
+  using io = captureStdio();
+
+  const exitCode = await runJsonMode(kitEntries, { detail, failOn, reportOn }, isJit);
+
+  return { exitCode, stdout: io.stdout, stderr: io.stderr };
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { version as installedEsbuildVersion } from 'esbuild';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CompileResult } from '../../compile/compileConfig.ts';
 import { compileConfig } from '../../compile/compileConfig.ts';
@@ -41,7 +42,6 @@ const PRIOR_VERSION = '0.19.2';
  */
 describe('verifyCommand --rebuild', () => {
   let tempDir: string;
-  let stdoutSpy: MockInstance;
   let originalCwd: string;
   let compiled: CompileResult;
 
@@ -50,8 +50,6 @@ describe('verifyCommand --rebuild', () => {
     writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '1.0.0' }));
     writeFileSync(path.join(tempDir, 'kit.ts'), KIT_SOURCE);
 
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     originalCwd = process.cwd();
     // esbuild renders each module's path against the working directory, so the fixture is compiled from
     // the directory it is verified from, as a real project is.
@@ -88,10 +86,10 @@ describe('verifyCommand --rebuild', () => {
   });
 
   it('passes an untouched tree', async () => {
-    const exitCode = await runVerify();
+    const { exitCode, stdout } = await runVerify();
 
     expect(exitCode).toBe(0);
-    expect(readPayload(stdoutSpy)).toMatchObject({
+    expect(readPayload(stdout)).toMatchObject({
       passed: true,
       kits: [{ name: 'demo', status: 'ok', sourceStatus: 'ok', rebuildStatus: 'ok' }],
     });
@@ -100,10 +98,10 @@ describe('verifyCommand --rebuild', () => {
   it('fails a bundle stale only in an inlined JSON file, which both recorded hashes still pass', async () => {
     writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
 
-    const exitCode = await runVerify();
+    const { exitCode, stdout } = await runVerify();
 
     expect(exitCode).toBe(1);
-    expect(readPayload(stdoutSpy)).toMatchObject({
+    expect(readPayload(stdout)).toMatchObject({
       passed: false,
       // The `.ts` and the `.js` are both untouched, so the hash verdicts see nothing wrong. Only the
       // rebuild reads the JSON the bundle inlined, which is the gap the flag exists to close.
@@ -124,10 +122,10 @@ describe('verifyCommand --rebuild', () => {
     // it go stale in agreement and keep matching. Only a recompile reads the version.
     restampBundle(tempDir, PRIOR_VERSION);
 
-    const exitCode = await runVerify();
+    const { exitCode, stdout } = await runVerify();
 
     expect(exitCode).toBe(1);
-    expect(readPayload(stdoutSpy)).toMatchObject({
+    expect(readPayload(stdout)).toMatchObject({
       passed: false,
       kits: [{ status: 'ok', sourceStatus: 'ok', rebuildStatus: 'mismatch', rebuildCompiledWith: PRIOR_VERSION }],
     });
@@ -136,9 +134,9 @@ describe('verifyCommand --rebuild', () => {
   it('reports matching recorded versions on a mismatch the record cannot explain', async () => {
     writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
 
-    await runVerify();
+    const { stdout } = await runVerify();
 
-    expect(readPayload(stdoutSpy).kits[0]).toMatchObject({
+    expect(readPayload(stdout).kits[0]).toMatchObject({
       rebuildStatus: 'mismatch',
       rebuildEsbuild: { recorded: installedEsbuildVersion, rebuilt: installedEsbuildVersion },
     });
@@ -148,9 +146,9 @@ describe('verifyCommand --rebuild', () => {
     patchKits(path.join(tempDir, 'manifest.json'), { esbuildVersion: '0.0.1-old' });
     writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
 
-    await runVerify();
+    const { stdout } = await runVerify();
 
-    expect(readPayload(stdoutSpy).kits[0]).toMatchObject({
+    expect(readPayload(stdout).kits[0]).toMatchObject({
       rebuildEsbuild: { recorded: '0.0.1-old', rebuilt: installedEsbuildVersion },
     });
   });
@@ -161,9 +159,9 @@ describe('verifyCommand --rebuild', () => {
     });
     writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
 
-    await runVerify();
+    const { stdout } = await runVerify();
 
-    expect(readPayload(stdoutSpy).kits[0]).toMatchObject({
+    expect(readPayload(stdout).kits[0]).toMatchObject({
       rebuildStatus: 'mismatch',
       rebuildDependencyChanges: [
         { name: 'picomatch', recorded: '0.0.1-old', rebuilt: readInstalledPackageVersion('picomatch') },
@@ -174,10 +172,10 @@ describe('verifyCommand --rebuild', () => {
   it('fails a hand-edited bundle', async () => {
     writeFileSync(path.join(tempDir, 'kit.js'), 'export default { checklists: [] };\n');
 
-    const exitCode = await runVerify();
+    const { exitCode, stdout } = await runVerify();
 
     expect(exitCode).toBe(1);
-    expect(readPayload(stdoutSpy)).toMatchObject({
+    expect(readPayload(stdout)).toMatchObject({
       kits: [{ status: 'drift', rebuildStatus: 'mismatch' }],
     });
   });
@@ -185,10 +183,10 @@ describe('verifyCommand --rebuild', () => {
   it('reports a passing rebuild beside a recorded hash that has gone wrong', async () => {
     patchKits(path.join(tempDir, 'manifest.json'), { targetHash: 'deadbeef' });
 
-    const exitCode = await runVerify();
+    const { exitCode, stdout } = await runVerify();
 
     expect(exitCode).toBe(1);
-    expect(readPayload(stdoutSpy)).toMatchObject({
+    expect(readPayload(stdout)).toMatchObject({
       kits: [{ status: 'drift', rebuildStatus: 'ok' }],
     });
   });
@@ -196,10 +194,10 @@ describe('verifyCommand --rebuild', () => {
   it('fails a kit whose source no longer compiles', async () => {
     writeFileSync(path.join(tempDir, 'kit.ts'), 'export default { checklists: [ ;\n');
 
-    const exitCode = await runVerify();
+    const { exitCode, stdout } = await runVerify();
 
     expect(exitCode).toBe(1);
-    expect(readPayload(stdoutSpy)).toMatchObject({
+    expect(readPayload(stdout)).toMatchObject({
       kits: [{ rebuildStatus: 'failed' }],
     });
   });
@@ -207,10 +205,10 @@ describe('verifyCommand --rebuild', () => {
   it('leaves every rebuild field out of the payload without the flag', async () => {
     writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '2.0.0' }));
 
-    const exitCode = await verifyCommand(['--manifest', 'manifest.json', '--json']);
+    const { exitCode, stdout } = await runVerify({ rebuild: false });
 
     expect(exitCode).toBe(0);
-    expect(readPayload(stdoutSpy).kits[0]).not.toHaveProperty('rebuildStatus');
+    expect(readPayload(stdout).kits[0]).not.toHaveProperty('rebuildStatus');
   });
 });
 
@@ -230,8 +228,8 @@ function patchKits(manifestPath: string, patch: Partial<RdyManifestKit>): void {
  * Parsed through the published schema rather than cast, so a payload that does not satisfy the
  * contract fails here rather than reaching an assertion that happens not to look at the bad field.
  */
-function readPayload(stdoutSpy: MockInstance): JsonVerifyOutput {
-  const emitted: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+function readPayload(stdout: string): JsonVerifyOutput {
+  const emitted: unknown = JSON.parse(stdout);
   return VerifyOutputSchema.parse(emitted);
 }
 
@@ -252,9 +250,17 @@ function restampBundle(tempDir: string, version: string): void {
   patchKits(path.join(tempDir, 'manifest.json'), { readyupVersion: version, targetHash: hashFile(bundlePath) });
 }
 
-/** Runs `verify` over the tempdir's manifest with the rebuild check and JSON output on. */
-async function runVerify(): Promise<number> {
-  return verifyCommand(['--manifest', 'manifest.json', '--rebuild', '--json']);
+/**
+ * Runs `verify` over the tempdir's manifest with JSON output on and the rebuild check on unless waived,
+ * returning its exit code alongside what it wrote.
+ */
+async function runVerify({ rebuild = true }: { rebuild?: boolean } = {}) {
+  using io = captureStdio();
+
+  const rebuildFlag = rebuild ? ['--rebuild'] : [];
+  const exitCode = await verifyCommand(['--manifest', 'manifest.json', ...rebuildFlag, '--json']);
+
+  return { exitCode, stdout: io.stdout };
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
@@ -3,8 +3,8 @@ import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { version as installedEsbuildVersion } from 'esbuild';
 import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { version as installedEsbuildVersion } from 'esbuild';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CompileResult } from '../../compile/compileConfig.ts';

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -1,5 +1,4 @@
-import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { captureError, captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockReadManifest = vi.hoisted(() => vi.fn());
@@ -505,9 +504,8 @@ describe(verifyCommand, () => {
 
       const { stdout } = await verify(['--rebuild', '--json']);
 
-      const payload = stdout;
-      expect(payload).not.toContain('rebuildEsbuild');
-      expect(payload).not.toContain('rebuildDependencyChanges');
+      expect(stdout).not.toContain('rebuildEsbuild');
+      expect(stdout).not.toContain('rebuildDependencyChanges');
     });
 
     it('fails a kit whose source no longer compiles, carrying the compile error', async () => {
@@ -610,8 +608,7 @@ describe(verifyCommand, () => {
 
       const { stdout } = await verify(['--rebuild', '--json']);
 
-      const payload = stdout;
-      expect(payload).not.toContain('rebuildCompiledWith');
+      expect(stdout).not.toContain('rebuildCompiledWith');
     });
 
     it('carries the compile error in the JSON payload for a kit that failed to build', async () => {
@@ -629,8 +626,7 @@ describe(verifyCommand, () => {
 
       const { stdout } = await verify(['--json']);
 
-      const payload = stdout;
-      expect(payload).not.toContain('rebuild');
+      expect(stdout).not.toContain('rebuild');
     });
 
     it('reports a config error naming the install command when esbuild is absent', async () => {

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -1,5 +1,6 @@
 import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockReadManifest = vi.hoisted(() => vi.fn());
 const mockCheckDrift = vi.hoisted(() => vi.fn());
@@ -46,11 +47,7 @@ const FAILED = richFormatter.tokens.failedError.glyph;
 const UNVERIFIED = richFormatter.tokens.skippedOptional.glyph;
 
 describe(verifyCommand, () => {
-  let stdoutSpy: MockInstance;
-
   beforeEach(() => {
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockCheckInputDrift.mockReturnValue({ kind: 'unverified' });
     mockCheckSourceDrift.mockReturnValue({ kind: 'unverified' });
     mockLoadEsbuild.mockResolvedValue({ build: vi.fn() });
@@ -76,12 +73,12 @@ describe(verifyCommand, () => {
     });
     mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
 
-    const exitCode = await verifyCommand([]);
+    const { exitCode, stdout } = await verify([]);
 
     expect(exitCode).toBe(0);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha`));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} beta`));
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('failed verification'));
+    expect(stdout).toContain(`${OK} alpha`);
+    expect(stdout).toContain(`${OK} beta`);
+    expect(stdout).not.toContain('failed verification');
   });
 
   it('returns 1 when any kit has drift', async () => {
@@ -101,12 +98,12 @@ describe(verifyCommand, () => {
       })
       .mockReturnValueOnce({ kind: 'ok', targetHash: 'bbbb2222' });
 
-    const exitCode = await verifyCommand([]);
+    const { exitCode, stdout } = await verify([]);
 
     expect(exitCode).toBe(1);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} alpha\n   drift`));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('expected aaaa1111, got aaaa9999'));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('1 of 2 kits failed verification'));
+    expect(stdout).toContain(`${FAILED} alpha\n   drift`);
+    expect(stdout).toContain('expected aaaa1111, got aaaa9999');
+    expect(stdout).toContain('1 of 2 kits failed verification');
   });
 
   it('returns 1 when any kit is missing', async () => {
@@ -116,10 +113,10 @@ describe(verifyCommand, () => {
     });
     mockCheckDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/alpha.js' });
 
-    const exitCode = await verifyCommand([]);
+    const { exitCode, stdout } = await verify([]);
 
     expect(exitCode).toBe(1);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} alpha\n   compiled file missing`));
+    expect(stdout).toContain(`${FAILED} alpha\n   compiled file missing`);
   });
 
   it('returns 0 when a kit is unverified (no targetHash)', async () => {
@@ -129,19 +126,19 @@ describe(verifyCommand, () => {
     });
     mockCheckDrift.mockReturnValue({ kind: 'unverified' });
 
-    const exitCode = await verifyCommand([]);
+    const { exitCode, stdout } = await verify([]);
 
     expect(exitCode).toBe(0);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${UNVERIFIED} alpha \u{00B7} unverified`));
+    expect(stdout).toContain(`${UNVERIFIED} alpha \u{00B7} unverified`);
   });
 
   it('returns 0 and reports no-kits message when the manifest is empty', async () => {
     mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-    const exitCode = await verifyCommand([]);
+    const { exitCode, stdout } = await verify([]);
 
     expect(exitCode).toBe(0);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('(no kits in manifest)'));
+    expect(stdout).toContain('(no kits in manifest)');
     expect(mockCheckDrift).not.toHaveBeenCalled();
   });
 
@@ -164,43 +161,39 @@ describe(verifyCommand, () => {
         resolvedPath: '/abs/alpha.ts',
       });
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`${FAILED} alpha\n   source stale (expected 5555aaaa, got 6666bbbb)`),
-      );
+      expect(stdout).toContain(`${FAILED} alpha\n   source stale (expected 5555aaaa, got 6666bbbb)`);
     });
 
     it('fails a kit whose recorded source file is gone', async () => {
       arrangeSingleKit();
       mockCheckSourceDrift.mockReturnValue({ kind: 'missing', resolvedPath: '/abs/alpha.ts' });
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`${FAILED} alpha\n   source file missing (expected alpha.ts)`),
-      );
+      expect(stdout).toContain(`${FAILED} alpha\n   source file missing (expected alpha.ts)`);
     });
 
     it('passes a kit whose source matches, leaving the line unchanged', async () => {
       arrangeSingleKit();
       mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha\n`));
+      expect(stdout).toContain(`${OK} alpha\n`);
     });
 
     it('passes a manifest that records no source hash, leaving the line unchanged', async () => {
       arrangeSingleKit();
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha\n`));
+      expect(stdout).toContain(`${OK} alpha\n`);
     });
 
     it('reports both verdicts when the source is stale and the target has drifted', async () => {
@@ -218,13 +211,11 @@ describe(verifyCommand, () => {
         resolvedPath: '/abs/alpha.ts',
       });
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `${FAILED} alpha\n   drift (expected aaaa1111, got aaaa9999)\n   source stale (expected 5555aaaa, got 6666bbbb)`,
-        ),
+      expect(stdout).toContain(
+        `${FAILED} alpha\n   drift (expected aaaa1111, got aaaa9999)\n   source stale (expected 5555aaaa, got 6666bbbb)`,
       );
     });
   });
@@ -249,13 +240,11 @@ describe(verifyCommand, () => {
         ],
       });
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `${FAILED} alpha\n   input stale: kits/shared.ts (module, expected 1111aaaa, got 2222bbbb)`,
-        ),
+      expect(stdout).toContain(
+        `${FAILED} alpha\n   input stale: kits/shared.ts (module, expected 1111aaaa, got 2222bbbb)`,
       );
     });
 
@@ -268,11 +257,9 @@ describe(verifyCommand, () => {
         ],
       });
 
-      await verifyCommand([]);
+      const { stdout } = await verify([]);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining('input stale: ../../package.json (inline, expected 3333cccc, got 4444dddd)'),
-      );
+      expect(stdout).toContain('input stale: ../../package.json (inline, expected 3333cccc, got 4444dddd)');
     });
 
     it('reports a picked field that has vanished with what went wrong rather than a pair of hashes', async () => {
@@ -289,12 +276,10 @@ describe(verifyCommand, () => {
         ],
       });
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining('input unprojectable: ../../package.json (path not found: version)'),
-      );
+      expect(stdout).toContain('input unprojectable: ../../package.json (path not found: version)');
     });
 
     it('reports an input the compile read that is gone', async () => {
@@ -304,9 +289,9 @@ describe(verifyCommand, () => {
         failures: [{ kind: 'module', path: 'kits/shared.ts', reason: 'missing' }],
       });
 
-      await verifyCommand([]);
+      const { stdout } = await verify([]);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('input missing: kits/shared.ts (module)'));
+      expect(stdout).toContain('input missing: kits/shared.ts (module)');
     });
 
     it('gives every failed input its own line beneath the kit', async () => {
@@ -319,13 +304,11 @@ describe(verifyCommand, () => {
         ],
       });
 
-      await verifyCommand([]);
+      const { stdout } = await verify([]);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `${FAILED} alpha\n   input missing: kits/shared.ts (module)\n` +
-            '   input stale: ../../package.json (inline, expected 3333cccc, got 4444dddd)',
-        ),
+      expect(stdout).toContain(
+        `${FAILED} alpha\n   input missing: kits/shared.ts (module)\n` +
+          '   input stale: ../../package.json (inline, expected 3333cccc, got 4444dddd)',
       );
     });
 
@@ -333,19 +316,19 @@ describe(verifyCommand, () => {
       arrangeSingleKit();
       mockCheckInputDrift.mockReturnValue({ kind: 'ok' });
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+      expect(stdout).toContain(`${OK} alpha\n`);
     });
 
     it('passes an entry that predates the closure, leaving the line it produces today unchanged', async () => {
       arrangeSingleKit();
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+      expect(stdout).toContain(`${OK} alpha\n`);
     });
 
     it('speaks a passing rebuild over a stale input, where it names the manifest as what went wrong', async () => {
@@ -356,9 +339,9 @@ describe(verifyCommand, () => {
       });
       mockCheckRebuild.mockResolvedValue({ kind: 'ok' });
 
-      await verifyCommand(['--rebuild']);
+      const { stdout } = await verify(['--rebuild']);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('rebuild ok'));
+      expect(stdout).toContain('rebuild ok');
     });
   });
 
@@ -367,7 +350,7 @@ describe(verifyCommand, () => {
       throw new Error('Manifest file not found: /path/to/manifest.json');
     });
 
-    const error = await captureError(RdyError, () => verifyCommand([]));
+    const { error } = await verifyRaising([]);
 
     expect(error.code).toBe('config');
     expect(error.message).toContain('Manifest file not found');
@@ -376,13 +359,13 @@ describe(verifyCommand, () => {
   it('honors --manifest flag to resolve a custom path', async () => {
     mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-    await verifyCommand(['--manifest', 'custom/manifest.json']);
+    await verify(['--manifest', 'custom/manifest.json']);
 
     expect(mockReadManifest).toHaveBeenCalledWith(expect.stringContaining('custom/manifest.json'));
   });
 
   it('reports a usage error when positional arguments are supplied', async () => {
-    const error = await captureError(RdyError, () => verifyCommand(['unexpected']));
+    const { error } = await verifyRaising(['unexpected']);
 
     expect(error.code).toBe('usage');
     expect(error.message).toContain('does not accept positional arguments');
@@ -402,34 +385,32 @@ describe(verifyCommand, () => {
     it('leaves the run untouched without the flag, never reaching for esbuild', async () => {
       arrangeSingleKit();
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(0);
       expect(mockCheckRebuild).not.toHaveBeenCalled();
       expect(mockLoadEsbuild).not.toHaveBeenCalled();
-      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+      expect(stdout).toContain(`${OK} alpha\n`);
     });
 
     it('passes a kit that reproduces, leaving its line unchanged', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'ok' });
 
-      const exitCode = await verifyCommand(['--rebuild']);
+      const { exitCode, stdout } = await verify(['--rebuild']);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+      expect(stdout).toContain(`${OK} alpha\n`);
     });
 
     it('fails a kit whose bundle differs from what its source rebuilds to', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'mismatch', expected: '1111aaaa', actual: '2222bbbb' });
 
-      const exitCode = await verifyCommand(['--rebuild']);
+      const { exitCode, stdout } = await verify(['--rebuild']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`${FAILED} alpha\n   rebuild mismatch (rebuilt 1111aaaa, on disk 2222bbbb)`),
-      );
+      expect(stdout).toContain(`${FAILED} alpha\n   rebuild mismatch (rebuilt 1111aaaa, on disk 2222bbbb)`);
     });
 
     it('names both versions on a mismatch spanning a readyup move', async () => {
@@ -441,11 +422,9 @@ describe(verifyCommand, () => {
         compiledWith: '0.0.1-old',
       });
 
-      await verifyCommand(['--rebuild']);
+      const { stdout } = await verify(['--rebuild']);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`compiled by readyup 0.0.1-old, rebuilt by ${VERSION}`),
-      );
+      expect(stdout).toContain(`compiled by readyup 0.0.1-old, rebuilt by ${VERSION}`);
     });
 
     it('names the esbuild move on a mismatch whose recorded version differs', async () => {
@@ -457,9 +436,9 @@ describe(verifyCommand, () => {
         esbuild: { recorded: '0.28.1', rebuilt: '0.29.0' },
       });
 
-      await verifyCommand(['--rebuild']);
+      const { stdout } = await verify(['--rebuild']);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('esbuild 0.28.1 -> 0.29.0'));
+      expect(stdout).toContain('esbuild 0.28.1 -> 0.29.0');
     });
 
     it('names each dependency change on a mismatch, one clause apiece', async () => {
@@ -476,11 +455,11 @@ describe(verifyCommand, () => {
         ],
       });
 
-      await verifyCommand(['--rebuild']);
+      const { stdout } = await verify(['--rebuild']);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('glob 10.0.0 no longer bundled'));
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('picomatch 4.0.2 newly bundled'));
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('zod 3.24.1 -> 4.0.0'));
+      expect(stdout).toContain('glob 10.0.0 no longer bundled');
+      expect(stdout).toContain('picomatch 4.0.2 newly bundled');
+      expect(stdout).toContain('zod 3.24.1 -> 4.0.0');
     });
 
     it('says the recorded versions match when the toolchain record clears every named cause', async () => {
@@ -492,11 +471,9 @@ describe(verifyCommand, () => {
         esbuild: { recorded: '0.29.0', rebuilt: '0.29.0' },
       });
 
-      await verifyCommand(['--rebuild']);
+      const { stdout } = await verify(['--rebuild']);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining('recorded esbuild and dependency versions match the rebuild'),
-      );
+      expect(stdout).toContain('recorded esbuild and dependency versions match the rebuild');
     });
 
     it('carries the esbuild comparison and dependency changes in the JSON payload', async () => {
@@ -509,9 +486,9 @@ describe(verifyCommand, () => {
         dependencyChanges: [{ name: 'zod', recorded: '3.24.1', rebuilt: '4.0.0' }],
       });
 
-      await verifyCommand(['--rebuild', '--json']);
+      const { stdout } = await verify(['--rebuild', '--json']);
 
-      const payload: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      const payload: unknown = JSON.parse(stdout);
       expect(payload).toMatchObject({
         kits: [
           {
@@ -526,9 +503,9 @@ describe(verifyCommand, () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'mismatch', expected: '1111aaaa', actual: '2222bbbb' });
 
-      await verifyCommand(['--rebuild', '--json']);
+      const { stdout } = await verify(['--rebuild', '--json']);
 
-      const payload = String(stdoutSpy.mock.calls.at(-1)?.[0]);
+      const payload = stdout;
       expect(payload).not.toContain('rebuildEsbuild');
       expect(payload).not.toContain('rebuildDependencyChanges');
     });
@@ -537,22 +514,20 @@ describe(verifyCommand, () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'failed', message: 'Unexpected token' });
 
-      const exitCode = await verifyCommand(['--rebuild']);
+      const { exitCode, stdout } = await verify(['--rebuild']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('rebuild failed (Unexpected token)'));
+      expect(stdout).toContain('rebuild failed (Unexpected token)');
     });
 
     it('fails a kit that cannot be rebuilt rather than waiving it', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'missing', reason: 'no source recorded in manifest' });
 
-      const exitCode = await verifyCommand(['--rebuild']);
+      const { exitCode, stdout } = await verify(['--rebuild']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining('cannot rebuild (no source recorded in manifest)'),
-      );
+      expect(stdout).toContain('cannot rebuild (no source recorded in manifest)');
     });
 
     it('states a passing rebuild beside a failing hash verdict, where it changes the reading', async () => {
@@ -565,20 +540,20 @@ describe(verifyCommand, () => {
       });
       mockCheckRebuild.mockResolvedValue({ kind: 'ok' });
 
-      const exitCode = await verifyCommand(['--rebuild']);
+      const { exitCode, stdout } = await verify(['--rebuild']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('drift (expected aaaa1111, got aaaa9999)'));
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('rebuild ok'));
+      expect(stdout).toContain('drift (expected aaaa1111, got aaaa9999)');
+      expect(stdout).toContain('rebuild ok');
     });
 
     it('carries the rebuild verdict and its hashes in the JSON payload', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'mismatch', expected: '1111aaaa', actual: '2222bbbb' });
 
-      await verifyCommand(['--rebuild', '--json']);
+      const { stdout } = await verify(['--rebuild', '--json']);
 
-      const payload: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      const payload: unknown = JSON.parse(stdout);
       expect(payload).toMatchObject({
         passed: false,
         kits: [{ name: 'alpha', rebuildStatus: 'mismatch', rebuildExpected: '1111aaaa', rebuildActual: '2222bbbb' }],
@@ -594,11 +569,11 @@ describe(verifyCommand, () => {
       mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
       mockCheckRebuild.mockResolvedValue({ kind: 'ok' });
 
-      const exitCode = await verifyCommand(['--rebuild']);
+      const { exitCode, stdout } = await verify(['--rebuild']);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} alpha`));
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('rebuild ok'));
+      expect(stdout).toContain(`${OK} alpha`);
+      expect(stdout).toContain('rebuild ok');
     });
 
     it('keeps the skip token on an unverified target the rebuild did not answer for', async () => {
@@ -608,10 +583,10 @@ describe(verifyCommand, () => {
       });
       mockCheckDrift.mockReturnValue({ kind: 'unverified' });
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode, stdout } = await verify([]);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${UNVERIFIED} alpha`));
+      expect(stdout).toContain(`${UNVERIFIED} alpha`);
     });
 
     it('carries the compiling version in the JSON payload when it differs from the runner', async () => {
@@ -623,9 +598,9 @@ describe(verifyCommand, () => {
         compiledWith: '0.0.1-old',
       });
 
-      await verifyCommand(['--rebuild', '--json']);
+      const { stdout } = await verify(['--rebuild', '--json']);
 
-      const payload: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      const payload: unknown = JSON.parse(stdout);
       expect(payload).toMatchObject({ kits: [{ rebuildCompiledWith: '0.0.1-old' }] });
     });
 
@@ -633,9 +608,9 @@ describe(verifyCommand, () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'mismatch', expected: '1111aaaa', actual: '2222bbbb' });
 
-      await verifyCommand(['--rebuild', '--json']);
+      const { stdout } = await verify(['--rebuild', '--json']);
 
-      const payload = String(stdoutSpy.mock.calls.at(-1)?.[0]);
+      const payload = stdout;
       expect(payload).not.toContain('rebuildCompiledWith');
     });
 
@@ -643,18 +618,18 @@ describe(verifyCommand, () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'failed', message: 'Unexpected token' });
 
-      await verifyCommand(['--rebuild', '--json']);
+      const { stdout } = await verify(['--rebuild', '--json']);
 
-      const payload: unknown = JSON.parse(String(stdoutSpy.mock.calls.at(-1)?.[0]));
+      const payload: unknown = JSON.parse(stdout);
       expect(payload).toMatchObject({ kits: [{ rebuildStatus: 'failed', rebuildError: 'Unexpected token' }] });
     });
 
     it('omits every rebuild field from the JSON payload without the flag', async () => {
       arrangeSingleKit();
 
-      await verifyCommand(['--json']);
+      const { stdout } = await verify(['--json']);
 
-      const payload = String(stdoutSpy.mock.calls.at(-1)?.[0]);
+      const payload = stdout;
       expect(payload).not.toContain('rebuild');
     });
 
@@ -662,7 +637,7 @@ describe(verifyCommand, () => {
       arrangeSingleKit();
       mockLoadEsbuild.mockRejectedValue(new Error('Cannot find module esbuild'));
 
-      const error = await captureError(RdyError, () => verifyCommand(['--rebuild']));
+      const { error } = await verifyRaising(['--rebuild']);
 
       expect(error.code).toBe('config');
       expect(error.message).toContain('pnpm add --save-dev esbuild');
@@ -672,17 +647,17 @@ describe(verifyCommand, () => {
       arrangeSingleKit();
       mockLoadEsbuild.mockRejectedValue(new Error('Cannot find module esbuild'));
 
-      await captureError(RdyError, () => verifyCommand(['--rebuild']));
+      const { stdout } = await verifyRaising(['--rebuild']);
 
       expect(mockReadManifest).not.toHaveBeenCalled();
-      expect(stdoutSpy).not.toHaveBeenCalled();
+      expect(stdout).toBe('');
     });
 
     it('verifies without esbuild when the flag is absent', async () => {
       arrangeSingleKit();
       mockLoadEsbuild.mockRejectedValue(new Error('Cannot find module esbuild'));
 
-      const exitCode = await verifyCommand([]);
+      const { exitCode } = await verify([]);
 
       expect(exitCode).toBe(0);
     });
@@ -700,26 +675,27 @@ describe(verifyCommand, () => {
     it.each(['\u{2705}', '\u{26A0}', '\u{2753}', '\u{2796}', '\u{FE0F}', '\u{2014}'])(
       'renders no %s for any verdict',
       async (retired) => {
+        const written: string[] = [];
         for (const verdict of verdicts) {
           mockReadManifest.mockReturnValue({
             version: 1,
             kits: [{ name: 'alpha', path: 'alpha.js', targetHash: 'aaaa1111', source: 'alpha.ts' }],
           });
           mockCheckDrift.mockReturnValue(verdict);
-          await verifyCommand([]);
+          const { stdout } = await verify([]);
+          written.push(stdout);
         }
 
-        const written = stdoutSpy.mock.calls.flat().join('\n');
-        expect(written).not.toContain(retired);
+        expect(written.join('\n')).not.toContain(retired);
       },
     );
 
     it('renders a section heading rather than a colon-terminated header', async () => {
       mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
-      await verifyCommand([]);
+      const { stdout } = await verify([]);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('\u{2500}\u{2500} Verifying kits against '));
+      expect(stdout).toContain('\u{2500}\u{2500} Verifying kits against ');
     });
 
     it('leaves a wholly verified kit carrying nothing beyond its token', async () => {
@@ -730,9 +706,31 @@ describe(verifyCommand, () => {
       mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
       mockCheckSourceDrift.mockReturnValue({ kind: 'ok', sourceHash: '5555aaaa' });
 
-      await verifyCommand([]);
+      const { stdout } = await verify([]);
 
-      expect(stdoutSpy).toHaveBeenCalledWith(`${OK} alpha\n`);
+      expect(stdout).toContain(`${OK} alpha\n`);
     });
   });
 });
+
+// region | Helpers
+
+/** Runs the command over the given arguments, returning its exit code alongside everything it wrote. */
+async function verify(args: string[]) {
+  using io = captureStdio();
+
+  const exitCode = await verifyCommand(args);
+
+  return { exitCode, stdout: io.stdout, stderr: io.stderr };
+}
+
+/** Runs the command expecting it to raise, returning the error alongside everything it wrote. */
+async function verifyRaising(args: string[]) {
+  using io = captureStdio();
+
+  const error = await captureError(RdyError, () => verifyCommand(args));
+
+  return { error, stdout: io.stdout, stderr: io.stderr };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
@@ -2,7 +2,8 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { richFormatter } from '../../layout/richFormatter.ts';
 import { VerifyOutputSchema } from '../../schemas/verifyOutputSchema.ts';
@@ -19,19 +20,10 @@ const FAILED = richFormatter.tokens.failedError.glyph;
 
 describe('verifyCommand wiring', () => {
   let tempDir: string;
-  let stdout: string[];
-  let stdoutSpy: MockInstance;
-  let stderrSpy: MockInstance;
   let originalCwd: string;
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'verify-integ-'));
-    stdout = [];
-    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
-      stdout.push(String(chunk));
-      return true;
-    });
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     originalCwd = process.cwd();
     process.chdir(tempDir);
   });
@@ -54,11 +46,11 @@ describe('verifyCommand wiring', () => {
       }),
     );
 
-    const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+    const { exitCode, stdout, stderr } = await verify(['--manifest', 'manifest.json']);
 
     expect(exitCode).toBe(0);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
-    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(stdout).toContain(`${OK} demo`);
+    expect(stderr).toBe('');
   });
 
   it('returns 1 and reports drift when on-disk compiled kit differs from manifest targetHash', async () => {
@@ -72,11 +64,11 @@ describe('verifyCommand wiring', () => {
       }),
     );
 
-    const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+    const { exitCode, stdout } = await verify(['--manifest', 'manifest.json']);
 
     expect(exitCode).toBe(1);
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} demo\n   drift`));
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('expected deadbeef'));
+    expect(stdout).toContain(`${FAILED} demo\n   drift`);
+    expect(stdout).toContain('expected deadbeef');
   });
 
   describe('source staleness', () => {
@@ -113,30 +105,30 @@ describe('verifyCommand wiring', () => {
     it('returns 0 when both the source and the compiled kit match the manifest', async () => {
       writeCompiledPair();
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
+      expect(stdout).toContain(`${OK} demo`);
     });
 
     it('returns 1 when the source was edited without a recompile', async () => {
       const sourcePath = writeCompiledPair();
       writeFileSync(sourcePath, 'export default defineRdyKit({ checklists: [], failOn: "warn" });\n');
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} demo\n   source stale`));
+      expect(stdout).toContain(`${FAILED} demo\n   source stale`);
     });
 
     it('returns 1 when the recorded source was deleted', async () => {
       const sourcePath = writeCompiledPair();
       rmSync(sourcePath);
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${FAILED} demo\n   source file missing`));
+      expect(stdout).toContain(`${FAILED} demo\n   source file missing`);
     });
 
     it('carries both source hashes in the JSON entry for a stale kit', async () => {
@@ -144,9 +136,9 @@ describe('verifyCommand wiring', () => {
       const edited = Buffer.from('export default defineRdyKit({ checklists: [], failOn: "warn" });\n');
       writeFileSync(sourcePath, edited);
 
-      await verifyCommand(['--manifest', 'manifest.json', '--json']);
+      const { stdout } = await verify(['--manifest', 'manifest.json', '--json']);
 
-      expect(JSON.parse(stdout.join(''))).toMatchObject({
+      expect(JSON.parse(stdout)).toMatchObject({
         passed: false,
         kits: [
           {
@@ -206,44 +198,40 @@ describe('verifyCommand wiring', () => {
     it('returns 0 when every file the compile read still matches', async () => {
       writeRecordedClosure();
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
+      expect(stdout).toContain(`${OK} demo`);
     });
 
     it('returns 1 when a module the bundle inlined was edited without a recompile', async () => {
       writeRecordedClosure();
       writeFileSync(path.join(tempDir, 'shared.ts'), 'export const shared = 2;\n');
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`${FAILED} demo\n   input stale: shared.ts (module`),
-      );
+      expect(stdout).toContain(`${FAILED} demo\n   input stale: shared.ts (module`);
     });
 
     it('returns 1 when the version the kit pinned to has moved', async () => {
       writeRecordedClosure();
       writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ ...PACKAGE_JSON, version: '4.0.0' }));
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(1);
-      expect(stdoutSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`${FAILED} demo\n   input stale: package.json (inline`),
-      );
+      expect(stdout).toContain(`${FAILED} demo\n   input stale: package.json (inline`);
     });
 
     it('returns 0 when a field the kit did not pick was edited', async () => {
       writeRecordedClosure();
       writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ ...PACKAGE_JSON, name: 'renamed' }));
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json']);
 
       expect(exitCode).toBe(0);
-      expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} demo`));
+      expect(stdout).toContain(`${OK} demo`);
     });
 
     it('carries the axis and every failure into the JSON entry, at the schema version it always emitted', async () => {
@@ -251,9 +239,9 @@ describe('verifyCommand wiring', () => {
       writeFileSync(path.join(tempDir, 'shared.ts'), 'export const shared = 2;\n');
       writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'demo' }));
 
-      await verifyCommand(['--manifest', 'manifest.json', '--json']);
+      const { stdout } = await verify(['--manifest', 'manifest.json', '--json']);
 
-      expect(VerifyOutputSchema.parse(JSON.parse(stdout.join('')))).toMatchObject({
+      expect(VerifyOutputSchema.parse(JSON.parse(stdout))).toMatchObject({
         schemaVersion: 1,
         passed: false,
         kits: [
@@ -298,10 +286,10 @@ describe('verifyCommand wiring', () => {
     it('reports every kit status with the hashes only a drift verdict compared', async () => {
       writeMixedManifest();
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json', '--json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json', '--json']);
 
       expect(exitCode).toBe(1);
-      expect(JSON.parse(stdout.join(''))).toStrictEqual({
+      expect(JSON.parse(stdout)).toStrictEqual({
         schemaVersion: 1,
         passed: false,
         kits: [
@@ -323,10 +311,10 @@ describe('verifyCommand wiring', () => {
     it('emits exactly one JSON document and sends the per-kit prose to stderr', async () => {
       writeMixedManifest();
 
-      await verifyCommand(['--manifest', 'manifest.json', '--json']);
+      const { stdoutChunks, stderr } = await verify(['--manifest', 'manifest.json', '--json']);
 
-      expect(stdoutSpy).toHaveBeenCalledTimes(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`${OK} clean`));
+      expect(stdoutChunks).toHaveLength(1);
+      expect(stderr).toContain(`${OK} clean`);
     });
 
     it('passes when every kit is ok or unverified', async () => {
@@ -343,19 +331,32 @@ describe('verifyCommand wiring', () => {
         }),
       );
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json', '--json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json', '--json']);
 
       expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout.join(''))).toMatchObject({ passed: true });
+      expect(JSON.parse(stdout)).toMatchObject({ passed: true });
     });
 
     it('reports an empty manifest as a passing run with no kits', async () => {
       writeFileSync(path.join(tempDir, 'manifest.json'), JSON.stringify({ version: 1, kits: [] }));
 
-      const exitCode = await verifyCommand(['--manifest', 'manifest.json', '--json']);
+      const { exitCode, stdout } = await verify(['--manifest', 'manifest.json', '--json']);
 
       expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout.join(''))).toStrictEqual({ schemaVersion: 1, passed: true, kits: [] });
+      expect(JSON.parse(stdout)).toStrictEqual({ schemaVersion: 1, passed: true, kits: [] });
     });
   });
 });
+
+// region | Helpers
+
+/** Runs the command over the given arguments, returning its exit code alongside everything it wrote. */
+async function verify(args: string[]) {
+  using io = captureStdio();
+
+  const exitCode = await verifyCommand(args);
+
+  return { exitCode, stdout: io.stdout, stdoutChunks: io.stdoutChunks, stderr: io.stderr };
+}
+
+// endregion | Helpers


### PR DESCRIPTION
## What

Completes the adoption of `captureStdio` from `@williamthorsen/toolbelt.testing` for stdio capture in tests, eliminating all remaining uses of `process.stdout` and `process.stderr` write spies.

## Why

Spy-based capture spread the same scaffolding across every suite: a `beforeEach` registration, a `MockInstance` field, and a hand-rolled helper to join the writes back into a string, duplicated fourteen times over. Reading `spy.mock.calls` also tied assertions to how output happened to be chunked, so a test about what the user sees could break on a change to how that text was written out.

## Details

### 🧪 Tests

Capture folds into a per-file call wrapper wherever a suite's tests share a call shape, which is the common case here: most of these suites differ test to test only in the arguments passed to one command. The wrappers are `route`, `compile`, `list`, `verify`, `run`, `warn`, and `discover`, each opening `using io = captureStdio()` and returning the call's own result alongside the captured streams. Suites with error-path tests that run through `captureError` gain a `*Raising` sibling. Three suites (`runHumanMode`, `runJsonMode`, `discoverKitProjects`) fold capture into wrappers they already had.

Assertion translation follows one rule per shape: `toHaveBeenCalledWith(expect.stringContaining(x))` becomes `toContain(x)`, `not.toHaveBeenCalled()` becomes `toBe('')`, and reads of `spy.mock.calls.at(-1)` on `--json` paths become reads of the whole stream. Two translations change what is asserted rather than how. `toContain` on the joined stream also matches a substring spanning two writes, which the per-write form missed. And of the fifteen sites asserting one exact write, seven were the whole stream and tighten to `toBe`, while eight were one line among several and loosen to `toContain`.

Ten assertions stay on the chunk arrays because write boundaries are what they claim: eight counts, now `expect(io.stdoutChunks).toHaveLength(n)`, and two full call-list comparisons, now `toStrictEqual` against `stderrChunks` — `listCommand.unit`'s warning-plus-hint pair and `route.unit`'s plain-style equivalent.

`verifyCommand.rebuild.tool.test.ts`'s no-flag test moves onto the shared `runVerify` wrapper, which gains a `rebuild` option to reach the flagless path under capture. `verifyCommand.unit.test.ts`'s retired-glyph loop accumulates per-iteration output into a local array, since the single spy it replaced accumulated across the whole loop on its own.

The files: `bin/route.unit`, `compile/compileCommand.unit`, `list/listCommand.{from,recursive,wiring}.unit` and `list/listCommand.unit`, `projects/discoverKitProjects.unit`, `run/{kit-staleness,packagesRun.wiring,runHumanMode,runJsonMode}.unit`, and `verify/verifyCommand.{unit,wiring.unit,rebuild.tool}`.


Closes #336
