### PR TITLE
#339 Move the `route.*` suites onto toolbelt's temp tree and cwd pointer

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -73,6 +73,20 @@ const config = defineConfig([
     extends: [await createConfig.vitest()],
   }),
   {
+    // The route.* suites bind `test.extend(...)` to `it` and register `it.aroundAll(...)`, which
+    // @vitest/eslint-plugin 1.6.27 misreads twice: `consistent-test-it` compares the resolved import name
+    // (`test`) rather than the local binding, so every describe-nested `it(...)` is a false positive; and
+    // `require-hook`'s call-chain table lacks `it.aroundAll`, so the hook registration reads as bare
+    // top-level code. Both are plugin defects; delete this block when the upstream fixes land:
+    // https://github.com/vitest-dev/eslint-plugin-vitest/issues/955 (require-hook) and
+    // https://github.com/vitest-dev/eslint-plugin-vitest/issues/956 (consistent-test-it).
+    files: ['packages/readyup/src/bin/__tests__/route.*.test.ts'],
+    rules: {
+      'vitest/consistent-test-it': 'off',
+      'vitest/require-hook': ['warn', { allowedFunctionCalls: ['it.aroundAll'] }],
+    },
+  },
+  {
     // Config files legitimately mutate and compose configuration objects at module top level.
     files: ['**/*.config.{cjs,js,mjs,ts}', '**/config/**'],
     rules: {

--- a/packages/readyup/package.json
+++ b/packages/readyup/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@types/picomatch": "4.0.3",
+    "@williamthorsen/toolbelt.filesystem": "catalog:",
     "@williamthorsen/toolbelt.testing": "catalog:",
     "@williamthorsen/toolbelt.vitest": "catalog:",
     "ajv": "8.20.0",

--- a/packages/readyup/src/bin/__tests__/route.compiledWithReporting.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.compiledWithReporting.unit.test.ts
@@ -1,22 +1,33 @@
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
-import { describe, expect, it } from 'vitest';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test } from 'vitest';
 
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { VERSION } from '../../version.ts';
 import { routeCommand } from '../route.ts';
 
 /** A kit whose single check passes, shared by every fixture here so only the stamp varies. */
 const KIT_BODY = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
 
-const temp = useTempDir({
-  prefix: 'readyup-compiled-with-',
-  cwd: 'chdir',
-  scope: 'file',
-  setup: () => {
-    temp.write('.readyup/kits/stamped.js', buildStampedKit('0.19.2'));
-    temp.write('.readyup/kits/current.js', buildStampedKit(VERSION));
-    temp.write('.readyup/kits/unstamped.js', KIT_BODY);
-  },
+const it = test.extend(
+  'temp',
+  { scope: 'file' },
+  makeFixture(() =>
+    createTempTree(
+      {
+        '.readyup/kits/current.js': buildStampedKit(VERSION),
+        '.readyup/kits/stamped.js': buildStampedKit('0.19.2'),
+        '.readyup/kits/unstamped.js': KIT_BODY,
+      },
+      { prefix: 'readyup-compiled-with-' },
+    ),
+  ),
+);
+
+it.aroundAll(async (runSuite, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir, { chdir: true });
+
+  await runSuite();
 });
 
 describe('compile-time readyup version in the run report', () => {

--- a/packages/readyup/src/bin/__tests__/route.detailProjection.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.detailProjection.unit.test.ts
@@ -1,7 +1,8 @@
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
-import { describe, expect, it } from 'vitest';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test } from 'vitest';
 
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { routeCommand } from '../route.ts';
 
 /** A kit with one passing check and one failing check that carries a fix. */
@@ -11,11 +12,16 @@ const MIXED_KIT =
   `  { name: 'nope', check: () => false, fix: 'do the thing' },\n` +
   `] }] };\n`;
 
-const temp = useTempDir({
-  prefix: 'readyup-detail-',
-  cwd: 'chdir',
-  scope: 'file',
-  setup: () => temp.write('.readyup/kits/default.js', MIXED_KIT),
+const it = test.extend(
+  'temp',
+  { scope: 'file' },
+  makeFixture(() => createTempTree({ '.readyup/kits/default.js': MIXED_KIT }, { prefix: 'readyup-detail-' })),
+);
+
+it.aroundAll(async (runSuite, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir, { chdir: true });
+
+  await runSuite();
 });
 
 describe('--detail projection', () => {

--- a/packages/readyup/src/bin/__tests__/route.exitCodes.tool.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.exitCodes.tool.test.ts
@@ -1,12 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
-import process from 'node:process';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test } from 'vitest';
 
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
-import { describe, expect, it } from 'vitest';
-
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { routeCommand } from '../route.ts';
 
 /** A kit whose single check passes. */
@@ -26,24 +22,36 @@ const MULTI_KIT =
   `  { name: 'lint', checks: [{ name: 'lint-ok', check: () => true }] },\n` +
   `] };\n`;
 
-const temp = useTempDir({
-  prefix: 'readyup-exit-codes-',
-  cwd: 'chdir',
-  scope: 'file',
-  setup: () => {
-    temp.write('.readyup/kits/passing.js', PASSING_KIT);
-    temp.write('.readyup/kits/failing.js', FAILING_KIT);
-    temp.write('.readyup/kits/invalid.js', INVALID_KIT);
-    temp.write('.readyup/kits/deploy.js', MULTI_KIT);
+const it = test.extend(
+  'temp',
+  { scope: 'file' },
+  makeFixture(() => {
+    const tree = createTempTree(
+      {
+        '.readyup/kits/deploy.js': MULTI_KIT,
+        '.readyup/kits/failing.js': FAILING_KIT,
+        '.readyup/kits/invalid.js': INVALID_KIT,
+        '.readyup/kits/passing.js': PASSING_KIT,
+        // Compiling this drives real esbuild, which writes its own diagnostic straight to stderr; the
+        // error banner that appears in an otherwise-passing test run belongs to this fixture.
+        'broken.ts': 'export default { this is not valid TypeScript\n',
+      },
+      { prefix: 'readyup-exit-codes-' },
+    );
     // A manifest whose recorded hash cannot match the file on disk, so `verify` reports drift.
-    temp.writeJson('.readyup/manifest.json', {
+    tree.writeJson('.readyup/manifest.json', {
       version: 1,
       kits: [{ name: 'passing', path: 'kits/passing.js', targetHash: '0'.repeat(8) }],
     });
-    // Compiling this drives real esbuild, which writes its own diagnostic straight to stderr; the
-    // error banner that appears in an otherwise-passing test run belongs to this fixture.
-    temp.write('broken.ts', 'export default { this is not valid TypeScript\n');
-  },
+
+    return tree;
+  }),
+);
+
+it.aroundAll(async (runSuite, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir, { chdir: true });
+
+  await runSuite();
 });
 
 describe('exit codes', () => {
@@ -93,25 +101,20 @@ describe('exit codes', () => {
 
   it('reports code "config" for an unreadable config file', async () => {
     // A separate tree, so the broken config does not reach the other cases in this file.
-    const brokenCwd = mkdtempSync(path.join(tmpdir(), 'readyup-bad-config-'));
-    mkdirSync(path.join(brokenCwd, '.config'), { recursive: true });
-    writeFileSync(path.join(brokenCwd, '.config/readyup.config.ts'), 'export default { compile: 42 };\n');
-    process.chdir(brokenCwd);
+    using broken = createTempTree(
+      { '.config/readyup.config.ts': 'export default { compile: 42 };\n' },
+      { prefix: 'readyup-bad-config-' },
+    );
+    using _cwd = pointCwdAt(broken.dir, { chdir: true });
+    using io = captureStdio();
 
-    try {
-      using io = captureStdio();
+    const exitCode = await routeCommand(['--json']);
 
-      const exitCode = await routeCommand(['--json']);
-
-      expect(exitCode).toBe(2);
-      expect(JSON.parse(io.stdout)).toStrictEqual({
-        schemaVersion: 1,
-        error: { code: 'config', message: expect.any(String) },
-      });
-    } finally {
-      process.chdir(temp.dir);
-      rmSync(brokenCwd, { recursive: true, force: true });
-    }
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(io.stdout)).toStrictEqual({
+      schemaVersion: 1,
+      error: { code: 'config', message: expect.any(String) },
+    });
   });
 });
 

--- a/packages/readyup/src/bin/__tests__/route.partialResults.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.partialResults.unit.test.ts
@@ -1,7 +1,8 @@
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
-import { describe, expect, it } from 'vitest';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test } from 'vitest';
 
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { routeCommand } from '../route.ts';
 
 /** A kit whose single check passes. */
@@ -10,14 +11,21 @@ const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ na
 /** A kit whose single error-severity check fails. */
 const FAILING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'nope', check: () => false }] }] };\n`;
 
-const temp = useTempDir({
-  prefix: 'readyup-partial-results-',
-  cwd: 'chdir',
-  scope: 'file',
-  setup: () => {
-    temp.write('.readyup/kits/passing.js', PASSING_KIT);
-    temp.write('.readyup/kits/failing.js', FAILING_KIT);
-  },
+const it = test.extend(
+  'temp',
+  { scope: 'file' },
+  makeFixture(() =>
+    createTempTree(
+      { '.readyup/kits/failing.js': FAILING_KIT, '.readyup/kits/passing.js': PASSING_KIT },
+      { prefix: 'readyup-partial-results-' },
+    ),
+  ),
+);
+
+it.aroundAll(async (runSuite, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir, { chdir: true });
+
+  await runSuite();
 });
 
 describe('partial results when a kit fails after dispatch', () => {

--- a/packages/readyup/src/bin/__tests__/route.styleSelection.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.styleSelection.unit.test.ts
@@ -1,10 +1,11 @@
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
-import { describe, expect, it, vi } from 'vitest';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test, vi } from 'vitest';
 
 import { plainFormatter } from '../../layout/plainFormatter.ts';
 import { STYLE_ENV_VAR } from '../../layout/resolveStyle.ts';
 import { richFormatter } from '../../layout/richFormatter.ts';
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { hashBytes } from '../../verify/targetHash.ts';
 import { routeCommand } from '../route.ts';
 
@@ -32,19 +33,27 @@ const RENDERING_COMMANDS = [
   { name: 'init', args: ['init', '--dry-run'], expected: /^PASS {2}\.config\/readyup\.config\.ts/mu },
 ] as const;
 
-const temp = useTempDir({
-  prefix: 'readyup-style-',
-  cwd: 'chdir',
-  scope: 'file',
-  setup: () => {
-    temp.write('.readyup/kits/passing.js', PASSING_KIT);
-    temp.write('src/passing.ts', PASSING_KIT);
-    temp.write('passing.js', COMPILED_BYTES);
-    temp.writeJson('manifest.json', {
+const it = test.extend(
+  'temp',
+  { scope: 'file' },
+  makeFixture(() => {
+    const tree = createTempTree(
+      { '.readyup/kits/passing.js': PASSING_KIT, 'passing.js': COMPILED_BYTES, 'src/passing.ts': PASSING_KIT },
+      { prefix: 'readyup-style-' },
+    );
+    tree.writeJson('manifest.json', {
       version: 1,
       kits: [{ name: 'passing', path: 'passing.js', source: 'src/passing.ts', targetHash: hashBytes(COMPILED_BYTES) }],
     });
-  },
+
+    return tree;
+  }),
+);
+
+it.aroundAll(async (runSuite, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir, { chdir: true });
+
+  await runSuite();
 });
 
 describe('--style plain', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@types/picomatch':
         specifier: 4.0.3
         version: 4.0.3
+      '@williamthorsen/toolbelt.filesystem':
+        specifier: 'catalog:'
+        version: 0.6.0
       '@williamthorsen/toolbelt.testing':
         specifier: 'catalog:'
         version: 0.3.0


### PR DESCRIPTION
## What

Moves the five `route.*` suites in the `readyup` package off the local `useTempDir` helper and onto toolbelt's utilities: `createTempTree` for the file-scoped tree, `pointCwdAt` for moving the process into it, and `makeFixture` for binding the tree as a Vitest fixture. The helper survives for the sixteen suites not yet migrated, which follow before it is deleted.

## Why

readyup's `useTempDir` is the last local re-implementation of an adopted utility: everything it provides now has an upstream home in toolbelt, and the helper can be deleted once its 21 consumer suites stop reaching the tree through it.

## Details

### 🧪 Tests

- Each of the five suites (`route.compiledWithReporting`, `route.detailProjection`, `route.exitCodes`, `route.partialResults`, `route.styleSelection`) binds Vitest's builder-style `test.extend('temp', { scope: 'file' }, …)` as `it` and registers an `it.aroundAll` hook that holds `pointCwdAt(temp.dir, { chdir: true })` for the suite's lifetime; requesting `{ temp }` in the hook is what builds the fixture even for tests that never name it.
- Every suite keeps its previous `chdir` cwd mode, and test bodies and assertions change only in how they reach the tree.
- `route.exitCodes`'s unreadable-config case replaces its hand-rolled `mkdtempSync` directory and `try`/`finally` cwd restore with nested `using` declarations over a second `createTempTree` and `pointCwdAt`.

### ⚙️ Tooling

- `eslint.config.ts` gains an override for the `route.*` files, turning `vitest/consistent-test-it` off and allowing `it.aroundAll` under `vitest/require-hook`: `@vitest/eslint-plugin` 1.6.27 misreads the fixture pattern twice, both defects are filed upstream (vitest-dev/eslint-plugin-vitest#955 and #956), and the block is marked for deletion when the fixes land.

### 📦 Dependencies

- `readyup` declares `@williamthorsen/toolbelt.filesystem` as a `catalog:` devDependency, the package its suites read `createTempTree` from and reached only transitively until now.

Closes #357
