### PR TITLE
#331 Widen `readyup/check-utils` to absolute paths and reconcile workspace discovery's `cwd`

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -99,6 +99,7 @@ const config = defineConfig([
       'packages/readyup/src/check-utils/__tests__/tool-versions.unit.test.ts',
       'packages/readyup/src/check-utils/__tests__/tsconfig.unit.test.ts',
       'packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts',
+      'packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts',
       'packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts',
       'packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts',
       'packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts',

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1155,6 +1155,8 @@ Reusable check functions for common assertions:
 import { fileExists, hasPackageJsonField } from 'readyup/check-utils';
 ```
 
+Every path a check utility takes resolves against `cwd` unless it is absolute, in which case it names the file itself; `filesExist` applies that rule to `baseDir` too, and an absolute entry in its list outranks the base directory.
+
 ### Outcomes
 
 | Function                                  | Returns                                                   |
@@ -1291,7 +1293,7 @@ It answers best effort: a project manifest it cannot read or parse yields `[]`. 
 
 These six are what an adoption kit needs -- one reporting where a project hand-rolls what a package it already installed provides. Both readers return `undefined` outside a git working tree, which an empty list does not say: a project that cannot be swept is a different answer from one that was swept and holds nothing.
 
-`listTrackedFiles` lists with `git ls-files -z`. The `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in quotes, and that file drops out of the sweep unreported. Below the repo root git emits paths relative to `cwd` and limited to that subtree, the same scope `readFile` works in. The sweep therefore follows the project `rdy` was invoked in, never the repository a kit was loaded from.
+`listTrackedFiles` lists with `git ls-files -z`. The `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in quotes, and that file drops out of the sweep unreported. Below the repo root git emits paths relative to `cwd` and limited to that subtree, the same scope a relative `readFile` path works in. The sweep therefore follows the project `rdy` was invoked in, never the repository a kit was loaded from.
 
 `readTrackedSources` applies its filter before any read, so a caller never pays for a file it excluded, and holds what it read for the life of the process. A file two kits both select costs one read between them, and each pays only for the remainder the other did not ask for. That cache lives here rather than in a kit because a compiled kit leaves its `readyup` imports unbundled, making `check-utils` one module instance across every kit of a run; a cache inside a bundled helper would be one per bundle. Listings are held the same way and are shared by checks that start together, which the runner does. The sweep never reads `node_modules/` or `.readyup/kits/*.js` whatever the filter answers for them -- the latter is readyup's own generated artifact, and sweeping it would report a kit's bundled source back to its author. That kit exclusion names the default `compile.outDir`; a project compiling its kits elsewhere excludes that directory itself. A caller wanting further exclusions applies them in its own filter.
 

--- a/packages/readyup/src/check-utils/__tests__/filesystem.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/filesystem.unit.test.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
@@ -25,6 +27,12 @@ describe(fileExists, () => {
 
   it('returns false when the file does not exist', () => {
     expect(fileExists('missing.txt')).toBe(false);
+  });
+
+  it('reads an absolute path as itself', ({ temp }) => {
+    temp.write('found.txt', 'content');
+
+    expect(fileExists(join(temp.dir, 'found.txt'))).toBe(true);
   });
 });
 
@@ -109,6 +117,25 @@ describe(filesExist, () => {
       progress: { type: 'fraction', passedCount: 1, count: 2 },
     });
   });
+
+  it('reads an absolute path as itself', ({ temp }) => {
+    temp.write('found.txt', '');
+
+    const result = filesExist([join(temp.dir, 'found.txt')]);
+
+    expect(result).toStrictEqual({
+      ok: true,
+      progress: { type: 'fraction', passedCount: 1, count: 1 },
+    });
+  });
+
+  it('reads an absolute path as itself in preference to baseDir', ({ temp }) => {
+    temp.write('outside-base.txt', '');
+
+    const result = filesExist([join(temp.dir, 'outside-base.txt')], { baseDir: 'sub' });
+
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe(readFile, () => {
@@ -120,5 +147,11 @@ describe(readFile, () => {
 
   it('returns undefined when the file does not exist', () => {
     expect(readFile('missing.txt')).toBeUndefined();
+  });
+
+  it('reads an absolute path as itself', ({ temp }) => {
+    temp.write('hello.txt', 'hello world');
+
+    expect(readFile(join(temp.dir, 'hello.txt'))).toBe('hello world');
   });
 });

--- a/packages/readyup/src/check-utils/__tests__/json.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/json.unit.test.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
@@ -37,6 +39,12 @@ describe(readJsonFile, () => {
     temp.write('bad.json', '{ not valid json }}}');
 
     expect(readJsonFile('bad.json')).toBeUndefined();
+  });
+
+  it('reads an absolute path as itself', ({ temp }) => {
+    temp.writeJson('config.json', { key: 'value' });
+
+    expect(readJsonFile(join(temp.dir, 'config.json'))).toStrictEqual({ key: 'value' });
   });
 });
 

--- a/packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts
@@ -1,0 +1,118 @@
+import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test, vi } from 'vitest';
+
+import { discoverWorkspaces, type Workspace } from '../workspaces.ts';
+
+/**
+ * The `node:fs` functions a repoint can be armed on: `existsSync` fires on the `pnpm-workspace.yaml` probe,
+ * discovery's first filesystem call after it snapshots the cwd, and `readdirSync` on the directory walk.
+ */
+type FsTrigger = 'existsSync' | 'readdirSync';
+
+// Hoisted alongside the `vi.mock` factory below, which runs before this module's own bindings initialize.
+const { repoint } = vi.hoisted(() => {
+  const repoint: { on: FsTrigger | undefined; to: string } = { on: undefined, to: '' };
+  return { repoint };
+});
+
+// The modules under test bind their `node:fs` functions at import, so a spy on the namespace never reaches them.
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+
+  function applyRepoint(fsFunction: FsTrigger): void {
+    if (repoint.on !== fsFunction) return;
+    repoint.on = undefined;
+    const decoyDir = repoint.to;
+    process.cwd = () => decoyDir;
+  }
+
+  return {
+    ...actual,
+    existsSync: (...args: Parameters<typeof actual.existsSync>) => {
+      applyRepoint('existsSync');
+      return actual.existsSync(...args);
+    },
+    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => {
+      applyRepoint('readdirSync');
+      return actual.readdirSync(...args);
+    },
+  };
+});
+
+const it = test.extend(
+  'temp',
+  makeFixture(() => createTempTree({}, { prefix: 'rdy-ws-cwd-' })),
+);
+
+it.aroundEach(async (runTest, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir);
+
+  await runTest();
+});
+
+// Every ordinary discovery assertion passes whether or not a helper reads through the `cwd` it was handed, because
+// the snapshot and the ambient cwd are the same directory. Moving the ambient one mid-discovery separates them.
+describe(`${discoverWorkspaces.name} cwd reconciliation`, () => {
+  it('reads the pattern list at the directory it snapshotted', ({ temp }) => {
+    temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/*'] });
+    temp.writeJson('packages/alpha/package.json', { name: 'alpha' });
+    const decoyDir = writeDecoyRoot(temp);
+
+    const workspaces = discoverWithCwdRepointedAt(decoyDir, 'existsSync');
+
+    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['alpha']);
+  });
+
+  it('reads the single-workspace manifest at the directory it snapshotted', ({ temp }) => {
+    temp.writeJson('package.json', { name: 'root', private: true });
+    const decoyDir = writeDecoyRoot(temp);
+
+    const workspaces = discoverWithCwdRepointedAt(decoyDir, 'existsSync');
+
+    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['root']);
+  });
+
+  it('reads each workspace manifest at the directory it snapshotted', ({ temp }) => {
+    temp.writeJson('package.json', { name: 'root', private: true });
+    temp.write('pnpm-workspace.yaml', ['packages:', '  - packages/*', ''].join('\n'));
+    temp.writeJson('packages/alpha/package.json', { name: 'alpha' });
+    const decoyDir = writeDecoyRoot(temp);
+
+    const workspaces = discoverWithCwdRepointedAt(decoyDir, 'readdirSync');
+
+    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['alpha']);
+  });
+});
+
+// region | Helpers
+
+/**
+ * Discovers workspaces with `process.cwd` repointed at `decoyDir` on the first call to `fsFunction`,
+ * restoring it before the caller asserts so a failure leaves nothing behind for the next test.
+ */
+function discoverWithCwdRepointedAt(decoyDir: string, fsFunction: FsTrigger): Workspace[] {
+  const rootDir = process.cwd();
+  repoint.on = fsFunction;
+  repoint.to = decoyDir;
+  try {
+    return discoverWorkspaces();
+  } finally {
+    repoint.on = undefined;
+    process.cwd = () => rootDir;
+  }
+}
+
+/**
+ * Writes a second repo root whose manifests all carry the name `decoy`, at the same relative paths as the real
+ * root's, so a helper reading through the ambient cwd reports a wrong name rather than an empty result.
+ */
+function writeDecoyRoot(temp: TempTree): string {
+  const decoyDir = temp.mkdir('decoy-root');
+  temp.writeJson('decoy-root/package.json', { name: 'decoy', private: true });
+  temp.writeJson('decoy-root/packages/alpha/package.json', { name: 'decoy' });
+  return decoyDir;
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/filesystem.ts
+++ b/packages/readyup/src/check-utils/filesystem.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { resolve } from 'node:path';
 
 import type { CheckOutcome } from '../kits/types.ts';
 import { missingFrom } from './missingFrom.ts';
@@ -8,40 +8,43 @@ import { missingFrom } from './missingFrom.ts';
 /** Regex matching only safe command names (alphanumeric, dash, underscore, dot). */
 const SAFE_COMMAND_NAME = /^[a-zA-Z0-9._-]+$/;
 
-/** Check whether a file exists relative to the working directory. */
-export function fileExists(relativePath: string): boolean {
-  return existsSync(join(process.cwd(), relativePath));
+/** Checks whether a file exists. A relative path resolves against the working directory. */
+export function fileExists(filePath: string): boolean {
+  return existsSync(resolve(process.cwd(), filePath));
 }
 
-/** Read a file relative to the working directory. Return undefined if it doesn't exist. */
-export function readFile(relativePath: string): string | undefined {
-  const fullPath = join(process.cwd(), relativePath);
+/**
+ * Reads a file, resolving a relative path against the working directory.
+ * Returns undefined if it doesn't exist.
+ */
+export function readFile(filePath: string): string | undefined {
+  const fullPath = resolve(process.cwd(), filePath);
   if (!existsSync(fullPath)) return undefined;
   return readFileSync(fullPath, 'utf8');
 }
 
-/** Check whether a file contains content matching a regex. */
-export function fileContains(relativePath: string, pattern: RegExp): boolean {
-  const content = readFile(relativePath);
+/** Checks whether a file contains content matching a regex. */
+export function fileContains(filePath: string, pattern: RegExp): boolean {
+  const content = readFile(filePath);
   if (content === undefined) return false;
   return pattern.test(content);
 }
 
-/** Check that a file does not contain content matching a regex. Pass if the file is absent. */
-export function fileDoesNotContain(relativePath: string, pattern: RegExp): boolean {
-  const content = readFile(relativePath);
+/** Checks that a file does not contain content matching a regex. Passes if the file is absent. */
+export function fileDoesNotContain(filePath: string, pattern: RegExp): boolean {
+  const content = readFile(filePath);
   if (content === undefined) return true;
   return !pattern.test(content);
 }
 
-/** Check whether all specified files exist, with optional base directory. */
+/** Checks whether all specified files exist, with optional base directory. An absolute path names itself. */
 export function filesExist(paths: string[], options?: { baseDir?: string }): CheckOutcome {
-  const base = options?.baseDir ? join(process.cwd(), options.baseDir) : process.cwd();
-  const presentPaths = paths.filter((p) => existsSync(join(base, p)));
+  const base = options?.baseDir ? resolve(process.cwd(), options.baseDir) : process.cwd();
+  const presentPaths = paths.filter((p) => existsSync(resolve(base, p)));
   return missingFrom('files', paths, presentPaths);
 }
 
-/** Check whether a command is available on PATH. Rejects names with shell metacharacters. */
+/** Checks whether a command is available on PATH. Rejects names with shell metacharacters. */
 export function commandExists(name: string): boolean {
   if (!SAFE_COMMAND_NAME.test(name)) {
     return false;

--- a/packages/readyup/src/check-utils/hashing.ts
+++ b/packages/readyup/src/check-utils/hashing.ts
@@ -2,14 +2,14 @@ import { createHash } from 'node:crypto';
 
 import { readFile } from './filesystem.ts';
 
-/** Compute the SHA-256 hex digest of a string. */
+/** Computes the SHA-256 hex digest of a string. */
 export function computeHash(content: string): string {
   return createHash('sha256').update(content).digest('hex');
 }
 
-/** Check whether a file's content matches an expected SHA-256 hash. */
-export function fileMatchesHash(relativePath: string, expectedHash: string): boolean {
-  const content = readFile(relativePath);
+/** Checks whether a file's content matches an expected SHA-256 hash. */
+export function fileMatchesHash(filePath: string, expectedHash: string): boolean {
+  const content = readFile(filePath);
   if (content === undefined) return false;
   return computeHash(content) === expectedHash;
 }

--- a/packages/readyup/src/check-utils/json.ts
+++ b/packages/readyup/src/check-utils/json.ts
@@ -5,32 +5,32 @@ import { readFile } from './filesystem.ts';
 import { getJsonValue } from './json-value.ts';
 import { missingFrom } from './missingFrom.ts';
 
-/** Read and parse a JSON file relative to cwd. Return undefined if it doesn't exist or isn't an object. */
-export function readJsonFile(relativePath: string): Record<string, unknown> | undefined {
-  const content = readFile(relativePath);
+/** Reads and parses a JSON file. Returns undefined if it doesn't exist or isn't an object. */
+export function readJsonFile(filePath: string): Record<string, unknown> | undefined {
+  const content = readFile(filePath);
   if (content === undefined) return undefined;
   const parsed = safeJsonParse(content);
   if (!isRecord(parsed)) return undefined;
   return parsed;
 }
 
-/** Check whether a JSON file has a field, optionally with a specific value. */
-export function hasJsonField(relativePath: string, field: string, expectedValue?: string): boolean {
-  const data = readJsonFile(relativePath);
+/** Checks whether a JSON file has a field, optionally with a specific value. */
+export function hasJsonField(filePath: string, field: string, expectedValue?: string): boolean {
+  const data = readJsonFile(filePath);
   if (data === undefined || !Object.hasOwn(data, field)) return false;
   return expectedValue === undefined || data[field] === expectedValue;
 }
 
-/** Read a JSON file and extract a nested value by traversing the key path. */
-export function readJsonValue(relativeFilePath: string, ...keys: string[]): unknown {
-  const obj = readJsonFile(relativeFilePath);
+/** Reads a JSON file and extracts a nested value by traversing the key path. */
+export function readJsonValue(filePath: string, ...keys: string[]): unknown {
+  const obj = readJsonFile(filePath);
   if (obj === undefined) return undefined;
   return getJsonValue(obj, ...keys);
 }
 
-/** Check whether a JSON file has all of the specified fields. */
-export function hasJsonFields(relativePath: string, fields: string[]): CheckOutcome {
-  const data = readJsonFile(relativePath) ?? {};
+/** Checks whether a JSON file has all of the specified fields. */
+export function hasJsonFields(filePath: string, fields: string[]): CheckOutcome {
+  const data = readJsonFile(filePath) ?? {};
   const presentFields = fields.filter((field) => Object.hasOwn(data, field));
   return missingFrom('fields', fields, presentFields);
 }

--- a/packages/readyup/src/check-utils/tool-versions.ts
+++ b/packages/readyup/src/check-utils/tool-versions.ts
@@ -7,8 +7,8 @@ const NODE_TOOL_NAMES = new Set(['node', 'nodejs']);
  * Reads the Node version declared in a `.tool-versions` file.
  * Returns undefined when the file is absent or declares no Node version.
  */
-export function readToolVersionsNode(relativePath = '.tool-versions'): string | undefined {
-  const content = readFile(relativePath);
+export function readToolVersionsNode(filePath = '.tool-versions'): string | undefined {
+  const content = readFile(filePath);
   if (content === undefined) return undefined;
 
   for (const line of content.split('\n')) {

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -65,9 +65,9 @@ interface Resolution {
  * declares in its own right. Returns undefined if the entry file is missing or unparseable; unresolvable parents
  * are reported in `unresolvedExtends` rather than treated as failures.
  */
-export function readTsconfigChain(relativePath: string): TsconfigChain | undefined {
+export function readTsconfigChain(filePath: string): TsconfigChain | undefined {
   const cwd = process.cwd();
-  const entryPath = resolve(cwd, relativePath);
+  const entryPath = resolve(cwd, filePath);
   const entryConfig = readJsonFile(entryPath);
   if (entryConfig === undefined) return undefined;
 
@@ -87,8 +87,8 @@ export function readTsconfigChain(relativePath: string): TsconfigChain | undefin
  * Reads a tsconfig's effective `lib` and `target` from its `extends` chain. Returns undefined if the entry file is
  * missing or unparseable; unresolvable parents are reported in `unresolvedExtends` rather than treated as failures.
  */
-export function readTsconfigLanguageLevel(relativePath: string): TsconfigLanguageLevel | undefined {
-  const resolved = readTsconfigChain(relativePath);
+export function readTsconfigLanguageLevel(filePath: string): TsconfigLanguageLevel | undefined {
+  const resolved = readTsconfigChain(filePath);
   if (resolved === undefined) return undefined;
 
   const { entries, unresolvedExtends } = resolved;

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -70,7 +70,7 @@ function buildWorkspaces(cwd: string): Workspace[] {
 
   if (patternResult === null) {
     // Single-workspace fallback uses the root package.json, which MUST exist.
-    const rootPackageJson = readJsonFile('package.json');
+    const rootPackageJson = readJsonFile(rootPackageJsonPath);
     if (rootPackageJson === undefined) {
       throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
     }
@@ -110,7 +110,7 @@ function resolveWorkspacePatterns(cwd: string): { patterns: string[]; source: Wo
     // `packages` key absent — fall through to npm/single detection.
   }
 
-  const rootPackageJson = readJsonFile('package.json');
+  const rootPackageJson = readJsonFile(join(cwd, 'package.json'));
   if (rootPackageJson !== undefined) {
     const workspaces = rootPackageJson['workspaces'];
     const npmPatterns = extractNpmWorkspacePatterns(workspaces);
@@ -180,8 +180,7 @@ function normalizePattern(pattern: string): string {
 /** Builds a `Workspace` for a relative directory; returns undefined if its `package.json` is missing or malformed. */
 function buildWorkspace(cwd: string, relDir: string): Workspace | undefined {
   const absoluteDir = resolve(cwd, relDir);
-  const packageJsonRelativePath = relDir === '.' ? 'package.json' : `${relDir}/package.json`;
-  const packageJson = readJsonFile(packageJsonRelativePath);
+  const packageJson = readJsonFile(join(absoluteDir, 'package.json'));
   if (packageJson === undefined) return undefined;
   return buildWorkspaceFromPackageJson(relDir, absoluteDir, packageJson);
 }


### PR DESCRIPTION
## What

Widens the path readers of `readyup/check-utils` (`fileExists`, `readFile`, and `filesExist`, and every reader layered on them) to accept an absolute path, which now names the file itself. A relative path resolves against `cwd` exactly as before. An absolute path used to be appended to `cwd`, producing a path that never existed, so these readers silently returned nothing.

Reconciles the helpers behind `discoverWorkspaces` with the directory they are handed: each now reads its manifests there rather than through the ambient `cwd`.

## Why

Workspace discovery's helpers promised in their signatures to work at a directory they never read through, agreeing with the ambient one only because a single caller passed both. Memoizing discovery raised what that latent divergence would cost: a wrong result would be cached under the wrong key rather than merely returned, and a workspace could come back carrying a path and a manifest from different directories. Closing it needed the published readers to take an absolute path first, which they could not.

## Details

### 🎉 Features

- `resolve(process.cwd(), path)` replaces `join(process.cwd(), path)` in `fileExists`, `readFile`, and `filesExist`. Every reader layered on `readFile` inherits the widening.
- `filesExist` applies the same rule to its `baseDir` option, and an absolute entry in its list outranks the base directory.
- The `relativePath` and `relativeFilePath` parameters rename to `filePath` throughout `check-utils`.

### ♻️ Refactoring

- `buildWorkspaces` reads through `rootPackageJsonPath`, the value its error message already named, so the read and the diagnostic can no longer disagree. `resolveWorkspacePatterns` reads through `join(cwd, 'package.json')`, and `buildWorkspace` through `join(absoluteDir, 'package.json')`, which drops its `relDir === '.'` special case.

### 🧪 Tests

- `workspaces.cwd.unit.test.ts` repoints `process.cwd` mid-discovery from a `node:fs` mock, once ahead of each of the module's three manifest reads. Ordinary discovery assertions cannot see the defect, because the snapshot and the ambient directory are the same path under normal operation; a helper that reverts reports a decoy repo's name instead.
- New cases cover an absolute path through `fileExists`, `readFile`, `filesExist` with and without `baseDir`, and `readJsonFile`.

### 📚 Documentation

- The README's check-utils section states that a path resolves against `cwd` unless it is absolute, and that `filesExist` applies the rule to `baseDir` too.

Closes #331
