### PR TITLE
#333 Consolidate workspace discovery onto the shared directory walker

### DIFF
--- a/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
@@ -162,8 +162,8 @@ describe(discoverWorkspaces, () => {
     });
   });
 
-  describe('skipping non-workspace matched directories', () => {
-    it('skips a matched directory without a package.json', ({ temp }) => {
+  describe('skipping directories that are not workspaces', () => {
+    it('skips a directory without a package.json', ({ temp }) => {
       writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
       writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
       temp.mkdir('packages/empty');
@@ -202,6 +202,37 @@ describe(discoverWorkspaces, () => {
       const workspaces = discoverWorkspaces();
 
       expect(workspaces.map((w) => w.name)).not.toContain('fake');
+    });
+  });
+
+  describe('pattern shapes', () => {
+    it('does not report the repo root as a workspace under a `**` pattern', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['**'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha']);
+    });
+
+    it('resolves a trailing-slash pattern to the same set as its bare form', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*/'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage(temp, 'packages/beta', { name: 'beta' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha', 'packages/beta']);
+    });
+
+    it('resolves a pattern that names its directory literally', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['tools/formatter'] });
+      writeWorkspacePackage(temp, 'tools/formatter', { name: 'formatter' });
+      writeWorkspacePackage(temp, 'tools/linter', { name: 'linter' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['tools/formatter']);
     });
   });
 

--- a/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
@@ -13,7 +13,7 @@ const { failures } = vi.hoisted(() => {
   return { failures };
 });
 
-// The module under test binds `readdirSync` at import, so a spy on the `node:fs` namespace never reaches it.
+// `walkDirectories` binds `readdirSync` at import, so a spy on the `node:fs` namespace never reaches it.
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return {
@@ -48,11 +48,11 @@ describe(`${discoverWorkspaces.name} directory walk`, () => {
     expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['alpha', 'locked', 'inner']);
   });
 
-  it('skips the subtree under a directory it cannot read for a benign reason, keeping the rest', ({ temp }) => {
+  it('drops a directory it cannot read for a benign reason along with its subtree, keeping the rest', ({ temp }) => {
     writeMonorepo(temp);
     failures.set(join(temp.dir, 'packages/locked'), 'EACCES');
 
-    expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['alpha', 'locked']);
+    expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['alpha']);
   });
 
   it('propagates a systemic read failure rather than answering with a partial walk', ({ temp }) => {
@@ -66,8 +66,9 @@ describe(`${discoverWorkspaces.name} directory walk`, () => {
 // region | Helpers
 
 /**
- * Writes a monorepo whose `packages/locked` holds a nested workspace, so a failed read of `locked`
- * costs `inner` and nothing else. `locked` itself is matched from reading `packages/`, so it survives.
+ * Writes a monorepo whose `packages/locked` holds a nested workspace, so a failed read of `locked` costs
+ * both while `alpha` survives. A directory qualifies as a workspace only when reading it reveals a
+ * `package.json`, and that is the read that fails.
  */
 function writeMonorepo(temp: TempTree): void {
   temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/**'] });

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -1,11 +1,9 @@
-import { type Dirent, existsSync, readdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-
-import picomatch from 'picomatch';
 
 import { deepFreeze } from '../portable/deepFreeze.ts';
 import { isRecord } from '../portable/isRecord.ts';
-import { isSkippableFilesystemError } from '../portable/isSkippableFilesystemError.ts';
+import { walkDirectories } from '../portable/walkDirectories.ts';
 import { readJsonFile } from './json.ts';
 import { readPnpmWorkspacePackages } from './pnpmWorkspaceYaml.ts';
 
@@ -30,15 +28,6 @@ export interface DiscoverWorkspacesOptions {
 }
 
 type WorkspacePatternSource = 'pnpm-workspace.yaml' | 'package.json';
-
-/** Maximum recursion depth for the glob walk. */
-const MAX_WALK_DEPTH = 10;
-
-/**
- * Directory names that are never traversed. Only `node_modules` is listed here;
- * dot-prefixed directories (including `.git`) are pruned separately in `walk`.
- */
-const PRUNED_NAMES = new Set(['node_modules']);
 
 /** Discovered workspaces by the `cwd` they were resolved against, held for the life of the process. */
 const workspacesByCwd = new Map<string, Workspace[]>();
@@ -152,8 +141,11 @@ function extractNpmWorkspacePatterns(workspaces: unknown): string[] | null {
 }
 
 /**
- * Expands each pattern against a pruned recursive directory walk, returning relative
- * dir paths (forward-slash style) sorted and deduplicated.
+ * Expands each pattern into the workspace directories it names, as relative forward-slash paths,
+ * sorted and deduplicated.
+ *
+ * Each pattern is rewritten to name the `package.json` inside the directories it matches, so
+ * `walkDirectories` yields those directories.
  */
 function expandPatterns(cwd: string, patterns: string[], source: WorkspacePatternSource): string[] {
   if (patterns.length === 0) return [];
@@ -170,51 +162,19 @@ function expandPatterns(cwd: string, patterns: string[], source: WorkspacePatter
     }
   }
 
-  const matchers = patterns.map((pattern) => picomatch(normalizePattern(pattern)));
-  const matched = new Set<string>();
+  const match = patterns.map((pattern) => `${normalizePattern(pattern)}/package.json`);
 
-  walk(cwd, '.', 0, (relDir) => {
-    if (relDir === '.') return;
-    if (matchers.some((isMatch) => isMatch(relDir))) {
-      matched.add(relDir);
-    }
-  });
-
-  return [...matched].toSorted();
+  // The root is not a workspace, and a pattern of `**` translates to a glob matching its own manifest.
+  return walkDirectories({ root: cwd, match }).filter((relDir) => relDir !== '.');
 }
 
 /**
  * Normalizes a workspace pattern.
- * Strips a trailing `/` because picomatch's `**` matches paths, not directories-with-slash.
+ * Strips a trailing `/`, which would otherwise double the separator when the manifest name is appended.
  */
 function normalizePattern(pattern: string): string {
   if (pattern.endsWith('/')) return pattern.slice(0, -1);
   return pattern;
-}
-
-/** Walks `cwd` recursively from `relDir`, calling `visit` for each directory. */
-function walk(cwd: string, relDir: string, depth: number, visit: (relDir: string) => void): void {
-  visit(relDir);
-  if (depth >= MAX_WALK_DEPTH) return;
-
-  const absDir = relDir === '.' ? cwd : join(cwd, relDir);
-  let entries: Dirent[];
-  try {
-    entries = readdirSync(absDir, { withFileTypes: true, encoding: 'utf8' });
-  } catch (error) {
-    // A systemic failure (e.g. EMFILE, EIO) is rethrown, so an incomplete walk isn't masked.
-    if (isSkippableFilesystemError(error)) return;
-    throw error;
-  }
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const name = entry.name;
-    if (PRUNED_NAMES.has(name)) continue;
-    if (name.startsWith('.')) continue;
-    const childRel = relDir === '.' ? name : `${relDir}/${name}`;
-    walk(cwd, childRel, depth + 1, visit);
-  }
 }
 
 /** Builds a `Workspace` for a relative directory; returns undefined if its `package.json` is missing or malformed. */

--- a/packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts
@@ -64,6 +64,12 @@ describe(walkDirectories, () => {
     expect(found).toStrictEqual(['twins']);
   });
 
+  it('yields the union of what its globs match when `match` is a list', ({ temp }) => {
+    const found = walkDirectories({ root: temp.dir, match: ['packages/*/package.json', 'deep/**/package.json'] });
+
+    expect(found).toStrictEqual(['deep/one/two', 'packages/a', 'packages/b']);
+  });
+
   it('yields the directory holding a matching directory, not the match itself', ({ temp }) => {
     const found = walkDirectories({ root: temp.dir, match: '**/.readyup', prune: [] });
 

--- a/packages/readyup/src/portable/walkDirectories.ts
+++ b/packages/readyup/src/portable/walkDirectories.ts
@@ -24,11 +24,11 @@ export interface WalkDirectoriesOptions {
   /** Directory the sweep descends from. Every returned path is relative to it. */
   root: string;
   /**
-   * Glob matched against each entry the sweep meets, file and directory alike, as a path relative to
+   * Globs matched against each entry the sweep meets, file and directory alike, as a path relative to
    * `root`. A matching entry contributes the directory holding it, so a recursive glob ending in
-   * `/package.json` names the directories that hold one.
+   * `/package.json` names the directories that hold one. A list matches what any one of its globs matches.
    */
-  match: string;
+  match: string | string[];
   /**
    * Globs matched against directory paths. A matching directory is neither traversed nor yielded, and
    * nothing else excludes anything: clearing this sweeps the whole tree, dot-directories included.


### PR DESCRIPTION
## What

Consolidates `readyup`'s workspace discovery onto `walkDirectories`, the shared directory walker, deleting the private recursive walk that `discoverWorkspaces` carried alongside it.

A workspace directory that cannot itself be listed is now dropped along with its subtree, where before it survived by being matched from its parent's listing. That brings `discoverWorkspaces` into line with `discoverProjects`, which already swept the tree this way.

## Why

Two walkers solved the same problem -- a depth-capped sweep that prunes `node_modules` and dot-directories, tolerates a benign read failure, and returns sorted relative paths -- with their own copies of the depth cap and the prune set, and nothing kept the copies in sync. The shared walker arrived after workspace discovery was already written and never picked it up as a consumer, so the drift was there from the day the second walker landed, and the two sweeps already disagreed about which directories a repository contains.

## Details

### 🏗️ Internal features

- `walkDirectories` accepts a list of match globs alongside a single glob, so a caller holding several patterns resolves them in one sweep rather than one sweep per pattern. picomatch takes either, so the change is the type and its doc comment.

### ♻️ Refactoring

- `expandPatterns` is now the negation guard, a pattern rewrite, and one `walkDirectories` call. Each workspace pattern gains a `/package.json` tail, so a walker that matches directory *entries* answers a question that used to be asked of directory *paths*.
- The repo root is filtered from the result, because `**` translates to a glob matching the root's own manifest where the directory pattern `**` never matched the root. That is the one place the translation is not faithful; every other shape, `packages/*`, `apps/**`, a trailing slash, and a bare literal among them, corresponds exactly.
- `walk`, `MAX_WALK_DEPTH`, and `PRUNED_NAMES` are deleted, with the `Dirent`, `readdirSync`, `picomatch`, and `isSkippableFilesystemError` imports they were the only users of. `MAX_WALK_DEPTH` duplicated the shared walker's `DEFAULT_MAX_DEPTH` and `PRUNED_NAMES` plus a dot-name check duplicated its `DEFAULT_PRUNE_GLOBS`.
- `expandPatterns` now returns only directories that hold a manifest, where it used to return every matching directory and leave `buildWorkspace` to drop the manifest-less ones. `buildWorkspace`'s `undefined` return narrows to a malformed manifest.

### 🧪 Tests

- Pattern-shape coverage for `**`, a trailing-slash pattern, and a bare literal, joining existing coverage of `packages/*`, `apps/**`, `packages/**`, and `**/*`.
- Coverage for the list-valued `match`, asserting the union of what its globs match.
- The benign-read-failure test asserts the new, narrower result and its title states the drop; the systemic-failure test is unchanged and still proves an `EMFILE` propagates rather than yielding a partial walk.

Closes #333
