### PR TITLE
#375 Let a source decline a finding with an `rdy-ignore` pragma

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -622,6 +622,26 @@ FAIL  Total: 1 error, 1 passed, 1 skipped (151ms)
 
 Once a style is named explicitly, output is byte-identical to a terminal or a pipe. `--style` is independent of `--json`: the JSON document never changes.
 
+### Declining a finding
+
+A check naming located sites reports each as `path:line`. A source declines one by carrying a pragma:
+
+```ts
+// rdy-ignore-next-line -- the bootstrap shim, no deps allowed
+error instanceof Error ? error.message : String(error);
+```
+
+| Token                  | Covers              |
+| ---------------------- | ------------------- |
+| `rdy-ignore`           | The line it sits on |
+| `rdy-ignore-next-line` | The line below it   |
+
+With no argument a pragma covers every check for the line, which is the form to reach for: a kit publishes advice rather than a lint rule, so silencing one reviewed site should cost a comment and nothing more. A trailing `-- <reason>` is optional everywhere and changes nothing about what is declined. One or more comma-separated check ids may follow the token; they are accepted and narrow nothing yet.
+
+A declined finding leaves the audit rather than being downgraded: out of the detail, and out of both halves of the check's fraction, so a project that has settled every remaining site reaches completion rather than resting one short.
+
+The token is read from the source's raw text and matched wherever it appears on the line, so a detector that blanks comments before it scans cannot erase a pragma first, and a line that quotes the token in a string declines a finding sited on it.
+
 ### Advisory warnings
 
 `rdy run` raises advisories about the run it is performing. Warnings go to stderr in both modes and appear under `warnings` in JSON; none affects the exit code.
@@ -1306,6 +1326,8 @@ These six are what an adoption kit needs -- one reporting where a project hand-r
 `buildFindingReport` takes every finding the project holds plus a predicate selecting the ones the calling check reports, and names each selected finding as `symbol (path:line)`, or `path:line` where it declares no symbol. Its fraction is derived from every finding passed rather than only the reported ones, so the checks of one run share a denominator the reader can compare across them.
 
 Pass `ownImplementation` -- the package name, the export names, and the swept sources -- and every finding sited in that package's own implementation drops, from the detail and from both halves of the fraction. A file qualifies by sitting inside a workspace whose `package.json` names the package and exporting one of the named exports, so the repo publishing an idiom is not told it hand-rolled it. The same doctrine governs `hasMinDevDependencyVersion`: a repo that publishes a package is not a consumer of it. The rule is file-scoped, because a workspace is the whole repository in a single-package project, where a workspace-wide rule would turn the check off; a second file in the package that declares the name without exporting it is a hand-roll and is still reported. A file that declares the export under another name and renames it on export from a second file is not recognized, which surfaces in the publishing repo itself rather than in a consumer's.
+
+`buildFindingReport` also honors the [`rdy-ignore` pragma](#declining-a-finding), dropping a declined finding from the detail and from both halves of the fraction. A kit passes nothing for it and recognizes nothing: the pragma is readyup's, so every kit reporting through this path speaks one dialect of it rather than each publishing its own.
 
 `undefined` is what a check skips on. Reporting it as a pass would say the project holds no hand-rolled sites, when what happened is that nothing was looked at.
 

--- a/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
+++ b/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
@@ -51,6 +51,8 @@ A detector reads what `blankNonCode` returns, never a source's raw text. An idio
 
 Your own repo is where the defect surfaces first. An adoption kit's `ownImplementation` declaration exempts the file defining the package's exports and nothing else, so the detector runs against every other source you wrote, comments included. A false positive there is the one a consumer would have got; fix the detector rather than the source.
 
+Suppression is readyup's rather than yours. A finding reported through `buildFindingReport` is declinable with an `rdy-ignore` pragma already, so publish no token of your own for it, and reach for no path filter to silence the one site a consumer reviewed and kept.
+
 Expect the site count to move in both directions. Blanking unmasks sites a comment was hiding, because a comment sitting mid-expression blanks to a run of spaces as wide as it was rather than breaking the anchor scan. Write an anchor that tolerates a whitespace run, not one that admits a single space.
 
 One pattern must not read blanked text: one matching a literal's own content, such as an import specifier, which blanking erases. `countPackageUsage` already answers that question against the text it needs; reach for it rather than hand-rolling the sweep.

--- a/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
@@ -135,6 +135,54 @@ describe(buildFindingReport, () => {
       expect(outcome).toStrictEqual({ ok: true, progress: { count: 2, passedCount: 2, type: 'fraction' } });
     });
   });
