### PR TITLE
#343 Add `--diagnose`, which reports skipped checks that would have passed

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -462,6 +462,7 @@ rdy run -- "--odd-kit-name"
 | `--checklists, -c <name,...>` | Filter checklists within the selected kit                             |
 | `--json`                      | Output results as JSON                                                |
 | `--detail <summary\|full>`    | How much of the JSON report to emit (default: `full`)                 |
+| `--diagnose`                  | Report skipped checks whose `check` would have passed                 |
 | `--fail-on <severity>`        | Fail on this severity or above                                        |
 | `--report-on <severity>`      | Show this severity or above                                           |
 | `--quiet`                     | Hide passed checks; incompatible with `--json`                        |
@@ -469,6 +470,8 @@ rdy run -- "--odd-kit-name"
 `--quiet` filters by status where `--report-on` filters by severity, so the two compose rather than override. Both keep the parent checks of anything they show, so a failure nested under passing parents stays reachable.
 
 A checklist either filter empties renders no block at all: its summary-table row states the same counts in a column the reader can compare across the run. A block is withheld only where a table will carry its row, so a run of one checklist reports its block however little it has to say, and a run that withholds one always ends with the table.
+
+`--diagnose` runs the `check` of every check its own `skip` turned off, and reports the ones that would have passed: a `skip` exists to prevent a wrong failure, and one that suppresses a right pass instead renders as an ordinary white circle that nothing fails. It is opt-in because it executes exactly the work a skip was written to avoid, which may reach a network or a registry. What it finds is reported as [advisory warnings](#advisory-warnings), and the statuses, counts, durations, and exit code are those of an undiagnosed run.
 
 A check's own [`quiet`](#checks) is this flag narrowed to that one check, and a kit whose every check declares it renders what `--quiet` renders. It is not `skip`, which reports that the check did not run and why: a quiet check runs, and its pass reaches the count line and the exit code like any other -- only the line is withheld. `--json` is unaffected, so `rdy run --json --detail full` shows a quiet check that passed.
 
@@ -585,7 +588,9 @@ Once a style is named explicitly, output is byte-identical to a terminal or a pi
 
 ### Advisory warnings
 
-`rdy run` compares the kits it is about to run against `.readyup/manifest.json` and says so when they disagree. Warnings go to stderr in both modes and appear under `warnings` in JSON; none affects the exit code.
+`rdy run` raises advisories about the run it is performing. Warnings go to stderr in both modes and appear under `warnings` in JSON; none affects the exit code.
+
+Three compare the kits it is about to run against `.readyup/manifest.json` and say so when they disagree.
 
 | Code           | Raised when                                                              |
 | -------------- | ------------------------------------------------------------------------ |
@@ -595,11 +600,20 @@ Once a style is named explicitly, output is byte-identical to a terminal or a pi
 
 They are silent when the manifest is absent, when no entry describes the kit, when an entry records no hashes or no input closure, or when a file they would compare is gone or cannot be read. Only the local manifest is consulted, so a kit reached through `--from` is out of scope -- run `rdy verify` in that root instead. They also do not apply to `--url` or `--jit`.
 
+Two more come from [`--diagnose`](#run-options), and are raised only where that flag asked for them.
+
+| Code                     | Raised when                                                        |
+| ------------------------ | ------------------------------------------------------------------ |
+| `diagnosis-inconclusive` | A diagnosed check threw, or returned a value expressing no verdict |
+| `skip-masks-pass`        | A check its own `skip` turned off would have passed had it run     |
+
+These read the checks rather than the manifest, so none of the silencing conditions above reaches them: they apply wherever the kit came from, `--url`, `--from`, `--packages`, and `--jit` alike. A check blocked by a failed precondition declared nothing and is not diagnosed.
+
 ### Kit import compatibility
 
 A compiled kit leaves its `readyup` imports unbundled, so it binds whichever readyup runs it rather than the one that built it. Before running a bundle, `rdy run` reads the `readyup` symbols it imports and compares them against what the running readyup exports.
 
-A kit importing a symbol, or a `readyup` subpath, the runner does not export does not run: the failure is a `kit-load` error naming every missing symbol, the kit, and the publishing package where the kit has one, and it exits `2`. Unlike the advisory warnings above, this check is not manifest-derived and applies wherever the kit came from, `--url`, `--from`, and `--packages` included. `--jit` runs load TypeScript source rather than a bundle, and are unaffected.
+A kit importing a symbol, or a `readyup` subpath, the runner does not export does not run: the failure is a `kit-load` error naming every missing symbol, the kit, and the publishing package where the kit has one, and it exits `2`. Unlike the staleness advisories above, this check is not manifest-derived and applies wherever the kit came from, `--url`, `--from`, and `--packages` included. `--jit` runs load TypeScript source rather than a bundle, and are unaffected.
 
 The remedy follows where the kit is maintained:
 

--- a/packages/readyup/src/bin/__tests__/route.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.unit.test.ts
@@ -181,6 +181,15 @@ describe(routeCommand, () => {
     expect(stdout).toContain('Examples:');
   });
 
+  it.each([
+    { label: 'top-level', args: ['--help'] },
+    { label: 'run', args: ['run', '--help'] },
+  ])('lists --diagnose in $label help', async ({ args }) => {
+    const { stdout } = await route(args);
+
+    expect(stdout).toContain('--diagnose');
+  });
+
   it('explains how to escape a positional starting with a dash in run help', async () => {
     const { stdout } = await route(['run', '--help']);
 

--- a/packages/readyup/src/bin/__tests__/route.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.unit.test.ts
@@ -285,6 +285,26 @@ describe(routeCommand, () => {
     expect(exitCode).toBe(0);
   });
 
+  it('passes --diagnose through to runCommand', async () => {
+    mockParseRunArgs.mockReturnValue({
+      kitSpecifiers: [],
+      checklists: undefined,
+      filePath: undefined,
+      fromValue: undefined,
+      urlValue: undefined,
+      jit: false,
+      internal: false,
+      json: false,
+      diagnose: true,
+    });
+    mockRunCommand.mockResolvedValue(0);
+
+    const { exitCode } = await route(['run', '--diagnose']);
+
+    expect(mockRunCommand).toHaveBeenCalledWith(expect.objectContaining({ diagnose: true }), false);
+    expect(exitCode).toBe(0);
+  });
+
   it('includes --json in run help text', async () => {
     const { stdout } = await route(['run', '--help']);
 

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -70,6 +70,7 @@ Run options:
   --checklists, -c <name,...>        Filter checklists within the selected kit
   --json                             Output results as JSON
   --detail <summary|full>            How much of the JSON report to emit (default: full); requires --json
+  --diagnose                         Report skipped checks whose check would have passed
   --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
   --quiet                            Hide passed checks from the report; incompatible with --json
   --report-on <severity>             Show this severity or above (error, warn, recommend)
@@ -118,6 +119,7 @@ Options:
                                      single kit and no ":" filter on it
   --json                             Output results as JSON
   --detail <summary|full>            How much of the JSON report to emit (default: full); requires --json
+  --diagnose                         Report skipped checks whose check would have passed
   --fail-on <severity>               Fail on this severity or above (error, warn, recommend)
   --quiet                            Hide passed checks from the report; incompatible with --json
   --report-on <severity>             Show this severity or above (error, warn, recommend)
@@ -138,6 +140,7 @@ Examples:
   rdy run --from global deploy           Run the deploy kit from the global directory
   rdy run --fail-on warn                 Fail the run on warnings as well as errors
   rdy run --quiet                        Report only what is not passing
+  rdy run --diagnose                     Report skips whose check would have passed
   rdy run --json --detail summary        Emit a JSON report carrying only failed checks
 
 ${DOCS_POINTER}
@@ -367,6 +370,7 @@ async function handleRun(flags: string[], json: boolean): Promise<number> {
     {
       kitEntries,
       json: parsed.json,
+      diagnose: parsed.diagnose,
       quiet: parsed.quiet,
       ...(parsed.detail !== undefined && { detail: parsed.detail }),
       ...(parsed.failOn !== undefined && { failOn: parsed.failOn }),

--- a/packages/readyup/src/index.ts
+++ b/packages/readyup/src/index.ts
@@ -20,6 +20,7 @@ export type {
   RemoteRefCompareResult,
   ResolvedRdyConfig,
   Severity,
+  SkipDiagnosis,
   SkippedResult,
   SkipResult,
   SummaryCounts,

--- a/packages/readyup/src/kitImports/describeUnresolvableImports.ts
+++ b/packages/readyup/src/kitImports/describeUnresolvableImports.ts
@@ -1,3 +1,4 @@
+import { describeKitOwner } from '../kits/describeKitOwner.ts';
 import type { KitProvenance } from '../kits/KitProvenance.ts';
 import { VERSION } from '../version.ts';
 import type { UnresolvableImports } from './UnresolvableKitImportsError.ts';
@@ -33,17 +34,12 @@ export function describeUnresolvableImports(
   ];
 
   return {
-    message: `kit "${context.kitName}"${describeOwner(context.provenance)} cannot run against readyup ${VERSION}: ${clauses.join('; ')}.`,
+    message: `kit "${context.kitName}"${describeKitOwner(context.provenance)} cannot run against readyup ${VERSION}: ${clauses.join('; ')}.`,
     hint: describeRemedy(context.provenance),
   };
 }
 
 // region | Helpers
-
-/** Names the package publishing a kit, for the provenance that has one. */
-function describeOwner(provenance: KitProvenance | undefined): string {
-  return provenance?.kind === 'package' ? ` from ${provenance.packageName}` : '';
-}
 
 /** Gives the one action that puts a kit back in reach of the running readyup. */
 function describeRemedy(provenance: KitProvenance | undefined): string {

--- a/packages/readyup/src/kits/describeKitOwner.ts
+++ b/packages/readyup/src/kits/describeKitOwner.ts
@@ -1,0 +1,10 @@
+import type { KitProvenance } from './KitProvenance.ts';
+
+/**
+ * Names the package publishing a kit, for the provenance that has one.
+ *
+ * Returns a clause to append after the kit's name, empty where no package published it.
+ */
+export function describeKitOwner(provenance: KitProvenance | undefined): string {
+  return provenance?.kind === 'package' ? ` from ${provenance.packageName}` : '';
+}

--- a/packages/readyup/src/kits/types.ts
+++ b/packages/readyup/src/kits/types.ts
@@ -235,10 +235,26 @@ export type RdyResult = PassedResult | FailedResult | SkippedResult;
 
 // -- Reports --
 
+/**
+ * What a skipped check's `check` would have concluded, produced only when diagnosis runs.
+ *
+ * A check that would have failed used its `skip` correctly and yields no entry, so every entry is a
+ * finding rather than a record of one diagnosis.
+ */
+export type SkipDiagnosis =
+  { name: string; verdict: 'masked-pass' } | { name: string; verdict: 'inconclusive'; reason: string };
+
 /** Aggregate report from running a single checklist. */
 export interface RdyReport {
   /** Individual check results. */
   results: RdyResult[];
+
+  /**
+   * Findings from diagnosing the checks that skipped `n/a`, absent when diagnosis did not run.
+   *
+   * Absent and empty say different things: nothing was asked, versus asked and nothing found.
+   */
+  diagnoses?: SkipDiagnosis[] | undefined;
 
   /**
    * True when no check at or above the failure threshold has `ok: false`.

--- a/packages/readyup/src/run/__tests__/parseRunArgs.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/parseRunArgs.unit.test.ts
@@ -305,6 +305,34 @@ describe(parseRunArgs, () => {
     expect(parseRunArgs(['--json'])).not.toHaveProperty('detail');
   });
 
+  describe('--diagnose', () => {
+    it('parses as a boolean', () => {
+      expect(parseRunArgs(['--diagnose']).diagnose).toBe(true);
+    });
+
+    it('defaults to false', () => {
+      expect(parseRunArgs([]).diagnose).toBe(false);
+    });
+
+    it.each([
+      ['--json', ['--diagnose', '--json']],
+      ['--jit', ['--diagnose', '--jit']],
+      ['--packages', ['--diagnose', '--packages']],
+      ['--from', ['--diagnose', '--from', 'global']],
+      ['--file', ['--diagnose', '--file', 'kit.js']],
+      ['--url', ['--diagnose', '--url', 'https://example.com/kit.js']],
+    ])('composes with %s, which it constrains in no way', (_label, flags) => {
+      expect(parseRunArgs(flags).diagnose).toBe(true);
+    });
+
+    it('composes with a kit selection', () => {
+      const parsed = parseRunArgs(['--diagnose', 'deploy']);
+
+      expect(parsed.diagnose).toBe(true);
+      expect(parsed.kitSpecifiers).toStrictEqual([{ kitName: 'deploy', checklists: [] }]);
+    });
+  });
+
   describe('--quiet', () => {
     it('parses as a boolean', () => {
       expect(parseRunArgs(['--quiet']).quiet).toBe(true);

--- a/packages/readyup/src/run/__tests__/runCommand.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runCommand.unit.test.ts
@@ -64,6 +64,28 @@ describe(runCommand, () => {
     );
   });
 
+  it('resolves an unrequested diagnose to an undiagnosed run', async () => {
+    await runCommand({ kitEntries: singleKitEntry(), json: false });
+
+    expect(mockRunHumanMode).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ diagnose: false }),
+      false,
+    );
+  });
+
+  it('passes the diagnose the invocation requested through to either mode', async () => {
+    await runCommand({ kitEntries: singleKitEntry(), json: false, diagnose: true });
+    await runCommand({ kitEntries: singleKitEntry(), json: true, diagnose: true });
+
+    expect(mockRunHumanMode).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ diagnose: true }),
+      false,
+    );
+    expect(mockRunJsonMode).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ diagnose: true }), false);
+  });
+
   it('resolves an unrequested quiet to a loud run', async () => {
     await runCommand({ kitEntries: singleKitEntry(), json: false });
 

--- a/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
@@ -118,6 +118,32 @@ describe(runHumanMode, () => {
     expect(exitCode).toBe(0);
   });
 
+  it('writes a diagnosed masked pass to stderr', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
+    mockRunRdy.mockResolvedValue({
+      results: [],
+      passed: true,
+      durationMs: 0,
+      diagnoses: [{ name: 'a', verdict: 'masked-pass' }],
+    });
+
+    const { exitCode, stderr } = await runHuman(singleKitEntry(['deploy']), { diagnose: true });
+
+    expect(stderr).toContain('skipped check "a" in kit "default" / checklist "deploy" would have passed.');
+    expect(exitCode).toBe(0);
+  });
+
+  it('asks the runner to diagnose only where --diagnose was passed', async () => {
+    mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
+    mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+    await runHuman(singleKitEntry(['deploy']));
+    expect(mockRunRdy).toHaveBeenLastCalledWith(expect.anything(), expect.objectContaining({ diagnose: false }));
+
+    await runHuman(singleKitEntry(['deploy']), { diagnose: true });
+    expect(mockRunRdy).toHaveBeenLastCalledWith(expect.anything(), expect.objectContaining({ diagnose: true }));
+  });
+
   it('reports an unknown checklist name against its kit and exits 2', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
@@ -590,6 +616,7 @@ function makePassedResult(name: string, severity: Severity): PassedResult {
 
 /** The settings a test names, over the defaults the dispatch would have resolved. */
 interface HumanRunOptions {
+  diagnose?: boolean;
   failOn?: Severity;
   isJit?: boolean;
   quiet?: boolean;
@@ -602,11 +629,11 @@ interface HumanRunOptions {
  */
 async function runHuman(
   kitEntries: ResolvedKitEntry[],
-  { failOn, isJit = false, quiet = false, reportOn }: HumanRunOptions = {},
+  { diagnose = false, failOn, isJit = false, quiet = false, reportOn }: HumanRunOptions = {},
 ) {
   using io = captureStdio();
 
-  const exitCode = await runHumanMode(kitEntries, { failOn, quiet, reportOn }, isJit);
+  const exitCode = await runHumanMode(kitEntries, { diagnose, failOn, quiet, reportOn }, isJit);
 
   return { exitCode, stdout: io.stdout, stderr: io.stderr };
 }

--- a/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
@@ -287,6 +287,38 @@ describe(runJsonMode, () => {
       expect(exitCode).toBe(0);
     });
 
+    it('carries a diagnosed masked pass into the report and onto stderr', async () => {
+      mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
+      mockRunRdy.mockResolvedValue({
+        results: [],
+        passed: true,
+        durationMs: 0,
+        diagnoses: [{ name: 'a', verdict: 'masked-pass' }],
+      });
+      mockFormatJsonReport.mockReturnValue('{"kits":[]}');
+
+      const { stderr } = await runJson(singleKitEntry(['deploy']), { diagnose: true });
+
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          warnings: [expect.objectContaining({ code: 'skip-masks-pass' })],
+        }),
+      );
+      expect(stderr).toContain('skipped check "a" in kit "default" / checklist "deploy" would have passed.');
+    });
+
+    it('asks the runner to diagnose only where --diagnose was passed', async () => {
+      mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
+      mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+
+      await runJson(singleKitEntry(['deploy']));
+      expect(mockRunRdy).toHaveBeenLastCalledWith(expect.anything(), expect.objectContaining({ diagnose: false }));
+
+      await runJson(singleKitEntry(['deploy']), { diagnose: true });
+      expect(mockRunRdy).toHaveBeenLastCalledWith(expect.anything(), expect.objectContaining({ diagnose: true }));
+    });
+
     it('omits the warnings field entirely when the run raised none', async () => {
       mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
@@ -325,6 +357,7 @@ describe(runJsonMode, () => {
 /** The settings a test names, over the defaults the dispatch would have resolved. */
 interface JsonRunOptions {
   detail?: JsonDetail;
+  diagnose?: boolean;
   failOn?: Severity;
   isJit?: boolean;
   reportOn?: Severity;
@@ -336,11 +369,11 @@ interface JsonRunOptions {
  */
 async function runJson(
   kitEntries: ResolvedKitEntry[],
-  { detail = 'full', failOn, isJit = false, reportOn }: JsonRunOptions = {},
+  { detail = 'full', diagnose = false, failOn, isJit = false, reportOn }: JsonRunOptions = {},
 ) {
   using io = captureStdio();
 
-  const exitCode = await runJsonMode(kitEntries, { detail, failOn, reportOn }, isJit);
+  const exitCode = await runJsonMode(kitEntries, { detail, diagnose, failOn, reportOn }, isJit);
 
   return { exitCode, stdout: io.stdout, stderr: io.stderr };
 }

--- a/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
@@ -951,6 +951,197 @@ describe(runRdy, () => {
     });
   });
 
+  describe('diagnosis', () => {
+    it('reports a skipped check whose check would have passed', async () => {
+      const checklist: RdyChecklist = {
+        name: 'masked',
+        checks: [{ name: 'masked-check', check: () => true, skip: () => 'not applicable' }],
+      };
+
+      const report = await runRdy(checklist, { diagnose: true });
+
+      expect(report.diagnoses).toStrictEqual([{ name: 'masked-check', verdict: 'masked-pass' }]);
+    });
+
+    it('reads a structured outcome the same way a boolean is read', async () => {
+      const checklist: RdyChecklist = {
+        name: 'masked',
+        checks: [
+          { name: 'masked-check', check: () => ({ ok: true }), skip: () => 'not applicable' },
+          { name: 'rightly-skipped', check: () => ({ ok: false }), skip: () => 'not applicable' },
+        ],
+      };
+
+      const report = await runRdy(checklist, { diagnose: true });
+
+      expect(report.diagnoses).toStrictEqual([{ name: 'masked-check', verdict: 'masked-pass' }]);
+    });
+
+    it('reports nothing for a skipped check whose check would have failed', async () => {
+      const checklist: RdyChecklist = {
+        name: 'rightly-skipped',
+        checks: [{ name: 'would-fail', check: () => false, skip: () => 'not applicable' }],
+      };
+
+      const report = await runRdy(checklist, { diagnose: true });
+
+      expect(report.diagnoses).toStrictEqual([]);
+    });
+
+    it('reports a check that throws as inconclusive, carrying its message', async () => {
+      const checklist: RdyChecklist = {
+        name: 'unreachable',
+        checks: [
+          {
+            name: 'registry-check',
+            check: () => {
+              throw new Error('fetch failed');
+            },
+            skip: () => 'offline',
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist, { diagnose: true });
+
+      expect(report.diagnoses).toStrictEqual([
+        { name: 'registry-check', verdict: 'inconclusive', reason: 'fetch failed' },
+      ]);
+    });
+
+    it('reports a check that expresses no verdict as inconclusive', async () => {
+      const checklist: RdyChecklist = {
+        name: 'broken',
+        checks: [{ name: 'no-verdict', check: returning('yes'), skip: () => 'not applicable' }],
+      };
+
+      const report = await runRdy(checklist, { diagnose: true });
+
+      expect(report.diagnoses).toStrictEqual([
+        {
+          name: 'no-verdict',
+          verdict: 'inconclusive',
+          reason: 'check() returned string "yes"; expected a boolean or an object with a boolean "ok" property.',
+        },
+      ]);
+    });
+
+    it('leaves diagnoses absent and runs no skipped check when diagnosis was not asked for', async () => {
+      let checkCalled = false;
+      const checklist: RdyChecklist = {
+        name: 'masked',
+        checks: [
+          {
+            name: 'masked-check',
+            check: () => {
+              checkCalled = true;
+              return true;
+            },
+            skip: () => 'not applicable',
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist);
+
+      expect(report.diagnoses).toBeUndefined();
+      expect(checkCalled).toBe(false);
+    });
+
+    it('leaves a precondition-blocked check undiagnosed', async () => {
+      let checkCalled = false;
+      const checklist: RdyChecklist = {
+        name: 'blocked',
+        preconditions: [{ name: 'gate', check: () => false }],
+        checks: [
+          {
+            name: 'downstream',
+            check: () => {
+              checkCalled = true;
+              return true;
+            },
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist, { diagnose: true });
+
+      expect(report.diagnoses).toStrictEqual([]);
+      expect(checkCalled).toBe(false);
+    });
+
+    it('diagnoses a precondition that skipped n/a', async () => {
+      const checklist: RdyChecklist = {
+        name: 'gated',
+        preconditions: [{ name: 'gate', check: () => true, skip: () => 'not applicable' }],
+        checks: [{ name: 'downstream', check: () => true }],
+      };
+
+      const report = await runRdy(checklist, { diagnose: true });
+
+      expect(report.diagnoses).toStrictEqual([{ name: 'gate', verdict: 'masked-pass' }]);
+    });
+
+    it('leaves the descendants of a skipped check unrun', async () => {
+      let childCalled = false;
+      const checklist: RdyChecklist = {
+        name: 'subtree',
+        checks: [
+          {
+            name: 'parent',
+            check: () => true,
+            skip: () => 'not applicable',
+            checks: [
+              {
+                name: 'child',
+                check: () => {
+                  childCalled = true;
+                  return true;
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const report = await runRdy(checklist, { diagnose: true });
+
+      expect(report.results.map((r) => r.name)).toStrictEqual(['parent']);
+      expect(report.diagnoses).toStrictEqual([{ name: 'parent', verdict: 'masked-pass' }]);
+      expect(childCalled).toBe(false);
+    });
+
+    it('leaves statuses, per-check durations, and the verdict identical to an undiagnosed run', async () => {
+      const buildChecklist = (): RdyChecklist => ({
+        name: 'mixed',
+        preconditions: [{ name: 'gate', check: () => true }],
+        checks: [
+          { name: 'passes', check: () => true },
+          { name: 'fails', check: () => false },
+          { name: 'masked', check: () => true, skip: () => 'not applicable' },
+          { name: 'blocked-parent', check: () => false, checks: [{ name: 'blocked-child', check: () => true }] },
+        ],
+      });
+
+      const plain = await runRdy(buildChecklist());
+      const diagnosed = await runRdy(buildChecklist(), { diagnose: true });
+
+      const shapeOf = (report: Awaited<ReturnType<typeof runRdy>>) =>
+        report.results.map((r) => ({
+          name: r.name,
+          status: r.status,
+          severity: r.severity,
+          skipReason: r.status === 'skipped' ? r.skipReason : undefined,
+        }));
+
+      expect(shapeOf(diagnosed)).toStrictEqual(shapeOf(plain));
+      expect(diagnosed.passed).toBe(plain.passed);
+      const skipped = diagnosed.results.filter((r) => r.status === 'skipped');
+      expect(skipped).not.toHaveLength(0);
+      expect(skipped.every((r) => r.durationMs === 0)).toBe(true);
+    });
+  });
+
   describe('authoring errors', () => {
     it.each([
       ['a string', 'yes', 'check() returned string "yes"'],

--- a/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
@@ -1111,6 +1111,28 @@ describe(runRdy, () => {
       expect(childCalled).toBe(false);
     });
 
+    it("orders findings by the report's order, not by the order the skips resolved", async () => {
+      const checklist: RdyChecklist = {
+        name: 'async-skips',
+        checks: [
+          {
+            name: 'slow-skip',
+            check: () => true,
+            skip: async () => {
+              await new Promise((resolve) => setTimeout(resolve, 20));
+              return 'not applicable';
+            },
+          },
+          { name: 'fast-skip', check: () => true, skip: () => 'not applicable' },
+        ],
+      };
+
+      const report = await runRdy(checklist, { diagnose: true });
+
+      expect(report.results.map((r) => r.name)).toStrictEqual(['slow-skip', 'fast-skip']);
+      expect(report.diagnoses?.map((d) => d.name)).toStrictEqual(['slow-skip', 'fast-skip']);
+    });
+
     it('leaves statuses, per-check durations, and the verdict identical to an undiagnosed run', async () => {
       const buildChecklist = (): RdyChecklist => ({
         name: 'mixed',

--- a/packages/readyup/src/run/__tests__/skip-diagnosis.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/skip-diagnosis.unit.test.ts
@@ -2,13 +2,17 @@ import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { describe, expect, it } from 'vitest';
 
 import type { SkipDiagnosis } from '../../kits/types.ts';
+import type { ResolvedKitEntry } from '../ResolvedKitEntry.ts';
 import { warnOnMaskedSkips } from '../skip-diagnosis.ts';
+
+/** The entry a locally-resolved kit produces: a name, and no package to attribute it to. */
+const LOCAL_KIT: ResolvedKitEntry = { name: 'default', source: { path: '.readyup/kits/default.js' }, checklists: [] };
 
 describe(warnOnMaskedSkips, () => {
   it('raises skip-masks-pass for a skip that suppressed a pass', () => {
-    const warnings = warn([{ name: 'Coverage is at least 90%', verdict: 'masked-pass' }]);
+    const { warnings } = warn([{ name: 'Coverage is at least 90%', verdict: 'masked-pass' }]);
 
-    expect(warnings.warnings).toStrictEqual([
+    expect(warnings).toStrictEqual([
       {
         code: 'skip-masks-pass',
         message: 'skipped check "Coverage is at least 90%" in kit "default" / checklist "repo" would have passed.',
@@ -18,9 +22,9 @@ describe(warnOnMaskedSkips, () => {
   });
 
   it('raises diagnosis-inconclusive for a check that reached no verdict', () => {
-    const warnings = warn([{ name: 'Registry is reachable', verdict: 'inconclusive', reason: 'fetch failed' }]);
+    const { warnings } = warn([{ name: 'Registry is reachable', verdict: 'inconclusive', reason: 'fetch failed' }]);
 
-    expect(warnings.warnings).toStrictEqual([
+    expect(warnings).toStrictEqual([
       {
         code: 'diagnosis-inconclusive',
         message:
@@ -31,20 +35,20 @@ describe(warnOnMaskedSkips, () => {
   });
 
   it('ends the sentence with one period where the reason already carries one', () => {
-    const warnings = warn([{ name: 'a', verdict: 'inconclusive', reason: 'check() returned null.' }]);
+    const { warnings } = warn([{ name: 'a', verdict: 'inconclusive', reason: 'check() returned null.' }]);
 
-    expect(warnings.warnings[0]?.message).toBe(
+    expect(warnings[0]?.message).toBe(
       'skipped check "a" in kit "default" / checklist "repo" could not be diagnosed: check() returned null.',
     );
   });
 
   it('writes every warning to stderr', () => {
-    const warnings = warn([
+    const { stderr } = warn([
       { name: 'a', verdict: 'masked-pass' },
       { name: 'b', verdict: 'inconclusive', reason: 'boom' },
     ]);
 
-    expect(warnings.stderr).toBe(
+    expect(stderr).toBe(
       'Warning: skipped check "a" in kit "default" / checklist "repo" would have passed. ' +
         'Narrow its skip to the states where the check would fail, or remove the skip.\n' +
         'Warning: skipped check "b" in kit "default" / checklist "repo" could not be diagnosed: boom. ' +
@@ -53,27 +57,62 @@ describe(warnOnMaskedSkips, () => {
   });
 
   it('stays silent where diagnosis did not run', () => {
-    const warnings = warn(undefined);
+    const { warnings, stderr } = warn(undefined);
 
-    expect(warnings.warnings).toStrictEqual([]);
-    expect(warnings.stderr).toBe('');
+    expect(warnings).toStrictEqual([]);
+    expect(stderr).toBe('');
   });
 
   it('stays silent where diagnosis found nothing', () => {
-    const warnings = warn([]);
+    const { warnings, stderr } = warn([]);
 
-    expect(warnings.warnings).toStrictEqual([]);
-    expect(warnings.stderr).toBe('');
+    expect(warnings).toStrictEqual([]);
+    expect(stderr).toBe('');
+  });
+
+  describe('kit identity', () => {
+    // Every kit `--packages` resolves carries the same name, so the package is the only thing that
+    // tells one run entry's warnings from another's.
+    it('names the publishing package beside the kit', () => {
+      const { warnings } = warn([{ name: 'a', verdict: 'masked-pass' }], packagedKit());
+
+      expect(warnings[0]?.message).toBe(
+        'skipped check "a" in kit "default" from @williamthorsen/nmr / checklist "repo" would have passed.',
+      );
+    });
+
+    it('names the kit alone for a source that is not a package', () => {
+      const remote: ResolvedKitEntry = {
+        name: 'deploy',
+        source: { url: 'https://example.com/deploy.js' },
+        checklists: [],
+        provenance: { kind: 'remote', label: 'example.com/deploy.js' },
+      };
+
+      const { warnings } = warn([{ name: 'a', verdict: 'masked-pass' }], remote);
+
+      expect(warnings[0]?.message).toBe('skipped check "a" in kit "deploy" / checklist "repo" would have passed.');
+    });
   });
 });
 
 // region | Helpers
 
+/** Builds the entry a kit published by an installed package resolves to. */
+function packagedKit(): ResolvedKitEntry {
+  return {
+    name: 'default',
+    source: { path: 'node_modules/@williamthorsen/nmr/.readyup/kits/default.js' },
+    checklists: [],
+    provenance: { kind: 'package', packageName: '@williamthorsen/nmr', version: '1.2.3' },
+  };
+}
+
 /** Warns over one checklist's diagnoses, returning the entries alongside everything they wrote. */
-function warn(diagnoses: SkipDiagnosis[] | undefined) {
+function warn(diagnoses: SkipDiagnosis[] | undefined, entry: ResolvedKitEntry = LOCAL_KIT) {
   using io = captureStdio();
 
-  const warnings = warnOnMaskedSkips('default', 'repo', diagnoses);
+  const warnings = warnOnMaskedSkips(entry, 'repo', diagnoses);
 
   return { warnings, stderr: io.stderr };
 }

--- a/packages/readyup/src/run/__tests__/skip-diagnosis.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/skip-diagnosis.unit.test.ts
@@ -1,0 +1,81 @@
+import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
+import { describe, expect, it } from 'vitest';
+
+import type { SkipDiagnosis } from '../../kits/types.ts';
+import { warnOnMaskedSkips } from '../skip-diagnosis.ts';
+
+describe(warnOnMaskedSkips, () => {
+  it('raises skip-masks-pass for a skip that suppressed a pass', () => {
+    const warnings = warn([{ name: 'Coverage is at least 90%', verdict: 'masked-pass' }]);
+
+    expect(warnings.warnings).toStrictEqual([
+      {
+        code: 'skip-masks-pass',
+        message: 'skipped check "Coverage is at least 90%" in kit "default" / checklist "repo" would have passed.',
+        remedy: 'Narrow its skip to the states where the check would fail, or remove the skip.',
+      },
+    ]);
+  });
+
+  it('raises diagnosis-inconclusive for a check that reached no verdict', () => {
+    const warnings = warn([{ name: 'Registry is reachable', verdict: 'inconclusive', reason: 'fetch failed' }]);
+
+    expect(warnings.warnings).toStrictEqual([
+      {
+        code: 'diagnosis-inconclusive',
+        message:
+          'skipped check "Registry is reachable" in kit "default" / checklist "repo" could not be diagnosed: fetch failed.',
+        remedy: 'Fix the check so it returns a verdict, then re-run with --diagnose.',
+      },
+    ]);
+  });
+
+  it('ends the sentence with one period where the reason already carries one', () => {
+    const warnings = warn([{ name: 'a', verdict: 'inconclusive', reason: 'check() returned null.' }]);
+
+    expect(warnings.warnings[0]?.message).toBe(
+      'skipped check "a" in kit "default" / checklist "repo" could not be diagnosed: check() returned null.',
+    );
+  });
+
+  it('writes every warning to stderr', () => {
+    const warnings = warn([
+      { name: 'a', verdict: 'masked-pass' },
+      { name: 'b', verdict: 'inconclusive', reason: 'boom' },
+    ]);
+
+    expect(warnings.stderr).toBe(
+      'Warning: skipped check "a" in kit "default" / checklist "repo" would have passed. ' +
+        'Narrow its skip to the states where the check would fail, or remove the skip.\n' +
+        'Warning: skipped check "b" in kit "default" / checklist "repo" could not be diagnosed: boom. ' +
+        'Fix the check so it returns a verdict, then re-run with --diagnose.\n',
+    );
+  });
+
+  it('stays silent where diagnosis did not run', () => {
+    const warnings = warn(undefined);
+
+    expect(warnings.warnings).toStrictEqual([]);
+    expect(warnings.stderr).toBe('');
+  });
+
+  it('stays silent where diagnosis found nothing', () => {
+    const warnings = warn([]);
+
+    expect(warnings.warnings).toStrictEqual([]);
+    expect(warnings.stderr).toBe('');
+  });
+});
+
+// region | Helpers
+
+/** Warns over one checklist's diagnoses, returning the entries alongside everything they wrote. */
+function warn(diagnoses: SkipDiagnosis[] | undefined) {
+  using io = captureStdio();
+
+  const warnings = warnOnMaskedSkips('default', 'repo', diagnoses);
+
+  return { warnings, stderr: io.stderr };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/run/check-return.ts
+++ b/packages/readyup/src/run/check-return.ts
@@ -2,17 +2,17 @@ import type { CheckOutcome } from '../kits/types.ts';
 import { describeValue } from '../portable/describe-value.ts';
 import { isRecord } from '../portable/isRecord.ts';
 
+/** Describes a `check` return value that expresses no verdict, naming what was expected instead. */
+export function describeUninterpretableReturn(raw: unknown): string {
+  return `check() returned ${describeValue(raw)}; expected a boolean or an object with a boolean "ok" property.`;
+}
+
 /**
- * Return true if a check's return value is a structured outcome.
+ * Returns true if a check's return value is a structured outcome.
  *
  * `ok` must be a boolean: a truthy value of any other type is an authoring mistake, not a pass, and
  * treating it as one is how a broken check reports success.
  */
 export function isCheckOutcome(raw: unknown): raw is CheckOutcome {
   return isRecord(raw) && typeof raw['ok'] === 'boolean';
-}
-
-/** Describes a `check` return value that expresses no verdict, naming what was expected instead. */
-export function describeUninterpretableReturn(raw: unknown): string {
-  return `check() returned ${describeValue(raw)}; expected a boolean or an object with a boolean "ok" property.`;
 }

--- a/packages/readyup/src/run/check-return.ts
+++ b/packages/readyup/src/run/check-return.ts
@@ -1,0 +1,18 @@
+import type { CheckOutcome } from '../kits/types.ts';
+import { describeValue } from '../portable/describe-value.ts';
+import { isRecord } from '../portable/isRecord.ts';
+
+/**
+ * Return true if a check's return value is a structured outcome.
+ *
+ * `ok` must be a boolean: a truthy value of any other type is an authoring mistake, not a pass, and
+ * treating it as one is how a broken check reports success.
+ */
+export function isCheckOutcome(raw: unknown): raw is CheckOutcome {
+  return isRecord(raw) && typeof raw['ok'] === 'boolean';
+}
+
+/** Describes a `check` return value that expresses no verdict, naming what was expected instead. */
+export function describeUninterpretableReturn(raw: unknown): string {
+  return `check() returned ${describeValue(raw)}; expected a boolean or an object with a boolean "ok" property.`;
+}

--- a/packages/readyup/src/run/parseRunArgs.ts
+++ b/packages/readyup/src/run/parseRunArgs.ts
@@ -13,6 +13,7 @@ import { validateRunFlags } from './validateRunFlags.ts';
 export interface ParsedRunArgs {
   checklists: string[] | undefined;
   detail?: JsonDetail;
+  diagnose: boolean;
   failOn?: Severity;
   filePath: string | undefined;
   fromValue: string | undefined;
@@ -40,6 +41,7 @@ const VALID_SEVERITIES = new Set<string>(['error', 'warn', 'recommend']);
 const runOptions = {
   checklists: { type: 'string', short: 'c' },
   detail: { type: 'string' },
+  diagnose: { type: 'boolean' },
   'fail-on': { type: 'string' },
   file: { type: 'string', short: 'f' },
   from: { type: 'string' },
@@ -83,6 +85,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   const parsed = {
     checklists: values.checklists,
     detail: values.detail,
+    diagnose: values.diagnose === true,
     file: values.file,
     from: values.from,
     internal: values.internal === true,
@@ -120,6 +123,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
 
   const parsedArgs: ParsedRunArgs = {
     checklists,
+    diagnose: parsed.diagnose,
     filePath: parsed.file,
     fromValue: parsed.from,
     internal: parsed.internal,

--- a/packages/readyup/src/run/runCommand.ts
+++ b/packages/readyup/src/run/runCommand.ts
@@ -8,6 +8,7 @@ interface RunCommandOptions {
   kitEntries: ResolvedKitEntry[];
   json: boolean;
   detail?: JsonDetail;
+  diagnose?: boolean;
   failOn?: Severity;
   quiet?: boolean;
   reportOn?: Severity;
@@ -15,11 +16,11 @@ interface RunCommandOptions {
 
 /** Runs rdy checklists across one or more kits. Returns a numeric exit code. */
 export async function runCommand(
-  { kitEntries, json, detail, failOn, quiet, reportOn }: RunCommandOptions,
+  { kitEntries, json, detail, diagnose, failOn, quiet, reportOn }: RunCommandOptions,
   isJit = false,
 ): Promise<number> {
   if (json) {
-    return runJsonMode(kitEntries, { detail: detail ?? 'full', failOn, reportOn }, isJit);
+    return runJsonMode(kitEntries, { detail: detail ?? 'full', diagnose: diagnose === true, failOn, reportOn }, isJit);
   }
-  return runHumanMode(kitEntries, { failOn, quiet: quiet === true, reportOn }, isJit);
+  return runHumanMode(kitEntries, { diagnose: diagnose === true, failOn, quiet: quiet === true, reportOn }, isJit);
 }

--- a/packages/readyup/src/run/runHumanMode.ts
+++ b/packages/readyup/src/run/runHumanMode.ts
@@ -16,8 +16,10 @@ import { resolveRunExitCode } from './resolveRunExitCode.ts';
 import { resolveThresholds } from './resolveThresholds.ts';
 import { runRdy } from './runRdy.ts';
 import { selectChecklists } from './selectChecklists.ts';
+import { warnOnMaskedSkips } from './skip-diagnosis.ts';
 
 interface HumanRunSettings {
+  diagnose: boolean;
   failOn: Severity | undefined;
   quiet: boolean;
   reportOn: Severity | undefined;
@@ -60,6 +62,7 @@ export async function runHumanMode(
 
       const kitResult = await runKit(kit, entry.checklists, settings, {
         isMultiKit,
+        kitName: entry.name,
         kitSegments,
         writeBlock,
       });
@@ -149,9 +152,10 @@ function resolveFixLocation(checklist: RdyChecklist | RdyStagedChecklist, kitDef
   return checklist.fixLocation ?? kitDefault ?? 'end';
 }
 
-/** What a kit's checklists need in order to take their place in the run's sequence of blocks. */
+/** What a kit's checklists need from the run they belong to. */
 interface KitBlockContext {
   isMultiKit: boolean;
+  kitName: string;
   kitSegments: BreadcrumbSegment[];
   writeBlock: BlockWriter;
 }
@@ -168,7 +172,7 @@ async function runKit(
   kit: RdyKit,
   checklistFilter: string[],
   settings: HumanRunSettings,
-  { isMultiKit, kitSegments, writeBlock }: KitBlockContext,
+  { isMultiKit, kitName, kitSegments, writeBlock }: KitBlockContext,
 ): Promise<KitRunResult> {
   const checklists = selectChecklists(kit, checklistFilter);
   const thresholds = resolveThresholds(kit, settings.failOn, settings.reportOn);
@@ -183,6 +187,7 @@ async function runKit(
   for (const checklist of checklists) {
     const report = await runRdy(checklist, {
       defaultSeverity: thresholds.defaultSeverity,
+      diagnose: settings.diagnose,
       failOn: thresholds.failOn,
     });
     const fixLocation = resolveFixLocation(checklist, kit.fixLocation);
@@ -202,6 +207,9 @@ async function runKit(
     } else {
       hasDroppedBlock = true;
     }
+
+    // Written after the block, so the reader has just seen the skipped line the warning is about.
+    warnOnMaskedSkips(kitName, checklist.name, report.diagnoses);
 
     if (!report.passed) {
       allPassed = false;

--- a/packages/readyup/src/run/runHumanMode.ts
+++ b/packages/readyup/src/run/runHumanMode.ts
@@ -61,8 +61,8 @@ export async function runHumanMode(
       warnOnKitStaleness(entry.name, entry.source, tracking);
 
       const kitResult = await runKit(kit, entry.checklists, settings, {
+        entry,
         isMultiKit,
-        kitName: entry.name,
         kitSegments,
         writeBlock,
       });
@@ -154,8 +154,8 @@ function resolveFixLocation(checklist: RdyChecklist | RdyStagedChecklist, kitDef
 
 /** What a kit's checklists need from the run they belong to. */
 interface KitBlockContext {
+  entry: ResolvedKitEntry;
   isMultiKit: boolean;
-  kitName: string;
   kitSegments: BreadcrumbSegment[];
   writeBlock: BlockWriter;
 }
@@ -172,7 +172,7 @@ async function runKit(
   kit: RdyKit,
   checklistFilter: string[],
   settings: HumanRunSettings,
-  { isMultiKit, kitName, kitSegments, writeBlock }: KitBlockContext,
+  { entry, isMultiKit, kitSegments, writeBlock }: KitBlockContext,
 ): Promise<KitRunResult> {
   const checklists = selectChecklists(kit, checklistFilter);
   const thresholds = resolveThresholds(kit, settings.failOn, settings.reportOn);
@@ -209,7 +209,7 @@ async function runKit(
     }
 
     // Written after the block, so the reader has just seen the skipped line the warning is about.
-    warnOnMaskedSkips(kitName, checklist.name, report.diagnoses);
+    warnOnMaskedSkips(entry, checklist.name, report.diagnoses);
 
     if (!report.passed) {
       allPassed = false;

--- a/packages/readyup/src/run/runJsonMode.ts
+++ b/packages/readyup/src/run/runJsonMode.ts
@@ -60,7 +60,7 @@ export async function runJsonMode(
           failOn: thresholds.failOn,
         });
         entries.push({ name: checklist.name, report });
-        warnings.push(...warnOnMaskedSkips(entry.name, checklist.name, report.diagnoses));
+        warnings.push(...warnOnMaskedSkips(entry, checklist.name, report.diagnoses));
         if (!report.passed) allPassed = false;
       }
 

--- a/packages/readyup/src/run/runJsonMode.ts
+++ b/packages/readyup/src/run/runJsonMode.ts
@@ -13,9 +13,11 @@ import { resolveRunExitCode } from './resolveRunExitCode.ts';
 import { resolveThresholds } from './resolveThresholds.ts';
 import { runRdy } from './runRdy.ts';
 import { selectChecklists } from './selectChecklists.ts';
+import { warnOnMaskedSkips } from './skip-diagnosis.ts';
 
 interface JsonRunSettings {
   detail: JsonDetail;
+  diagnose: boolean;
   failOn: Severity | undefined;
   reportOn: Severity | undefined;
 }
@@ -33,7 +35,7 @@ export async function runJsonMode(
   settings: JsonRunSettings,
   isJit: boolean,
 ): Promise<number> {
-  const { detail, failOn, reportOn } = settings;
+  const { detail, diagnose, failOn, reportOn } = settings;
   const kitInputs: KitInput[] = [];
   const warnings: JsonWarning[] = [];
   const tracking = readManifestTracking(isJit);
@@ -54,9 +56,11 @@ export async function runJsonMode(
       for (const checklist of checklists) {
         const report = await runRdy(checklist, {
           defaultSeverity: thresholds.defaultSeverity,
+          diagnose,
           failOn: thresholds.failOn,
         });
         entries.push({ name: checklist.name, report });
+        warnings.push(...warnOnMaskedSkips(entry.name, checklist.name, report.diagnoses));
         if (!report.passed) allPassed = false;
       }
 

--- a/packages/readyup/src/run/runRdy.ts
+++ b/packages/readyup/src/run/runRdy.ts
@@ -28,17 +28,24 @@ export interface RunRdyOptions {
   diagnose?: boolean;
 }
 
+/** A check whose `skip` fired, paired with the result standing in for it. */
+interface PendingDiagnosis {
+  check: RdyCheck;
+  result: SkippedResult;
+}
+
 /** What every step of a checklist walk carries with it. */
 interface RunContext {
   defaultSeverity: Severity;
 
   /**
-   * The checks whose `skip` returned a reason, in the order the walk reached them.
+   * The checks whose `skip` returned a reason, in the order their skips resolved.
    *
    * Collected unconditionally, because recording a reference executes nothing; only the diagnosis
-   * that reads them is gated on the option.
+   * that reads them is gated on the option. Each carries its result, which is what lets the findings
+   * be read back in the report's own order rather than in the order the skips happened to settle.
    */
-  skippedChecks: RdyCheck[];
+  pendingDiagnoses: PendingDiagnosis[];
 }
 
 /**
@@ -164,9 +171,10 @@ async function executeCheck(check: RdyCheck, run: RunContext, depth = 0): Promis
       // author wrote, whatever the declared type promised.
       const skipResult: unknown = await check.skip();
       if (typeof skipResult === 'string') {
-        run.skippedChecks.push(check);
+        const result = buildSkippedResult({ ...context, skipReason: 'n/a', detail: skipResult });
+        run.pendingDiagnoses.push({ check, result });
         // An `n/a` skip terminates its subtree: descendants produce no results at all.
-        return [buildSkippedResult({ ...context, skipReason: 'n/a', detail: skipResult })];
+        return [result];
       }
       if (skipResult !== false) {
         const error = new Error(
@@ -338,6 +346,18 @@ async function runStagedChecks(
 }
 
 /**
+ * Orders the checks awaiting diagnosis by where their results sit in the report.
+ *
+ * Siblings resolve concurrently, so an asynchronous `skip` records out of declaration order. Reading
+ * the order back off `results`, which is declaration-ordered by construction, is what keeps the
+ * advisories in the order the reader met the skipped lines, run after run.
+ */
+function orderByResult(results: RdyResult[], pending: PendingDiagnosis[]): RdyCheck[] {
+  const checkByResult = new Map<RdyResult, RdyCheck>(pending.map(({ check, result }) => [result, check]));
+  return results.map((result) => checkByResult.get(result)).filter((check) => check !== undefined);
+}
+
+/**
  * Run all checks in a checklist and produce a report.
  *
  * Preconditions run first. If any fails, all subsequent checks are skipped; a precondition
@@ -359,7 +379,7 @@ export async function runRdy(
   const start = performance.now();
   const results: RdyResult[] = [];
 
-  const run: RunContext = { defaultSeverity, skippedChecks: [] };
+  const run: RunContext = { defaultSeverity, pendingDiagnoses: [] };
 
   const preconditionsPassed = await runPreconditions(checklist.preconditions ?? [], results, run);
 
@@ -373,7 +393,7 @@ export async function runRdy(
   const passed = results.every((r) => !(r.status === 'failed' && meetsThreshold(r.severity, failOn)));
 
   const diagnoses: SkipDiagnosis[] | undefined =
-    options.diagnose === true ? await diagnoseSkips(run.skippedChecks) : undefined;
+    options.diagnose === true ? await diagnoseSkips(orderByResult(results, run.pendingDiagnoses)) : undefined;
 
   return { results, passed, durationMs, ...(diagnoses !== undefined && { diagnoses }) };
 }

--- a/packages/readyup/src/run/runRdy.ts
+++ b/packages/readyup/src/run/runRdy.ts
@@ -1,7 +1,6 @@
 import { performance } from 'node:perf_hooks';
 
 import type {
-  CheckOutcome,
   FailedResult,
   PassedResult,
   Progress,
@@ -11,17 +10,35 @@ import type {
   RdyResult,
   RdyStagedChecklist,
   Severity,
+  SkipDiagnosis,
   SkippedResult,
 } from '../kits/types.ts';
 import { isFlatChecklist } from '../kits/types.ts';
 import { describeValue } from '../portable/describe-value.ts';
-import { isRecord } from '../portable/isRecord.ts';
 import { meetsThreshold } from '../severity/meetsThreshold.ts';
+import { describeUninterpretableReturn, isCheckOutcome } from './check-return.ts';
+import { diagnoseSkips } from './skip-diagnosis.ts';
 
 /** Options controlling failure and severity defaults for a run. */
 export interface RunRdyOptions {
   defaultSeverity?: Severity;
   failOn?: Severity;
+
+  /** Whether to ask each skipped check what its `check` would have concluded. */
+  diagnose?: boolean;
+}
+
+/** What every step of a checklist walk carries with it. */
+interface RunContext {
+  defaultSeverity: Severity;
+
+  /**
+   * The checks whose `skip` returned a reason, in the order the walk reached them.
+   *
+   * Collected unconditionally, because recording a reference executes nothing; only the diagnosis
+   * that reads them is gated on the option.
+   */
+  skippedChecks: RdyCheck[];
 }
 
 /**
@@ -135,8 +152,8 @@ function buildAuthoringErrorResult(
  *
  * Returns the check's own result followed by all descendant results in depth-first order.
  */
-async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 0): Promise<RdyResult[]> {
-  const context = buildCheckContext(check, defaultSeverity, depth);
+async function executeCheck(check: RdyCheck, run: RunContext, depth = 0): Promise<RdyResult[]> {
+  const context = buildCheckContext(check, run.defaultSeverity, depth);
   const children = check.checks ?? [];
 
   // Evaluate skip condition before running the check.
@@ -147,6 +164,7 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
       // author wrote, whatever the declared type promised.
       const skipResult: unknown = await check.skip();
       if (typeof skipResult === 'string') {
+        run.skippedChecks.push(check);
         // An `n/a` skip terminates its subtree: descendants produce no results at all.
         return [buildSkippedResult({ ...context, skipReason: 'n/a', detail: skipResult })];
       }
@@ -155,13 +173,13 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
           `skip() returned ${describeValue(skipResult)}; expected false to run the check, or a reason string to skip it.`,
         );
         const result = buildAuthoringErrorResult(check, context, performance.now() - start, error);
-        const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
+        const childResults = skipAllDescendants(children, run, depth + 1);
         return [result, ...childResults];
       }
     } catch (error_: unknown) {
       const error = error_ instanceof Error ? error_ : new Error(String(error_));
       const result = buildAuthoringErrorResult(check, context, performance.now() - start, error);
-      const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
+      const childResults = skipAllDescendants(children, run, depth + 1);
       return [result, ...childResults];
     }
   }
@@ -184,18 +202,16 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
     } else {
       // Reported as a defect rather than as an ordinary failure: the check never expressed a
       // verdict, so the severity it declared for its subject says nothing about this outcome.
-      const error = new Error(
-        `check() returned ${describeValue(raw)}; expected a boolean or an object with a boolean "ok" property.`,
-      );
+      const error = new Error(describeUninterpretableReturn(raw));
       result = buildAuthoringErrorResult(check, context, durationMs, error);
     }
 
-    const childResults = await collectChildResults(result, children, defaultSeverity, depth + 1);
+    const childResults = await collectChildResults(result, children, run, depth + 1);
     return [result, ...childResults];
   } catch (error_: unknown) {
     const error = error_ instanceof Error ? error_ : new Error(String(error_));
     const result = buildAuthoringErrorResult(check, context, performance.now() - start, error);
-    const childResults = skipAllDescendants(children, defaultSeverity, depth + 1);
+    const childResults = skipAllDescendants(children, run, depth + 1);
     return [result, ...childResults];
   }
 }
@@ -209,16 +225,16 @@ async function executeCheck(check: RdyCheck, defaultSeverity: Severity, depth = 
 async function collectChildResults(
   parentResult: PassedResult | FailedResult,
   children: RdyCheck[],
-  defaultSeverity: Severity,
+  run: RunContext,
   childDepth: number,
 ): Promise<RdyResult[]> {
   if (children.length === 0) return [];
 
   if (parentResult.status === 'failed') {
-    return skipAllDescendants(children, defaultSeverity, childDepth);
+    return skipAllDescendants(children, run, childDepth);
   }
 
-  return runSiblingChecks(children, defaultSeverity, childDepth);
+  return runSiblingChecks(children, run, childDepth);
 }
 
 /**
@@ -228,8 +244,8 @@ async function collectChildResults(
  * preserves declaration order: each sibling's own result is followed by its
  * subtree before the next sibling appears.
  */
-async function runSiblingChecks(checks: RdyCheck[], defaultSeverity: Severity, depth: number): Promise<RdyResult[]> {
-  const siblingTrees = await Promise.all(checks.map((c) => executeCheck(c, defaultSeverity, depth)));
+async function runSiblingChecks(checks: RdyCheck[], run: RunContext, depth: number): Promise<RdyResult[]> {
+  const siblingTrees = await Promise.all(checks.map((c) => executeCheck(c, run, depth)));
   return siblingTrees.flat();
 }
 
@@ -239,32 +255,28 @@ async function runSiblingChecks(checks: RdyCheck[], defaultSeverity: Severity, d
  * Every skip produced here is a `precondition` skip: an `n/a` skip terminates its own
  * subtree in `executeCheck` and so never reaches this function.
  */
-function skipAllDescendants(checks: RdyCheck[], defaultSeverity: Severity, depth: number): RdyResult[] {
+function skipAllDescendants(checks: RdyCheck[], run: RunContext, depth: number): RdyResult[] {
   const results: RdyResult[] = [];
   for (const check of checks) {
-    results.push(skipCheck(check, defaultSeverity, depth));
+    results.push(skipCheck(check, run, depth));
     if (check.checks !== undefined && check.checks.length > 0) {
-      results.push(...skipAllDescendants(check.checks, defaultSeverity, depth + 1));
+      results.push(...skipAllDescendants(check.checks, run, depth + 1));
     }
   }
   return results;
 }
 
 /** Mark a check as skipped because a precondition or ancestor check failed. */
-function skipCheck(check: RdyCheck, defaultSeverity: Severity, depth: number): RdyResult {
-  const context = buildCheckContext(check, defaultSeverity, depth);
+function skipCheck(check: RdyCheck, run: RunContext, depth: number): RdyResult {
+  const context = buildCheckContext(check, run.defaultSeverity, depth);
   return buildSkippedResult({ ...context, skipReason: 'precondition', detail: null });
 }
 
 /** Run preconditions concurrently. Return true if all passed. */
-async function runPreconditions(
-  preconditions: RdyCheck[],
-  results: RdyResult[],
-  defaultSeverity: Severity,
-): Promise<boolean> {
+async function runPreconditions(preconditions: RdyCheck[], results: RdyResult[], run: RunContext): Promise<boolean> {
   if (preconditions.length === 0) return true;
 
-  const trees = await Promise.all(preconditions.map((c) => executeCheck(c, defaultSeverity)));
+  const trees = await Promise.all(preconditions.map((c) => executeCheck(c, run)));
   const flat = trees.flat();
   results.push(...flat);
 
@@ -278,14 +290,14 @@ async function runFlatChecks(
   checklist: RdyChecklist,
   results: RdyResult[],
   preconditionsPassed: boolean,
-  defaultSeverity: Severity,
+  run: RunContext,
 ): Promise<void> {
   if (!preconditionsPassed) {
-    results.push(...skipAllDescendants(checklist.checks, defaultSeverity, 0));
+    results.push(...skipAllDescendants(checklist.checks, run, 0));
     return;
   }
 
-  const checkResults = await runSiblingChecks(checklist.checks, defaultSeverity, 0);
+  const checkResults = await runSiblingChecks(checklist.checks, run, 0);
   results.push(...checkResults);
 }
 
@@ -294,12 +306,12 @@ async function runStagedChecks(
   checklist: RdyStagedChecklist,
   results: RdyResult[],
   preconditionsPassed: boolean,
-  defaultSeverity: Severity,
+  run: RunContext,
   failOn: Severity,
 ): Promise<void> {
   if (!preconditionsPassed) {
     for (const group of checklist.groups) {
-      results.push(...skipAllDescendants(group, defaultSeverity, 0));
+      results.push(...skipAllDescendants(group, run, 0));
     }
     return;
   }
@@ -307,11 +319,11 @@ async function runStagedChecks(
   let shouldSkipRemaining = false;
   for (const group of checklist.groups) {
     if (shouldSkipRemaining) {
-      results.push(...skipAllDescendants(group, defaultSeverity, 0));
+      results.push(...skipAllDescendants(group, run, 0));
       continue;
     }
 
-    const groupResults = await runSiblingChecks(group, defaultSeverity, 0);
+    const groupResults = await runSiblingChecks(group, run, 0);
     results.push(...groupResults);
 
     // Only top-level group results (depth 0) determine whether to halt subsequent groups,
@@ -333,6 +345,10 @@ async function runStagedChecks(
  * Flat checklists run all checks concurrently. Staged checklists run groups
  * sequentially, bailing on later groups when an earlier group has a failure
  * at or above the failure threshold.
+ *
+ * Diagnosis, when asked for, runs once the duration and the verdict are settled. Observing the run
+ * cannot then alter it: no diagnostic check can reach a conclusion that already exists, and none
+ * enters the wall clock the report carries.
  */
 export async function runRdy(
   checklist: RdyChecklist | RdyStagedChecklist,
@@ -343,26 +359,21 @@ export async function runRdy(
   const start = performance.now();
   const results: RdyResult[] = [];
 
-  const preconditionsPassed = await runPreconditions(checklist.preconditions ?? [], results, defaultSeverity);
+  const run: RunContext = { defaultSeverity, skippedChecks: [] };
+
+  const preconditionsPassed = await runPreconditions(checklist.preconditions ?? [], results, run);
 
   await (isFlatChecklist(checklist)
-    ? runFlatChecks(checklist, results, preconditionsPassed, defaultSeverity)
-    : runStagedChecks(checklist, results, preconditionsPassed, defaultSeverity, failOn));
+    ? runFlatChecks(checklist, results, preconditionsPassed, run)
+    : runStagedChecks(checklist, results, preconditionsPassed, run, failOn));
 
   const durationMs = performance.now() - start;
 
   // The run passes when no failed result has severity at or above the failure threshold.
   const passed = results.every((r) => !(r.status === 'failed' && meetsThreshold(r.severity, failOn)));
 
-  return { results, passed, durationMs };
-}
+  const diagnoses: SkipDiagnosis[] | undefined =
+    options.diagnose === true ? await diagnoseSkips(run.skippedChecks) : undefined;
 
-/**
- * Return true if a check's return value is a structured outcome.
- *
- * `ok` must be a boolean: a truthy value of any other type is an authoring mistake, not a pass, and
- * treating it as one is how a broken check reports success.
- */
-function isCheckOutcome(raw: unknown): raw is CheckOutcome {
-  return isRecord(raw) && typeof raw['ok'] === 'boolean';
+  return { results, passed, durationMs, ...(diagnoses !== undefined && { diagnoses }) };
 }

--- a/packages/readyup/src/run/skip-diagnosis.ts
+++ b/packages/readyup/src/run/skip-diagnosis.ts
@@ -1,0 +1,41 @@
+import type { RdyCheck, SkipDiagnosis } from '../kits/types.ts';
+import { describeUninterpretableReturn, isCheckOutcome } from './check-return.ts';
+
+/**
+ * Reports what the `check` of each skipped check would have concluded.
+ *
+ * Runs them concurrently, as the runner runs siblings, calling each `check` once and re-evaluating
+ * no `skip`. A check that would have failed used its skip correctly and contributes nothing, so
+ * every entry returned is a finding.
+ */
+export async function diagnoseSkips(checks: RdyCheck[]): Promise<SkipDiagnosis[]> {
+  const diagnoses = await Promise.all(checks.map(diagnoseSkip));
+  return diagnoses.filter((diagnosis) => diagnosis !== undefined);
+}
+
+// region | Helpers
+
+/**
+ * Diagnoses one skipped check, answering with nothing where its `check` would have failed.
+ *
+ * A `check` that throws, or that returns a value expressing no verdict, leaves the question
+ * undecided: reporting either as a masked pass would assert something the run never established.
+ */
+async function diagnoseSkip(check: RdyCheck): Promise<SkipDiagnosis | undefined> {
+  let raw: unknown;
+  try {
+    // Widened to `unknown`: a kit runs as JavaScript, so its functions return whatever their author
+    // wrote, whatever the declared type promised.
+    raw = await check.check();
+  } catch (error_: unknown) {
+    const error = error_ instanceof Error ? error_ : new Error(String(error_));
+    return { name: check.name, verdict: 'inconclusive', reason: error.message };
+  }
+
+  if (typeof raw === 'boolean') return raw ? { name: check.name, verdict: 'masked-pass' } : undefined;
+  if (isCheckOutcome(raw)) return raw.ok ? { name: check.name, verdict: 'masked-pass' } : undefined;
+
+  return { name: check.name, verdict: 'inconclusive', reason: describeUninterpretableReturn(raw) };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/run/skip-diagnosis.ts
+++ b/packages/readyup/src/run/skip-diagnosis.ts
@@ -1,8 +1,10 @@
 import process from 'node:process';
 
+import { describeKitOwner } from '../kits/describeKitOwner.ts';
 import type { RdyCheck, SkipDiagnosis } from '../kits/types.ts';
 import type { RaisedWarning } from '../schemas/common.ts';
 import { describeUninterpretableReturn, isCheckOutcome } from './check-return.ts';
+import type { ResolvedKitEntry } from './ResolvedKitEntry.ts';
 
 /**
  * Reports what the `check` of each skipped check would have concluded.
@@ -29,13 +31,13 @@ export async function diagnoseSkips(checks: RdyCheck[]): Promise<SkipDiagnosis[]
  * that family, these are check-derived rather than manifest-derived, so no kit source silences them.
  */
 export function warnOnMaskedSkips(
-  kitName: string,
+  entry: ResolvedKitEntry,
   checklistName: string,
   diagnoses: SkipDiagnosis[] | undefined,
 ): RaisedWarning[] {
   if (diagnoses === undefined) return [];
 
-  const warnings = diagnoses.map((diagnosis) => toWarning(kitName, checklistName, diagnosis));
+  const warnings = diagnoses.map((diagnosis) => toWarning(entry, checklistName, diagnosis));
   for (const warning of warnings) {
     process.stderr.write(`Warning: ${warning.message} ${warning.remedy}\n`);
   }
@@ -43,6 +45,17 @@ export function warnOnMaskedSkips(
 }
 
 // region | Helpers
+
+/**
+ * Names the check a warning is about, down to the checklist that holds it.
+ *
+ * A masked pass is a property of one check where the staleness advisories are properties of a kit,
+ * and one run may carry many of both, so the check's name alone would not say which line to look at.
+ */
+function describeCheck(entry: ResolvedKitEntry, checklistName: string, name: string): string {
+  const kit = `kit "${entry.name}"${describeKitOwner(entry.provenance)}`;
+  return `skipped check "${name}" in ${kit} / checklist "${checklistName}"`;
+}
 
 /**
  * Diagnoses one skipped check, answering with nothing where its `check` would have failed.
@@ -67,19 +80,9 @@ async function diagnoseSkip(check: RdyCheck): Promise<SkipDiagnosis | undefined>
   return { name: check.name, verdict: 'inconclusive', reason: describeUninterpretableReturn(raw) };
 }
 
-/**
- * Names the check a warning is about, down to the checklist that holds it.
- *
- * A masked pass is a property of one check where the staleness advisories are properties of a kit,
- * and one run may carry many of both, so the check's name alone would not say which line to look at.
- */
-function describeCheck(kitName: string, checklistName: string, name: string): string {
-  return `skipped check "${name}" in kit "${kitName}" / checklist "${checklistName}"`;
-}
-
 /** Composes the warning one diagnosis raises. */
-function toWarning(kitName: string, checklistName: string, diagnosis: SkipDiagnosis): RaisedWarning {
-  const subject = describeCheck(kitName, checklistName, diagnosis.name);
+function toWarning(entry: ResolvedKitEntry, checklistName: string, diagnosis: SkipDiagnosis): RaisedWarning {
+  const subject = describeCheck(entry, checklistName, diagnosis.name);
 
   if (diagnosis.verdict === 'masked-pass') {
     return {

--- a/packages/readyup/src/run/skip-diagnosis.ts
+++ b/packages/readyup/src/run/skip-diagnosis.ts
@@ -1,4 +1,7 @@
+import process from 'node:process';
+
 import type { RdyCheck, SkipDiagnosis } from '../kits/types.ts';
+import type { RaisedWarning } from '../schemas/common.ts';
 import { describeUninterpretableReturn, isCheckOutcome } from './check-return.ts';
 
 /**
@@ -11,6 +14,32 @@ import { describeUninterpretableReturn, isCheckOutcome } from './check-return.ts
 export async function diagnoseSkips(checks: RdyCheck[]): Promise<SkipDiagnosis[]> {
   const diagnoses = await Promise.all(checks.map(diagnoseSkip));
   return diagnoses.filter((diagnosis) => diagnosis !== undefined);
+}
+
+/**
+ * Emits an advisory stderr warning for each diagnosed skip, and returns the entries.
+ *
+ * `skip-masks-pass` says the skip suppressed a pass, which is the condition `--diagnose` exists to
+ * expose. `diagnosis-inconclusive` says the check reached no verdict, so the run established
+ * nothing about that skip either way; the two are separate codes because a consumer branching on
+ * one must never read the other as a masked pass.
+ *
+ * Mirrors `warnOnKitStaleness`: the stderr lines are written in both output modes, and the returned
+ * entries are what JSON mode captures into the report for a consumer that owns only stdout. Unlike
+ * that family, these are check-derived rather than manifest-derived, so no kit source silences them.
+ */
+export function warnOnMaskedSkips(
+  kitName: string,
+  checklistName: string,
+  diagnoses: SkipDiagnosis[] | undefined,
+): RaisedWarning[] {
+  if (diagnoses === undefined) return [];
+
+  const warnings = diagnoses.map((diagnosis) => toWarning(kitName, checklistName, diagnosis));
+  for (const warning of warnings) {
+    process.stderr.write(`Warning: ${warning.message} ${warning.remedy}\n`);
+  }
+  return warnings;
 }
 
 // region | Helpers
@@ -36,6 +65,40 @@ async function diagnoseSkip(check: RdyCheck): Promise<SkipDiagnosis | undefined>
   if (isCheckOutcome(raw)) return raw.ok ? { name: check.name, verdict: 'masked-pass' } : undefined;
 
   return { name: check.name, verdict: 'inconclusive', reason: describeUninterpretableReturn(raw) };
+}
+
+/**
+ * Names the check a warning is about, down to the checklist that holds it.
+ *
+ * A masked pass is a property of one check where the staleness advisories are properties of a kit,
+ * and one run may carry many of both, so the check's name alone would not say which line to look at.
+ */
+function describeCheck(kitName: string, checklistName: string, name: string): string {
+  return `skipped check "${name}" in kit "${kitName}" / checklist "${checklistName}"`;
+}
+
+/** Composes the warning one diagnosis raises. */
+function toWarning(kitName: string, checklistName: string, diagnosis: SkipDiagnosis): RaisedWarning {
+  const subject = describeCheck(kitName, checklistName, diagnosis.name);
+
+  if (diagnosis.verdict === 'masked-pass') {
+    return {
+      code: 'skip-masks-pass',
+      message: `${subject} would have passed.`,
+      remedy: 'Narrow its skip to the states where the check would fail, or remove the skip.',
+    };
+  }
+
+  return {
+    code: 'diagnosis-inconclusive',
+    message: `${subject} could not be diagnosed: ${trimTrailingPeriod(diagnosis.reason)}.`,
+    remedy: 'Fix the check so it returns a verdict, then re-run with --diagnose.',
+  };
+}
+
+/** Trims a reason's trailing period, so the sentence carrying it ends with exactly one. */
+function trimTrailingPeriod(reason: string): string {
+  return reason.endsWith('.') ? reason.slice(0, -1) : reason;
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
@@ -65,7 +65,10 @@ describe('generated JSON Schemas', () => {
 
     it('publishes the warning vocabulary as an open set that still names its known codes', () => {
       expect(valueAt(report, '$defs', 'WarningCode', 'anyOf')).toStrictEqual([
-        { type: 'string', enum: ['input-stale', 'source-stale', 'target-drift'] },
+        {
+          type: 'string',
+          enum: ['diagnosis-inconclusive', 'input-stale', 'skip-masks-pass', 'source-stale', 'target-drift'],
+        },
         { type: 'string' },
       ]);
     });

--- a/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
@@ -249,8 +249,12 @@ describe('JSON payload schemas', () => {
     });
 
     it('binds a producer to the vocabulary this version declares while the wire stays open', () => {
-      expectTypeOf<RaisedWarning['code']>().toEqualTypeOf<'input-stale' | 'source-stale' | 'target-drift'>();
-      expectTypeOf<JsonWarning['code']>().not.toEqualTypeOf<'input-stale' | 'source-stale' | 'target-drift'>();
+      expectTypeOf<RaisedWarning['code']>().toEqualTypeOf<
+        'diagnosis-inconclusive' | 'input-stale' | 'skip-masks-pass' | 'source-stale' | 'target-drift'
+      >();
+      expectTypeOf<JsonWarning['code']>().not.toEqualTypeOf<
+        'diagnosis-inconclusive' | 'input-stale' | 'skip-masks-pass' | 'source-stale' | 'target-drift'
+      >();
     });
 
     it('publishes the known warning codes as distinguishable members of an open set', () => {
@@ -260,6 +264,8 @@ describe('JSON payload schemas', () => {
       expectTypeOf<'target-drift'>().toExtend<JsonWarningCode>();
       expectTypeOf<'source-stale'>().toExtend<JsonWarningCode>();
       expectTypeOf<'input-stale'>().toExtend<JsonWarningCode>();
+      expectTypeOf<'skip-masks-pass'>().toExtend<JsonWarningCode>();
+      expectTypeOf<'diagnosis-inconclusive'>().toExtend<JsonWarningCode>();
       expectTypeOf<'kit-deprecated'>().toExtend<JsonWarningCode>();
     });
   });

--- a/packages/readyup/src/schemas/common.ts
+++ b/packages/readyup/src/schemas/common.ts
@@ -50,7 +50,13 @@ export const CountsSchema = z
   .meta({ id: 'Counts' });
 
 /** The advisory vocabulary this version raises. `RaisedWarning` binds producers to it. */
-export const WarningCodeSchema = z.enum(['input-stale', 'source-stale', 'target-drift']);
+export const WarningCodeSchema = z.enum([
+  'diagnosis-inconclusive',
+  'input-stale',
+  'skip-masks-pass',
+  'source-stale',
+  'target-drift',
+]);
 
 /**
  * The wire form of a warning code: a known value, or any other string.


### PR DESCRIPTION
## What

Adds `rdy run --diagnose`, which runs the `check` of each skipped check and reports the ones that would have passed. It reports them as two new warnings, `skip-masks-pass` and `diagnosis-inconclusive`, written to stderr in both output modes and listed under `warnings` in JSON; statuses, counts, durations, and the exit code are the same as a run without the flag. The flag is off by default because it runs checks that a kit author chose to skip, and such a check may reach a network or a registry.

## Why

A `skip` is meant to stop a check from failing when it does not apply, not to hide a check that would have passed, and nothing caught the difference. Three checks across three kits in `node-monorepo-tools` were skipped in states where they would have passed; one ran the same test in `skip` and in `check`, so it could never pass. Nothing flagged them, because a skipped check renders as an ordinary skipped line and the run still succeeds.

## Details

### 🎉 Features

- `--diagnose` is a boolean flag on `rdy run`. It works with every kit source and both output modes, and no combination is rejected.
- Two new warning codes: `skip-masks-pass` when the skipped check would have passed, and `diagnosis-inconclusive` when its `check` threw an error or returned a value that is neither a pass nor a fail. A check that would have failed used its `skip` correctly, so it produces no warning.
- Each warning names the check, its checklist, and its kit, plus the package that publishes the kit. A `--packages` run loads several kits that are all named `default`, so the package name is what tells them apart. The wording matches the existing kit-import error message.
- Which checks get diagnosed is decided from the checks themselves rather than from the manifest, so the flag works no matter where the kit came from: `--url`, `--from`, `--packages`, and `--jit`. The conditions that silence the staleness warnings do not apply to it. A check blocked by a failed precondition is not diagnosed, because it never declared a skip of its own, and the children of a diagnosed check are not run.
- The warnings are reported in the top-level `warnings` list rather than on the check's own JSON entry. Both `--detail summary` and a filtering `--report-on` drop the skipped check from the report, so a warning attached to that check would disappear with it.

### 🏗️ Internal features

- `runRdy` takes a `diagnose` option. Diagnosis runs after the timer stops and after the pass/fail verdict is computed, so it cannot add to `durationMs` or change the result.
- `RdyReport.diagnoses` carries the results of diagnosis out of the runner. It is absent when diagnosis did not run, which distinguishes "not asked" from "asked, and found nothing". `SkipDiagnosis` is now one of the package's exported types.
- Warnings are listed in the order their checks appear in the report. Matching is by object identity, so two checks with the same name cannot be swapped, and an asynchronous `skip` cannot change the order between runs.

### ♻️ Refactoring

- The `defaultSeverity` parameter passed through every step of the runner is replaced by a `RunContext` object, which also holds the checks waiting to be diagnosed.
- The type guard for a `check` return value, and the error text for a value it cannot read, move to `check-return.ts`, so the runner and the diagnosis share one definition.
- `describeKitOwner` moves out of `describeUnresolvableImports` into `kits/`, so both messages name the publishing package the same way. The import error message itself is unchanged.

### 🧪 Tests

- Runner tests cover both ways a check can report a pass, both ways it can be inconclusive, the precondition exclusion, a precondition that skipped on its own, children left unrun, ordering when a `skip` is asynchronous, and a pair of runs asserting that statuses, per-check durations, and the verdict are the same with and without the flag.
- Warning tests cover both codes, the exact text of each message and remedy, the forms with and without a package name, and a run that did not ask for diagnosis.
- CLI tests cover parsing, use alongside every source flag, and the hand-off from `route` to `runCommand` and on to both output modes.

### 📚 Documentation

- The README's run-options table and both `rdy --help` blocks list the flag, and the run examples gain a `--diagnose` line.
- The README's advisory-warnings section is split into the three codes derived from the manifest and the two that come from `--diagnose`. The two sets are silenced by different things, so the paragraph describing what silences a warning now applies only to the manifest codes.

Closes #343
