### PR TITLE
#358 Reshape `useFailingDirectoryRead` and move its suites onto fixtures

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -73,17 +73,27 @@ const config = defineConfig([
     extends: [await createConfig.vitest()],
   }),
   {
-    // The route.* suites bind `test.extend(...)` to `it` and register `it.aroundAll(...)`, which
-    // @vitest/eslint-plugin 1.6.27 misreads twice: `consistent-test-it` compares the resolved import name
-    // (`test`) rather than the local binding, so every describe-nested `it(...)` is a false positive; and
-    // `require-hook`'s call-chain table lacks `it.aroundAll`, so the hook registration reads as bare
-    // top-level code. Both are plugin defects; delete this block when the upstream fixes land:
+    // The suites taking their trees as fixtures bind `test.extend(...)` to `it` and register
+    // `it.aroundAll(...)` or `it.aroundEach(...)`, which @vitest/eslint-plugin 1.6.27 misreads twice:
+    // `consistent-test-it` compares the resolved import name (`test`) rather than the local binding, so every
+    // describe-nested `it(...)` is a false positive; and `require-hook`'s call-chain table lacks both hooks,
+    // so the registration reads as bare top-level code. Both are plugin defects; delete this block when the
+    // upstream fixes land:
     // https://github.com/vitest-dev/eslint-plugin-vitest/issues/955 (require-hook) and
     // https://github.com/vitest-dev/eslint-plugin-vitest/issues/956 (consistent-test-it).
-    files: ['packages/readyup/src/bin/__tests__/route.*.test.ts'],
+    //
+    // The list grows per migrated suite rather than the preamble collapsing into a shared helper: an imported
+    // `it` traces back to no vitest export, at which point the plugin stops applying every vitest rule to the
+    // file.
+    files: [
+      'packages/readyup/src/bin/__tests__/route.*.test.ts',
+      'packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts',
+      'packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts',
+      'packages/readyup/src/projects/__tests__/discoverKitProjects.unit.test.ts',
+    ],
     rules: {
       'vitest/consistent-test-it': 'off',
-      'vitest/require-hook': ['warn', { allowedFunctionCalls: ['it.aroundAll'] }],
+      'vitest/require-hook': ['warn', { allowedFunctionCalls: ['it.aroundAll', 'it.aroundEach'] }],
     },
   },
   {

--- a/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
@@ -1,9 +1,11 @@
-import { captureError, captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { captureError, captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 const mockReaddirSync = vi.hoisted(() => vi.fn());
 
-// Only directory reads are intercepted; the temporary-directory helper still writes through to disk.
+// Only directory reads are intercepted; the temporary tree still writes through to disk.
 vi.mock(import('node:fs'), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, readdirSync: mockReaddirSync };
@@ -12,92 +14,92 @@ vi.mock(import('node:fs'), async (importOriginal) => {
 import { RdyError } from '../../errors/RdyError.ts';
 import { setStyle } from '../../layout/engine.ts';
 import { ListOutputSchema } from '../../schemas/listOutputSchema.ts';
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { useFailingDirectoryRead } from '../../test-utils/useFailingDirectoryRead.ts';
 import { listCommand } from '../listCommand.ts';
 
-const tempDir = useTempDir({
-  prefix: 'rdy-recursive-',
-  cwd: 'mock',
-  setup: () => {
-    // Sweep root, holding one kit of its own.
-    tempDir.writeJson('package.json', { name: 'root' });
-    tempDir.write('.readyup/kits/demo.js', 'export default {};');
-    tempDir.writeJson('.readyup/manifest.json', {
-      version: 1,
-      kits: [{ name: 'demo', path: 'kits/demo.js' }],
-    });
-
-    // Two kits with descriptions, on the convention output directory.
-    tempDir.writeJson('packages/readyup/package.json', { name: 'readyup' });
-    tempDir.write('packages/readyup/.readyup/kits/default.js', 'export default {};');
-    tempDir.write('packages/readyup/.readyup/kits/publishing.js', 'export default {};');
-    tempDir.writeJson('packages/readyup/.readyup/manifest.json', {
-      version: 1,
-      kits: [
+const it = test
+  .extend(
+    'temp',
+    makeFixture(() =>
+      createTempTree(
         {
-          name: 'default',
-          path: 'kits/default.js',
-          description: 'Authoring hygiene for a project that defines readyup kits',
-          readyupVersion: '0.24.0',
+          // Sweep root, holding one kit of its own.
+          'package.json': JSON.stringify({ name: 'root' }),
+          '.readyup/kits/demo.js': 'export default {};',
+          '.readyup/manifest.json': JSON.stringify({
+            version: 1,
+            kits: [{ name: 'demo', path: 'kits/demo.js' }],
+          }),
+
+          // Two kits with descriptions, on the convention output directory.
+          'packages/readyup/package.json': JSON.stringify({ name: 'readyup' }),
+          'packages/readyup/.readyup/kits/default.js': 'export default {};',
+          'packages/readyup/.readyup/kits/publishing.js': 'export default {};',
+          'packages/readyup/.readyup/manifest.json': JSON.stringify({
+            version: 1,
+            kits: [
+              {
+                name: 'default',
+                path: 'kits/default.js',
+                description: 'Authoring hygiene for a project that defines readyup kits',
+                readyupVersion: '0.24.0',
+              },
+              {
+                name: 'publishing',
+                path: 'kits/publishing.js',
+                description: 'Publication readiness for a package that ships readyup kits',
+              },
+            ],
+          }),
+
+          // A relocated output directory, compiled with no manifest beside its kits.
+          'packages/tooling/package.json': JSON.stringify({ name: 'tooling' }),
+          'packages/tooling/.config/readyup.config.ts':
+            "export default { compile: { srcDir: 'kit-sources', outDir: 'dist/kits' } };",
+          'packages/tooling/dist/kits/lint.js': 'export default {};',
+
+          // One kit, no description recorded for it.
+          'packages/ui/package.json': JSON.stringify({ name: 'ui' }),
+          'packages/ui/.readyup/kits/default.js': 'export default {};',
+          'packages/ui/.readyup/manifest.json': JSON.stringify({
+            version: 1,
+            kits: [{ name: 'default', path: 'kits/default.js' }],
+          }),
+
+          // Discovered for its sources, with nothing compiled to show.
+          'packages/authored/package.json': JSON.stringify({ name: 'authored' }),
+          'packages/authored/.readyup/kits/default.ts': 'export default {};',
+
+          // Discovered for its manifest, which now lists nothing.
+          'packages/emptied/package.json': JSON.stringify({ name: 'emptied' }),
+          'packages/emptied/.readyup/manifest.json': JSON.stringify({ version: 1, kits: [] }),
+
+          // Compiled kits beside a manifest that cannot be parsed.
+          'packages/corrupt/package.json': JSON.stringify({ name: 'corrupt' }),
+          'packages/corrupt/.readyup/kits/audit.js': 'export default {};',
+          'packages/corrupt/.readyup/manifest.json': '{ "version": 1, "kits": [',
+
+          // Discovered for its sources, with its output directory barred to the process.
+          'packages/blocked/package.json': JSON.stringify({ name: 'blocked' }),
+          'packages/blocked/.config/readyup.config.ts':
+            "export default { compile: { srcDir: 'kit-sources', outDir: 'dist/kits' } };",
+          'packages/blocked/kit-sources/probe.ts': 'export default {};',
+          'packages/blocked/dist/kits/probe.js': 'export default {};',
         },
-        {
-          name: 'publishing',
-          path: 'kits/publishing.js',
-          description: 'Publication readiness for a package that ships readyup kits',
-        },
-      ],
-    });
+        { prefix: 'rdy-recursive-' },
+      ),
+    ),
+  )
+  .extend('reads', { auto: true }, ({ temp }) => useFailingDirectoryRead(mockReaddirSync, temp.dir));
 
-    // A relocated output directory, compiled with no manifest beside its kits.
-    tempDir.writeJson('packages/tooling/package.json', { name: 'tooling' });
-    tempDir.write(
-      'packages/tooling/.config/readyup.config.ts',
-      "export default { compile: { srcDir: 'kit-sources', outDir: 'dist/kits' } };",
-    );
-    tempDir.write('packages/tooling/dist/kits/lint.js', 'export default {};');
+it.aroundEach(async (runTest, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir);
 
-    // One kit, no description recorded for it.
-    tempDir.writeJson('packages/ui/package.json', { name: 'ui' });
-    tempDir.write('packages/ui/.readyup/kits/default.js', 'export default {};');
-    tempDir.writeJson('packages/ui/.readyup/manifest.json', {
-      version: 1,
-      kits: [{ name: 'default', path: 'kits/default.js' }],
-    });
-
-    // Discovered for its sources, with nothing compiled to show.
-    tempDir.writeJson('packages/authored/package.json', { name: 'authored' });
-    tempDir.write('packages/authored/.readyup/kits/default.ts', 'export default {};');
-
-    // Discovered for its manifest, which now lists nothing.
-    tempDir.writeJson('packages/emptied/package.json', { name: 'emptied' });
-    tempDir.writeJson('packages/emptied/.readyup/manifest.json', { version: 1, kits: [] });
-
-    // Compiled kits beside a manifest that cannot be parsed.
-    tempDir.writeJson('packages/corrupt/package.json', { name: 'corrupt' });
-    tempDir.write('packages/corrupt/.readyup/kits/audit.js', 'export default {};');
-    tempDir.write('packages/corrupt/.readyup/manifest.json', '{ "version": 1, "kits": [');
-
-    // Discovered for its sources, with its output directory barred to the process.
-    tempDir.writeJson('packages/blocked/package.json', { name: 'blocked' });
-    tempDir.write(
-      'packages/blocked/.config/readyup.config.ts',
-      "export default { compile: { srcDir: 'kit-sources', outDir: 'dist/kits' } };",
-    );
-    tempDir.write('packages/blocked/kit-sources/probe.ts', 'export default {};');
-    tempDir.write('packages/blocked/dist/kits/probe.js', 'export default {};');
-  },
+  await runTest();
 });
 
-const { failReadOf, passAllReads } = useFailingDirectoryRead(mockReaddirSync, () => tempDir.dir);
-
 describe('list --recursive', () => {
-  beforeEach(() => {
-    passAllReads();
-  });
-
   afterEach(() => {
-    vi.restoreAllMocks();
     setStyle('rich');
   });
 
@@ -200,8 +202,8 @@ describe('list --recursive', () => {
   });
 
   describe('an empty sweep', () => {
-    it('emits an empty kit list under --json', async () => {
-      vi.spyOn(process, 'cwd').mockReturnValue(`${tempDir.dir}/packages/authored`);
+    it('emits an empty kit list under --json', async ({ temp }) => {
+      using _cwd = pointCwdAt(temp.resolve('packages/authored'));
 
       const { stdout } = await list(['--recursive', '--json']);
       const payload = JSON.parse(stdout);
@@ -209,8 +211,8 @@ describe('list --recursive', () => {
       expect(payload).toStrictEqual({ schemaVersion: 1, kits: [] });
     });
 
-    it('prints the empty-sweep message for a tree whose projects have nothing compiled', async () => {
-      vi.spyOn(process, 'cwd').mockReturnValue(`${tempDir.dir}/packages/authored`);
+    it('prints the empty-sweep message for a tree whose projects have nothing compiled', async ({ temp }) => {
+      using _cwd = pointCwdAt(temp.resolve('packages/authored'));
 
       const { stdout } = await list(['--recursive']);
 
@@ -238,8 +240,8 @@ describe('list --recursive', () => {
       });
     });
 
-    it('drops a project whose output directory it cannot read, and lists the rest', async () => {
-      failReadOf('packages/blocked/dist/kits', 'EACCES');
+    it('drops a project whose output directory it cannot read, and lists the rest', async ({ reads }) => {
+      reads.failReadOf('packages/blocked/dist/kits', 'EACCES');
 
       const { exitCode, stdout, stderr } = await list(['--recursive']);
 
@@ -249,8 +251,8 @@ describe('list --recursive', () => {
       expect(stderr).toContain('Omitting packages/blocked from the listing');
     });
 
-    it('rethrows a filesystem failure that is not benign', async () => {
-      failReadOf('packages/blocked/dist/kits', 'EMFILE');
+    it('rethrows a filesystem failure that is not benign', async ({ reads }) => {
+      reads.failReadOf('packages/blocked/dist/kits', 'EMFILE');
 
       await expect(listCommand(['--recursive'])).rejects.toThrow('read failed: EMFILE');
     });

--- a/packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts
@@ -1,116 +1,118 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test, vi } from 'vitest';
 
 const mockReaddirSync = vi.hoisted(() => vi.fn());
 
-// Only directory reads are intercepted; the temporary-directory helper still writes through to disk.
+// Only directory reads are intercepted; the temporary tree still writes through to disk.
 vi.mock(import('node:fs'), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, readdirSync: mockReaddirSync };
 });
 
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { useFailingDirectoryRead } from '../../test-utils/useFailingDirectoryRead.ts';
 import { walkDirectories } from '../walkDirectories.ts';
 
-const tempDir = useTempDir({
-  prefix: 'rdy-walk-',
-  setup: () => {
-    tempDir.write('package.json', '{}');
-    tempDir.write('packages/a/package.json', '{}');
-    tempDir.write('packages/a/.readyup/kits/default.ts', '');
-    tempDir.write('packages/b/package.json', '{}');
-    tempDir.write('packages/b/node_modules/dep/package.json', '{}');
-    tempDir.write('.hidden/package.json', '{}');
-    tempDir.write('node_modules/dep/package.json', '{}');
-    tempDir.write('docs/readme.md', '');
-    tempDir.write('deep/one/two/package.json', '{}');
-  },
-});
-
-const { failReadOf, passAllReads } = useFailingDirectoryRead(mockReaddirSync, () => tempDir.dir);
+const it = test
+  .extend(
+    'temp',
+    makeFixture(() =>
+      createTempTree(
+        {
+          '.hidden/package.json': '{}',
+          'deep/one/two/package.json': '{}',
+          'docs/readme.md': '',
+          'node_modules/dep/package.json': '{}',
+          'package.json': '{}',
+          'packages/a/.readyup/kits/default.ts': '',
+          'packages/a/package.json': '{}',
+          'packages/b/node_modules/dep/package.json': '{}',
+          'packages/b/package.json': '{}',
+        },
+        { prefix: 'rdy-walk-' },
+      ),
+    ),
+  )
+  .extend('reads', { auto: true }, ({ temp }) => useFailingDirectoryRead(mockReaddirSync, temp.dir));
 
 describe(walkDirectories, () => {
-  beforeEach(() => {
-    passAllReads();
-  });
-
-  it('yields every directory holding a match, root-relative and sorted', () => {
-    const found = walkDirectories({ root: tempDir.dir, match: '**/package.json' });
+  it('yields every directory holding a match, root-relative and sorted', ({ temp }) => {
+    const found = walkDirectories({ root: temp.dir, match: '**/package.json' });
 
     expect(found).toStrictEqual(['.', 'deep/one/two', 'packages/a', 'packages/b']);
   });
 
-  it('yields the sweep root as "." when the root itself holds a match', () => {
-    const found = walkDirectories({ root: tempDir.dir, match: 'package.json' });
+  it('yields the sweep root as "." when the root itself holds a match', ({ temp }) => {
+    const found = walkDirectories({ root: temp.dir, match: 'package.json' });
 
     expect(found).toStrictEqual(['.']);
   });
 
-  it('omits a directory whose entries match nothing', () => {
-    const found = walkDirectories({ root: tempDir.dir, match: '**/package.json' });
+  it('omits a directory whose entries match nothing', ({ temp }) => {
+    const found = walkDirectories({ root: temp.dir, match: '**/package.json' });
 
     expect(found).not.toContain('docs');
     expect(found).not.toContain('packages');
   });
 
-  it('yields a directory once however many of its entries match', () => {
-    tempDir.write('twins/first.json', '{}');
-    tempDir.write('twins/second.json', '{}');
+  it('yields a directory once however many of its entries match', ({ temp }) => {
+    temp.write('twins/first.json', '{}');
+    temp.write('twins/second.json', '{}');
 
-    const found = walkDirectories({ root: tempDir.dir, match: 'twins/*.json' });
+    const found = walkDirectories({ root: temp.dir, match: 'twins/*.json' });
 
     expect(found).toStrictEqual(['twins']);
   });
 
-  it('yields the directory holding a matching directory, not the match itself', () => {
-    const found = walkDirectories({ root: tempDir.dir, match: '**/.readyup', prune: [] });
+  it('yields the directory holding a matching directory, not the match itself', ({ temp }) => {
+    const found = walkDirectories({ root: temp.dir, match: '**/.readyup', prune: [] });
 
     expect(found).toStrictEqual(['packages/a']);
   });
 
-  it('prunes node_modules and dot-directories by default', () => {
-    const found = walkDirectories({ root: tempDir.dir, match: '**/package.json' });
+  it('prunes node_modules and dot-directories by default', ({ temp }) => {
+    const found = walkDirectories({ root: temp.dir, match: '**/package.json' });
 
     expect(found).not.toContain('node_modules/dep');
     expect(found).not.toContain('packages/b/node_modules/dep');
     expect(found).not.toContain('.hidden');
   });
 
-  it('honors custom prune globs in place of the defaults', () => {
-    const found = walkDirectories({ root: tempDir.dir, match: '**/package.json', prune: ['**/packages'] });
+  it('honors custom prune globs in place of the defaults', ({ temp }) => {
+    const found = walkDirectories({ root: temp.dir, match: '**/package.json', prune: ['**/packages'] });
 
     expect(found).toStrictEqual(['.', '.hidden', 'deep/one/two', 'node_modules/dep']);
   });
 
-  it('descends no further than the depth cap', () => {
-    const found = walkDirectories({ root: tempDir.dir, match: '**/package.json', maxDepth: 2 });
+  it('descends no further than the depth cap', ({ temp }) => {
+    const found = walkDirectories({ root: temp.dir, match: '**/package.json', maxDepth: 2 });
 
     expect(found).toStrictEqual(['.', 'packages/a', 'packages/b']);
   });
 
-  it('reaches a directory the depth cap admits', () => {
-    const found = walkDirectories({ root: tempDir.dir, match: '**/package.json', maxDepth: 3 });
+  it('reaches a directory the depth cap admits', ({ temp }) => {
+    const found = walkDirectories({ root: temp.dir, match: '**/package.json', maxDepth: 3 });
 
     expect(found).toContain('deep/one/two');
   });
 
-  it.each(['EACCES', 'ENOENT', 'EPERM'])('skips a directory it cannot read for a benign %s', (code) => {
-    failReadOf('packages/b', code);
+  it.for(['EACCES', 'ENOENT', 'EPERM'])('skips a directory it cannot read for a benign %s', (code, { reads, temp }) => {
+    reads.failReadOf('packages/b', code);
 
-    const found = walkDirectories({ root: tempDir.dir, match: '**/package.json' });
+    const found = walkDirectories({ root: temp.dir, match: '**/package.json' });
 
     expect(found).toStrictEqual(['.', 'deep/one/two', 'packages/a']);
   });
 
-  it('returns nothing for a root that does not exist', () => {
-    const found = walkDirectories({ root: `${tempDir.dir}/absent`, match: '**/package.json' });
+  it('returns nothing for a root that does not exist', ({ temp }) => {
+    const found = walkDirectories({ root: `${temp.dir}/absent`, match: '**/package.json' });
 
     expect(found).toStrictEqual([]);
   });
 
-  it('rethrows a filesystem failure that is not benign', () => {
-    failReadOf('packages/b', 'EMFILE');
+  it('rethrows a filesystem failure that is not benign', ({ reads, temp }) => {
+    reads.failReadOf('packages/b', 'EMFILE');
 
-    expect(() => walkDirectories({ root: tempDir.dir, match: '**/package.json' })).toThrow('read failed: EMFILE');
+    expect(() => walkDirectories({ root: temp.dir, match: '**/package.json' })).toThrow('read failed: EMFILE');
   });
 });

--- a/packages/readyup/src/projects/__tests__/discoverKitProjects.unit.test.ts
+++ b/packages/readyup/src/projects/__tests__/discoverKitProjects.unit.test.ts
@@ -1,83 +1,76 @@
-import path from 'node:path';
-import process from 'node:process';
-
-import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test, vi } from 'vitest';
 
 const mockReaddirSync = vi.hoisted(() => vi.fn());
 
-// Only directory reads are intercepted; the temporary-directory helper still writes through to disk.
+// Only directory reads are intercepted; the temporary tree still writes through to disk.
 vi.mock(import('node:fs'), async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, readdirSync: mockReaddirSync };
 });
 
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { useFailingDirectoryRead } from '../../test-utils/useFailingDirectoryRead.ts';
 import { discoverKitProjects } from '../discoverKitProjects.ts';
 
-const tempDir = useTempDir({
-  prefix: 'rdy-projects-',
-  scope: 'file',
-  setup: () => {
-    // Sweep root: compiled kits and a manifest of its own.
-    tempDir.writeJson('package.json', { name: 'root' });
-    tempDir.write('.readyup/kits/demo.js', 'export default {};');
-    tempDir.writeJson('.readyup/manifest.json', { version: 1, kits: [{ name: 'demo' }] });
+const it = test
+  .extend(
+    'temp',
+    { scope: 'file' },
+    makeFixture(() =>
+      createTempTree(
+        {
+          // Sweep root: compiled kits and a manifest of its own.
+          'package.json': JSON.stringify({ name: 'root' }),
+          '.readyup/kits/demo.js': 'export default {};',
+          '.readyup/manifest.json': JSON.stringify({ version: 1, kits: [{ name: 'demo' }] }),
 
-    // Authored but never compiled, under the default source directory.
-    tempDir.writeJson('packages/authored/package.json', { name: 'authored' });
-    tempDir.write('packages/authored/.readyup/kits/default.ts', 'export default {};');
+          // Authored but never compiled, under the default source directory.
+          'packages/authored/package.json': JSON.stringify({ name: 'authored' }),
+          'packages/authored/.readyup/kits/default.ts': 'export default {};',
 
-    // A config that cannot be evaluated, over a project that is a kit project regardless.
-    tempDir.writeJson('packages/broken/package.json', { name: 'broken' });
-    tempDir.write('packages/broken/.config/readyup.config.ts', 'export default { this is not TypeScript');
-    tempDir.writeJson('packages/broken/.readyup/manifest.json', { version: 1, kits: [] });
+          // A config that cannot be evaluated, over a project that is a kit project regardless.
+          'packages/broken/package.json': JSON.stringify({ name: 'broken' }),
+          'packages/broken/.config/readyup.config.ts': 'export default { this is not TypeScript',
+          'packages/broken/.readyup/manifest.json': JSON.stringify({ version: 1, kits: [] }),
 
-    // Compiled with --skip-manifest: kits on disk, no manifest beside them.
-    tempDir.writeJson('packages/compiled-only/package.json', { name: 'compiled-only' });
-    tempDir.write('packages/compiled-only/.readyup/kits/thing.js', 'export default {};');
+          // Compiled with --skip-manifest: kits on disk, no manifest beside them.
+          'packages/compiled-only/package.json': JSON.stringify({ name: 'compiled-only' }),
+          'packages/compiled-only/.readyup/kits/thing.js': 'export default {};',
 
-    // Authored but never compiled, under a source directory the config repoints.
-    tempDir.writeJson('packages/custom/package.json', { name: 'custom' });
-    tempDir.write('packages/custom/.config/readyup.config.ts', "export default { compile: { srcDir: 'src/kits' } };");
-    tempDir.write('packages/custom/src/kits/lint.ts', 'export default {};');
+          // Authored but never compiled, under a source directory the config repoints.
+          'packages/custom/package.json': JSON.stringify({ name: 'custom' }),
+          'packages/custom/.config/readyup.config.ts': "export default { compile: { srcDir: 'src/kits' } };",
+          'packages/custom/src/kits/lint.ts': 'export default {};',
 
-    // Kits since deleted, manifest left behind.
-    tempDir.writeJson('packages/emptied/package.json', { name: 'emptied' });
-    tempDir.writeJson('packages/emptied/.readyup/manifest.json', { version: 1, kits: [{ name: 'gone' }] });
+          // Kits since deleted, manifest left behind.
+          'packages/emptied/package.json': JSON.stringify({ name: 'emptied' }),
+          'packages/emptied/.readyup/manifest.json': JSON.stringify({ version: 1, kits: [{ name: 'gone' }] }),
 
-    // A workspace with no readyup footprint at all.
-    tempDir.writeJson('packages/plain/package.json', { name: 'plain' });
-    tempDir.write('packages/plain/src/index.ts', 'export {};');
+          // A workspace with no readyup footprint at all.
+          'packages/plain/package.json': JSON.stringify({ name: 'plain' }),
+          'packages/plain/src/index.ts': 'export {};',
 
-    // Compiled to an output directory the config repoints.
-    tempDir.writeJson('packages/tooling/package.json', { name: 'tooling' });
-    tempDir.write(
-      'packages/tooling/.config/readyup.config.ts',
-      "export default { compile: { srcDir: 'kit-sources', outDir: 'dist/kits' } };",
-    );
-    tempDir.write('packages/tooling/dist/kits/lint.js', 'export default {};');
+          // Compiled to an output directory the config repoints.
+          'packages/tooling/package.json': JSON.stringify({ name: 'tooling' }),
+          'packages/tooling/.config/readyup.config.ts':
+            "export default { compile: { srcDir: 'kit-sources', outDir: 'dist/kits' } };",
+          'packages/tooling/dist/kits/lint.js': 'export default {};',
 
-    // An installed dependency that publishes kits, which is not a project of this repo.
-    tempDir.writeJson('node_modules/dep/package.json', { name: 'dep' });
-    tempDir.write('node_modules/dep/.readyup/kits/dep.js', 'export default {};');
-  },
-});
-
-const { failReadOf, passAllReads } = useFailingDirectoryRead(mockReaddirSync, () => tempDir.dir);
+          // An installed dependency that publishes kits, which is not a project of this repo.
+          'node_modules/dep/package.json': JSON.stringify({ name: 'dep' }),
+          'node_modules/dep/.readyup/kits/dep.js': 'export default {};',
+        },
+        { prefix: 'rdy-projects-' },
+      ),
+    ),
+  )
+  .extend('reads', { auto: true }, ({ temp }) => useFailingDirectoryRead(mockReaddirSync, temp.dir));
 
 describe(discoverKitProjects, () => {
-  beforeEach(() => {
-    passAllReads();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('reports every kit project in the tree, the sweep root first', async () => {
-    await expect(discoverDirs()).resolves.toStrictEqual([
+  it('reports every kit project in the tree, the sweep root first', async ({ temp }) => {
+    await expect(discoverDirs(temp.dir)).resolves.toStrictEqual([
       '.',
       'packages/authored',
       'packages/broken',
@@ -89,32 +82,32 @@ describe(discoverKitProjects, () => {
   });
 
   // A sweep has to reach this project to rewrite the manifest left behind.
-  it('reports a project whose kits were deleted but whose manifest remains', async () => {
-    await expect(discoverDirs()).resolves.toContain('packages/emptied');
+  it('reports a project whose kits were deleted but whose manifest remains', async ({ temp }) => {
+    await expect(discoverDirs(temp.dir)).resolves.toContain('packages/emptied');
   });
 
-  it('reports a project with kit sources but no manifest and no compiled output', async () => {
-    await expect(discoverDirs()).resolves.toContain('packages/authored');
+  it('reports a project with kit sources but no manifest and no compiled output', async ({ temp }) => {
+    await expect(discoverDirs(temp.dir)).resolves.toContain('packages/authored');
   });
 
-  it('reports a never-compiled project whose config repoints the source directory', async () => {
-    await expect(discoverDirs()).resolves.toContain('packages/custom');
+  it('reports a never-compiled project whose config repoints the source directory', async ({ temp }) => {
+    await expect(discoverDirs(temp.dir)).resolves.toContain('packages/custom');
   });
 
-  it('reports a project compiled without a manifest beside its kits', async () => {
-    await expect(discoverDirs()).resolves.toContain('packages/compiled-only');
+  it('reports a project compiled without a manifest beside its kits', async ({ temp }) => {
+    await expect(discoverDirs(temp.dir)).resolves.toContain('packages/compiled-only');
   });
 
-  it('omits a workspace with neither a readyup directory nor a readyup config', async () => {
-    await expect(discoverDirs()).resolves.not.toContain('packages/plain');
+  it('omits a workspace with neither a readyup directory nor a readyup config', async ({ temp }) => {
+    await expect(discoverDirs(temp.dir)).resolves.not.toContain('packages/plain');
   });
 
-  it('omits an installed dependency that publishes kits', async () => {
-    await expect(discoverDirs()).resolves.not.toContain('node_modules/dep');
+  it('omits an installed dependency that publishes kits', async ({ temp }) => {
+    await expect(discoverDirs(temp.dir)).resolves.not.toContain('node_modules/dep');
   });
 
-  it('reads each project under its own config', async () => {
-    const { projects } = await discover();
+  it('reads each project under its own config', async ({ temp }) => {
+    const { projects } = await discover(temp.dir);
     const byDir = new Map(projects.map((project) => [project.dir, project]));
 
     expect(byDir.get('packages/custom')?.config.compile.srcDir).toBe('src/kits');
@@ -122,17 +115,17 @@ describe(discoverKitProjects, () => {
     expect(byDir.get('.')?.config.compile.outDir).toBe('.readyup/kits');
   });
 
-  it('resolves each project against the sweep root, manifest path included', async () => {
-    const { projects } = await discover();
+  it('resolves each project against the sweep root, manifest path included', async ({ temp }) => {
+    const { projects } = await discover(temp.dir);
     const emptied = projects.find((project) => project.dir === 'packages/emptied');
 
-    expect(emptied?.absolutePath).toBe(path.join(tempDir.dir, 'packages/emptied'));
-    expect(emptied?.manifestPath).toBe(path.join(tempDir.dir, 'packages/emptied/.readyup/manifest.json'));
+    expect(emptied?.absolutePath).toBe(temp.resolve('packages/emptied'));
+    expect(emptied?.manifestPath).toBe(temp.resolve('packages/emptied/.readyup/manifest.json'));
   });
 
   // Discovery is read-only, so a config nobody can evaluate costs that project its settings, not its place.
-  it('reports a project whose config fails to evaluate, reading it with default settings', async () => {
-    const { projects, stderr } = await discover();
+  it('reports a project whose config fails to evaluate, reading it with default settings', async ({ temp }) => {
+    const { projects, stderr } = await discover(temp.dir);
     const broken = projects.find((project) => project.dir === 'packages/broken');
 
     expect(broken?.config.compile.srcDir).toBe('.readyup/kits');
@@ -140,55 +133,58 @@ describe(discoverKitProjects, () => {
   });
 
   // Topology comes from the filesystem, so a repo declaring no workspaces is swept like any other.
-  it('finds nested projects with no workspace file anywhere in the tree', async () => {
-    await expect(discoverDirs()).resolves.toContain('packages/authored');
+  it('finds nested projects with no workspace file anywhere in the tree', async ({ temp }) => {
+    await expect(discoverDirs(temp.dir)).resolves.toContain('packages/authored');
   });
 
-  it('reports nothing for a tree holding no kit project', async () => {
-    const { projects } = await discover(path.join(tempDir.dir, 'packages/plain'));
+  it('reports nothing for a tree holding no kit project', async ({ temp }) => {
+    const { projects } = await discover(temp.resolve('packages/plain'));
 
     expect(projects).toStrictEqual([]);
   });
 
-  it('sweeps the working directory when no root is named', async () => {
+  it('sweeps the working directory when no root is named', async ({ temp }) => {
     using _io = captureStdio();
-    vi.spyOn(process, 'cwd').mockReturnValue(path.join(tempDir.dir, 'packages/emptied'));
+    using _cwd = pointCwdAt(temp.resolve('packages/emptied'));
 
     const projects = await discoverKitProjects();
 
     expect(projects.map((project) => project.dir)).toStrictEqual(['.']);
   });
 
-  it.each(['EACCES', 'EPERM'])('omits a project whose kit directory it cannot read for a benign %s', async (code) => {
-    failReadOf('packages/compiled-only/.readyup/kits', code);
+  it.for(['EACCES', 'EPERM'])(
+    'omits a project whose kit directory it cannot read for a benign %s',
+    async (code, { reads, temp }) => {
+      reads.failReadOf('packages/compiled-only/.readyup/kits', code);
 
-    const { dirs, stderr } = await discover();
+      const { dirs, stderr } = await discover(temp.dir);
 
-    expect(dirs).not.toContain('packages/compiled-only');
-    expect(dirs).toStrictEqual(expect.arrayContaining(['.', 'packages/authored', 'packages/tooling']));
-    expect(stderr).toContain('packages/compiled-only');
-  });
+      expect(dirs).not.toContain('packages/compiled-only');
+      expect(dirs).toStrictEqual(expect.arrayContaining(['.', 'packages/authored', 'packages/tooling']));
+      expect(stderr).toContain('packages/compiled-only');
+    },
+  );
 
-  it('omits a project whose source directory it cannot read', async () => {
-    failReadOf('packages/custom/src/kits', 'EACCES');
+  it('omits a project whose source directory it cannot read', async ({ reads, temp }) => {
+    reads.failReadOf('packages/custom/src/kits', 'EACCES');
 
-    const dirs = await discoverDirs();
+    const dirs = await discoverDirs(temp.dir);
 
     expect(dirs).not.toContain('packages/custom');
     expect(dirs).toContain('packages/authored');
   });
 
-  it('rethrows a filesystem failure that is not benign', async () => {
-    failReadOf('packages/compiled-only/.readyup/kits', 'EMFILE');
+  it('rethrows a filesystem failure that is not benign', async ({ reads, temp }) => {
+    reads.failReadOf('packages/compiled-only/.readyup/kits', 'EMFILE');
 
-    await expect(discover()).rejects.toThrow('read failed: EMFILE');
+    await expect(discover(temp.dir)).rejects.toThrow('read failed: EMFILE');
   });
 });
 
 // region | Helpers
 
 /** Sweeps the fixture tree for kit projects, returning them alongside what the sweep wrote to stderr. */
-async function discover(root: string = tempDir.dir) {
+async function discover(root: string) {
   using io = captureStdio();
 
   const projects = await discoverKitProjects({ root });
@@ -197,8 +193,8 @@ async function discover(root: string = tempDir.dir) {
 }
 
 /** Returns the root-relative directories discovery reports for the fixture tree. */
-async function discoverDirs(): Promise<string[]> {
-  const { dirs } = await discover();
+async function discoverDirs(root: string): Promise<string[]> {
+  const { dirs } = await discover(root);
   return dirs;
 }
 

--- a/packages/readyup/src/test-utils/useFailingDirectoryRead.ts
+++ b/packages/readyup/src/test-utils/useFailingDirectoryRead.ts
@@ -9,28 +9,25 @@ const { readdirSync: readdirSyncActual } = await vi.importActual<typeof import('
 export interface FailingDirectoryRead {
   /** Fails the directory at a root-relative path, letting every other read through to the filesystem. */
   failReadOf: (relativePath: string, code: string) => void;
-  /** Points the mock back at the real reader, failing nothing. */
-  passAllReads: () => void;
 }
 
 /**
- * Binds a suite's mocked `readdirSync` to a directory tree.
+ * Binds a suite's mocked `readdirSync` to a directory tree, failing nothing until asked.
  *
- * The mock is a parameter because `vi.mock` hoists per file, so each suite owns its own. `resolveRoot` is
- * a thunk because a temporary directory is built in a hook, after this call has already run.
+ * The mock is a parameter because `vi.mock` hoists per file, so each suite owns its own. Binding points the
+ * mock at the real reader, so a suite that binds once per test starts each test from a reader that fails
+ * nothing.
  */
-export function useFailingDirectoryRead(mock: Mock, resolveRoot: () => string): FailingDirectoryRead {
+export function useFailingDirectoryRead(mock: Mock, root: string): FailingDirectoryRead {
+  mock.mockImplementation(readdirSyncActual);
+
   return {
     failReadOf: (relativePath, code) => {
-      const failingDir = path.join(resolveRoot(), relativePath);
+      const failingDir = path.join(root, relativePath);
       mock.mockImplementation((...args: Parameters<typeof readdirSyncActual>) => {
         if (args[0] === failingDir) throw Object.assign(new Error(`read failed: ${code}`), { code });
         return readdirSyncActual(...args);
       });
-    },
-
-    passAllReads: () => {
-      mock.mockImplementation(readdirSyncActual);
     },
   };
 }


### PR DESCRIPTION
## What

Moves the `discoverKitProjects`, `list --recursive`, and `walkDirectories` suites onto `createTempTree` fixtures, so each test reaches its tree as a parameter rather than through a module-level handle. Reshapes `useFailingDirectoryRead` to take the tree's root rather than a thunk resolving it, and folds the reader's reset into binding, which retires `passAllReads`. Both suites that point the working directory reach it through `pointCwdAt` rather than a `process.cwd` spy.

## Why

`useFailingDirectoryRead`'s thunk existed only because `useTempDir` builds its tree inside a hook, after the call binding the control has already run. Once the tree arrives as a test parameter the indirection buys nothing, and a test's dependency on the tree becomes visible in its own signature instead of implicit in a module-level binding. The signature change touches every call site, so the reshape and its three consumer suites move together.

## Details

### 🧪 Tests

- `useFailingDirectoryRead` takes `root: string`, and the control it returns carries `failReadOf` alone. Binding installs the pass-through implementation, which is what a per-test binding uses in place of `passAllReads`.
- Each suite binds `temp` and an `auto` read control through its own `test.extend` preamble, written out in full rather than shared. The `auto` control is load-bearing rather than convenient: the mocked `readdirSync` is a bare `vi.fn()`, so the fixture is what gives every test a reader that reaches the filesystem.
- Tree scope is preserved per suite. `discoverKitProjects` keeps its file-scoped tree; the other two build one per test, which is what keeps `walkDirectories`' twins test from leaking its writes.
- `list --recursive` registers its suite-wide cwd pointer as `it.aroundEach`, and the two empty-sweep tests nest their own pointer at `packages/authored` inside it.
- The two parameterized cases move from `it.each` to `it.for`, which passes the fixture context as a fixed second argument.
- `discoverKitProjects` and `list --recursive` drop the `vi.restoreAllMocks()` hooks that covered their `process.cwd` spies; Vitest 4 restores only the `vi.spyOn` set, so neither hook reached the mocked reader. Test names and assertions are unchanged apart from how each test reaches the tree.

### ⚙️ Tooling

- The vitest suppression block in `eslint.config.ts` widens to the three migrated suites and admits `it.aroundEach` alongside `it.aroundAll` under `require-hook`. `@vitest/eslint-plugin` 1.6.27 resolves the extended `it` back to its `test` import, so `consistent-test-it` reports every describe-nested `it(...)`; the block still names both upstream issues and the instruction to delete it once they land.
- Its comment also records why the list grows per migrated suite rather than the preamble collapsing into a shared helper: an imported `it` traces back to no vitest export, at which point the plugin stops applying every vitest rule to the file.

Closes #358
