### PR TITLE
#374 Exempt the publishing package's own source from its adoption checks

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -101,6 +101,8 @@ const config = defineConfig([
       'packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts',
       'packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts',
       'packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts',
+      'packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts',
+      'packages/readyup/src/check-utils/project/__tests__/definesOwnImplementation.unit.test.ts',
       'packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.tool.test.ts',
       'packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts',
       'packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts',

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1303,6 +1303,8 @@ These six are what an adoption kit needs -- one reporting where a project hand-r
 
 `buildFindingReport` takes every finding the project holds plus a predicate selecting the ones the calling check reports, and names each selected finding as `symbol (path:line)`, or `path:line` where it declares no symbol. Its fraction is derived from every finding passed rather than only the reported ones, so the checks of one run share a denominator the reader can compare across them.
 
+Pass `ownImplementation` -- the package name, the export names, and the swept sources -- and every finding sited in that package's own implementation drops, from the detail and from both halves of the fraction. A file qualifies by sitting inside a workspace whose `package.json` names the package and exporting one of the named exports, so the repo publishing an idiom is not told it hand-rolled it. The same doctrine governs `hasMinDevDependencyVersion`: a repo that publishes a package is not a consumer of it. The rule is file-scoped, because a workspace is the whole repository in a single-package project, where a workspace-wide rule would turn the check off; a second file in the package that declares the name without exporting it is a hand-roll and is still reported. A file that declares the export under another name and renames it on export from a second file is not recognized, which surfaces in the publishing repo itself rather than in a consumer's.
+
 `undefined` is what a check skips on. Reporting it as a pass would say the project holds no hand-rolled sites, when what happened is that nothing was looked at.
 
 ```ts
@@ -1319,9 +1321,15 @@ const check = {
   check: async () => {
     const sources = (await readTrackedSources(isSource)) ?? [];
     const findings = sources.flatMap((source) => listHandRolledSites(blankNonCode(source.text), source.path));
-    const adoptedCount = countPackageUsage(sources, { exportNames: ['describeError'], packageName: '@scope/errors' });
+    const usage = { exportNames: ['describeError'], packageName: '@scope/errors' };
+    const adoptedCount = countPackageUsage(sources, usage);
 
-    return buildFindingReport({ adoptedCount, findings, shouldReport: (finding) => finding.kind === 'clone' });
+    return buildFindingReport({
+      adoptedCount,
+      findings,
+      ownImplementation: { ...usage, sources },
+      shouldReport: (finding) => finding.kind === 'clone',
+    });
   },
 };
 ```

--- a/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
+++ b/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
@@ -49,7 +49,7 @@ A blocked subtree does not consult a descendant's own `skip`, so a check that wo
 
 A detector reads what `blankNonCode` returns, never a source's raw text. An idiom written in a comment or a string is prose about the code rather than a site in it, and reporting one is a false positive -- which is what discredits a kit permanently, because a reader who finds one stops trusting the rest of what it says.
 
-Nothing in your own repo will show you the defect. An adoption kit skips the workspace publishing the package it checks, so the detector never runs against the comments you wrote; the false positives surface in consumer repos, where the reader who gets one cannot fix it.
+Your own repo is where the defect surfaces first. An adoption kit's `ownImplementation` declaration exempts the file defining the package's exports and nothing else, so the detector runs against every other source you wrote, comments included. A false positive there is the one a consumer would have got; fix the detector rather than the source.
 
 Expect the site count to move in both directions. Blanking unmasks sites a comment was hiding, because a comment sitting mid-expression blanks to a run of spaces as wide as it was rather than breaking the anchor scan. Write an anchor that tolerates a whitespace run, not one that admits a single space.
 

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -29,6 +29,7 @@ export type { BuildFindingReportOptions, Finding } from './project/buildFindingR
 export { buildFindingReport } from './project/buildFindingReport.ts';
 export type { CountPackageUsageOptions } from './project/countPackageUsage.ts';
 export { countPackageUsage } from './project/countPackageUsage.ts';
+export type { OwnImplementation } from './project/definesOwnImplementation.ts';
 export { listTrackedFiles } from './project/listTrackedFiles.ts';
 export type { PathFilter, ProjectSource } from './project/readTrackedSources.ts';
 export { readTrackedSources } from './project/readTrackedSources.ts';

--- a/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test } from 'vitest';
 
 import { buildFindingReport, type Finding } from '../buildFindingReport.ts';
+import type { OwnImplementation } from '../definesOwnImplementation.ts';
 
 interface KindedFinding extends Finding {
   kind: 'clone' | 'inline';
@@ -8,6 +12,36 @@ interface KindedFinding extends Finding {
 
 const CLONE: KindedFinding = { kind: 'clone', line: 12, path: 'src/errors.ts', symbol: 'describeError' };
 const INLINE: KindedFinding = { kind: 'inline', line: 44, path: 'src/report.ts' };
+
+const IMPLEMENTATION_PATH = 'packages/errors/src/describeError.ts';
+const OWN_CLONE: KindedFinding = { kind: 'clone', line: 8, path: IMPLEMENTATION_PATH, symbol: 'describeError' };
+const OWN_INLINE: KindedFinding = { kind: 'inline', line: 20, path: IMPLEMENTATION_PATH };
+const SIBLING_CLONE: KindedFinding = {
+  kind: 'clone',
+  line: 5,
+  path: 'packages/errors/src/format.ts',
+  symbol: 'formatError',
+};
+
+const OWN_IMPLEMENTATION: OwnImplementation = {
+  exportNames: ['describeError'],
+  packageName: '@scope/errors',
+  sources: [
+    { path: IMPLEMENTATION_PATH, text: 'export function describeError(error: unknown) {}' },
+    { path: 'packages/errors/src/format.ts', text: 'function formatError(error: unknown) {}' },
+  ],
+};
+
+const it = test.extend(
+  'temp',
+  makeFixture(() => createTempTree({}, { prefix: 'rdy-finding-report-' })),
+);
+
+it.aroundEach(async (runTest, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir);
+
+  await runTest();
+});
 
 describe(buildFindingReport, () => {
   it('passes when the check reports none of the findings the project holds', () => {
@@ -46,4 +80,71 @@ describe(buildFindingReport, () => {
 
     expect(outcome).toStrictEqual({ ok: true, progress: { count: 0, passedCount: 0, type: 'fraction' } });
   });
+
+  describe('given a check that names its own package', () => {
+    it('drops every finding sited in the implementation it names', ({ temp }) => {
+      writeMonorepo(temp);
+
+      const outcome = buildFindingReport({
+        adoptedCount: 0,
+        findings: [OWN_CLONE, OWN_INLINE, CLONE],
+        ownImplementation: OWN_IMPLEMENTATION,
+        shouldReport: () => true,
+      });
+
+      expect(outcome.detail).toBe('describeError (src/errors.ts:12)');
+    });
+
+    it('counts an exempt finding in neither half of the fraction', ({ temp }) => {
+      writeMonorepo(temp);
+
+      const outcome = buildFindingReport({
+        adoptedCount: 1,
+        findings: [OWN_CLONE, OWN_INLINE, CLONE],
+        ownImplementation: OWN_IMPLEMENTATION,
+        shouldReport: () => true,
+      });
+
+      expect(outcome.progress).toStrictEqual({ count: 2, passedCount: 1, type: 'fraction' });
+    });
+
+    it('reports a second file in that package hand-rolling the idiom', ({ temp }) => {
+      writeMonorepo(temp);
+
+      const outcome = buildFindingReport({
+        adoptedCount: 0,
+        findings: [OWN_CLONE, SIBLING_CLONE],
+        ownImplementation: OWN_IMPLEMENTATION,
+        shouldReport: () => true,
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.detail).toBe('formatError (packages/errors/src/format.ts:5)');
+    });
+
+    it('passes where the implementation held the only findings', ({ temp }) => {
+      writeMonorepo(temp);
+
+      const outcome = buildFindingReport({
+        adoptedCount: 2,
+        findings: [OWN_CLONE, OWN_INLINE],
+        ownImplementation: OWN_IMPLEMENTATION,
+        shouldReport: () => true,
+      });
+
+      expect(outcome).toStrictEqual({ ok: true, progress: { count: 2, passedCount: 2, type: 'fraction' } });
+    });
+  });
 });
+
+// region | Helpers
+
+/** Writes a two-workspace repo in which `packages/errors` publishes the package the fixtures name. */
+function writeMonorepo(temp: TempTree): void {
+  temp.writeJson('package.json', { name: 'root', private: true });
+  temp.write('pnpm-workspace.yaml', ['packages:', '  - packages/*', ''].join('\n'));
+  temp.writeJson('packages/errors/package.json', { name: '@scope/errors', version: '1.0.0' });
+  temp.writeJson('packages/app/package.json', { name: '@scope/app', version: '1.0.0' });
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/__tests__/definesOwnImplementation.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/definesOwnImplementation.unit.test.ts
@@ -30,6 +30,22 @@ describe(definesOwnImplementation, () => {
       expect(definesOwnImplementation(path, own)).toBe(true);
     });
 
+    it.for([
+      ['const', 'export const describeError = (error: unknown) => {};'],
+      ['let', 'export let describeError = (error: unknown) => {};'],
+      ['var', 'export var describeError = (error: unknown) => {};'],
+      ['class', 'export class describeError {}'],
+      ['async function', 'export async function describeError(error: unknown) {}'],
+      ['generator function', 'export function* describeError(error: unknown) {}'],
+      ['default function', 'export default function describeError(error: unknown) {}'],
+    ] as const)('exempts a file declaring the export as an exported %s', ([, text], { temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/describeError.ts';
+      const own = buildOwnImplementation([{ path, text }]);
+
+      expect(definesOwnImplementation(path, own)).toBe(true);
+    });
+
     it('exempts a file that renames a local binding to a recommended export', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/errors/src/describeError.ts';

--- a/packages/readyup/src/check-utils/project/__tests__/definesOwnImplementation.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/definesOwnImplementation.unit.test.ts
@@ -1,0 +1,161 @@
+import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test } from 'vitest';
+
+import { definesOwnImplementation, type OwnImplementation } from '../definesOwnImplementation.ts';
+import type { ProjectSource } from '../readTrackedSources.ts';
+
+const EXPORT_NAMES = ['describeError'];
+const PACKAGE_NAME = '@scope/errors';
+
+const it = test.extend(
+  'temp',
+  makeFixture(() => createTempTree({}, { prefix: 'rdy-own-impl-' })),
+);
+
+it.aroundEach(async (runTest, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir);
+
+  await runTest();
+});
+
+describe(definesOwnImplementation, () => {
+  describe('in a monorepo', () => {
+    it('exempts a file in the publishing workspace that declares a recommended export', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/describeError.ts';
+      const own = buildOwnImplementation([{ path, text: 'export function describeError(error: unknown) {}' }]);
+
+      expect(definesOwnImplementation(path, own)).toBe(true);
+    });
+
+    it('exempts a file that renames a local binding to a recommended export', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/describeError.ts';
+      const text = 'function toMessage(error: unknown) {}\nexport { toMessage as describeError };\n';
+      const own = buildOwnImplementation([{ path, text }]);
+
+      expect(definesOwnImplementation(path, own)).toBe(true);
+    });
+
+    it('exempts a file that exports a separately declared binding under its own name', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/describeError.ts';
+      const text = 'function describeError(error: unknown) {}\nexport { describeError };\n';
+      const own = buildOwnImplementation([{ path, text }]);
+
+      expect(definesOwnImplementation(path, own)).toBe(true);
+    });
+
+    it('reports a file in the publishing workspace that declares the name without exporting it', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/format.ts';
+      const own = buildOwnImplementation([{ path, text: 'function describeError(error: unknown) {}\n' }]);
+
+      expect(definesOwnImplementation(path, own)).toBe(false);
+    });
+
+    it('reports a file exporting the name under a different one', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/format.ts';
+      const text = 'function describeError(error: unknown) {}\nexport { describeError as toMessage };\n';
+      const own = buildOwnImplementation([{ path, text }]);
+
+      expect(definesOwnImplementation(path, own)).toBe(false);
+    });
+
+    it('reports a file in the publishing workspace that only imports and calls the export', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/report.ts';
+      const text = "import { describeError } from '@scope/errors';\nconst message = describeError(error);\n";
+      const own = buildOwnImplementation([{ path, text }]);
+
+      expect(definesOwnImplementation(path, own)).toBe(false);
+    });
+
+    it('reports a declaration that appears only in a comment', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/report.ts';
+      const own = buildOwnImplementation([{ path, text: '// function describeError(error: unknown) {}\n' }]);
+
+      expect(definesOwnImplementation(path, own)).toBe(false);
+    });
+
+    it('reports a defining file outside the publishing workspace', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/app/src/describeError.ts';
+      const own = buildOwnImplementation([{ path, text: 'export function describeError(error: unknown) {}' }]);
+
+      expect(definesOwnImplementation(path, own)).toBe(false);
+    });
+
+    it('reports every file when no workspace carries the declared name', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/describeError.ts';
+      const sources = [{ path, text: 'export function describeError(error: unknown) {}' }];
+      const own = { ...buildOwnImplementation(sources), packageName: '@scope/absent' };
+
+      expect(definesOwnImplementation(path, own)).toBe(false);
+    });
+
+    it('reports a path the sweep never read', ({ temp }) => {
+      writeMonorepo(temp);
+      const own = buildOwnImplementation([]);
+
+      expect(definesOwnImplementation('packages/errors/src/describeError.ts', own)).toBe(false);
+    });
+
+    it('reports every file when the check names no exports', ({ temp }) => {
+      writeMonorepo(temp);
+      const path = 'packages/errors/src/describeError.ts';
+      const sources = [{ path, text: 'export function describeError(error: unknown) {}' }];
+      const own = { ...buildOwnImplementation(sources), exportNames: [] };
+
+      expect(definesOwnImplementation(path, own)).toBe(false);
+    });
+  });
+
+  describe('in a single-package repo', () => {
+    it('exempts the defining file alone, not the repo', ({ temp }) => {
+      writeSinglePackage(temp);
+      const sources = [
+        { path: 'src/describeError.ts', text: 'export function describeError(error: unknown) {}' },
+        { path: 'src/report.ts', text: 'const message = describeError(error);\n' },
+      ];
+      const own = buildOwnImplementation(sources);
+
+      expect(definesOwnImplementation('src/describeError.ts', own)).toBe(true);
+      expect(definesOwnImplementation('src/report.ts', own)).toBe(false);
+    });
+  });
+
+  it('reports every file in a repo whose workspaces cannot be discovered', () => {
+    const path = 'src/describeError.ts';
+    const own = buildOwnImplementation([{ path, text: 'export function describeError(error: unknown) {}' }]);
+
+    expect(definesOwnImplementation(path, own)).toBe(false);
+  });
+});
+
+// region | Helpers
+
+/** Builds the declaration a check hands the rule, over the sources the case supplies. */
+function buildOwnImplementation(sources: readonly ProjectSource[]): OwnImplementation {
+  return { exportNames: EXPORT_NAMES, packageName: PACKAGE_NAME, sources };
+}
+
+/** Writes a two-workspace repo in which `packages/errors` publishes the package under test. */
+function writeMonorepo(temp: TempTree): void {
+  temp.writeJson('package.json', { name: 'root', private: true });
+  temp.write('pnpm-workspace.yaml', ['packages:', '  - packages/*', ''].join('\n'));
+  temp.writeJson('packages/errors/package.json', { name: PACKAGE_NAME, version: '1.0.0' });
+  temp.writeJson('packages/app/package.json', { name: '@scope/app', version: '1.0.0' });
+}
+
+/** Writes a repo whose single workspace is the root, publishing the package under test. */
+function writeSinglePackage(temp: TempTree): void {
+  temp.writeJson('package.json', { name: PACKAGE_NAME, version: '1.0.0' });
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/buildFindingReport.ts
+++ b/packages/readyup/src/check-utils/project/buildFindingReport.ts
@@ -1,4 +1,5 @@
 import type { CheckOutcome } from '../../kits/types.ts';
+import { definesOwnImplementation, type OwnImplementation } from './definesOwnImplementation.ts';
 
 /** One located site a check names. */
 export interface Finding {
@@ -12,6 +13,8 @@ export interface BuildFindingReportOptions<F extends Finding> {
   findings: readonly F[];
   shouldReport: (finding: F) => boolean;
   adoptedCount: number;
+  /** The package the check is about, whose own implementation the report passes over. */
+  ownImplementation?: OwnImplementation | undefined;
 }
 
 /**
@@ -20,13 +23,18 @@ export interface BuildFindingReportOptions<F extends Finding> {
  * The fraction is derived from every finding passed, not only the reported ones, so the checks of one run share a
  * denominator the reader can compare across them. Passing only the reported findings would state a fraction of a
  * different whole for each check, which is why the selection is made here rather than by the caller.
+ *
+ * A check naming its own package drops the findings sited in that package's implementation, from the detail and from
+ * both halves of the fraction. The repo publishing an idiom is where the idiom lives, and a kit reporting it there
+ * spends the credibility it needs in every other repo it runs in.
  */
 export function buildFindingReport<F extends Finding>(options: BuildFindingReportOptions<F>): CheckOutcome {
-  const { adoptedCount, findings, shouldReport } = options;
+  const { adoptedCount, findings, ownImplementation, shouldReport } = options;
 
-  const reported = findings.filter((finding) => shouldReport(finding));
+  const retained = excludeOwnImplementation(findings, ownImplementation);
+  const reported = retained.filter((finding) => shouldReport(finding));
   const progress = {
-    count: adoptedCount + findings.length,
+    count: adoptedCount + retained.length,
     passedCount: adoptedCount,
     type: 'fraction',
   } as const;
@@ -41,6 +49,28 @@ export function buildFindingReport<F extends Finding>(options: BuildFindingRepor
 function describeFinding(finding: Finding): string {
   const location = `${finding.path}:${finding.line}`;
   return finding.symbol === undefined ? location : `${finding.symbol} (${location})`;
+}
+
+/**
+ * Drops the findings sited in the declared package's own implementation.
+ *
+ * Each path is decided once, so a file holding ten findings is read and blanked once between them.
+ */
+function excludeOwnImplementation<F extends Finding>(
+  findings: readonly F[],
+  ownImplementation: OwnImplementation | undefined,
+): readonly F[] {
+  if (ownImplementation === undefined) return findings;
+
+  const verdicts = new Map<string, boolean>();
+  return findings.filter((finding) => {
+    let exempt = verdicts.get(finding.path);
+    if (exempt === undefined) {
+      exempt = definesOwnImplementation(finding.path, ownImplementation);
+      verdicts.set(finding.path, exempt);
+    }
+    return !exempt;
+  });
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/check-utils/project/definesOwnImplementation.ts
+++ b/packages/readyup/src/check-utils/project/definesOwnImplementation.ts
@@ -1,0 +1,81 @@
+import { blankNonCode } from '../../portable/blankNonCode.ts';
+import { discoverWorkspaces } from '../workspaces.ts';
+import type { ProjectSource } from './readTrackedSources.ts';
+
+/** The package a check is about, the exports whose definition marks a file as its implementation, and the swept sources. */
+export interface OwnImplementation {
+  packageName: string;
+  exportNames: readonly string[];
+  sources: readonly ProjectSource[];
+}
+
+/**
+ * Reports whether a path holds the declared package's own implementation: a file inside the workspace publishing the
+ * package that defines one of its recommended exports.
+ *
+ * Both halves are required. A repo publishing the package is where the idiom is supposed to live, but the workspace is
+ * the whole repository in a single-package project, so a workspace-wide rule would turn the check off there, and in
+ * any repo it would silence a second file hand-rolling the idiom instead of importing the local implementation.
+ *
+ * The definition is read from the file's text, so a detector reporting sites that declare nothing is exempted on the
+ * same terms as one reporting a declaration. A file the sweep never read cannot be shown to define anything, and a
+ * repo whose workspaces cannot be discovered holds no publishing workspace to be inside.
+ */
+export function definesOwnImplementation(path: string, ownImplementation: OwnImplementation): boolean {
+  const { exportNames, packageName, sources } = ownImplementation;
+  if (exportNames.length === 0) return false;
+
+  const publishingDirs = findPublishingWorkspaceDirs(packageName);
+  const inPublishingWorkspace = publishingDirs.some((dir) => containsPath(dir, path));
+  if (!inPublishingWorkspace) return false;
+
+  const source = sources.find((candidate) => candidate.path === path);
+  if (source === undefined) return false;
+
+  return definesAnyExport(blankNonCode(source.text), exportNames);
+}
+
+// region | Helpers
+
+/** Reports whether a workspace directory contains a path, both being relative to the same `cwd`. */
+function containsPath(dir: string, path: string): boolean {
+  if (dir === '.') return true;
+  return path === dir || path.startsWith(`${dir}/`);
+}
+
+/**
+ * Reports whether blanked source exports any of the names.
+ *
+ * Two forms count: a declaration the `export` keyword introduces, and an export clause naming the binding, whether it
+ * was declared under that name or renamed to it. The export is what separates the package's implementation from a
+ * second file in it declaring a private helper of the same name, which is a hand-roll the check exists to report. A
+ * clause exporting the name under a different one exports something else, and matches neither pattern.
+ */
+function definesAnyExport(code: string, exportNames: readonly string[]): boolean {
+  const names = exportNames.map((name) => RegExp.escape(name)).join('|');
+  const exportedDeclaration = new RegExp(
+    String.raw`\bexport\s+(?:default\s+)?(?:async\s+)?(?:function[\s*]+|const\s+|let\s+|var\s+|class\s+)(?:${names})\b`,
+  );
+  const exportClause = new RegExp(String.raw`\bexport\s*\{[^}]*\b(?:${names})\s*(?:,|\})`);
+
+  return exportedDeclaration.test(code) || exportClause.test(code);
+}
+
+/**
+ * Names the directories of the workspaces publishing the package.
+ *
+ * Discovery answers best effort here: a repo it cannot read reports as one holding no such workspace, so a check that
+ * worked before the rule existed keeps working rather than erroring out of it. The match is on the declared name
+ * alone, because what the rule needs is a repo holding the implementation, not one publishing it to a registry.
+ */
+function findPublishingWorkspaceDirs(packageName: string): string[] {
+  try {
+    return discoverWorkspaces({ filter: (workspace) => workspace.name === packageName }).map(
+      (workspace) => workspace.dir,
+    );
+  } catch {
+    return [];
+  }
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/definesOwnImplementation.ts
+++ b/packages/readyup/src/check-utils/project/definesOwnImplementation.ts
@@ -2,7 +2,10 @@ import { blankNonCode } from '../../portable/blankNonCode.ts';
 import { discoverWorkspaces } from '../workspaces.ts';
 import type { ProjectSource } from './readTrackedSources.ts';
 
-/** The package a check is about, the exports whose definition marks a file as its implementation, and the swept sources. */
+/**
+ * The package a check is about, the exports whose definition marks a file as its implementation, and the swept
+ * sources.
+ */
 export interface OwnImplementation {
   packageName: string;
   exportNames: readonly string[];


### PR DESCRIPTION
## What

Adds `ownImplementation` to `buildFindingReport` in `readyup/check-utils`. When a file in the package's own source exports one of that package's recommended exports, that file is no longer flagged as a candidate to use it. The exemption is file-scoped, so other files in the package are not exempt from the check.

## Why

An adoption kit run against the repository that publishes the package it checks reported that package's own implementation as a hand-roll, and the remedy was manual and recurring: a mark on the declaration, another on its body, rewritten for every check the author writes.

The workspace-wide alternative would have made the author's own repository the one place the detector never ran, so a false positive would surface first in a consumer's repo, where the reader who gets one cannot fix it.

## Details

### 🎉 Features

- `buildFindingReport` accepts `ownImplementation` as one optional object carrying `packageName`, `exportNames`, and the swept `sources`, so the three co-required inputs cannot be supplied apart. The pair a check already hands `countPackageUsage` spreads into it.
- A file qualifies by sitting inside a workspace whose `package.json` names the package and exporting one of the named exports. The export is what separates the implementation from a private helper of the same name, which is a hand-roll the check exists to report.
- The definition is read from the file's own text through `blankNonCode`, so a detector reporting sites that declare nothing is exempted on the same terms as one reporting a declaration. Recognized forms are an exported `function` (including `async` and generator), `const`, `let`, `var`, `class`, a default export, and an export clause naming the binding, whether it was declared under that name or renamed to it.
- Workspace resolution goes through `discoverWorkspaces`, which is synchronous and memoized, so the rule adds no read and nothing asynchronous. A repo whose workspaces cannot be discovered holds no publishing workspace, and its checks report as they did before.
- A file declaring the export under another name and renaming it on export from a second file is not recognized. Closing that would take a real parse, and the miss surfaces in the author's own repo, where it is visible and fixable.
- `OwnImplementation` is exported as a type from `readyup/check-utils`; the predicate itself stays off the kit-author surface.

### 🧪 Tests

- A suite for the predicate covers monorepo and single-package layouts, and the declining cases: a file that only imports and calls the export, a declaration appearing only in a comment, a file outside the publishing workspace, a file exporting the name under a different one, a path the sweep never read, a check naming no exports, and a repo whose workspaces cannot be discovered.
- Each declaration form the rule admits has a case of its own, so narrowing the set fails a test.
- The `buildFindingReport` cases assert the detail and the fraction independently, including the sibling file that stays reported and the run where the implementation held every finding.

### 📚 Documentation

- The README's project-sources section states what `ownImplementation` takes and which files it exempts, and the worked adoption kit passes it alongside the pair it already hands `countPackageUsage`.
- The kit-authoring rulebook told an author that an adoption kit skips the workspace publishing the package it checks, so nothing in that repo would surface the detector's false positives. That paragraph now reports the opposite, and directs the author to fix the detector rather than the source.

Closes #374

