### PR TITLE
#216 Test the genericity claims against a second consumer's vocabulary

### DIFF
--- a/packages/compositor/README.md
+++ b/packages/compositor/README.md
@@ -4,6 +4,8 @@ Content-agnostic engine that resolves declaratively opted-in content across prec
 
 Private and unreleased: the name is provisional. What ships today is the plan schema, the contract the engine's output satisfies, and the flows built against it: the config model, source resolution, selection, the dependency closure, the mechanisms that own part of a destination and overlay a target's metadata, the per-target transform pipeline that renders one artifact's content, the snapshot that gathers all of it, the composition that turns a snapshot into a plan, the apply that writes one to a destination, and the validation that reports what a config and its content get wrong. Entries ownership is the one mechanism no flow routes content to yet. The requirements it is built to are tracked in [issue #158](https://github.com/williamthorsen/workshop/issues/158).
 
+Content-agnostic is a testable claim, and `src/__tests__/genericity.unit.test.ts` is where it is tested: it composes and applies a second consumer whose content format, comment syntax, token delimiter, link grammar, and deployed layout all differ from the vocabulary the rest of the suite is written in.
+
 ## Config
 
 A config is a list of tiers, lowest precedence first, the order a fold applies them. Each tier declares the sources it adds or drops, and per artifact kind the artifacts it uses or drops. `loadConfig` reads one file per tier, but files are one way to obtain a config rather than the only one: what it returns is the same shape a caller can build in memory and hand straight to the flows downstream, which is what lets an edited config be evaluated without touching disk.

