### PR TITLE
#330 Add adoption-kit support to `check-utils`

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1215,7 +1215,7 @@ function isSource(path: string): boolean {
 const check = {
   name: 'No source defines its own description helper',
   // The sweep is cached, so the skip and the check share one pass over the project.
-  skip: async () => (await readTrackedSources(isSource)) === undefined && 'the project is not a git working tree',
+  skip: async () => (await readTrackedSources(isSource)) === undefined && 'The project is not a git working tree',
   check: async () => {
     const sources = (await readTrackedSources(isSource)) ?? [];
     const findings = sources.flatMap(listHandRolledSites);

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1193,7 +1193,7 @@ It answers best effort: a project manifest it cannot read or parse yields `[]`. 
 | `countPackageUsage(sources, options)` | Calls into a package, counted only where the source imports it |
 | `buildFindingReport(options)`         | A `CheckOutcome` naming located findings, with a fraction      |
 
-These four are what an adoption kit needs -- one reporting where a project hand-rolls what a package it already installed provides. Both readers answer `undefined` outside a git working tree, which an empty list does not say: a project that cannot be swept is a different answer from one that was swept and holds nothing.
+These four are what an adoption kit needs -- one reporting where a project hand-rolls what a package it already installed provides. Both readers return `undefined` outside a git working tree, which an empty list does not say: a project that cannot be swept is a different answer from one that was swept and holds nothing.
 
 `listTrackedFiles` lists with `git ls-files -z`. The `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in quotes, and that file drops out of the sweep unreported. Below the repo root git emits paths relative to `cwd` and limited to that subtree, the same scope `readFile` works in. The sweep therefore follows the project `rdy` was invoked in, never the repository a kit was loaded from.
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1184,6 +1184,37 @@ const missing = discoverKitPackages().filter((name) => !configuredPackages.inclu
 
 It answers best effort: a project manifest it cannot read or parse yields `[]`. An empty result therefore does not distinguish a project with no kit-publishing dependencies from one whose manifest could not be read, which a check treating the result as authoritative would report as a pass either way.
 
+### Project sources
+
+| Function                              | Returns                                                        |
+| ------------------------------------- | -------------------------------------------------------------- |
+| `listTrackedFiles()`                  | Paths git tracks under `cwd`                                   |
+| `readTrackedSources(filter?)`         | `{ path, text }` for each tracked path the filter selects      |
+| `countPackageUsage(sources, options)` | Calls into a package, counted only where the source imports it |
+| `buildFindingReport(report)`          | A `CheckOutcome` naming located findings, with a fraction      |
+
+These four are what an adoption kit needs -- one reporting where a project hand-rolls what a package it already installed provides. Both readers answer `undefined` outside a git working tree, which an empty list does not say: a project that cannot be swept is a different answer from one that was swept and holds nothing.
+
+`listTrackedFiles` lists with `git ls-files -z`. The `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in quotes, and that file drops out of the sweep unreported. Below the repo root git emits paths relative to `cwd` and limited to that subtree, which is the scope `readFile` and `rdy run --from <other-repo>` already work in.
+
+`readTrackedSources` applies its filter before any read, so a caller never pays for a file it excluded, and holds what it read for the life of the process. A file two kits both select costs one read between them, and each pays only for the remainder the other did not ask for. That cache lives here rather than in a kit because a compiled kit leaves its `readyup` imports unbundled, making `check-utils` one module instance across every kit of a run; a cache inside a bundled helper would be one per bundle. Listings are held the same way and are shared by checks that start together, which the runner does. The sweep never reads `node_modules/` or `.readyup/kits/*.js` whatever the filter answers for them -- the latter is readyup's own generated artifact, and sweeping it would report a kit's bundled source back to its author. A caller wanting further exclusions applies them in its own filter.
+
+`countPackageUsage` counts calls to the named exports and counts none in a source that never imports the package, from its root or any subpath. The import is what separates adoption from a name collision: a project hand-rolling its own `describeError` calls that name as often as an adopter calls the real one.
+
+`buildFindingReport` takes every finding the project holds plus a predicate selecting the ones the calling check reports, and names each selected finding as `symbol (path:line)`, or `path:line` where it declares no symbol. Its fraction is derived from every finding passed rather than only the reported ones, so the checks of one run share a denominator the reader can compare across them.
+
+```ts
+import { buildFindingReport, countPackageUsage, readTrackedSources } from 'readyup/check-utils';
+
+const sources = await readTrackedSources((path) => /\.[cm]?[jt]sx?$/.test(path));
+if (sources === undefined) return { ok: true };
+
+const findings = sources.flatMap(listHandRolledSites);
+const adoptedCount = countPackageUsage(sources, { exportNames: ['describeError'], packageName: '@scope/errors' });
+
+return buildFindingReport({ adoptedCount, findings, shouldReport: (finding) => finding.kind === 'clone' });
+```
+
 ## Compatibility
 
 `readyup/check-utils` is the stable, versioned surface for kit-author imports. It follows semver: no breaking changes within a major version.

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1191,28 +1191,39 @@ It answers best effort: a project manifest it cannot read or parse yields `[]`. 
 | `listTrackedFiles()`                  | Paths git tracks under `cwd`                                   |
 | `readTrackedSources(filter?)`         | `{ path, text }` for each tracked path the filter selects      |
 | `countPackageUsage(sources, options)` | Calls into a package, counted only where the source imports it |
-| `buildFindingReport(report)`          | A `CheckOutcome` naming located findings, with a fraction      |
+| `buildFindingReport(options)`         | A `CheckOutcome` naming located findings, with a fraction      |
 
 These four are what an adoption kit needs -- one reporting where a project hand-rolls what a package it already installed provides. Both readers answer `undefined` outside a git working tree, which an empty list does not say: a project that cannot be swept is a different answer from one that was swept and holds nothing.
 
-`listTrackedFiles` lists with `git ls-files -z`. The `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in quotes, and that file drops out of the sweep unreported. Below the repo root git emits paths relative to `cwd` and limited to that subtree, which is the scope `readFile` and `rdy run --from <other-repo>` already work in.
+`listTrackedFiles` lists with `git ls-files -z`. The `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in quotes, and that file drops out of the sweep unreported. Below the repo root git emits paths relative to `cwd` and limited to that subtree, the same scope `readFile` works in. The sweep therefore follows the project `rdy` was invoked in, never the repository a kit was loaded from.
 
-`readTrackedSources` applies its filter before any read, so a caller never pays for a file it excluded, and holds what it read for the life of the process. A file two kits both select costs one read between them, and each pays only for the remainder the other did not ask for. That cache lives here rather than in a kit because a compiled kit leaves its `readyup` imports unbundled, making `check-utils` one module instance across every kit of a run; a cache inside a bundled helper would be one per bundle. Listings are held the same way and are shared by checks that start together, which the runner does. The sweep never reads `node_modules/` or `.readyup/kits/*.js` whatever the filter answers for them -- the latter is readyup's own generated artifact, and sweeping it would report a kit's bundled source back to its author. A caller wanting further exclusions applies them in its own filter.
+`readTrackedSources` applies its filter before any read, so a caller never pays for a file it excluded, and holds what it read for the life of the process. A file two kits both select costs one read between them, and each pays only for the remainder the other did not ask for. That cache lives here rather than in a kit because a compiled kit leaves its `readyup` imports unbundled, making `check-utils` one module instance across every kit of a run; a cache inside a bundled helper would be one per bundle. Listings are held the same way and are shared by checks that start together, which the runner does. The sweep never reads `node_modules/` or `.readyup/kits/*.js` whatever the filter answers for them -- the latter is readyup's own generated artifact, and sweeping it would report a kit's bundled source back to its author. That kit exclusion names the default `compile.outDir`; a project compiling its kits elsewhere excludes that directory itself. A caller wanting further exclusions applies them in its own filter.
 
 `countPackageUsage` counts calls to the named exports and counts none in a source that never imports the package, from its root or any subpath. The import is what separates adoption from a name collision: a project hand-rolling its own `describeError` calls that name as often as an adopter calls the real one.
 
 `buildFindingReport` takes every finding the project holds plus a predicate selecting the ones the calling check reports, and names each selected finding as `symbol (path:line)`, or `path:line` where it declares no symbol. Its fraction is derived from every finding passed rather than only the reported ones, so the checks of one run share a denominator the reader can compare across them.
 
+`undefined` is what a check skips on. Reporting it as a pass would say the project holds no hand-rolled sites, when what happened is that nothing was looked at.
+
 ```ts
 import { buildFindingReport, countPackageUsage, readTrackedSources } from 'readyup/check-utils';
 
-const sources = await readTrackedSources((path) => /\.[cm]?[jt]sx?$/.test(path));
-if (sources === undefined) return { ok: true };
+function isSource(path: string): boolean {
+  return /\.[cm]?[jt]sx?$/.test(path);
+}
 
-const findings = sources.flatMap(listHandRolledSites);
-const adoptedCount = countPackageUsage(sources, { exportNames: ['describeError'], packageName: '@scope/errors' });
+const check = {
+  name: 'No source defines its own description helper',
+  // The sweep is cached, so the skip and the check share one pass over the project.
+  skip: async () => (await readTrackedSources(isSource)) === undefined && 'the project is not a git working tree',
+  check: async () => {
+    const sources = (await readTrackedSources(isSource)) ?? [];
+    const findings = sources.flatMap(listHandRolledSites);
+    const adoptedCount = countPackageUsage(sources, { exportNames: ['describeError'], packageName: '@scope/errors' });
 
-return buildFindingReport({ adoptedCount, findings, shouldReport: (finding) => finding.kind === 'clone' });
+    return buildFindingReport({ adoptedCount, findings, shouldReport: (finding) => finding.kind === 'clone' });
+  },
+};
 ```
 
 ## Compatibility

--- a/packages/readyup/src/check-utils/git/__tests__/run-git.unit.test.ts
+++ b/packages/readyup/src/check-utils/git/__tests__/run-git.unit.test.ts
@@ -3,7 +3,7 @@ import { promisify } from 'node:util';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { expandHome, isRefMissingError, runGit } from '../run-git.ts';
+import { expandHome, isRefMissingError, runGit, runGitRaw } from '../run-git.ts';
 
 const execFileAsync = vi.hoisted(() =>
   vi.fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr: string }>>(),
@@ -64,6 +64,29 @@ describe(runGit, () => {
     await runGit('/home/~user/repo', 'status');
 
     expect(execFileAsync).toHaveBeenCalledWith('git', ['-C', '/home/~user/repo', 'status']);
+  });
+});
+
+describe(runGitRaw, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns stdout unchanged, keeping the whitespace a trim would take', async () => {
+    execFileAsync.mockResolvedValue({ stdout: ' leading-space.txt\0normal.txt\0', stderr: '' });
+
+    const result = await runGitRaw('/repo', 'ls-files', '-z');
+
+    expect(result).toBe(' leading-space.txt\0normal.txt\0');
+    expect(execFileAsync).toHaveBeenCalledWith('git', ['-C', '/repo', 'ls-files', '-z']);
+  });
+
+  it('expands ~/ prefix to the home directory', async () => {
+    execFileAsync.mockResolvedValue({ stdout: 'ok\n', stderr: '' });
+
+    await runGitRaw('~/projects/repo', 'status');
+
+    expect(execFileAsync).toHaveBeenCalledWith('git', ['-C', `${homedir()}/projects/repo`, 'status']);
   });
 });
 

