### PR TITLE
#359 Move three `readyup` test suites onto toolbelt's temp trees

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -88,6 +88,7 @@ const config = defineConfig([
     files: [
       'packages/readyup/src/bin/__tests__/route.*.test.ts',
       'packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts',
+      'packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts',
       'packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts',
       'packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts',
       'packages/readyup/src/projects/__tests__/discoverKitProjects.unit.test.ts',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -73,7 +73,7 @@ const config = defineConfig([
     extends: [await createConfig.vitest()],
   }),
   {
-    // The suites taking their trees as fixtures bind `test.extend(...)` to `it` and register
+    // The suites taking their trees as fixtures bind `test.extend(...)` to `it`, and some of them register
     // `it.aroundAll(...)` or `it.aroundEach(...)`, which @vitest/eslint-plugin 1.6.27 misreads twice:
     // `consistent-test-it` compares the resolved import name (`test`) rather than the local binding, so every
     // describe-nested `it(...)` is a false positive; and `require-hook`'s call-chain table lacks both hooks,
@@ -87,6 +87,7 @@ const config = defineConfig([
     // file.
     files: [
       'packages/readyup/src/bin/__tests__/route.*.test.ts',
+      'packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts',
       'packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts',
       'packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts',
       'packages/readyup/src/projects/__tests__/discoverKitProjects.unit.test.ts',

--- a/packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts
@@ -1,58 +1,57 @@
-import path from 'node:path';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test } from 'vitest';
 
-import { describe, expect, it } from 'vitest';
-
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { discoverKitPackages } from '../discoverKitPackages.ts';
 
-const temp = useTempDir({
-  prefix: 'discover-packages-',
-  scope: 'file',
-  setup: () => {
-    temp.writeJson('package.json', {
-      name: 'consumer',
-      dependencies: { 'zebra-kit': '1.0.0' },
-      devDependencies: { '@acme/kits': '1.0.0', kitless: '1.0.0' },
-    });
+const it = test.extend(
+  'temp',
+  { scope: 'file' },
+  makeFixture(() =>
+    createTempTree(
+      {
+        'package.json': JSON.stringify({
+          name: 'consumer',
+          dependencies: { 'zebra-kit': '1.0.0' },
+          devDependencies: { '@acme/kits': '1.0.0', kitless: '1.0.0' },
+        }),
 
-    installPackage('zebra-kit', ['smoke']);
-    installPackage('@acme/kits', ['drift']);
-    installPackage('kitless', []);
-    // Installed and publishing kits, but never declared as a dependency.
-    installPackage('undeclared-kit', ['drift']);
-  },
-});
+        'node_modules/@acme/kits/package.json': JSON.stringify({ name: '@acme/kits', version: '1.0.0' }),
+        'node_modules/@acme/kits/.readyup/kits/drift.js': 'export default {};\n',
 
-const manifestless = useTempDir({ prefix: 'discover-no-manifest-', scope: 'file' });
+        // Declared and installed, publishing nothing: an empty kit directory, not an absent one.
+        'node_modules/kitless/package.json': JSON.stringify({ name: 'kitless', version: '1.0.0' }),
+        'node_modules/kitless/.readyup/kits/': '',
+
+        // Installed and publishing kits, but never declared as a dependency.
+        'node_modules/undeclared-kit/package.json': JSON.stringify({ name: 'undeclared-kit', version: '1.0.0' }),
+        'node_modules/undeclared-kit/.readyup/kits/drift.js': 'export default {};\n',
+
+        'node_modules/zebra-kit/package.json': JSON.stringify({ name: 'zebra-kit', version: '1.0.0' }),
+        'node_modules/zebra-kit/.readyup/kits/smoke.js': 'export default {};\n',
+      },
+      { prefix: 'discover-packages-' },
+    ),
+  ),
+);
 
 describe(discoverKitPackages, () => {
-  it('names declared dependencies that publish kits, sorted, across both dependency fields', () => {
+  it('names declared dependencies that publish kits, sorted, across both dependency fields', ({ temp }) => {
     expect(discoverKitPackages(temp.dir)).toStrictEqual(['@acme/kits', 'zebra-kit']);
   });
 
-  it('omits a declared dependency that publishes no kits', () => {
+  it('omits a declared dependency that publishes no kits', ({ temp }) => {
     expect(discoverKitPackages(temp.dir)).not.toContain('kitless');
   });
 
   // Suggesting a package the reader never chose to depend on is not something they can act on.
-  it('omits an installed package that is not a declared dependency', () => {
+  it('omits an installed package that is not a declared dependency', ({ temp }) => {
     expect(discoverKitPackages(temp.dir)).not.toContain('undeclared-kit');
   });
 
   it('answers with nothing when the project manifest cannot be read', () => {
+    using manifestless = createTempTree({}, { prefix: 'discover-no-manifest-' });
+
     expect(discoverKitPackages(manifestless.dir)).toStrictEqual([]);
   });
 });
-
-// region | Helpers
-
-/** Installs a package into a fixture project, optionally publishing kits. */
-function installPackage(name: string, kits: string[]): void {
-  temp.writeJson(path.join('node_modules', name, 'package.json'), { name, version: '1.0.0' });
-  temp.mkdir(path.join('node_modules', name, '.readyup', 'kits'));
-  for (const kit of kits) {
-    temp.write(path.join('node_modules', name, '.readyup', 'kits', `${kit}.js`), 'export default {};\n');
-  }
-}
-
-// endregion | Helpers

--- a/packages/readyup/src/check-utils/__tests__/pnpmWorkspaceYaml.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/pnpmWorkspaceYaml.unit.test.ts
@@ -1,9 +1,8 @@
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { disposeOnTestFinished } from '@williamthorsen/toolbelt.vitest/candidate';
 import { describe, expect, it } from 'vitest';
 
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { readPnpmWorkspacePackages } from '../pnpmWorkspaceYaml.ts';
-
-const temp = useTempDir({ prefix: 'rdy-yaml-' });
 
 describe(readPnpmWorkspacePackages, () => {
   it('returns a single unquoted item', () => {
@@ -198,9 +197,10 @@ describe(readPnpmWorkspacePackages, () => {
 
 // region | Helpers
 
-/** Writes the workspace manifest and returns its path, which the parser under test is given directly. */
+/** Writes the workspace manifest into a tree of its own and returns its path, which the parser is given directly. */
 function writeYaml(content: string): string {
-  return temp.write('pnpm-workspace.yaml', content);
+  const tree = disposeOnTestFinished(createTempTree({ 'pnpm-workspace.yaml': content }, { prefix: 'rdy-yaml-' }));
+  return tree.resolve('pnpm-workspace.yaml');
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts
@@ -1,51 +1,68 @@
-import path from 'node:path';
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test } from 'vitest';
 
-import { describe, expect, it } from 'vitest';
-
-import { useTempDir } from '../../test-utils/tempDir.ts';
 import { expandConfiguredPackages } from '../expandConfiguredPackages.ts';
 
-const temp = useTempDir({
-  prefix: 'expand-packages-',
-  scope: 'file',
-  setup: () => {
-    installPackage('@acme/kits', '2.1.0', {
-      kits: ['drift', 'preflight'],
-      manifest: JSON.stringify({ version: 1, kits: [{ name: 'drift' }, { name: 'preflight' }] }),
-    });
-    installPackage('plain-kit', '0.4.0', { kits: ['smoke'] });
-    installPackage('kitless', '1.0.0');
-    installPackage('broken-manifest', '1.0.0', { kits: ['drift'], manifest: '{ not json' });
-  },
-});
+const it = test.extend(
+  'temp',
+  { scope: 'file' },
+  makeFixture(() =>
+    createTempTree(
+      {
+        'node_modules/@acme/kits/package.json': JSON.stringify({ name: '@acme/kits', version: '2.1.0' }),
+        'node_modules/@acme/kits/.readyup/kits/drift.js': 'export default {};\n',
+        'node_modules/@acme/kits/.readyup/kits/preflight.js': 'export default {};\n',
+        'node_modules/@acme/kits/.readyup/manifest.json': JSON.stringify({
+          version: 1,
+          kits: [{ name: 'drift' }, { name: 'preflight' }],
+        }),
+
+        // Kits on disk under a manifest nobody can parse.
+        'node_modules/broken-manifest/package.json': JSON.stringify({ name: 'broken-manifest', version: '1.0.0' }),
+        'node_modules/broken-manifest/.readyup/kits/drift.js': 'export default {};\n',
+        'node_modules/broken-manifest/.readyup/manifest.json': '{ not json',
+
+        // Installed, publishing nothing: an empty kit directory, not an absent one.
+        'node_modules/kitless/package.json': JSON.stringify({ name: 'kitless', version: '1.0.0' }),
+        'node_modules/kitless/.readyup/kits/': '',
+
+        // Kits on disk with no manifest beside them.
+        'node_modules/plain-kit/package.json': JSON.stringify({ name: 'plain-kit', version: '0.4.0' }),
+        'node_modules/plain-kit/.readyup/kits/smoke.js': 'export default {};\n',
+      },
+      { prefix: 'expand-packages-' },
+    ),
+  ),
+);
 
 describe(expandConfiguredPackages, () => {
-  it('expands a scoped package into the kits its manifest declares', () => {
+  it('expands a scoped package into the kits its manifest declares', ({ temp }) => {
     expect(expandConfiguredPackages(['@acme/kits'], '.js', temp.dir)).toStrictEqual([
       {
         packageName: '@acme/kits',
         version: '2.1.0',
         kitName: 'drift',
-        path: path.join(temp.dir, 'node_modules', '@acme/kits', '.readyup', 'kits', 'drift.js'),
+        path: temp.resolve('node_modules/@acme/kits/.readyup/kits/drift.js'),
       },
       {
         packageName: '@acme/kits',
         version: '2.1.0',
         kitName: 'preflight',
-        path: path.join(temp.dir, 'node_modules', '@acme/kits', '.readyup', 'kits', 'preflight.js'),
+        path: temp.resolve('node_modules/@acme/kits/.readyup/kits/preflight.js'),
       },
     ]);
   });
 
   // The same precedence a local `--from` source follows, so a package and a directory answer alike.
-  it('falls back to the kit directory when a package ships no manifest', () => {
+  it('falls back to the kit directory when a package ships no manifest', ({ temp }) => {
     const [kit] = expandConfiguredPackages(['plain-kit'], '.js', temp.dir);
 
     expect(kit?.kitName).toBe('smoke');
     expect(kit?.version).toBe('0.4.0');
   });
 
-  it('expands every configured package, in configured order', () => {
+  it('expands every configured package, in configured order', ({ temp }) => {
     const kits = expandConfiguredPackages(['plain-kit', '@acme/kits'], '.js', temp.dir);
 
     expect(kits.map((kit) => `${kit.packageName}:${kit.kitName}`)).toStrictEqual([
@@ -55,43 +72,20 @@ describe(expandConfiguredPackages, () => {
     ]);
   });
 
-  it('names the package when it is not installed', () => {
+  it('names the package when it is not installed', ({ temp }) => {
     expect(() => expandConfiguredPackages(['absent-package'], '.js', temp.dir)).toThrow(
       /Configured package "absent-package" is not installed/,
     );
   });
 
-  it('names the package when it publishes no kits', () => {
+  it('names the package when it publishes no kits', ({ temp }) => {
     expect(() => expandConfiguredPackages(['kitless'], '.js', temp.dir)).toThrow(
       /Configured package "kitless" publishes no kits/,
     );
   });
 
   // Falling back here would report a kit list the publisher never declared.
-  it('surfaces a malformed manifest instead of reading around it', () => {
+  it('surfaces a malformed manifest instead of reading around it', ({ temp }) => {
     expect(() => expandConfiguredPackages(['broken-manifest'], '.js', temp.dir)).toThrow(/invalid JSON/);
   });
 });
-
-// region | Helpers
-
-/** Installs a package into the fixture project, with the kit files and manifest it publishes. */
-function installPackage(
-  name: string,
-  version: string,
-  options: { kits?: string[]; manifest?: string | undefined } = {},
-): void {
-  const root = path.join('node_modules', name);
-  temp.mkdir(path.join(root, '.readyup', 'kits'));
-  temp.writeJson(path.join(root, 'package.json'), { name, version });
-
-  const kits = options.kits ?? [];
-  for (const kit of kits) {
-    temp.write(path.join(root, '.readyup', 'kits', `${kit}.js`), 'export default {};\n');
-  }
-  if (options.manifest !== undefined) {
-    temp.write(path.join(root, '.readyup', 'manifest.json'), options.manifest);
-  }
-}
-
-// endregion | Helpers


### PR DESCRIPTION
## What

Moves three `readyup` test suites off the package's own `useTempDir` helper onto `createTempTree` from `@williamthorsen/toolbelt.filesystem`. The `discoverKitPackages` and `expandConfiguredPackages` suites take their trees as `test.extend` fixtures declared as literal entry maps; the `pnpmWorkspaceYaml` suite builds a tree per test.

## Why

These were the last three suites taking a tree from `useTempDir` without pointing cwd at it, so they stood between the helper and its removal in #360. Each also carried scaffolding of its own for building the same fixture shape, which a literal entry map states directly and keeps in one place.

## Details

### 🧪 Tests

- `discoverKitPackages.unit.test.ts` replaces its module-level `useTempDir` handle and `setup` callback with a file-scoped `test.extend('temp', …, makeFixture(() => createTempTree(…)))`, and its tests reach the tree through a `{ temp }` fixture. The second, single-use tree moves into the one test that reads it, as a `using` declaration.
- `expandConfiguredPackages.unit.test.ts` takes the same shape. Its path assertions read `temp.resolve('node_modules/@acme/kits/.readyup/kits/drift.js')` in place of a `path.join` over `temp.dir`, which lets the `node:path` import go from both suites.
- `pnpmWorkspaceYaml.unit.test.ts` keeps its `writeYaml` helper, which now builds a tree per call and registers it with `disposeOnTestFinished`; all 24 test bodies are unchanged.
- Both entry maps carry `kitless`'s empty kit directory as a trailing-slash entry, so the two "publishes no kits" cases still exercise an empty directory rather than a missing one, which `enumerateKits` answers alike.
- Suite counts hold at 4, 6, and 24, with assertions unchanged apart from how each reaches its tree.

### ⚙️ Tooling

- `eslint.config.ts` adds the two fixture-bearing suites to the `@vitest/eslint-plugin` suppression block, whose comment now says that only some of the listed suites register `it.aroundAll` or `it.aroundEach`. The `test.extend` preamble stays written out per suite: behind a shared helper the plugin resolves the `it` binding to `"local"` and stops applying every vitest rule to the file.

Closes #359