--- a/packages/compositor/src/__tests__/genericity.unit.test.ts
+++ b/packages/compositor/src/__tests__/genericity.unit.test.ts
@@ -1,0 +1,109 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import type { ApplyOutcome } from '../apply/ApplyOutcome.ts';
+import { applyPlan } from '../apply/applyPlan.ts';
+import { composePlan } from '../plan/composePlan.ts';
+import { readDirNames } from '../portable/readDirNames.ts';
+import {
+  captureGenericityComposition,
+  CONTRACT_HOST_PATH,
+  RATES_PDF_BYTES,
+  REGION_MARKERS,
+} from '../test-utils/genericity-fixture.ts';
+
+const EXHIBIT_ENTRY = 'exhibits/schedule-of-fees/EXHIBIT.adoc';
+const INDEMNITY = 'articles/clause-indemnity.adoc';
+
+describe('a second consumer', () => {
+  it('expands a directive written behind a line comment, the close no fixture beside this one exercises', async () => {
+    const { targetRoot } = await composeAndApply();
+
+    await expect(readFile(path.join(targetRoot, INDEMNITY), 'utf8')).resolves.toContain(
+      'NOTE: This clause is a standard-form provision.',
+    );
+  });
+
+  it('renders a referent token behind its own delimiter as the name the artifact deploys under', async () => {
+    const { targetRoot } = await composeAndApply();
+
+    await expect(readFile(path.join(targetRoot, CONTRACT_HOST_PATH), 'utf8')).resolves.toContain(
+      '§clause-governing-law',
+    );
+  });
+
+  it('renders a mapping token behind its own delimiter as the name the target maps it to', async () => {
+    const { targetRoot } = await composeAndApply();
+
+    const body = await readFile(path.join(targetRoot, INDEMNITY), 'utf8');
+
+    expect(body).toContain('The Supplier shall indemnify');
+    expect(body).not.toContain('Vendor');
+  });
+
+  it('rewrites a link written in its own grammar to the path its target deploys at', async () => {
+    const { targetRoot } = await composeAndApply();
+
+    await expect(readFile(path.join(targetRoot, INDEMNITY), 'utf8')).resolves.toContain(
+      `xref:${targetRoot}/${EXHIBIT_ENTRY}[the fee schedule]`,
+    );
+  });
+
+  it('deploys a kind under the target’s layout and name template, never the layout its source holds it in', async () => {
+    const { outcome, targetRoot } = await composeAndApply();
+
+    expect(outcome.files.map(({ path: filePath }) => filePath)).toContain(INDEMNITY);
+    await expect(readDirNames(targetRoot)).resolves.not.toContain('clauses');
+  });
+
+  it('aggregates a routed kind into its host behind its own markers', async () => {
+    const { targetRoot } = await composeAndApply();
+
+    const host = await readFile(path.join(targetRoot, CONTRACT_HOST_PATH), 'utf8');
+
+    expect(host).toContain(REGION_MARKERS.open);
+    expect(host).toContain('// tag::definition:affiliate[]');
+    expect(host).toContain('Affiliate: any entity controlling the Supplier');
+  });
+
+  it('copies an asset an artifact ships beside its entry file, byte for byte', async () => {
+    const { targetRoot } = await composeAndApply();
+
+    const copied = await readFile(path.join(targetRoot, 'exhibits/schedule-of-fees/rates.pdf'));
+
+    expect(Uint8Array.from(copied)).toStrictEqual(RATES_PDF_BYTES);
+  });
+
+  it('reaches an artifact no tier named, through a referent token behind its own delimiter', async () => {
+    const { outcome, targetRoot } = await composeAndApply();
+
+    expect(outcome.files.map(({ path: filePath }) => filePath)).toContain('articles/clause-governing-law.adoc');
+    await expect(readFile(path.join(targetRoot, 'articles/clause-governing-law.adoc'), 'utf8')).resolves.toContain(
+      '= Governing law',
+    );
+  });
+
+  it('finds nothing to do the second time, the destination already holding what was planned', async () => {
+    const { config, snapshot, targetRoot } = await captureGenericityComposition();
+    const plan = composePlan(config, snapshot);
+
+    await applyPlan(plan, { baseDir: targetRoot });
+    const second = await applyPlan(plan, { baseDir: targetRoot });
+
+    expect(second.files.map(({ action }) => action)).toStrictEqual(second.files.map(() => 'unchanged'));
+  });
+});
+
+// region | Helpers
+
+/** Composes the fixture’s plan and applies it, returning the outcome beside the root it was written into. */
+async function composeAndApply(): Promise<{ outcome: ApplyOutcome; targetRoot: string }> {
+  const { config, snapshot, targetRoot } = await captureGenericityComposition();
+  const outcome = await applyPlan(composePlan(config, snapshot), { baseDir: targetRoot });
+
+  return { outcome, targetRoot };
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/test-utils/genericity-fixture.ts
+++ b/packages/compositor/src/test-utils/genericity-fixture.ts
@@ -1,0 +1,215 @@
+/**
+ * A second consumer, declared to falsify the claim that this package's mechanisms are generic.
+ *
+ * Every mechanism reads its vocabulary from a declaration, and the rest of the suite declares one consumer's: Markdown
+ * bodies, `<!-- -->` directives, `{kind:name}` tokens, Markdown links, and skill-shaped layouts. A suite written in one
+ * vocabulary can show a mechanism works; it cannot show the mechanism is general. This is the control -- a legal clause
+ * library in AsciiDoc, differing from `composition-fixture.ts` in every dimension where a compiled-in assumption could
+ * hide. Nothing here is to be normalized toward the vocabulary beside it: folding a declaration back toward Markdown,
+ * brace tokens, or a skill-shaped layout destroys what the fixture exists to prove.
+ *
+ * It shares no declaration and no capture path with `composition-fixture.ts` and `captureComposition.ts`. Reaching the
+ * pipeline through those would inherit their defaults, and a default silently inherited is the assumption this fixture
+ * exists to have none of.
+ *
+ * The three kinds are the ones bearing a genericity claim. The guidance fixture's other structural cases -- an
+ * aggregate emitting no files, a kind no target deploys -- bear none, and mirroring its structure would make this a
+ * translation of that fixture rather than an independent consumer.
+ *
+ * No frontmatter stage is declared. `mergeFrontmatter` emits a `---`-fenced YAML block by construction, writing one
+ * onto content that carried none, so the stage serves formats carrying such a header and AsciiDoc is not one. That is
+ * where the genericity claim stops, rather than a gap in the coverage of it.
+ */
+
+import type { ArtifactRead, EdgeContribution } from '../closure/EdgeContributor.ts';
+import type { ResolveKind } from '../schemas/catalog-schemas.ts';
+import type { CompositorConfig } from '../schemas/config-schemas.ts';
+import type { MarkerPair, RenderTarget } from '../schemas/render-target-schemas.ts';
+import type { TokenKind } from '../schemas/token-kind-schemas.ts';
+import type { CompositionSnapshot } from '../snapshot/captureSnapshot.ts';
+import { captureSnapshot } from '../snapshot/captureSnapshot.ts';
+import { extractTokenEdges } from '../tokens/extractTokenEdges.ts';
+import { buildConfig } from './buildConfig.ts';
+import { buildTempTree } from './buildTempTree.ts';
+
+/** Builds the source tree the fixture composes over, fresh so that a test may add to it or take from it. */
+export function buildGenericitySourceFiles(): Record<string, string | Uint8Array> {
+  return {
+    'clauses/governing-law.adoc': '= Governing law\n\nThe laws of the stated jurisdiction govern this agreement.\n',
+    'clauses/indemnity.adoc': [
+      '= Indemnity',
+      '',
+      '// include: ../partials/notice.adoc /',
+      '',
+      'The <<party:Vendor>> shall indemnify the Customer.',
+      '',
+      'See xref:../exhibits/schedule-of-fees/EXHIBIT.adoc[the fee schedule].',
+      '',
+    ].join('\n'),
+    'definitions/affiliate.adoc':
+      'Affiliate: any entity controlling the <<party:Vendor>>, as qualified by <<clause:governing-law>>.\n',
+    'exhibits/schedule-of-fees/EXHIBIT.adoc': '= Schedule of fees\n\nFees are stated in the attached rates table.\n',
+    'exhibits/schedule-of-fees/rates.pdf': RATES_PDF_BYTES,
+    'partials/notice.adoc': 'NOTE: This clause is a standard-form provision.\n',
+  };
+}
+
+/**
+ * Builds the jurisdiction the fixture deploys into: clauses as named files, definitions aggregated into one region.
+ *
+ * The clause deployment is rooted at `articles` while the source roots the kind at `clauses`, so a layout read from the
+ * source rather than from the target's own declaration lands the file in the wrong tree.
+ */
+export function buildJurisdictionTarget(targetRoot: string): RenderTarget {
+  return {
+    id: 'de',
+    label: 'Germany',
+    root: targetRoot,
+    tokenMappings: [
+      { kindId: 'clause-reference', entries: [], sigil: '§' },
+      { kindId: 'party', entries: [{ from: 'Vendor', to: 'Supplier' }] },
+    ],
+    deployments: [
+      {
+        form: 'tree',
+        kindId: 'clause',
+        layout: { form: 'file', root: 'articles', extension: '.adoc' },
+        nameTemplate: 'clause-{slug}',
+      },
+      {
+        form: 'region',
+        kindId: 'definition',
+        host: CONTRACT_HOST_PATH,
+        markers: REGION_MARKERS,
+        contributionMarkers: CONTRIBUTION_MARKERS,
+      },
+      { form: 'tree', kindId: 'exhibit', layout: { form: 'directory', root: 'exhibits', entryFile: 'EXHIBIT.adoc' } },
+    ],
+    stages: [
+      { kind: 'transclusion', syntax: { open: '//', close: '' } },
+      { kind: 'tokens' },
+      { kind: 'links', pattern: String.raw`xref:([^\[]+)\[` },
+    ],
+  };
+}
+
+/**
+ * Captures a composition over a temporary source tree and destination root, both removed when the test ends.
+ *
+ * Only the `indemnity` clause is selected. The other clause is reached through the referent token a definition carries,
+ * so a closure that failed to read a token behind this consumer's delimiter would leave it out of the composition.
+ */
+export async function captureGenericityComposition(): Promise<GenericityFixture> {
+  const sourceDir = await buildTempTree(buildGenericitySourceFiles(), 'compositor-clauses');
+  const targetRoot = await buildTempTree({ '.keep': '' }, 'compositor-jurisdiction');
+
+  const config = buildConfig([
+    {
+      id: 'firm',
+      sources: { use: [{ name: 'firm', path: sourceDir }] },
+      select: {
+        clause: { use: ['indemnity'] },
+        definition: { use: [{ source: 'firm' }] },
+        exhibit: { use: [{ source: 'firm' }] },
+      },
+    },
+  ]);
+
+  const snapshot = await captureSnapshot({
+    config,
+    baseDir: targetRoot,
+    kinds: GENERICITY_KINDS,
+    targets: [buildJurisdictionTarget(targetRoot)],
+    tokenKinds: GENERICITY_TOKEN_KINDS,
+    edgeRules: [],
+    kindKeys: {},
+    contributeEdges: contributeTokenEdges,
+    contentKeyPath: ['contracts', 'content'],
+  });
+
+  return { config, snapshot, sourceDir, targetRoot };
+}
+
+/** The path of the host the fixture's definitions aggregate into. */
+export const CONTRACT_HOST_PATH = 'master-agreement.adoc';
+
+/** The markers delimiting one contributor's block within the fixture's host, in AsciiDoc's tagged-region syntax. */
+export const CONTRIBUTION_MARKERS: MarkerPair = {
+  open: '// tag::{artifactId}[]',
+  close: '// end::{artifactId}[]',
+};
+
+/**
+ * The kinds the fixture is written against, each bearing a claim that a mechanism reads its vocabulary declaratively.
+ *
+ * `clause` is one file per artifact and deploys under a name template; `definition` routes into a shared host; and
+ * `exhibit` is a directory per artifact, so it ships an asset beside the entry file carrying its body.
+ */
+export const GENERICITY_KINDS: ReadonlyArray<ResolveKind> = [
+  {
+    id: 'clause',
+    label: 'Clause',
+    emitsFiles: true,
+    layout: { form: 'file', root: 'clauses', extension: '.adoc' },
+  },
+  {
+    id: 'definition',
+    label: 'Definition',
+    emitsFiles: true,
+    layout: { form: 'file', root: 'definitions', extension: '.adoc' },
+  },
+  {
+    id: 'exhibit',
+    label: 'Exhibit',
+    emitsFiles: true,
+    layout: { form: 'directory', root: 'exhibits', entryFile: 'EXHIBIT.adoc' },
+  },
+];
+
+/**
+ * The token kinds the fixture declares, in both forms and neither brace-delimited.
+ *
+ * `clause-reference` resolves to the name its clause deploys under, and `party` resolves through the target's own
+ * mapping table.
+ */
+export const GENERICITY_TOKEN_KINDS: ReadonlyArray<TokenKind> = [
+  {
+    id: 'clause-reference',
+    label: 'Clause reference',
+    form: 'referent',
+    pattern: String.raw`<<clause:([a-z][a-z0-9-]*)>>`,
+    artifactKindId: 'clause',
+  },
+  { id: 'party', label: 'Party', form: 'mapping', pattern: String.raw`<<party:(\w+)>>` },
+];
+
+/** A captured composition, with the config it answers and the directories it was captured over. */
+export interface GenericityFixture {
+  readonly config: CompositorConfig;
+  readonly snapshot: CompositionSnapshot;
+  readonly sourceDir: string;
+  readonly targetRoot: string;
+}
+
+/** A PDF signature, standing in for an asset an exhibit ships and no target transforms. */
+export const RATES_PDF_BYTES = Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]);
+
+/** The markers fencing the span the engine owns within the fixture's host. */
+export const REGION_MARKERS: MarkerPair = {
+  open: '// tag::contract-engine[]',
+  close: '// end::contract-engine[]',
+};
+
+// region | Helpers
+
+/**
+ * Contributes the closure edges an artifact's own body declares through its referent tokens.
+ *
+ * The body is read as written rather than expanded first: what carries a genericity claim is the declared pattern, not
+ * the attribution of an edge to the partial it arrived through.
+ */
+function contributeTokenEdges(read: ArtifactRead): EdgeContribution {
+  return { edges: extractTokenEdges([{ lines: read.content.split('\n') }], GENERICITY_TOKEN_KINDS), partials: [] };
+}
+
+// endregion | Helpers