--- a/packages/readyup/src/check-utils/git/run-git.ts
+++ b/packages/readyup/src/check-utils/git/run-git.ts
@@ -10,7 +10,7 @@ export async function runGit(path: string, ...args: string[]): Promise<string> {
 }
 
 /**
- * Runs a git command in the given directory and answers with its stdout byte for byte.
+ * Runs a git command in the given directory and returns its stdout byte for byte.
  *
  * Reach for this where a path is part of the output: trimming strips a leading space or tab from the first path of a
  * listing, and the file it names then reads as missing.

--- a/packages/readyup/src/check-utils/git/run-git.ts
+++ b/packages/readyup/src/check-utils/git/run-git.ts
@@ -6,9 +6,19 @@ const execFileAsync = promisify(execFile);
 
 /** Run a git command in the given directory and return trimmed stdout. */
 export async function runGit(path: string, ...args: string[]): Promise<string> {
+  return (await runGitRaw(path, ...args)).trim();
+}
+
+/**
+ * Runs a git command in the given directory and answers with its stdout byte for byte.
+ *
+ * Reach for this where a path is part of the output: trimming strips a leading space or tab from the first path of a
+ * listing, and the file it names then reads as missing.
+ */
+export async function runGitRaw(path: string, ...args: string[]): Promise<string> {
   const resolved = expandHome(path);
   const { stdout } = await execFileAsync('git', ['-C', resolved, ...args]);
-  return stdout.trim();
+  return stdout;
 }
 
 /**

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -23,7 +23,7 @@ export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json
 export { getJsonValue, hasJsonValue } from './json-value.ts';
 export { missingFrom } from './missingFrom.ts';
 export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
-export type { Finding, FindingReport } from './project/buildFindingReport.ts';
+export type { BuildFindingReportOptions, Finding } from './project/buildFindingReport.ts';
 export { buildFindingReport } from './project/buildFindingReport.ts';
 export type { CountPackageUsageOptions } from './project/countPackageUsage.ts';
 export { countPackageUsage } from './project/countPackageUsage.ts';

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -23,6 +23,13 @@ export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json
 export { getJsonValue, hasJsonValue } from './json-value.ts';
 export { missingFrom } from './missingFrom.ts';
 export { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from './package-json.ts';
+export type { Finding, FindingReport } from './project/buildFindingReport.ts';
+export { buildFindingReport } from './project/buildFindingReport.ts';
+export type { CountPackageUsageOptions } from './project/countPackageUsage.ts';
+export { countPackageUsage } from './project/countPackageUsage.ts';
+export { listTrackedFiles } from './project/listTrackedFiles.ts';
+export type { PathFilter, ProjectSource } from './project/readTrackedSources.ts';
+export { readTrackedSources } from './project/readTrackedSources.ts';
 export { compareVersions } from './semver.ts';
 export { readToolVersionsNode } from './tool-versions.ts';
 export type { TsconfigChain, TsconfigChainEntry, TsconfigLanguageLevel, UnresolvedExtends } from './tsconfig.ts';

--- a/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFindingReport, type Finding } from '../buildFindingReport.ts';
+
+interface KindedFinding extends Finding {
+  kind: 'clone' | 'inline';
+}
+
+const CLONE: KindedFinding = { kind: 'clone', line: 12, path: 'src/errors.ts', symbol: 'describeError' };
+const INLINE: KindedFinding = { kind: 'inline', line: 44, path: 'src/report.ts' };
+
+describe(buildFindingReport, () => {
+  it('passes when the check reports none of the findings the project holds', () => {
+    const outcome = buildFindingReport({
+      adoptedCount: 3,
+      findings: [INLINE],
+      shouldReport: (finding) => finding.kind === 'clone',
+    });
+
+    expect(outcome).toStrictEqual({ ok: true, progress: { count: 4, passedCount: 3, type: 'fraction' } });
+  });
+
+  it('counts an unreported finding in the denominator', () => {
+    const outcome = buildFindingReport({
+      adoptedCount: 1,
+      findings: [CLONE, INLINE],
+      shouldReport: (finding) => finding.kind === 'clone',
+    });
+
+    expect(outcome.progress).toStrictEqual({ count: 3, passedCount: 1, type: 'fraction' });
+  });
+
+  it('fails and names each reported finding, by symbol where one is declared', () => {
+    const outcome = buildFindingReport({
+      adoptedCount: 0,
+      findings: [CLONE, INLINE],
+      shouldReport: () => true,
+    });
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.detail).toBe('describeError (src/errors.ts:12), src/report.ts:44');
+  });
+
+  it('passes with no detail for a project holding no findings at all', () => {
+    const outcome = buildFindingReport({ adoptedCount: 0, findings: [], shouldReport: () => true });
+
+    expect(outcome).toStrictEqual({ ok: true, progress: { count: 0, passedCount: 0, type: 'fraction' } });
+  });
+});

--- a/packages/readyup/src/check-utils/project/__tests__/countPackageUsage.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/countPackageUsage.unit.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { countPackageUsage } from '../countPackageUsage.ts';
+import type { ProjectSource } from '../readTrackedSources.ts';
+
+const PACKAGE_NAME = '@williamthorsen/toolbelt.errors';
+const EXPORT_NAMES = ['assertIsError', 'describeError'];
+
+describe(countPackageUsage, () => {
+  it('returns zero for a source that defines and calls its own helper of the same name', () => {
+    const source = buildSource(`
+      function describeError(error) { return String(error); }
+      export const first = describeError(new Error('a'));
+      export const second = describeError(new Error('b'));
+    `);
+
+    expect(count(source)).toBe(0);
+  });
+
+  it('counts calls in a source importing the package root', () => {
+    const source = buildSource(`
+      import { assertIsError, describeError } from '${PACKAGE_NAME}';
+      export const described = describeError(error);
+      export function guard(error) { assertIsError(error); }
+    `);
+
+    expect(count(source)).toBe(2);
+  });
+
+  it('counts calls in a source importing a subpath', () => {
+    const source = buildSource(`
+      import { assertIsError } from '${PACKAGE_NAME}/candidate';
+      export function guard(error) { assertIsError(error); }
+    `);
+
+    expect(count(source)).toBe(1);
+  });
+
+  it('recognizes a require and a dynamic import as imports of the package', () => {
+    const required = buildSource(`
+      const { describeError } = require('${PACKAGE_NAME}');
+      module.exports = describeError(error);
+    `);
+    const imported = buildSource(`
+      const { describeError } = await import('${PACKAGE_NAME}');
+      export const described = describeError(error);
+    `);
+
+    expect(count(required)).toBe(1);
+    expect(count(imported)).toBe(1);
+  });
+
+  it('matches a dot in the package name literally', () => {
+    const source = buildSource(`
+      import { describeError } from '@williamthorsen/toolbeltXerrors';
+      export const described = describeError(error);
+    `);
+
+    expect(count(source)).toBe(0);
+  });
+
+  it('totals the calls of every importing source', () => {
+    const first = buildSource(`import { describeError } from '${PACKAGE_NAME}';\nexport const a = describeError(e);`);
+    const second = buildSource(`import { describeError } from '${PACKAGE_NAME}';\nexport const b = describeError(e);`);
+    const third = buildSource('export const c = describeError(e);');
+
+    expect(count(first, second, third)).toBe(2);
+  });
+
+  it('returns zero when no export names are named', () => {
+    const source = buildSource(`import { describeError } from '${PACKAGE_NAME}';\nexport const a = describeError(e);`);
+
+    expect(countPackageUsage([source], { exportNames: [], packageName: PACKAGE_NAME })).toBe(0);
+  });
+});
+
+// region | Helpers
+
+/** Builds a source holding the given text, at a path this function never reads. */
+function buildSource(text: string): ProjectSource {
+  return { path: 'src/source.ts', text };
+}
+
+/** Counts usage of the package under test across the given sources. */
+function count(...sources: ProjectSource[]): number {
+  return countPackageUsage(sources, { exportNames: EXPORT_NAMES, packageName: PACKAGE_NAME });
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.tool.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.tool.test.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import { useTempDir } from '../../../test-utils/tempDir.ts';
+import { listTrackedFiles } from '../listTrackedFiles.ts';
+
+// Separated from the module's unit suite, which answers git from a stub: only real git escapes and quotes a path,
+// so only real git can show that `-z` defeats it.
+const temp = useTempDir({ prefix: 'rdy-tracked-', cwd: 'mock' });
+
+describe(listTrackedFiles, () => {
+  it('returns a path holding a non-ASCII byte intact and unquoted', async () => {
+    temp.write('packages/ascii/index.ts', 'export const value = 1;\n');
+    temp.write('packages/日本語/index.ts', 'export const value = 2;\n');
+    initRepository();
+
+    await expect(listTrackedFiles()).resolves.toStrictEqual(['packages/ascii/index.ts', 'packages/日本語/index.ts']);
+  });
+
+  it('returns undefined outside a git working tree', async () => {
+    temp.write('packages/ascii/index.ts', 'export const value = 1;\n');
+
+    await expect(listTrackedFiles()).resolves.toBeUndefined();
+  });
+});
+
+// region | Helpers
+
+/** Initializes a git repository over the temporary directory and stages everything in it. */
+function initRepository(): void {
+  execFileSync('git', ['-C', temp.dir, 'init', '--quiet']);
+  // Pinned rather than inherited: quoting is git's default, and a reader whose global config disables it would
+  // otherwise see this suite pass against a listing built without `-z`.
+  execFileSync('git', ['-C', temp.dir, 'config', 'core.quotePath', 'true']);
+  execFileSync('git', ['-C', temp.dir, 'add', '--all']);
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.unit.test.ts
@@ -42,6 +42,12 @@ describe(listTrackedFiles, () => {
     await expect(listTrackedFiles()).resolves.toStrictEqual(['src/index.ts', 'src/check-utils/json.ts']);
   });
 
+  it('keeps the leading whitespace of the first path', async () => {
+    respondWith({ trackedOutput: ' leading-space.txt\0normal.txt\0' });
+
+    await expect(listTrackedFiles()).resolves.toStrictEqual([' leading-space.txt', 'normal.txt']);
+  });
+
   it('lists with `-z`, so git neither escapes nor quotes a path', async () => {
     respondWith({ trackedOutput: 'src/index.ts\0' });
 

--- a/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.unit.test.ts
@@ -1,0 +1,105 @@
+import { promisify } from 'node:util';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileAsync = vi.hoisted(() =>
+  vi.fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr: string }>>(),
+);
+
+vi.mock('node:child_process', () => {
+  const stub = Object.assign(vi.fn(), { [promisify.custom]: execFileAsync });
+  return { execFile: stub };
+});
+
+vi.mock(import('node:fs'), () => ({
+  existsSync: () => true,
+}));
+
+import { listTrackedFiles } from '../listTrackedFiles.ts';
+
+describe(listTrackedFiles, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Each test claims a `cwd` of its own, so the module's per-`cwd` memoization starts empty for every case.
+    vi.spyOn(process, 'cwd').mockReturnValue(`/repo/${expect.getState().currentTestName}`);
+  });
+
+  it('returns undefined outside a git working tree', async () => {
+    respondWith({ isRepo: false });
+
+    await expect(listTrackedFiles()).resolves.toBeUndefined();
+  });
+
+  it('returns an empty list inside a working tree that tracks nothing', async () => {
+    respondWith({ trackedOutput: '' });
+
+    await expect(listTrackedFiles()).resolves.toStrictEqual([]);
+  });
+
+  it('splits the listing on NUL and drops the trailing empty entry', async () => {
+    respondWith({ trackedOutput: 'src/index.ts\0src/check-utils/json.ts\0' });
+
+    await expect(listTrackedFiles()).resolves.toStrictEqual(['src/index.ts', 'src/check-utils/json.ts']);
+  });
+
+  it('lists with `-z`, so git neither escapes nor quotes a path', async () => {
+    respondWith({ trackedOutput: 'src/index.ts\0' });
+
+    await listTrackedFiles();
+
+    expect(execFileAsync).toHaveBeenCalledWith('git', ['-C', process.cwd(), 'ls-files', '-z']);
+  });
+
+  it('invokes git once for calls that run concurrently', async () => {
+    respondWith({ trackedOutput: 'src/index.ts\0' });
+
+    const [first, second] = await Promise.all([listTrackedFiles(), listTrackedFiles()]);
+
+    expect(first).toStrictEqual(['src/index.ts']);
+    expect(second).toStrictEqual(['src/index.ts']);
+    expect(listInvocationCount()).toBe(1);
+  });
+
+  it('invokes git once for a later call, which reads the memoized listing', async () => {
+    respondWith({ trackedOutput: 'src/index.ts\0' });
+
+    await listTrackedFiles();
+    await listTrackedFiles();
+
+    expect(listInvocationCount()).toBe(1);
+  });
+
+  it('does not memoize a rejected listing', async () => {
+    execFileAsync.mockImplementation((_file, args) => {
+      if (args.includes('rev-parse')) return Promise.resolve({ stdout: '.git\n', stderr: '' });
+      return Promise.reject(new Error('fatal: unable to read index'));
+    });
+
+    await expect(listTrackedFiles()).rejects.toThrow('unable to read index');
+
+    respondWith({ trackedOutput: 'src/index.ts\0' });
+    await expect(listTrackedFiles()).resolves.toStrictEqual(['src/index.ts']);
+  });
+});
+
+// region | Helpers
+
+/** Counts the `ls-files` invocations made so far, ignoring the repo probe that precedes each listing. */
+function listInvocationCount(): number {
+  return execFileAsync.mock.calls.filter(([, args]) => args.includes('ls-files')).length;
+}
+
+/** Answers the repo probe and the listing that follows it, defaulting the probe to a working tree. */
+function respondWith(options: { isRepo?: boolean; trackedOutput?: string }): void {
+  const { isRepo = true, trackedOutput = '' } = options;
+  execFileAsync.mockImplementation((_file, args) => {
+    if (args.includes('rev-parse')) {
+      return isRepo
+        ? Promise.resolve({ stdout: '.git\n', stderr: '' })
+        : Promise.reject(Object.assign(new Error('fatal: not a git repository'), { code: 128 }));
+    }
+    return Promise.resolve({ stdout: trackedOutput, stderr: '' });
+  });
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
@@ -110,6 +110,17 @@ describe(readTrackedSources, () => {
     expect(countProbes('src/deleted.ts')).toBe(1);
   });
 
+  it('omits a tracked path that resolves to a directory', async () => {
+    temp.write('website/docs/page.md', 'page');
+    temp.symlinkDir('docs', 'website/docs');
+    temp.write('src/present.ts', 'present');
+    trackPaths('docs', 'src/present.ts');
+
+    await expect(readTrackedSources()).resolves.toStrictEqual([{ path: 'src/present.ts', text: 'present' }]);
+    // The read is what tells a directory from a source, so a fixture git never listed would pass this vacuously.
+    expect(countReads('docs')).toBe(1);
+  });
+
   it('returns undefined outside a git working tree', async () => {
     temp.write('src/present.ts', 'present');
     execFileAsync.mockRejectedValue(Object.assign(new Error('fatal: not a git repository'), { code: 128 }));

--- a/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
@@ -1,0 +1,141 @@
+import { promisify } from 'node:util';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { existsProbes, readPaths } = vi.hoisted(() => {
+  const existsProbes: string[] = [];
+  const readPaths: string[] = [];
+  return { existsProbes, readPaths };
+});
+
+const execFileAsync = vi.hoisted(() =>
+  vi.fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr: string }>>(),
+);
+
+vi.mock('node:child_process', () => {
+  const stub = Object.assign(vi.fn(), { [promisify.custom]: execFileAsync });
+  return { execFile: stub };
+});
+
+// The modules under test bind their `node:fs` functions at import, so a spy on the namespace never reaches them.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: (...args: Parameters<typeof actual.existsSync>) => {
+      existsProbes.push(String(args[0]));
+      return actual.existsSync(...args);
+    },
+    readFileSync: (...args: Parameters<typeof actual.readFileSync>) => {
+      readPaths.push(String(args[0]));
+      return actual.readFileSync(...args);
+    },
+  };
+});
+
+import { useTempDir } from '../../../test-utils/tempDir.ts';
+import { readTrackedSources } from '../readTrackedSources.ts';
+
+const temp = useTempDir({ prefix: 'rdy-sources-', cwd: 'mock' });
+
+describe(readTrackedSources, () => {
+  beforeEach(() => {
+    existsProbes.length = 0;
+    readPaths.length = 0;
+  });
+
+  it('reads each file once across calls passing different filters', async () => {
+    temp.write('src/shared.ts', 'shared');
+    temp.write('src/first.ts', 'first');
+    temp.write('src/second.ts', 'second');
+    trackPaths('src/first.ts', 'src/second.ts', 'src/shared.ts');
+
+    const first = await readTrackedSources((path) => path !== 'src/second.ts');
+    const second = await readTrackedSources((path) => path !== 'src/first.ts');
+
+    expect(first).toStrictEqual([
+      { path: 'src/first.ts', text: 'first' },
+      { path: 'src/shared.ts', text: 'shared' },
+    ]);
+    expect(second).toStrictEqual([
+      { path: 'src/second.ts', text: 'second' },
+      { path: 'src/shared.ts', text: 'shared' },
+    ]);
+    expect(countReads('src/shared.ts')).toBe(1);
+    expect(countReads('src/first.ts')).toBe(1);
+    expect(countReads('src/second.ts')).toBe(1);
+  });
+
+  it('never reads a path the filter rejects', async () => {
+    temp.write('src/kept.ts', 'kept');
+    temp.write('src/rejected.ts', 'rejected');
+    trackPaths('src/kept.ts', 'src/rejected.ts');
+
+    await readTrackedSources((path) => path === 'src/kept.ts');
+
+    expect(countReads('src/rejected.ts')).toBe(0);
+    expect(countProbes('src/rejected.ts')).toBe(0);
+  });
+
+  it('never reads an excluded path, whatever the filter answers for it', async () => {
+    temp.write('src/kept.ts', 'kept');
+    temp.write('node_modules/dependency/index.js', 'dependency');
+    temp.write('.readyup/kits/default.js', 'bundle');
+    trackPaths('.readyup/kits/default.js', 'node_modules/dependency/index.js', 'src/kept.ts');
+
+    const sources = await readTrackedSources(() => true);
+
+    expect(sources).toStrictEqual([{ path: 'src/kept.ts', text: 'kept' }]);
+    expect(countReads('node_modules/dependency/index.js')).toBe(0);
+    expect(countReads('.readyup/kits/default.js')).toBe(0);
+  });
+
+  it('sweeps a kit source, which only its compiled bundle is excluded from', async () => {
+    temp.write('.readyup/kits/default.ts', 'kit source');
+    trackPaths('.readyup/kits/default.ts');
+
+    await expect(readTrackedSources(() => true)).resolves.toStrictEqual([
+      { path: '.readyup/kits/default.ts', text: 'kit source' },
+    ]);
+  });
+
+  it('omits a tracked path that cannot be read, and probes the filesystem for it once', async () => {
+    temp.write('src/present.ts', 'present');
+    trackPaths('src/deleted.ts', 'src/present.ts');
+
+    const first = await readTrackedSources();
+    await readTrackedSources();
+
+    expect(first).toStrictEqual([{ path: 'src/present.ts', text: 'present' }]);
+    expect(countProbes('src/deleted.ts')).toBe(1);
+  });
+
+  it('returns undefined outside a git working tree', async () => {
+    temp.write('src/present.ts', 'present');
+    execFileAsync.mockRejectedValue(Object.assign(new Error('fatal: not a git repository'), { code: 128 }));
+
+    await expect(readTrackedSources()).resolves.toBeUndefined();
+  });
+});
+
+// region | Helpers
+
+/** Counts the filesystem existence probes made for a directory-relative path. */
+function countProbes(relativePath: string): number {
+  return existsProbes.filter((probed) => probed.endsWith(`/${relativePath}`)).length;
+}
+
+/** Counts the reads made of a directory-relative path. */
+function countReads(relativePath: string): number {
+  return readPaths.filter((read) => read.endsWith(`/${relativePath}`)).length;
+}
+
+/** Answers the repo probe with a working tree, and the listing with the given paths. */
+function trackPaths(...paths: string[]): void {
+  execFileAsync.mockImplementation((_file, args) => {
+    if (args.includes('rev-parse')) return Promise.resolve({ stdout: '.git\n', stderr: '' });
+    return Promise.resolve({ stdout: `${paths.join('\0')}\0`, stderr: '' });
+  });
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/buildFindingReport.ts
+++ b/packages/readyup/src/check-utils/project/buildFindingReport.ts
@@ -1,0 +1,46 @@
+import type { CheckOutcome } from '../../kits/types.ts';
+
+/** One located site a check names. */
+export interface Finding {
+  readonly path: string;
+  readonly line: number;
+  readonly symbol?: string | undefined;
+}
+
+/** Every finding a project holds, which of them the calling check reports, and how far adoption already got. */
+export interface FindingReport<F extends Finding> {
+  findings: readonly F[];
+  shouldReport: (finding: F) => boolean;
+  adoptedCount: number;
+}
+
+/**
+ * Reports whether a project holds the findings the calling check names, naming each and how far adoption got.
+ *
+ * The fraction is derived from every finding passed, not only the reported ones, so the checks of one run share a
+ * denominator the reader can compare across them. Passing only the reported findings would state a fraction of a
+ * different whole for each check, which is why the selection is made here rather than by the caller.
+ */
+export function buildFindingReport<F extends Finding>(report: FindingReport<F>): CheckOutcome {
+  const { adoptedCount, findings, shouldReport } = report;
+
+  const reported = findings.filter((finding) => shouldReport(finding));
+  const progress = {
+    count: adoptedCount + findings.length,
+    passedCount: adoptedCount,
+    type: 'fraction',
+  } as const;
+
+  if (reported.length === 0) return { ok: true, progress };
+  return { detail: reported.map((finding) => describeFinding(finding)).join(', '), ok: false, progress };
+}
+
+// region | Helpers
+
+/** Names one finding by where it is, and by the symbol it declares where it declares one. */
+function describeFinding(finding: Finding): string {
+  const location = `${finding.path}:${finding.line}`;
+  return finding.symbol === undefined ? location : `${finding.symbol} (${location})`;
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/buildFindingReport.ts
+++ b/packages/readyup/src/check-utils/project/buildFindingReport.ts
@@ -8,7 +8,7 @@ export interface Finding {
 }
 
 /** Every finding a project holds, which of them the calling check reports, and how far adoption already got. */
-export interface FindingReport<F extends Finding> {
+export interface BuildFindingReportOptions<F extends Finding> {
   findings: readonly F[];
   shouldReport: (finding: F) => boolean;
   adoptedCount: number;
@@ -21,8 +21,8 @@ export interface FindingReport<F extends Finding> {
  * denominator the reader can compare across them. Passing only the reported findings would state a fraction of a
  * different whole for each check, which is why the selection is made here rather than by the caller.
  */
-export function buildFindingReport<F extends Finding>(report: FindingReport<F>): CheckOutcome {
-  const { adoptedCount, findings, shouldReport } = report;
+export function buildFindingReport<F extends Finding>(options: BuildFindingReportOptions<F>): CheckOutcome {
+  const { adoptedCount, findings, shouldReport } = options;
 
   const reported = findings.filter((finding) => shouldReport(finding));
   const progress = {

--- a/packages/readyup/src/check-utils/project/countPackageUsage.ts
+++ b/packages/readyup/src/check-utils/project/countPackageUsage.ts
@@ -1,0 +1,46 @@
+import type { ProjectSource } from './readTrackedSources.ts';
+
+/** Names a package and the exports whose calls count as adoption of it. */
+export interface CountPackageUsageOptions {
+  packageName: string;
+  exportNames: readonly string[];
+}
+
+/**
+ * Counts calls to a package's exports across a project's sources, counting none in a source that never imports it.
+ *
+ * The import is what separates adoption from a name collision. A project hand-rolling its own helper of the same
+ * name calls it as often as an adopter calls the real one, and counting those would report the project as adopted in
+ * the same breath as naming the clone it should retire.
+ */
+export function countPackageUsage(sources: readonly ProjectSource[], options: CountPackageUsageOptions): number {
+  const { exportNames, packageName } = options;
+  if (exportNames.length === 0) return 0;
+
+  const callPattern = buildCallPattern(exportNames);
+  const importPattern = buildImportPattern(packageName);
+
+  let total = 0;
+  for (const source of sources) {
+    if (!importPattern.test(source.text)) continue;
+    total += source.text.matchAll(callPattern).toArray().length;
+  }
+
+  return total;
+}
+
+// region | Helpers
+
+/** Builds the pattern matching a call to any of the named exports. */
+function buildCallPattern(exportNames: readonly string[]): RegExp {
+  const names = exportNames.map((name) => RegExp.escape(name)).join('|');
+  return new RegExp(String.raw`\b(?:${names})\s*\(`, 'g');
+}
+
+/** Builds the pattern matching an import of the package, from its root or any of its subpaths. */
+function buildImportPattern(packageName: string): RegExp {
+  const specifier = `${RegExp.escape(packageName)}(?:/[^'"]+)?`;
+  return new RegExp(String.raw`(?:from|import\(|require\()\s*['"]${specifier}['"]`);
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/listTrackedFiles.ts
+++ b/packages/readyup/src/check-utils/project/listTrackedFiles.ts
@@ -5,10 +5,10 @@ import { runGitRaw } from '../git/run-git.ts';
 const listingsByCwd = new Map<string, Promise<readonly string[] | undefined>>();
 
 /**
- * Lists the paths git tracks under the working directory, or nothing where it is not a git working tree.
+ * Lists the paths git tracks under the working directory, or `undefined` where it is not a git working tree.
  *
- * Nothing and an empty list are distinct answers: a project outside a working tree cannot be swept at all, while one
- * inside an empty tree was swept and holds no tracked file.
+ * `undefined` and an empty list are distinct results: a project outside a working tree cannot be swept at all,
+ * while one inside an empty tree was swept and holds no tracked file.
  *
  * Memoized per `cwd` for the life of the process. The promise is held rather than the value it settles to, because
  * the runner starts sibling checks together: a cache filled on resolution arrives too late for every check that
@@ -30,7 +30,7 @@ export function listTrackedFiles(): Promise<readonly string[] | undefined> {
 
 // region | Helpers
 
-/** Reads the tracked paths of the working tree at `cwd`, or nothing where `cwd` is outside one. */
+/** Reads the tracked paths of the working tree at `cwd`, or `undefined` where `cwd` is outside one. */
 async function readTrackedPaths(cwd: string): Promise<readonly string[] | undefined> {
   if (!(await isGitRepo(cwd))) return undefined;
 

--- a/packages/readyup/src/check-utils/project/listTrackedFiles.ts
+++ b/packages/readyup/src/check-utils/project/listTrackedFiles.ts
@@ -1,0 +1,43 @@
+import { isGitRepo } from '../git/repo-predicates.ts';
+import { runGit } from '../git/run-git.ts';
+
+/** Tracked-path listings by the `cwd` they were resolved against, held for the life of the process. */
+const listingsByCwd = new Map<string, Promise<readonly string[] | undefined>>();
+
+/**
+ * Lists the paths git tracks under the working directory, or nothing where it is not a git working tree.
+ *
+ * Nothing and an empty list are distinct answers: a project outside a working tree cannot be swept at all, while one
+ * inside an empty tree was swept and holds no tracked file.
+ *
+ * Memoized per `cwd` for the life of the process. The promise is held rather than the value it settles to, because
+ * the runner starts sibling checks together: a cache filled on resolution arrives too late for every check that
+ * started alongside the first, and each would invoke git of its own. A rejected listing is dropped, so a failure is
+ * retried rather than remembered.
+ */
+export function listTrackedFiles(): Promise<readonly string[] | undefined> {
+  const cwd = process.cwd();
+
+  let listing = listingsByCwd.get(cwd);
+  if (listing === undefined) {
+    listing = readTrackedPaths(cwd);
+    listingsByCwd.set(cwd, listing);
+    void listing.catch(() => listingsByCwd.delete(cwd));
+  }
+
+  return listing;
+}
+
+// region | Helpers
+
+/** Reads the tracked paths of the working tree at `cwd`, or nothing where `cwd` is outside one. */
+async function readTrackedPaths(cwd: string): Promise<readonly string[] | undefined> {
+  if (!(await isGitRepo(cwd))) return undefined;
+
+  // `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in
+  // quotes, which no reader can open, and that file drops out of the sweep unreported.
+  const tracked = await runGit(cwd, 'ls-files', '-z');
+  return tracked.split('\0').filter((path) => path !== '');
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/listTrackedFiles.ts
+++ b/packages/readyup/src/check-utils/project/listTrackedFiles.ts
@@ -1,5 +1,5 @@
 import { isGitRepo } from '../git/repo-predicates.ts';
-import { runGit } from '../git/run-git.ts';
+import { runGitRaw } from '../git/run-git.ts';
 
 /** Tracked-path listings by the `cwd` they were resolved against, held for the life of the process. */
 const listingsByCwd = new Map<string, Promise<readonly string[] | undefined>>();
@@ -35,8 +35,9 @@ async function readTrackedPaths(cwd: string): Promise<readonly string[] | undefi
   if (!(await isGitRepo(cwd))) return undefined;
 
   // `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in
-  // quotes, which no reader can open, and that file drops out of the sweep unreported.
-  const tracked = await runGit(cwd, 'ls-files', '-z');
+  // quotes, which no reader can open, and that file drops out of the sweep unreported. Reading stdout untrimmed keeps
+  // the same promise for the first path, whose leading space or tab a trim would take.
+  const tracked = await runGitRaw(cwd, 'ls-files', '-z');
   return tracked.split('\0').filter((path) => path !== '');
 }
 

--- a/packages/readyup/src/check-utils/project/readTrackedSources.ts
+++ b/packages/readyup/src/check-utils/project/readTrackedSources.ts
@@ -25,8 +25,8 @@ const textsByCwd = new Map<string, Map<string, string | undefined>>();
  *
  * The filter decides a path before anything reads it, so a caller never pays for a file it excluded. Text is held per
  * `cwd` for the life of the process, so a file two kits both select costs one read between them, and each pays only
- * for the remainder the other did not ask for. A path that cannot be read is omitted and remembered as unreadable,
- * so a later filter selecting it probes the filesystem no second time.
+ * for the remainder the other did not ask for. A path that cannot be read as text is omitted and remembered as
+ * unreadable, so a later filter selecting it probes the filesystem no second time.
  */
 export async function readTrackedSources(filter?: PathFilter): Promise<readonly ProjectSource[] | undefined> {
   const tracked = await listTrackedFiles();
@@ -39,7 +39,7 @@ export async function readTrackedSources(filter?: PathFilter): Promise<readonly 
     if (filter !== undefined && !filter(path)) continue;
 
     if (!texts.has(path)) {
-      texts.set(path, readFile(path));
+      texts.set(path, readText(path));
     }
 
     const text = texts.get(path);
@@ -56,6 +56,20 @@ export async function readTrackedSources(filter?: PathFilter): Promise<readonly 
 /** Reports whether a path is one no sweep reads. */
 function isExcluded(path: string): boolean {
   return EXCLUDED_PATH_PATTERNS.some((pattern) => pattern.test(path));
+}
+
+/**
+ * Reads a tracked path as text, answering with nothing where it holds none.
+ *
+ * `git ls-files` names entries that are not files: a symlink to a directory, and the gitlink of a checked-out
+ * submodule. Both exist, so only the read itself can tell them from a source.
+ */
+function readText(path: string): string | undefined {
+  try {
+    return readFile(path);
+  } catch {
+    return undefined;
+  }
 }
 
 /** Answers with the text cache belonging to `cwd`, opening one where this is the first sweep under it. */

--- a/packages/readyup/src/check-utils/project/readTrackedSources.ts
+++ b/packages/readyup/src/check-utils/project/readTrackedSources.ts
@@ -21,7 +21,7 @@ const EXCLUDED_PATH_PATTERNS = [/(?:^|\/)node_modules\//, /(?:^|\/)\.readyup\/ki
 const textsByCwd = new Map<string, Map<string, string | undefined>>();
 
 /**
- * Reads the project's tracked sources that `filter` selects, or nothing outside a git working tree.
+ * Reads the project's tracked sources that `filter` selects, or `undefined` outside a git working tree.
  *
  * The filter decides a path before anything reads it, so a caller never pays for a file it excluded. Text is held per
  * `cwd` for the life of the process, so a file two kits both select costs one read between them, and each pays only
@@ -59,7 +59,7 @@ function isExcluded(path: string): boolean {
 }
 
 /**
- * Reads a tracked path as text, answering with nothing where it holds none.
+ * Reads a tracked path as text, returning `undefined` where it holds none.
  *
  * `git ls-files` names entries that are not files: a symlink to a directory, and the gitlink of a checked-out
  * submodule. Both exist, so only the read itself can tell them from a source.
@@ -72,7 +72,7 @@ function readText(path: string): string | undefined {
   }
 }
 
-/** Answers with the text cache belonging to `cwd`, opening one where this is the first sweep under it. */
+/** Returns the text cache belonging to `cwd`, opening one where this is the first sweep under it. */
 function resolveTextCache(cwd: string): Map<string, string | undefined> {
   let texts = textsByCwd.get(cwd);
   if (texts === undefined) {

--- a/packages/readyup/src/check-utils/project/readTrackedSources.ts
+++ b/packages/readyup/src/check-utils/project/readTrackedSources.ts
@@ -1,0 +1,71 @@
+import { readFile } from '../filesystem.ts';
+import { listTrackedFiles } from './listTrackedFiles.ts';
+
+/** Selects the tracked paths a sweep reads. */
+export type PathFilter = (path: string) => boolean;
+
+/** A tracked file and the text it holds. */
+export interface ProjectSource {
+  readonly path: string;
+  readonly text: string;
+}
+
+/**
+ * Paths no sweep reads, whatever a filter says of them. `node_modules/` is not the reader's own code, and
+ * `.readyup/kits/*.js` is readyup's generated artifact, which a sweep would report back to the author of the kit it
+ * was compiled from.
+ */
+const EXCLUDED_PATH_PATTERNS = [/(?:^|\/)node_modules\//, /(?:^|\/)\.readyup\/kits\/[^/]+\.js$/];
+
+/** File text by path, by the `cwd` it was read under. A stored `undefined` marks a path that could not be read. */
+const textsByCwd = new Map<string, Map<string, string | undefined>>();
+
+/**
+ * Reads the project's tracked sources that `filter` selects, or nothing outside a git working tree.
+ *
+ * The filter decides a path before anything reads it, so a caller never pays for a file it excluded. Text is held per
+ * `cwd` for the life of the process, so a file two kits both select costs one read between them, and each pays only
+ * for the remainder the other did not ask for. A path that cannot be read is omitted and remembered as unreadable,
+ * so a later filter selecting it probes the filesystem no second time.
+ */
+export async function readTrackedSources(filter?: PathFilter): Promise<readonly ProjectSource[] | undefined> {
+  const tracked = await listTrackedFiles();
+  if (tracked === undefined) return undefined;
+
+  const texts = resolveTextCache(process.cwd());
+  const sources: ProjectSource[] = [];
+  for (const path of tracked) {
+    if (isExcluded(path)) continue;
+    if (filter !== undefined && !filter(path)) continue;
+
+    if (!texts.has(path)) {
+      texts.set(path, readFile(path));
+    }
+
+    const text = texts.get(path);
+    if (text !== undefined) {
+      sources.push({ path, text });
+    }
+  }
+
+  return sources;
+}
+
+// region | Helpers
+
+/** Reports whether a path is one no sweep reads. */
+function isExcluded(path: string): boolean {
+  return EXCLUDED_PATH_PATTERNS.some((pattern) => pattern.test(path));
+}
+
+/** Answers with the text cache belonging to `cwd`, opening one where this is the first sweep under it. */
+function resolveTextCache(cwd: string): Map<string, string | undefined> {
+  let texts = textsByCwd.get(cwd);
+  if (texts === undefined) {
+    texts = new Map();
+    textsByCwd.set(cwd, texts);
+  }
+  return texts;
+}
+
+// endregion | Helpers


### PR DESCRIPTION
## What

Adds four utilities to `readyup/check-utils` for kits that audit a project's own sources: `listTrackedFiles`, `readTrackedSources`, `countPackageUsage`, and `buildFindingReport`. A file is read at most once per process however many kits select it, and the listing behind it is built once for the checks a run starts together. Both readers return `undefined` outside a git working tree.

## Why

An adoption kit -- one reporting where a project hand-rolls what a package it already installed provides -- needs plumbing `check-utils` did not have, and the two kits that exist hand-roll all of it near-identically.

Reading the project is the piece that has to live in readyup. A compiled kit leaves its `readyup` imports unbundled, so this is the only place a cache is one instance across the kits of a run; a cache inside a bundled helper would be one per bundle. Without it, a consumer installing a dozen kit-bearing packages sweeps its repository a dozen times.

## Details

### 🎉 Features

- `listTrackedFiles()` returns the paths git tracks under the working directory, or `undefined` outside a working tree. It lists with `git ls-files -z`, so a path holding a non-ASCII byte is neither escaped nor quoted, and reads the output untrimmed, so a first path's leading space or tab survives.
- `readTrackedSources(filter?)` returns `{ path, text }` for each tracked path the filter selects. The filter decides a path before anything reads it, so a caller never pays for a file it excluded, and text is held per working directory for the life of the process. `node_modules/` and the compiled kits under the default `compile.outDir` are never read, whatever the filter answers for them; a caller wanting further exclusions applies them in its own filter.
- `countPackageUsage(sources, options)` totals calls to a package's named exports, counting none in a source that never imports the package, from its root or any subpath. The import gate is what separates adoption from a name collision: a project hand-rolling its own `describeError` calls that name as often as an adopter calls the real one.
- `buildFindingReport(options)` turns located findings into a `CheckOutcome`, naming each reported finding as `symbol (path:line)` and carrying adoption as a fraction. The denominator is derived from every finding passed rather than only the reported ones, so the checks of one run share a denominator the reader can compare across them.

### 🏗️ Internal features

- `runGitRaw` joins `runGit` in `check-utils/git/run-git.ts`, answering with git's stdout byte for byte for output that carries a path. `runGit` is re-expressed in terms of it and keeps its trim, which is right for the single-value output it was written for.

### 🧪 Tests

- Unit suites for all four functions, covering the read-once-per-process contract against an instrumented `readFileSync`, the concurrent listing that invokes git once, and the rejected listing that is not memoized.
- A tool-tier suite exercising `listTrackedFiles` against a real `git init` repository with `core.quotePath` pinned on, which is the only way to show `-z` defeats git's quoting.
- Coverage for the two entries `git ls-files` names that hold no text -- a symlink to a directory and a submodule gitlink -- both of which pass an existence probe and are omitted from the sweep rather than throwing out of it.

### 📚 Documentation

- A "Project sources" section in `packages/readyup/README.md` covering the four functions, the caching contract, the built-in exclusions and the `compile.outDir` they name, and a worked adoption check that skips outside a git working tree.

Closes #330