+
+  describe('given a source declining a finding', () => {
+    it('drops a finding on a line carrying `rdy-ignore`', ({ temp }) => {
+      writeSourceLine(temp, 'src/errors.ts', 12, 'error instanceof Error; // rdy-ignore');
+
+      const outcome = buildFindingReport({
+        adoptedCount: 0,
+        findings: [CLONE, INLINE],
+        shouldReport: () => true,
+      });
+
+      expect(outcome.detail).toBe('src/report.ts:44');
+    });
+
+    it('drops a finding on the line after an `rdy-ignore-next-line`', ({ temp }) => {
+      writeSourceLine(temp, 'src/errors.ts', 11, '// rdy-ignore-next-line -- the bootstrap shim, no deps allowed');
+
+      const outcome = buildFindingReport({ adoptedCount: 0, findings: [CLONE], shouldReport: () => true });
+
+      expect(outcome).toStrictEqual({ ok: true, progress: { count: 0, passedCount: 0, type: 'fraction' } });
+    });
+
+    it('counts a declined finding in neither half of the fraction', ({ temp }) => {
+      writeSourceLine(temp, 'src/errors.ts', 12, 'error instanceof Error; // rdy-ignore');
+
+      const outcome = buildFindingReport({
+        adoptedCount: 1,
+        findings: [CLONE, INLINE],
+        shouldReport: () => true,
+      });
+
+      expect(outcome.progress).toStrictEqual({ count: 2, passedCount: 1, type: 'fraction' });
+    });
+
+    it('honors a pragma for a check that also names its own package', ({ temp }) => {
+      writeMonorepo(temp);
+      writeSourceLine(temp, 'packages/errors/src/format.ts', 5, 'formatError(); // rdy-ignore');
+
+      const outcome = buildFindingReport({
+        adoptedCount: 0,
+        findings: [SIBLING_CLONE],
+        ownImplementation: OWN_IMPLEMENTATION,
+        shouldReport: () => true,
+      });
+
+      expect(outcome).toStrictEqual({ ok: true, progress: { count: 0, passedCount: 0, type: 'fraction' } });
+    });
+  });
 });
 
 // region | Helpers