--- a/packages/compositor/src/test-utils/genericity-fixture.ts
+++ b/packages/compositor/src/test-utils/genericity-fixture.ts
@@ -16,9 +16,11 @@
  * aggregate emitting no files, a kind no target deploys -- bear none, and mirroring its structure would make this a
  * translation of that fixture rather than an independent consumer.
  *
- * No frontmatter stage is declared. `mergeFrontmatter` emits a `---`-fenced YAML block by construction, writing one
- * onto content that carried none, so the stage serves formats carrying such a header and AsciiDoc is not one. That is
- * where the genericity claim stops, rather than a gap in the coverage of it.
+ * No frontmatter stage is declared, and `edgeRules` is empty for the same reason. `mergeFrontmatter` emits a
+ * `---`-fenced YAML block by construction, and `readFrontmatterEdges` reads its declarations through
+ * `parseFrontmatter`, which finds a block only where the content opens with that delimiter. Both mechanisms serve
+ * formats carrying such a header, and AsciiDoc is not one. That is where the genericity claim stops, rather than a
+ * gap in the coverage of it.
  */
 
 import type { ArtifactRead, EdgeContribution } from '../closure/EdgeContributor.ts';
@@ -32,7 +34,7 @@ import { extractTokenEdges } from '../tokens/extractTokenEdges.ts';
 import { buildConfig } from './buildConfig.ts';
 import { buildTempTree } from './buildTempTree.ts';
 
-/** Builds the source tree the fixture composes over, fresh so that a test may add to it or take from it. */
+/** Builds the source tree the fixture composes over. */
 export function buildGenericitySourceFiles(): Record<string, string | Uint8Array> {
   return {
     'clauses/governing-law.adoc': '= Governing law\n\nThe laws of the stated jurisdiction govern this agreement.\n',
@@ -177,7 +179,7 @@ export const GENERICITY_TOKEN_KINDS: ReadonlyArray<TokenKind> = [
     id: 'clause-reference',
     label: 'Clause reference',
     form: 'referent',
-    pattern: String.raw`<<clause:([a-z][a-z0-9-]*)>>`,
+    pattern: '<<clause:([a-z][a-z0-9-]*)>>',
     artifactKindId: 'clause',
   },
   { id: 'party', label: 'Party', form: 'mapping', pattern: String.raw`<<party:(\w+)>>` },


### PR DESCRIPTION
## What

Adds a `genericity-fixture.ts` to serve as a hypothetical consumer of `compositor` that is unlike the other content previously tested as the only consumer. A test suite verifies that the `compositor` handles this dissimilar content correctly, checking for correct handling of such features as line-comment directives, `<<label:...>>` tokens, and templating. A feature hard-coded in `compositor` instead of read from the consumer's declaration fails this suite, where the existing pipeline tests would not notice it.

## Why

Every mechanism the package ships claims to be generic, and no test could contradict the claim. The suite is written in one consumer's vocabulary throughout -- skills, rulebooks, `~/.claude`, `SKILL.md` -- so a mechanism carrying its vocabulary compiled in would pass every test beside it. That monoculture has hidden a gap before: until #208 closed it, every destination fixture was rooted at a home-relative path, so a destination at an ordinary directory went unexercised end to end with nothing to say so.

## Details

### 🧪 Tests

- `genericity-fixture.ts` declares three kinds (`clause`, `definition`, `exhibit`), one jurisdiction target, two token kinds covering both the referent and the mapping form, and an edge contributor that reads referent tokens out of an artifact's own body. `captureGenericityComposition()` builds a temporary source tree and destination root and captures a snapshot over them.
- The fixture shares no declaration and no capture path with `composition-fixture.ts` or `captureComposition.ts`, reaching only the vocabulary-free `buildConfig` and `buildTempTree`. A default inherited from the guidance fixture would be the untested assumption this fixture exists to have none of.
- Every dimension where a compiled-in assumption could hide differs from the guidance fixtures: the `.adoc` content format, the `{open: '//', close: ''}` directive syntax, the `<<...>>` token delimiter in both forms, the `xref:([^\[]+)\[` link grammar, the `clause-{slug}` name template, and a target layout rooted at `articles` where the source roots the kind at `clauses`.
- Three seams reach the pipeline for the first time in any vocabulary: the `tokens` and `links` stages, which until now were exercised only by `renderArtifact`'s own tests; the `contributeEdges` seam, which the guidance fixture passes nothing for; and the empty-close branch of the directive grammar.
- Each of the eight assertions is keyed to one mechanism, so a compiled-in assumption names itself in the failure. The closure assertion is the indirect one: only `indemnity` is selected, and `clause-governing-law` reaches the destination solely because a definition's `<<clause:governing-law>>` was read through the declared pattern.
- The module records where the genericity claim stops. No `frontmatter` stage is declared and `edgeRules` is empty, both because `mergeFrontmatter` emits a `---`-fenced block by construction and `readFrontmatterEdges` reads its declarations through `parseFrontmatter`, which finds a block only where the content opens with that delimiter.

### 📚 Documentation

- The `compositor` README's opening paragraph names `src/__tests__/genericity.unit.test.ts` and enumerates the dimensions the fixture varies, so a reader of any genericity claim further down the page can find the evidence for it.

Closes #216