@@ -145,6 +193,11 @@ function writeMonorepo(temp: TempTree): void {
   temp.write('pnpm-workspace.yaml', ['packages:', '  - packages/*', ''].join('\n'));
   temp.writeJson('packages/errors/package.json', { name: '@scope/errors', version: '1.0.0' });
   temp.writeJson('packages/app/package.json', { name: '@scope/app', version: '1.0.0' });
+}
+
+/** Writes a source whose 1-based `line` reads `text`, padded above with the blank lines that put it there. */
+function writeSourceLine(temp: TempTree, path: string, line: number, text: string): void {
+  temp.write(path, [...Array.from({ length: line - 1 }, () => ''), text, ''].join('\n'));
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/check-utils/project/__tests__/declinesFinding.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/declinesFinding.unit.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { declinesFinding } from '../declinesFinding.ts';
+
+describe(declinesFinding, () => {
+  describe('given an `rdy-ignore`', () => {
+    it('declines a finding on the line it sits on', () => {
+      const lines = linesOf('const a = 1;\nerror instanceof Error; // rdy-ignore\nconst b = 2;');
+
+      expect(declinesFinding(lines, 2)).toBe(true);
+    });
+
+    it('declines nothing on the line below it', () => {
+      const lines = linesOf('// rdy-ignore\nerror instanceof Error;');
+
+      expect(declinesFinding(lines, 2)).toBe(false);
+    });
+
+    it('declines a finding on the first line', () => {
+      const lines = linesOf('error instanceof Error; // rdy-ignore');
+
+      expect(declinesFinding(lines, 1)).toBe(true);
+    });
+  });
+
+  describe('given an `rdy-ignore-next-line`', () => {
+    it('declines a finding on the line below it', () => {
+      const lines = linesOf('// rdy-ignore-next-line\nerror instanceof Error;');
+
+      expect(declinesFinding(lines, 2)).toBe(true);
+    });
+
+    it('declines nothing on the line it sits on', () => {
+      const lines = linesOf('error instanceof Error; // rdy-ignore-next-line');
+
+      expect(declinesFinding(lines, 1)).toBe(false);
+    });
+  });
+
+  describe('given a tail after the token', () => {
+    it('accepts a reason', () => {
+      const lines = linesOf('error instanceof Error; // rdy-ignore -- the bootstrap shim, no deps allowed');
+
+      expect(declinesFinding(lines, 1)).toBe(true);
+    });
+
+    it('accepts check ids, which narrow nothing', () => {
+      const lines = linesOf('error instanceof Error; // rdy-ignore toolbelt.errors/no-instanceof-error');
+
+      expect(declinesFinding(lines, 1)).toBe(true);
+    });
+
+    it('accepts check ids followed by a reason', () => {
+      const lines = linesOf('// rdy-ignore-next-line toolbelt.errors/no-instanceof-error, x/y -- the shim\nerror;');
+
+      expect(declinesFinding(lines, 2)).toBe(true);
+    });
+  });
+
+  describe('given a token the grammar does not name', () => {
+    it('declines nothing for a word the token only prefixes', () => {
+      const lines = linesOf('const rdy-ignored = 1;');
+
+      expect(declinesFinding(lines, 1)).toBe(false);
+    });
+
+    it('declines nothing for a misspelt next-line suffix', () => {
+      const lines = linesOf('// rdy-ignore-nextline\nerror instanceof Error;');
+
+      expect(declinesFinding(lines, 1)).toBe(false);
+      expect(declinesFinding(lines, 2)).toBe(false);
+    });
+
+    it('declines nothing for a token a longer word ends with', () => {
+      const lines = linesOf('const notrdy-ignore = 1;');
+
+      expect(declinesFinding(lines, 1)).toBe(false);
+    });
+  });
+
+  it('reads a pragma a block comment closes against without a space', () => {
+    const lines = linesOf('error instanceof Error; /*rdy-ignore*/');
+
+    expect(declinesFinding(lines, 1)).toBe(true);
+  });
+
+  it('answers for each scope where one line carries both tokens', () => {
+    const lines = linesOf('// rdy-ignore rdy-ignore-next-line\nerror;');
+
+    expect(declinesFinding(lines, 1)).toBe(true);
+    expect(declinesFinding(lines, 2)).toBe(true);
+  });
+
+  it('declines nothing where no line carries a pragma', () => {
+    const lines = linesOf('const a = 1;\nerror instanceof Error;');
+
+    expect(declinesFinding(lines, 2)).toBe(false);
+  });
+});
+
+// region | Helpers
+
+/** Parts a source into the lines `declinesFinding` reads. */
+function linesOf(source: string): readonly string[] {
+  return source.split('\n');
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
@@ -36,7 +36,7 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
-import { readTrackedSources } from '../readTrackedSources.ts';
+import { readSourceText, readTrackedSources } from '../readTrackedSources.ts';
 
 const it = test.extend(
   'temp',
@@ -137,6 +137,42 @@ describe(readTrackedSources, () => {
     execFileAsync.mockRejectedValue(Object.assign(new Error('fatal: not a git repository'), { code: 128 }));
 
     await expect(readTrackedSources()).resolves.toBeUndefined();
+  });
+});
+
+describe(readSourceText, () => {
+  beforeEach(() => {
+    existsProbes.length = 0;
+    readPaths.length = 0;
+  });
+
+  it('returns the text a sweep read, reading the file no second time', async ({ temp }) => {
+    temp.write('src/swept.ts', 'swept');
+    trackPaths('src/swept.ts');
+    await readTrackedSources();
+
+    expect(readSourceText('src/swept.ts')).toBe('swept');
+    expect(countReads('src/swept.ts')).toBe(1);
+  });
+
+  it('reads a path no sweep selected, and reads it once across calls', ({ temp }) => {
+    temp.write('src/unswept.ts', 'unswept');
+
+    expect(readSourceText('src/unswept.ts')).toBe('unswept');
+    expect(readSourceText('src/unswept.ts')).toBe('unswept');
+    expect(countReads('src/unswept.ts')).toBe(1);
+  });
+
+  it('reads a path a sweep excludes, since exclusion governs what a sweep goes looking at', ({ temp }) => {
+    temp.write('node_modules/dependency/index.js', 'dependency');
+
+    expect(readSourceText('node_modules/dependency/index.js')).toBe('dependency');
+  });
+
+  it('returns undefined for a path holding no text, and probes the filesystem for it once', () => {
+    expect(readSourceText('src/absent.ts')).toBeUndefined();
+    expect(readSourceText('src/absent.ts')).toBeUndefined();
+    expect(countProbes('src/absent.ts')).toBe(1);
   });
 });
 

--- a/packages/readyup/src/check-utils/project/buildFindingReport.ts
+++ b/packages/readyup/src/check-utils/project/buildFindingReport.ts
@@ -1,5 +1,7 @@
 import type { CheckOutcome } from '../../kits/types.ts';
+import { declinesFinding } from './declinesFinding.ts';
 import { definesOwnImplementation, type OwnImplementation } from './definesOwnImplementation.ts';
+import { readSourceText } from './readTrackedSources.ts';
 
 /** One located site a check names. */
 export interface Finding {
@@ -24,14 +26,20 @@ export interface BuildFindingReportOptions<F extends Finding> {
  * denominator the reader can compare across them. Passing only the reported findings would state a fraction of a
  * different whole for each check, which is why the selection is made here rather than by the caller.
  *
- * A check naming its own package drops the findings sited in that package's implementation, from the detail and from
- * both halves of the fraction. The repo publishing an idiom is where the idiom lives, and a kit reporting it there
- * spends the credibility it needs in every other repo it runs in.
+ * A source declines a finding with an `rdy-ignore` pragma, which drops it from the detail and from both halves of
+ * the fraction, so a project that has settled every remaining site reaches completion rather than resting one short.
+ * The pragma belongs to readyup rather than to any kit, so a kit inherits it by reporting here and declares nothing
+ * for it.
+ *
+ * A check naming its own package drops the findings sited in that package's implementation the same way. The repo
+ * publishing an idiom is where the idiom lives, and a kit reporting it there spends the credibility it needs in
+ * every other repo it runs in.
  */
 export function buildFindingReport<F extends Finding>(options: BuildFindingReportOptions<F>): CheckOutcome {
   const { adoptedCount, findings, ownImplementation, shouldReport } = options;
 
-  const retained = excludeOwnImplementation(findings, ownImplementation);
+  const undeclined = excludeDeclined(findings);
+  const retained = excludeOwnImplementation(undeclined, ownImplementation);
   const reported = retained.filter((finding) => shouldReport(finding));
   const progress = {
     count: adoptedCount + retained.length,
@@ -49,6 +57,24 @@ export function buildFindingReport<F extends Finding>(options: BuildFindingRepor
 function describeFinding(finding: Finding): string {
   const location = `${finding.path}:${finding.line}`;
   return finding.symbol === undefined ? location : `${finding.symbol} (${location})`;
+}
+
+/**
+ * Drops the findings a source declined with an `rdy-ignore` pragma.
+ *
+ * Each path is parted into lines once, so a file holding ten findings costs one read and one split between them. A
+ * path holding no readable text declines nothing.
+ */
+function excludeDeclined<F extends Finding>(findings: readonly F[]): readonly F[] {
+  const linesByPath = new Map<string, readonly string[] | undefined>();
+  return findings.filter((finding) => {
+    if (!linesByPath.has(finding.path)) {
+      linesByPath.set(finding.path, readSourceText(finding.path)?.split('\n'));
+    }
+
+    const lines = linesByPath.get(finding.path);
+    return lines === undefined || !declinesFinding(lines, finding.line);
+  });
 }
 
 /**

--- a/packages/readyup/src/check-utils/project/declinesFinding.ts
+++ b/packages/readyup/src/check-utils/project/declinesFinding.ts
@@ -1,0 +1,37 @@
+/**
+ * Matches either ignore pragma, capturing the `-next-line` suffix that moves what it covers to the following line.
+ *
+ * Both sides are bounded against a word character or a hyphen, so `rdy-ignored` and `rdy-ignore-nextline` are words
+ * of their own rather than pragmas, while a token a block comment closes against without a space is a pragma.
+ */
+const IGNORE_PRAGMA = /(?<![\w-])rdy-ignore(-next-line)?(?![\w-])/g;
+
+/**
+ * Reports whether a source declines a finding on a line: an `rdy-ignore` sits on that line, or an
+ * `rdy-ignore-next-line` on the one above it.
+ *
+ * Whatever follows the token -- the check ids it names, a `-- <reason>` tail, both, neither -- is accepted and read
+ * no further. Lines are the source's raw text rather than blanked code, so a detector that blanks comments before it
+ * scans cannot erase a pragma first.
+ */
+export function declinesFinding(lines: readonly string[], line: number): boolean {
+  return carriesPragma(lines[line - 1], 'line') || carriesPragma(lines[line - 2], 'next-line');
+}
+
+// region | Helpers
+
+/**
+ * Reports whether a line carries a pragma covering the named scope. A line past either end of the source carries
+ * none.
+ */
+function carriesPragma(line: string | undefined, scope: 'line' | 'next-line'): boolean {
+  if (line === undefined) return false;
+
+  for (const match of line.matchAll(IGNORE_PRAGMA)) {
+    const covered = match[1] === undefined ? 'line' : 'next-line';
+    if (covered === scope) return true;
+  }
+  return false;
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/project/readTrackedSources.ts
+++ b/packages/readyup/src/check-utils/project/readTrackedSources.ts
@@ -21,6 +21,20 @@ const EXCLUDED_PATH_PATTERNS = [/(?:^|\/)node_modules\//, /(?:^|\/)\.readyup\/ki
 const textsByCwd = new Map<string, Map<string, string | undefined>>();
 
 /**
+ * Reads one path's text, from the cache where a sweep already read it, and `undefined` where the path holds none.
+ *
+ * The exclusions governing what a sweep reads do not apply here. This answers about a path its caller already holds,
+ * such as the one a finding names, rather than deciding what a sweep goes looking at.
+ */
+export function readSourceText(path: string): string | undefined {
+  const texts = resolveTextCache(process.cwd());
+  if (!texts.has(path)) {
+    texts.set(path, readText(path));
+  }
+  return texts.get(path);
+}
+
+/**
  * Reads the project's tracked sources that `filter` selects, or `undefined` outside a git working tree.
  *
  * The filter decides a path before anything reads it, so a caller never pays for a file it excluded. Text is held per
@@ -32,17 +46,12 @@ export async function readTrackedSources(filter?: PathFilter): Promise<readonly 
   const tracked = await listTrackedFiles();
   if (tracked === undefined) return undefined;
 
-  const texts = resolveTextCache(process.cwd());
   const sources: ProjectSource[] = [];
   for (const path of tracked) {
     if (isExcluded(path)) continue;
     if (filter !== undefined && !filter(path)) continue;
 
-    if (!texts.has(path)) {
-      texts.set(path, readText(path));
-    }
-
-    const text = texts.get(path);
+    const text = readSourceText(path);
     if (text !== undefined) {
       sources.push({ path, text });
     }


### PR DESCRIPTION
## What

Adds an `rdy-ignore` pragma that can be included in a comment to decline a ReadyUp finding: `rdy-ignore` covers the line it sits on; `rdy-ignore-next-line` covers the line below it. A declined finding is excluded from the report.

A pragma without an argument covers every check for the line. The pragma accepts a comma-separated list of check IDs, but narrowing is not yet implemented. A trailing `-- <reason>` is optional.

## Why

An adoption check names each site it finds as `path:line`, and a consumer who reviewed one and chose to keep it had no way to say so. The only suppression available belonged to the kit -- a path filter, or a blanket skip -- and each silences a whole class of paths rather than the one site, so a project that had deliberately settled every remaining site could never reach a clean fraction.

## Details

### 🎉 Features

- The token is read from each source's raw text and matched wherever it appears on the line, so a detector that blanks comments before it scans cannot erase a pragma first. The cost is a line that both quotes the token and carries a finding sited on it.
- The filter sits in `buildFindingReport`, ahead of the own-implementation exemption. Unqualified semantics follow from where it sits: `buildFindingReport` does not know which check called it, so no argument means every check for the line.
- `BuildFindingReportOptions` is unchanged, and neither the pragma recognizer nor the text accessor is exported from `readyup/check-utils`.

### ♻️ Refactoring

- `readTrackedSources`'s inner get-or-read collapses into a new `readSourceText`, which reaches the sweep's per-`cwd` text cache from a synchronous caller, so one memo path exists rather than two.

### 🧪 Tests

- A new suite pins the grammar over lines, covering each near-miss the token bounding exists for: `rdy-ignored`, `rdy-ignore-nextline`, and `notrdy-ignore`.
- The `buildFindingReport` cases site the pragma inside a `//` comment, so an implementation that blanked before matching would fail them.
- The `readSourceText` cases separate a sweep-cached read, an unswept path memoized across calls, and an excluded path that is read anyway.

### 📚 Documentation

- The README gains `### Declining a finding` under **Running checks**, and a cross-reference beside the `ownImplementation` paragraph under **Check utilities**.
- The kit-authoring rulebook states that suppression is readyup's, so a kit publishes no token of its own and reaches for no path filter to silence one reviewed site.

Closes #375

