### PR TITLE
#386 Say a pragma suppresses a finding, not declines it

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -115,7 +115,7 @@ const config = defineConfig([
       'packages/readyup/src/projects/__tests__/project-discovery.unit.test.ts',
       'packages/readyup/src/run/__tests__/pragma-report.unit.test.ts',
       'packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts',
-      'packages/readyup/src/run/__tests__/qualifiedDeclining.wiring.unit.test.ts',
+      'packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts',
       'packages/readyup/src/run/__tests__/resolveConfiguredPackages.unit.test.ts',
       'packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts',
     ],

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -206,16 +206,16 @@ A checklist carries either `checks` or `groups`, never both.
 
 ### Checks
 
-| Field      | Type                                              | Default                     | Meaning                                      |
-| ---------- | ------------------------------------------------- | --------------------------- | -------------------------------------------- |
-| `name`     | `string`                                          | required                    | The claim being asserted                     |
-| `id`       | `string`                                          | --                          | What a pragma writes to decline its findings |
-| `check`    | `() => boolean \| CheckOutcome \| FindingOutcome` | required                    | The assertion; may be async                  |
-| `severity` | `Severity`                                        | the kit's `defaultSeverity` | Overrides the kit's `defaultSeverity`        |
-| `quiet`    | `boolean`                                         | `false`                     | Renders only when the check does not pass    |
-| `skip`     | `() => false \| string`                           | --                          | Reason string to skip; `false` to run        |
-| `fix`      | `string`                                          | --                          | Remediation, shown when the check fails      |
-| `checks`   | `RdyCheck[]`                                      | --                          | Nested checks, run only if this one passes   |
+| Field      | Type                                              | Default                     | Meaning                                       |
+| ---------- | ------------------------------------------------- | --------------------------- | --------------------------------------------- |
+| `name`     | `string`                                          | required                    | The claim being asserted                      |
+| `id`       | `string`                                          | --                          | What a pragma writes to suppress its findings |
+| `check`    | `() => boolean \| CheckOutcome \| FindingOutcome` | required                    | The assertion; may be async                   |
+| `severity` | `Severity`                                        | the kit's `defaultSeverity` | Overrides the kit's `defaultSeverity`         |
+| `quiet`    | `boolean`                                         | `false`                     | Renders only when the check does not pass     |
+| `skip`     | `() => false \| string`                           | --                          | Reason string to skip; `false` to run         |
+| `fix`      | `string`                                          | --                          | Remediation, shown when the check fails       |
+| `checks`   | `RdyCheck[]`                                      | --                          | Nested checks, run only if this one passes    |
 
 A check returns a boolean or a `CheckOutcome`:
 
@@ -233,9 +233,9 @@ A check naming located sites returns a `FindingOutcome` instead, and the runner 
 | `adoptedCount` | `number`           | Sites already settled, the fraction's numerator; omitted, there is none    |
 | `scanned`      | `string[]`         | Paths this check examined and read no other way; omitted, it declares none |
 
-`reported` marks the sites this check names; the rest count toward the fraction and do nothing else. The runner drops the sites a [pragma declines](#declining-a-finding), renders the reported survivors as the `detail`, reads `ok` off whether any survived, and counts every survivor into the fraction. `buildFindingReport` builds one of these for the common case; see [project sources](#project-sources).
+`reported` marks the sites this check names; the rest count toward the fraction and do nothing else. The runner drops the sites a [pragma suppresses](#suppressing-a-finding), renders the reported survivors as the `detail`, reads `ok` off whether any survived, and counts every survivor into the fraction. `buildFindingReport` builds one of these for the common case; see [project sources](#project-sources).
 
-`scanned` is the escape hatch, not the usual path. A sweep read through [`readTrackedSources`](#project-sources) is recorded on its own, in `skip` and in `check` alike, so a check reading the project that way declares nothing and its files are still evidence for the [pragma that declined nothing](#advisory-warnings). Declare `scanned` where the check reads files another way -- shelling out to a tool, walking `listTrackedFiles` and reading them itself, or reaching for `fs` directly -- because nothing else can see what those read.
+`scanned` is the escape hatch, not the usual path. A sweep read through [`readTrackedSources`](#project-sources) is recorded on its own, in `skip` and in `check` alike, so a check reading the project that way declares nothing and its files are still evidence for the [pragma that suppressed nothing](#advisory-warnings). Declare `scanned` where the check reads files another way -- shelling out to a tool, walking `listTrackedFiles` and reading them itself, or reaching for `fs` directly -- because nothing else can see what those read.
 
 ### Naming checks
 
@@ -356,7 +356,7 @@ The third row is the failure mode to watch for: `skip` and `check` ran the ident
 
 **Only a skipping parent collapses a group.** A parent whose `skip` fires reports alone: its descendants are not run, not reported, and not counted. A parent that _fails_ instead renders every descendant as its own 🚫, which is one blocked line per descendant where one skipped line was wanted. `quiet` helps with neither, suppressing passes only.
 
-**⚪ and 🚫 read differently.** ⚪ means the check declined to apply; 🚫 means it never ran, because an ancestor failed or a [precondition](#preconditions) gated it. A blocked subtree does not consult a descendant's own `skip`, so a check that would have reported "does not apply" renders as blocked instead. Read a 🚫 as evidence about an ancestor, never about the thing the blocked check names.
+**⚪ and 🚫 read differently.** ⚪ means the check does not apply; 🚫 means it never ran, because an ancestor failed or a [precondition](#preconditions) gated it. A blocked subtree does not consult a descendant's own `skip`, so a check that would have reported "does not apply" renders as blocked instead. Read a 🚫 as evidence about an ancestor, never about the thing the blocked check names.
 
 **Prefer a plain-string `fix`.** Outcome-specific remediation belongs in `detail`, which the check returns after running and can therefore name what actually went wrong. A [getter](#validation) serves one purpose: reaching a value declared below the kit literal.
 
@@ -635,9 +635,9 @@ FAIL  Total: 1 error, 1 passed, 1 skipped (151ms)
 
 Once a style is named explicitly, output is byte-identical to a terminal or a pipe. `--style` is independent of `--json`: the JSON document never changes.
 
-### Declining a finding
+### Suppressing a finding
 
-A check naming located sites reports each as `path:line`. A source declines one by carrying a pragma:
+A check naming located sites reports each as `path:line`. A source suppresses one by carrying a pragma:
 
 ```ts
 // rdy-ignore-next-line -- the bootstrap shim, no deps allowed
@@ -649,9 +649,9 @@ error instanceof Error ? error.message : String(error);
 | `rdy-ignore`           | The line it sits on |
 | `rdy-ignore-next-line` | The line below it   |
 
-With no argument a pragma covers every check for the line, which is the form to reach for: a kit publishes advice rather than a lint rule, so silencing one reviewed site should cost a comment and nothing more. A trailing `-- <reason>` is optional everywhere and changes nothing about what is declined.
+With no argument a pragma covers every check for the line, which is the form to reach for: a kit publishes advice rather than a lint rule, so silencing one reviewed site should cost a comment and nothing more. A trailing `-- <reason>` is optional everywhere and changes nothing about what is suppressed.
 
-One or more comma-separated check ids may follow the token, and the pragma then declines for those checks alone:
+One or more comma-separated check ids may follow the token, and the pragma then suppresses for those checks alone:
 
 ```ts
 // rdy-ignore-next-line toolbelt.errors/no-instanceof-error -- the bootstrap shim, no deps allowed
@@ -665,13 +665,13 @@ A failed check prints its id bracketed ahead of its fraction, and that printed f
    src/a.ts:4, src/b.ts:9
 ```
 
-A kit an installed package publishes namespaces its checks under that package's name with the scope stripped, so `@williamthorsen/toolbelt.errors` yields `toolbelt.errors/<id>`. The fully-qualified `@williamthorsen/toolbelt.errors/<id>` is accepted too; the bare id is not, because the namespace is what keeps two kits' same-named checks apart. A kit reached any other way -- from the local kits directory, a `--from` directory, or a URL -- has no namespace, and its bare id stands. An id naming no check in the run declines nothing, as does a pragma on a check that declares no id at all.
+A kit an installed package publishes namespaces its checks under that package's name with the scope stripped, so `@williamthorsen/toolbelt.errors` yields `toolbelt.errors/<id>`. The fully-qualified `@williamthorsen/toolbelt.errors/<id>` is accepted too; the bare id is not, because the namespace is what keeps two kits' same-named checks apart. A kit reached any other way -- from the local kits directory, a `--from` directory, or a URL -- has no namespace, and its bare id stands. An id naming no check in the run suppresses nothing, as does a pragma on a check that declares no id at all.
 
-The id list ends at the first token that is not an id: a `--` reason, the delimiter closing a block comment, a second pragma token, or the line's end. Everything before that is read as ids, so a reason written without `--` names checks rather than explaining the decision: `// rdy-ignore because the API is frozen` declines for a check called `because`, and therefore for none. Write a reason behind `--`. Under `--json`, each check entry carries its `id` in both detail projections.
+The id list ends at the first token that is not an id: a `--` reason, the delimiter closing a block comment, a second pragma token, or the line's end. Everything before that is read as ids, so a reason written without `--` names checks rather than explaining the decision: `// rdy-ignore because the API is frozen` suppresses for a check called `because`, and therefore for none. Write a reason behind `--`. Under `--json`, each check entry carries its `id` in both detail projections.
 
-A declined finding leaves the audit rather than being downgraded: out of the detail, and out of both halves of the check's fraction, so a project that has settled every remaining site reaches completion rather than resting one short. An unqualified pragma takes the site out of every check's fraction at once, which is what keeps the checks of one run comparable; a qualified one takes it out of the checks it names and leaves it standing in the rest.
+A suppressed finding leaves the audit rather than being downgraded: out of the detail, and out of both halves of the check's fraction, so a project that has settled every remaining site reaches completion rather than resting one short. An unqualified pragma takes the site out of every check's fraction at once, which is what keeps the checks of one run comparable; a qualified one takes it out of the checks it names and leaves it standing in the rest.
 
-The token is read from the source's raw text and matched wherever it appears on the line, so a detector that blanks comments before it scans cannot erase a pragma first, and a line that quotes the token in a string declines a finding sited on it.
+The token is read from the source's raw text and matched wherever it appears on the line, so a detector that blanks comments before it scans cannot erase a pragma first, and a line that quotes the token in a string suppresses a finding sited on it.
 
 A pragma that outlives the finding it was written for is reported under [`pragma-unused`](#advisory-warnings), so a site rewritten or a check retired leaves a comment the next run names rather than dead text nobody notices.
 
@@ -698,17 +698,17 @@ Two more come from [`--diagnose`](#run-options), and are raised only where that 
 
 These read the checks rather than the manifest, so none of the silencing conditions above reaches them: they apply wherever the kit came from, `--url`, `--from`, `--packages`, and `--jit` alike. A check blocked by a failed precondition declared nothing and is not diagnosed.
 
-One more reads the sources the run's checks examined and reports the pragmas among them that declined nothing.
+One more reads the sources the run's checks examined and reports the pragmas among them that suppressed nothing.
 
-| Code            | Raised when                                                                    |
-| --------------- | ------------------------------------------------------------------------------ |
-| `pragma-unused` | An [`rdy-ignore` pragma](#declining-a-finding) declined no finding in this run |
+| Code            | Raised when                                                                        |
+| --------------- | ---------------------------------------------------------------------------------- |
+| `pragma-unused` | An [`rdy-ignore` pragma](#suppressing-a-finding) suppressed no finding in this run |
 
-The evidence is what the checks read. A pragma is reported only where some check examined the file holding it -- swept it through [`readTrackedSources`](#project-sources), or named it in [`scanned`](#checks) -- and no check of the run declined a finding on the line the pragma covers; a pragma in a file no check examined is not reported, because the run established nothing about it. Paths are matched by their resolved form, so a check declaring absolute paths and one reporting relative finding paths agree, and the warning prints the path relative to `cwd`, the form findings print in. One ledger spans the invocation, so a file two kits both examined is scanned once. A diagnosis contributes neither examined paths nor declines, the run having turned that check off; a sweep the check read in its own `skip` before returning the reason was recorded when it ran, and stands.
+The evidence is what the checks read. A pragma is reported only where some check examined the file holding it -- swept it through [`readTrackedSources`](#project-sources), or named it in [`scanned`](#checks) -- and no check of the run suppressed a finding on the line the pragma covers; a pragma in a file no check examined is not reported, because the run established nothing about it. Paths are matched by their resolved form, so a check declaring absolute paths and one reporting relative finding paths agree, and the warning prints the path relative to `cwd`, the form findings print in. One ledger spans the invocation, so a file two kits both examined is scanned once. A diagnosis contributes neither examined paths nor suppressions, the run having turned that check off; a sweep the check read in its own `skip` before returning the reason was recorded when it ran, and stands.
 
-Recognition for the report is stricter than for declining. A token is a site when it sits in a comment with nothing but whitespace and `*` between it and the `//` or `/*` that opened one, in a JavaScript-family file. A token in a string, in a regular expression, following prose or code inside a comment, or second on its line is not a site. Declining is unchanged and still matches the raw text of every file type, so the report can only ever withhold a warning, never license a finding.
+Recognition for the report is stricter than for suppression. A token is a site when it sits in a comment with nothing but whitespace and `*` between it and the `//` or `/*` that opened one, in a JavaScript-family file. A token in a string, in a regular expression, following prose or code inside a comment, or second on its line is not a site. Suppression is unchanged and still matches the raw text of every file type, so the report can only ever withhold a warning, never license a finding.
 
-Two limits follow from that. Recognition reads JavaScript-family syntax, so a pragma in a source of any other kind is never reported. And a pragma written for a check that skipped, was blocked, or was not loaded is reported where any check examined its file, that skipped check's own `skip` included where it swept before skipping: the run holds no evidence the check would have declined anything.
+Two limits follow from that. Recognition reads JavaScript-family syntax, so a pragma in a source of any other kind is never reported. And a pragma written for a check that skipped, was blocked, or was not loaded is reported where any check examined its file, that skipped check's own `skip` included where it swept before skipping: the run holds no evidence the check would have suppressed anything.
 
 ### Kit import compatibility
 
@@ -1354,7 +1354,7 @@ It answers best effort: a project manifest it cannot read or parse yields `[]`. 
 | `blankNonCode(text)`                  | The same text with every comment and literal blanked           |
 | `getLineAtOffset(text, offset)`       | The 1-based line holding an offset                             |
 | `countPackageUsage(sources, options)` | Calls into a package, counted only where the source imports it |
-| `buildFindingReport(options)`         | A `FindingOutcome` the runner declines, renders, and counts    |
+| `buildFindingReport(options)`         | A `FindingOutcome` the runner suppresses, renders, and counts  |
 
 These six are what an adoption kit needs -- one reporting where a project hand-rolls what a package it already installed provides. Both readers return `undefined` outside a git working tree, which an empty list does not say: a project that cannot be swept is a different answer from one that was swept and holds nothing.
 
@@ -1362,7 +1362,7 @@ These six are what an adoption kit needs -- one reporting where a project hand-r
 
 `readTrackedSources` applies its filter before any read, so a caller never pays for a file it excluded, and holds what it read for the life of the process. A file two kits both select costs one read between them, and each pays only for the remainder the other did not ask for. That cache lives here rather than in a kit because a compiled kit leaves its `readyup` imports unbundled, making `check-utils` one module instance across every kit of a run; a cache inside a bundled helper would be one per bundle. Listings are held the same way and are shared by checks that start together, which the runner does. The sweep never reads `node_modules/` or `.readyup/kits/*.js` whatever the filter answers for them -- the latter is readyup's own generated artifact, and sweeping it would report a kit's bundled source back to its author. That kit exclusion names the default `compile.outDir`; a project compiling its kits elsewhere excludes that directory itself. A caller wanting further exclusions applies them in its own filter.
 
-It also reports the paths it returns to the run, which is the evidence a [pragma that declined nothing](#advisory-warnings) is judged against, so a check reading the project this way declares no `scanned` of its own and a sweep it reads in `skip` counts as much as one it reads in `check`. `listTrackedFiles` reports nothing, so a check taking that listing and reading the files itself declares `scanned`.
+It also reports the paths it returns to the run, which is the evidence a [pragma that suppressed nothing](#advisory-warnings) is judged against, so a check reading the project this way declares no `scanned` of its own and a sweep it reads in `skip` counts as much as one it reads in `check`. `listTrackedFiles` reports nothing, so a check taking that listing and reading the files itself declares `scanned`.
 
 `blankNonCode` is what a detector scans instead of the raw text. It replaces every comment and every literal's text with spaces, so an idiom written in prose is invisible to an anchor scan while the code around the prose is not; a recommendation pointing at a comment is a false positive, and a false positive is what discredits a kit. Literal delimiters survive and only the text between them blanks, because a literal is an operand -- a scan reading the token before a `[` would otherwise take `'abc'[0]` for an array literal -- and an expression interpolated into a template literal stays visible as the code it is. Where a `/` could open a regular expression or divide, the ambiguity resolves toward division, and a quoted string or regular expression whose closing delimiter never arrives on its line was neither, so a misjudgment leaves text standing rather than blanking an expression that runs. That direction holds because a `/` is classified against the operand before it, so every construct completing an operand has to present itself as one: a postfix operator -- `++`, `--`, and TypeScript's `!` -- attaches to its operand rather than replacing it, and a member name keeps the `.` or `#` that introduced it, so a property spelled like a keyword is read as the property it is. `>` is classified the other way, because `=>` obliges it to open a regular expression, so a JSX text node beginning with `/` blanks as far as its closing tag's slash. It reads JavaScript-family syntax; a source in another language yields arbitrary output rather than an error, so a filter selecting `.md` or `.yaml` paths should not reach for it.
 
@@ -1370,11 +1370,11 @@ It also reports the paths it returns to the run, which is the evidence a [pragma
 
 `countPackageUsage` counts calls to the named exports and counts none in a source that never imports the package, from its root or any subpath. The import is what separates adoption from a name collision: a project hand-rolling its own `describeError` calls that name as often as an adopter calls the real one. Its two patterns read two texts -- the call scan reads a blanked source, so a call named in prose is not counted as one made, while the import test locates its match in a source with comments alone blanked, because the specifier it matches is itself a string literal that full blanking would erase, then reads the blanked text at that offset so a source quoting an import is not taken for one making it.
 
-`buildFindingReport` takes every finding the project holds plus a predicate selecting the ones the calling check reports, and returns them as a `FindingOutcome` for the runner to decline, render, and count. The runner names each reported finding as `symbol (path:line)`, or `path:line` where it declares no symbol, and derives the fraction from every finding passed rather than only the reported ones, so the checks of one run share a denominator the reader can compare across them.
+`buildFindingReport` takes every finding the project holds plus a predicate selecting the ones the calling check reports, and returns them as a `FindingOutcome` for the runner to suppress, render, and count. The runner names each reported finding as `symbol (path:line)`, or `path:line` where it declares no symbol, and derives the fraction from every finding passed rather than only the reported ones, so the checks of one run share a denominator the reader can compare across them.
 
 Pass `ownImplementation` -- the package name, the export names, and the swept sources -- and every finding sited in that package's own implementation drops, from the detail and from both halves of the fraction. A file qualifies by sitting inside a workspace whose `package.json` names the package and exporting one of the named exports, so the repo publishing an idiom is not told it hand-rolled it. The same doctrine governs `hasMinDevDependencyVersion`: a repo that publishes a package is not a consumer of it. The rule is file-scoped, because a workspace is the whole repository in a single-package project, where a workspace-wide rule would turn the check off; a second file in the package that declares the name without exporting it is a hand-roll and is still reported. A file that declares the export under another name and renames it on export from a second file is not recognized, which surfaces in the publishing repo itself rather than in a consumer's.
 
-The [`rdy-ignore` pragma](#declining-a-finding) is honored by the runner rather than here, which is the layer holding both the check and the provenance a pragma naming that check is matched against. A kit passes nothing for it and recognizes nothing: the pragma is readyup's, so every kit reporting through this path speaks one dialect of it rather than each publishing its own. Give the check an `id` and a consumer can decline its findings by name.
+The [`rdy-ignore` pragma](#suppressing-a-finding) is honored by the runner rather than here, which is the layer holding both the check and the provenance a pragma naming that check is matched against. A kit passes nothing for it and recognizes nothing: the pragma is readyup's, so every kit reporting through this path speaks one dialect of it rather than each publishing its own. Give the check an `id` and a consumer can suppress its findings by name.
 
 `undefined` is what a check skips on. Reporting it as a pass would say the project holds no hand-rolled sites, when what happened is that nothing was looked at.
 

--- a/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
+++ b/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
@@ -41,7 +41,7 @@ To make a whole checklist inapplicable, nest its checks under one parent check w
 
 ## Reading a run
 
-⚪ means the check declined to apply. 🚫 means the check never ran.
+⚪ means the check does not apply. 🚫 means the check never ran.
 
 A blocked subtree does not consult a descendant's own `skip`, so a check that would have reported "does not apply" renders as blocked instead. Read a 🚫 as evidence about an ancestor, never about the thing the blocked check names.
 
@@ -51,9 +51,9 @@ A detector reads what `blankNonCode` returns, never a source's raw text. An idio
 
 Your own repo is where the defect surfaces first. An adoption kit's `ownImplementation` declaration exempts the file defining the package's exports and nothing else, so the detector runs against every other source you wrote, comments included. A false positive there is the one a consumer would have got; fix the detector rather than the source.
 
-Suppression is readyup's rather than yours. A finding reported through `buildFindingReport` is declinable with an `rdy-ignore` pragma already, so publish no token of your own for it, and reach for no path filter to silence the one site a consumer reviewed and kept.
+Suppression is readyup's rather than yours. A finding reported through `buildFindingReport` is suppressible with an `rdy-ignore` pragma already, so publish no token of your own for it, and reach for no path filter to silence the one site a consumer reviewed and kept.
 
-Give every check that names located sites an `id`. Without one, a consumer declining a finding of yours declines every other check's finding on that line too, your kit's and every other kit's alike. Write it bare and kebab-cased, restating the claim rather than the defect -- `no-hand-rolled-describe-error`, not `bad-error-handling` -- because it is a name a consumer types into their source and reads back a year later. The runner namespaces it under the package publishing your kit, so it has to be unique within the kit and nowhere wider. Changing it un-declines every site that named the old one, and the next run reports each such site under `pragma-unused`, provided some check examined the file holding it.
+Give every check that names located sites an `id`. Without one, a consumer suppressing a finding of yours suppresses every other check's finding on that line too, your kit's and every other kit's alike. Write it bare and kebab-cased, restating the claim rather than the defect -- `no-hand-rolled-describe-error`, not `bad-error-handling` -- because it is a name a consumer types into their source and reads back a year later. The runner namespaces it under the package publishing your kit, so it has to be unique within the kit and nowhere wider. Changing it stops suppressing every site that named the old one, and the next run reports each such site under `pragma-unused`, provided some check examined the file holding it.
 
 Expect the site count to move in both directions. Blanking unmasks sites a comment was hiding, because a comment sitting mid-expression blanks to a run of spaces as wide as it was rather than breaking the anchor scan. Write an anchor that tolerates a whitespace run, not one that admits a single space.
 

--- a/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
@@ -66,7 +66,7 @@ describe(buildFindingReport, () => {
     expect(outcome).toStrictEqual({ adoptedCount: 0, findings: [] });
   });
 
-  it('declines nothing, leaving a site carrying a pragma to the runner', ({ temp }) => {
+  it('suppresses nothing, leaving a site carrying a pragma to the runner', ({ temp }) => {
     temp.write('src/errors.ts', ['', ...Array.from({ length: 10 }, () => ''), 'x; // rdy-ignore', ''].join('\n'));
 
     const outcome = buildFindingReport({ adoptedCount: 0, findings: [CLONE], shouldReport: () => true });

--- a/packages/readyup/src/check-utils/project/buildFindingReport.ts
+++ b/packages/readyup/src/check-utils/project/buildFindingReport.ts
@@ -19,10 +19,10 @@ export interface BuildFindingReportOptions<F extends Finding> {
 
 /**
  * Returns the findings a project holds, each marked whether the calling check reports it, for the runner to
- * decline, render, and count.
+ * suppress, render, and count.
  *
  * Every retained finding is returned rather than only the reported ones, so the checks of one run share a
- * denominator the reader can compare across them, and so a site a pragma declines leaves every check's
+ * denominator the reader can compare across them, and so a site a pragma suppresses leaves every check's
  * fraction rather than only the fraction of the check that names it.
  *
  * A check naming its own package drops the findings sited in that package's implementation. The repo

--- a/packages/readyup/src/kits/types.ts
+++ b/packages/readyup/src/kits/types.ts
@@ -130,7 +130,7 @@ export interface OutcomeFinding {
   /**
    * Whether the check reports this site, rather than only counting it toward the fraction.
    *
-   * An unreported site reaches the runner all the same, because a site a pragma declines has to leave
+   * An unreported site reaches the runner all the same, because a site a pragma suppresses has to leave
    * every check's denominator rather than only the denominator of the check naming it.
    */
   reported: boolean;
@@ -139,7 +139,7 @@ export interface OutcomeFinding {
 /**
  * A check's located sites, from which the runner derives the verdict, the detail, and the fraction.
  *
- * The sites a pragma declines drop there rather than here: the runner is the only layer holding both the
+ * The sites a pragma suppresses drop there rather than here: the runner is the only layer holding both the
  * check and the kit's provenance, which is what a pragma naming a check is matched against.
  */
 export interface FindingOutcome {
@@ -173,7 +173,7 @@ export interface RdyCheck {
   name: string;
 
   /**
-   * Stable identifier a pragma writes to decline this check's findings and no other check's.
+   * Stable identifier a pragma writes to suppress this check's findings and no other check's.
    *
    * Bare here: the runner namespaces it under the publishing package where the kit has one. A check
    * naming no located site needs none, and one declaring none is named by no pragma.

--- a/packages/readyup/src/run/PragmaLedger.ts
+++ b/packages/readyup/src/run/PragmaLedger.ts
@@ -3,17 +3,17 @@ import process from 'node:process';
 
 /**
  * What one invocation observed about the sources its checks read: which paths were examined, and which
- * sites a pragma declined a finding on.
+ * sites a pragma suppressed a finding on.
  *
  * Together they are the evidence the unused-pragma report rests on. A path no check examined yields no
- * report at all, and a site some check declined is a pragma that did its work.
+ * report at all, and a site some check suppressed is a pragma that did its work.
  */
 export interface PragmaLedger {
-  /** Reports whether a pragma declined a finding at a site. */
-  hasDeclined: (filePath: string, line: number) => boolean;
+  /** Reports whether a pragma suppressed a finding at a site. */
+  hasSuppressed: (filePath: string, line: number) => boolean;
 
-  /** Records that a pragma declined a finding at a site. */
-  recordDeclined: (filePath: string, line: number) => void;
+  /** Records that a pragma suppressed a finding at a site. */
+  recordSuppressed: (filePath: string, line: number) => void;
 
   /** Records the paths a check examined. */
   recordScanned: (paths: readonly string[]) => void;
@@ -31,12 +31,12 @@ export interface PragmaLedger {
  */
 export function createPragmaLedger(): PragmaLedger {
   const scanned = new Set<string>();
-  const declined = new Set<string>();
+  const suppressed = new Set<string>();
 
   return {
-    hasDeclined: (filePath, line) => declined.has(toSiteKey(filePath, line)),
-    recordDeclined: (filePath, line) => {
-      declined.add(toSiteKey(filePath, line));
+    hasSuppressed: (filePath, line) => suppressed.has(toSiteKey(filePath, line)),
+    recordSuppressed: (filePath, line) => {
+      suppressed.add(toSiteKey(filePath, line));
     },
     recordScanned: (paths) => {
       for (const filePath of paths) scanned.add(resolvePath(filePath));

--- a/packages/readyup/src/run/__tests__/PragmaLedger.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/PragmaLedger.unit.test.ts
@@ -10,7 +10,7 @@ describe(createPragmaLedger, () => {
     const ledger = createPragmaLedger();
 
     expect(ledger.scannedPaths()).toStrictEqual([]);
-    expect(ledger.hasDeclined('src/a.ts', 3)).toBe(false);
+    expect(ledger.hasSuppressed('src/a.ts', 3)).toBe(false);
   });
 
   it('resolves every recorded path against the working directory', () => {
@@ -30,20 +30,20 @@ describe(createPragmaLedger, () => {
     expect(ledger.scannedPaths()).toHaveLength(2);
   });
 
-  it('matches a relative decline against the absolute form of the same site', () => {
+  it('matches a relative suppression against the absolute form of the same site', () => {
     const ledger = createPragmaLedger();
 
-    ledger.recordDeclined('src/a.ts', 3);
+    ledger.recordSuppressed('src/a.ts', 3);
 
-    expect(ledger.hasDeclined(path.resolve(process.cwd(), 'src/a.ts'), 3)).toBe(true);
+    expect(ledger.hasSuppressed(path.resolve(process.cwd(), 'src/a.ts'), 3)).toBe(true);
   });
 
-  it('holds a decline to the line it was recorded on', () => {
+  it('holds a suppression to the line it was recorded on', () => {
     const ledger = createPragmaLedger();
 
-    ledger.recordDeclined('src/a.ts', 3);
+    ledger.recordSuppressed('src/a.ts', 3);
 
-    expect(ledger.hasDeclined('src/a.ts', 4)).toBe(false);
-    expect(ledger.hasDeclined('src/b.ts', 3)).toBe(false);
+    expect(ledger.hasSuppressed('src/a.ts', 4)).toBe(false);
+    expect(ledger.hasSuppressed('src/b.ts', 3)).toBe(false);
   });
 });

--- a/packages/readyup/src/run/__tests__/pragma-report.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/pragma-report.unit.test.ts
@@ -29,12 +29,12 @@ describe(warnOnUnusedPragmas, () => {
     expect(warnings).toStrictEqual([
       {
         code: 'pragma-unused',
-        message: '`rdy-ignore-next-line` pragma at src/a.ts:3 declined no finding in this run.',
+        message: '`rdy-ignore-next-line` pragma at src/a.ts:3 suppressed no finding in this run.',
         remedy: REMEDY,
       },
     ]);
     expect(stderr).toBe(
-      `Warning: \`rdy-ignore-next-line\` pragma at src/a.ts:3 declined no finding in this run. ${REMEDY}\n`,
+      `Warning: \`rdy-ignore-next-line\` pragma at src/a.ts:3 suppressed no finding in this run. ${REMEDY}\n`,
     );
   });
 
@@ -75,7 +75,7 @@ describe(warnOnUnusedPragmas, () => {
     const { warnings } = warn(scanning([temp.resolve('src/a.ts')]));
 
     expect(warnings.map((warning) => warning.message)).toStrictEqual([
-      '`rdy-ignore` pragma at src/a.ts:1 declined no finding in this run.',
+      '`rdy-ignore` pragma at src/a.ts:1 suppressed no finding in this run.',
     ]);
   });
 
@@ -96,9 +96,9 @@ describe(warnOnUnusedPragmas, () => {
     const { warnings } = warn(scanning(['src/b.ts', 'src/a.ts']));
 
     expect(warnings.map((warning) => warning.message)).toStrictEqual([
-      '`rdy-ignore` pragma at src/a.ts:1 declined no finding in this run.',
-      '`rdy-ignore` pragma at src/a.ts:3 declined no finding in this run.',
-      '`rdy-ignore` pragma at src/b.ts:1 declined no finding in this run.',
+      '`rdy-ignore` pragma at src/a.ts:1 suppressed no finding in this run.',
+      '`rdy-ignore` pragma at src/a.ts:3 suppressed no finding in this run.',
+      '`rdy-ignore` pragma at src/b.ts:1 suppressed no finding in this run.',
     ]);
   });
 

--- a/packages/readyup/src/run/__tests__/pragma-report.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/pragma-report.unit.test.ts
@@ -38,10 +38,10 @@ describe(warnOnUnusedPragmas, () => {
     );
   });
 
-  it('stays silent about a pragma whose covered line a check declined', ({ temp }) => {
+  it('stays silent about a pragma whose covered line a check suppressed', ({ temp }) => {
     temp.write('src/a.ts', ['x; // rdy-ignore', ''].join('\n'));
     const ledger = scanning(['src/a.ts']);
-    ledger.recordDeclined('src/a.ts', 1);
+    ledger.recordSuppressed('src/a.ts', 1);
 
     expect(warn(ledger).warnings).toStrictEqual([]);
   });
@@ -61,10 +61,10 @@ describe(warnOnUnusedPragmas, () => {
     expect(warn(ledger).warnings).toHaveLength(1);
   });
 
-  it('matches a declined site declared in absolute form against a relative examined path', ({ temp }) => {
+  it('matches a suppressed site declared in absolute form against a relative examined path', ({ temp }) => {
     temp.write('src/a.ts', ['x; // rdy-ignore', ''].join('\n'));
     const ledger = scanning(['src/a.ts']);
-    ledger.recordDeclined(temp.resolve('src/a.ts'), 1);
+    ledger.recordSuppressed(temp.resolve('src/a.ts'), 1);
 
     expect(warn(ledger).warnings).toStrictEqual([]);
   });
@@ -111,7 +111,7 @@ describe(warnOnUnusedPragmas, () => {
 
 // region | Helpers
 
-/** Opens a ledger holding the given paths as examined and nothing as declined. */
+/** Opens a ledger holding the given paths as examined and nothing as suppressed. */
 function scanning(paths: readonly string[]): PragmaLedger {
   const ledger = createPragmaLedger();
   ledger.recordScanned(paths);

--- a/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
@@ -37,16 +37,16 @@ it.aroundEach(async (runTest, { temp }) => {
   await runTest();
 });
 
-describe('a run recording what its checks examined and declined', () => {
-  it('records the examined paths and the declined sites', async ({ temp }) => {
+describe('a run recording what its checks examined and suppressed', () => {
+  it('records the examined paths and the suppressed sites', async ({ temp }) => {
     temp.write(SOURCE_PATH, SOURCE_TEXT);
     const ledger = createPragmaLedger();
 
     await runRdy(scanningChecklist(), { pragmaLedger: ledger });
 
     expect(ledger.scannedPaths()).toStrictEqual([temp.resolve(SOURCE_PATH)]);
-    expect(ledger.hasDeclined(SOURCE_PATH, 1)).toBe(true);
-    expect(ledger.hasDeclined(SOURCE_PATH, 2)).toBe(false);
+    expect(ledger.hasSuppressed(SOURCE_PATH, 1)).toBe(true);
+    expect(ledger.hasSuppressed(SOURCE_PATH, 2)).toBe(false);
   });
 
   it('records nothing for a diagnosed check', async ({ temp }) => {
@@ -56,10 +56,10 @@ describe('a run recording what its checks examined and declined', () => {
     await runRdy(scanningChecklist('not applicable'), { diagnose: true, pragmaLedger: ledger });
 
     expect(ledger.scannedPaths()).toStrictEqual([]);
-    expect(ledger.hasDeclined(SOURCE_PATH, 1)).toBe(false);
+    expect(ledger.hasSuppressed(SOURCE_PATH, 1)).toBe(false);
   });
 
-  it('declines and reports as before for an invocation keeping no ledger', async ({ temp }) => {
+  it('suppresses and reports as before for an invocation keeping no ledger', async ({ temp }) => {
     temp.write(SOURCE_PATH, SOURCE_TEXT);
 
     const report = await runRdy(scanningChecklist());

--- a/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
@@ -13,7 +13,7 @@ const SOURCE_PATH = 'src/errors.ts';
 
 const it = test.extend(
   'temp',
-  makeFixture(() => createTempTree({}, { prefix: 'rdy-qualified-declining-' })),
+  makeFixture(() => createTempTree({}, { prefix: 'rdy-qualified-suppression-' })),
 );
 
 it.aroundEach(async (runTest, { temp }) => {
@@ -23,7 +23,7 @@ it.aroundEach(async (runTest, { temp }) => {
 });
 
 describe('a pragma reaching the check ids the runner resolved', () => {
-  it('declines the named check and leaves its sibling standing on the same line', async ({ temp }) => {
+  it('suppresses the named check and leaves its sibling standing on the same line', async ({ temp }) => {
     temp.write(SOURCE_PATH, 'error instanceof Error; // rdy-ignore toolbelt.errors/no-instanceof-error\n');
 
     const report = await runRdy(twoChecksOverOneLine(), { provenance: PACKAGE });
@@ -34,7 +34,7 @@ describe('a pragma reaching the check ids the runner resolved', () => {
     ]);
   });
 
-  it('declines the named check where the pragma writes the fully-qualified form', async ({ temp }) => {
+  it('suppresses the named check where the pragma writes the fully-qualified form', async ({ temp }) => {
     const pragma = '// rdy-ignore @williamthorsen/toolbelt.errors/no-instanceof-error';
     temp.write(SOURCE_PATH, `error instanceof Error; ${pragma}\n`);
 
@@ -43,7 +43,7 @@ describe('a pragma reaching the check ids the runner resolved', () => {
     expect(verdicts(report.results)[0]?.status).toBe('passed');
   });
 
-  it('declines neither where the pragma names a check the run does not hold', async ({ temp }) => {
+  it('suppresses neither where the pragma names a check the run does not hold', async ({ temp }) => {
     temp.write(SOURCE_PATH, 'error instanceof Error; // rdy-ignore other.kit/no-instanceof-error\n');
 
     const report = await runRdy(twoChecksOverOneLine(), { provenance: PACKAGE });
@@ -51,7 +51,7 @@ describe('a pragma reaching the check ids the runner resolved', () => {
     expect(verdicts(report.results).map((verdict) => verdict.status)).toStrictEqual(['failed', 'failed']);
   });
 
-  it('declines both where the pragma names no check', async ({ temp }) => {
+  it('suppresses both where the pragma names no check', async ({ temp }) => {
     temp.write(SOURCE_PATH, 'error instanceof Error; // rdy-ignore\n');
 
     const report = await runRdy(twoChecksOverOneLine(), { provenance: PACKAGE });
@@ -59,7 +59,7 @@ describe('a pragma reaching the check ids the runner resolved', () => {
     expect(verdicts(report.results).map((verdict) => verdict.status)).toStrictEqual(['passed', 'passed']);
   });
 
-  it('declines nothing by name where the kit has no publishing package to namespace under', async ({ temp }) => {
+  it('suppresses nothing by name where the kit has no publishing package to namespace under', async ({ temp }) => {
     temp.write(SOURCE_PATH, 'error instanceof Error; // rdy-ignore toolbelt.errors/no-instanceof-error\n');
 
     const report = await runRdy(twoChecksOverOneLine());
@@ -91,7 +91,7 @@ function twoChecksOverOneLine(): RdyChecklist {
   };
 }
 
-/** Reduces results to what a declining decision shows up in. */
+/** Reduces results to what a suppression shows up in. */
 function verdicts(results: RdyResult[]): Array<{ detail: string | null; id: string | null; status: string }> {
   return results.map((result) => ({ detail: result.detail, id: result.id, status: result.status }));
 }

--- a/packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts
@@ -50,7 +50,7 @@ describe(resolveFindingOutcome, () => {
     expect(outcome.progress).toBeUndefined();
   });
 
-  describe('given a source declining a finding', () => {
+  describe('given a source suppressing a finding', () => {
     it('drops a finding on a line carrying `rdy-ignore`', ({ temp }) => {
       writeSourceLine(temp, 'src/errors.ts', 12, 'error instanceof Error; // rdy-ignore');
 
@@ -67,7 +67,7 @@ describe(resolveFindingOutcome, () => {
       expect(outcome).toStrictEqual({ ok: true, progress: { count: 0, passedCount: 0, type: 'fraction' } });
     });
 
-    it('counts a declined finding in neither half of the fraction', ({ temp }) => {
+    it('counts a suppressed finding in neither half of the fraction', ({ temp }) => {
       writeSourceLine(temp, 'src/errors.ts', 12, 'error instanceof Error; // rdy-ignore');
 
       const outcome = resolveFindingOutcome({ adoptedCount: 1, findings: [CLONE, INLINE] }, []);
@@ -149,23 +149,23 @@ describe(resolveFindingOutcome, () => {
       expect(ledger.scannedPaths()).toStrictEqual([]);
     });
 
-    it('records the site of every finding a pragma declined', ({ temp }) => {
+    it('records the site of every finding a pragma suppressed', ({ temp }) => {
       writeSourceLine(temp, 'src/errors.ts', 12, 'x; // rdy-ignore');
       const ledger = createPragmaLedger();
 
       resolveFindingOutcome({ adoptedCount: 0, findings: [CLONE, INLINE] }, [], ledger);
 
-      expect(ledger.hasDeclined('src/errors.ts', 12)).toBe(true);
-      expect(ledger.hasDeclined('src/report.ts', 44)).toBe(false);
+      expect(ledger.hasSuppressed('src/errors.ts', 12)).toBe(true);
+      expect(ledger.hasSuppressed('src/report.ts', 44)).toBe(false);
     });
 
-    it('records no decline where the pragma names another check', ({ temp }) => {
+    it('records no suppression where the pragma names another check', ({ temp }) => {
       writeSourceLine(temp, 'src/errors.ts', 12, 'x; // rdy-ignore other/check');
       const ledger = createPragmaLedger();
 
       resolveFindingOutcome({ adoptedCount: 0, findings: [CLONE] }, NAMED, ledger);
 
-      expect(ledger.hasDeclined('src/errors.ts', 12)).toBe(false);
+      expect(ledger.hasSuppressed('src/errors.ts', 12)).toBe(false);
     });
   });
 });

--- a/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
@@ -345,7 +345,7 @@ describe(runJsonMode, () => {
   describe('unused-pragma advisories', () => {
     const PRAGMA_UNUSED = {
       code: 'pragma-unused',
-      message: '`rdy-ignore` pragma at src/a.ts:3 declined no finding in this run.',
+      message: '`rdy-ignore` pragma at src/a.ts:3 suppressed no finding in this run.',
       remedy: 'Remove the pragma, or run the kit whose check it was written for.',
     };
 

--- a/packages/readyup/src/run/__tests__/suppressesFinding.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/suppressesFinding.unit.test.ts
@@ -1,108 +1,108 @@
 import { describe, expect, it } from 'vitest';
 
-import { declinesFinding } from '../declinesFinding.ts';
+import { suppressesFinding } from '../suppressesFinding.ts';
 
 const NAMED = ['toolbelt.errors/no-instanceof-error'];
 
-describe(declinesFinding, () => {
+describe(suppressesFinding, () => {
   describe('given an `rdy-ignore`', () => {
-    it('declines a finding on the line it sits on', () => {
+    it('suppresses a finding on the line it sits on', () => {
       const lines = linesOf('const a = 1;\nerror instanceof Error; // rdy-ignore\nconst b = 2;');
 
-      expect(declinesFinding(lines, 2, [])).toBe(true);
+      expect(suppressesFinding(lines, 2, [])).toBe(true);
     });
 
-    it('declines nothing on the line below it', () => {
+    it('suppresses nothing on the line below it', () => {
       const lines = linesOf('// rdy-ignore\nerror instanceof Error;');
 
-      expect(declinesFinding(lines, 2, [])).toBe(false);
+      expect(suppressesFinding(lines, 2, [])).toBe(false);
     });
 
-    it('declines a finding on the first line', () => {
+    it('suppresses a finding on the first line', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore');
 
-      expect(declinesFinding(lines, 1, [])).toBe(true);
+      expect(suppressesFinding(lines, 1, [])).toBe(true);
     });
   });
 
   describe('given an `rdy-ignore-next-line`', () => {
-    it('declines a finding on the line below it', () => {
+    it('suppresses a finding on the line below it', () => {
       const lines = linesOf('// rdy-ignore-next-line\nerror instanceof Error;');
 
-      expect(declinesFinding(lines, 2, [])).toBe(true);
+      expect(suppressesFinding(lines, 2, [])).toBe(true);
     });
 
-    it('declines nothing on the line it sits on', () => {
+    it('suppresses nothing on the line it sits on', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore-next-line');
 
-      expect(declinesFinding(lines, 1, [])).toBe(false);
+      expect(suppressesFinding(lines, 1, [])).toBe(false);
     });
   });
 
   describe('given a pragma naming no check', () => {
-    it('declines whatever ids the check carries', () => {
+    it('suppresses whatever ids the check carries', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore');
 
-      expect(declinesFinding(lines, 1, NAMED)).toBe(true);
+      expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
     });
 
     it('accepts a reason, which names no check', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore -- the bootstrap shim, no deps allowed');
 
-      expect(declinesFinding(lines, 1, NAMED)).toBe(true);
+      expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
     });
   });
 
   describe('given a pragma naming checks', () => {
-    it('declines for a check it names', () => {
+    it('suppresses for a check it names', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore toolbelt.errors/no-instanceof-error');
 
-      expect(declinesFinding(lines, 1, NAMED)).toBe(true);
+      expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
     });
 
-    it('declines nothing for a check it does not name', () => {
+    it('suppresses nothing for a check it does not name', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore toolbelt.errors/other-check');
 
-      expect(declinesFinding(lines, 1, NAMED)).toBe(false);
+      expect(suppressesFinding(lines, 1, NAMED)).toBe(false);
     });
 
-    it('declines nothing for a check carrying no id at all', () => {
+    it('suppresses nothing for a check carrying no id at all', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore toolbelt.errors/no-instanceof-error');
 
-      expect(declinesFinding(lines, 1, [])).toBe(false);
+      expect(suppressesFinding(lines, 1, [])).toBe(false);
     });
 
-    it('declines where it names either form the check accepts', () => {
+    it('suppresses where it names either form the check accepts', () => {
       const accepted = ['toolbelt.errors/no-instanceof-error', '@williamthorsen/toolbelt.errors/no-instanceof-error'];
       const lines = linesOf(
         'error instanceof Error; // rdy-ignore @williamthorsen/toolbelt.errors/no-instanceof-error',
       );
 
-      expect(declinesFinding(lines, 1, accepted)).toBe(true);
+      expect(suppressesFinding(lines, 1, accepted)).toBe(true);
     });
 
-    it('declines for any check a comma-separated list names', () => {
+    it('suppresses for any check a comma-separated list names', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore x/y,toolbelt.errors/no-instanceof-error');
 
-      expect(declinesFinding(lines, 1, NAMED)).toBe(true);
+      expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
     });
 
     it('reads a list spaced around its commas', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore x/y , toolbelt.errors/no-instanceof-error , z');
 
-      expect(declinesFinding(lines, 1, NAMED)).toBe(true);
+      expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
     });
 
-    it('declines nothing where the named check belongs to another kit', () => {
+    it('suppresses nothing where the named check belongs to another kit', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore other.kit/no-instanceof-error');
 
-      expect(declinesFinding(lines, 1, NAMED)).toBe(false);
+      expect(suppressesFinding(lines, 1, NAMED)).toBe(false);
     });
 
     it('narrows the pragma covering the line below it', () => {
       const lines = linesOf('// rdy-ignore-next-line toolbelt.errors/other-check\nerror instanceof Error;');
 
-      expect(declinesFinding(lines, 2, NAMED)).toBe(false);
+      expect(suppressesFinding(lines, 2, NAMED)).toBe(false);
     });
   });
 
@@ -110,67 +110,67 @@ describe(declinesFinding, () => {
     it('ends at a reason', () => {
       const lines = linesOf('// rdy-ignore-next-line toolbelt.errors/no-instanceof-error -- the shim\nerror;');
 
-      expect(declinesFinding(lines, 2, NAMED)).toBe(true);
+      expect(suppressesFinding(lines, 2, NAMED)).toBe(true);
     });
 
     it('ends at the delimiter closing a block comment', () => {
       const lines = linesOf('error instanceof Error; /* rdy-ignore toolbelt.errors/no-instanceof-error */');
 
-      expect(declinesFinding(lines, 1, NAMED)).toBe(true);
+      expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
     });
 
     it('ends at a second pragma token rather than reading it as an id', () => {
       const lines = linesOf('// rdy-ignore rdy-ignore-next-line\nerror;');
 
-      expect(declinesFinding(lines, 1, NAMED)).toBe(true);
-      expect(declinesFinding(lines, 2, NAMED)).toBe(true);
+      expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
+      expect(suppressesFinding(lines, 2, NAMED)).toBe(true);
     });
   });
 
   describe('given a token the grammar does not name', () => {
-    it('declines nothing for a word the token only prefixes', () => {
+    it('suppresses nothing for a word the token only prefixes', () => {
       const lines = linesOf('const rdy-ignored = 1;');
 
-      expect(declinesFinding(lines, 1, [])).toBe(false);
+      expect(suppressesFinding(lines, 1, [])).toBe(false);
     });
 
-    it('declines nothing for a misspelt next-line suffix', () => {
+    it('suppresses nothing for a misspelt next-line suffix', () => {
       const lines = linesOf('// rdy-ignore-nextline\nerror instanceof Error;');
 
-      expect(declinesFinding(lines, 1, [])).toBe(false);
-      expect(declinesFinding(lines, 2, [])).toBe(false);
+      expect(suppressesFinding(lines, 1, [])).toBe(false);
+      expect(suppressesFinding(lines, 2, [])).toBe(false);
     });
 
-    it('declines nothing for a token a longer word ends with', () => {
+    it('suppresses nothing for a token a longer word ends with', () => {
       const lines = linesOf('const notrdy-ignore = 1;');
 
-      expect(declinesFinding(lines, 1, [])).toBe(false);
+      expect(suppressesFinding(lines, 1, [])).toBe(false);
     });
   });
 
   it('reads a pragma a block comment closes against without a space', () => {
     const lines = linesOf('error instanceof Error; /*rdy-ignore*/');
 
-    expect(declinesFinding(lines, 1, [])).toBe(true);
+    expect(suppressesFinding(lines, 1, [])).toBe(true);
   });
 
   it('answers for each scope where one line carries both tokens', () => {
     const lines = linesOf('// rdy-ignore rdy-ignore-next-line\nerror;');
 
-    expect(declinesFinding(lines, 1, [])).toBe(true);
-    expect(declinesFinding(lines, 2, [])).toBe(true);
+    expect(suppressesFinding(lines, 1, [])).toBe(true);
+    expect(suppressesFinding(lines, 2, [])).toBe(true);
   });
 
-  it('declines nothing where no line carries a pragma', () => {
+  it('suppresses nothing where no line carries a pragma', () => {
     const lines = linesOf('const a = 1;\nerror instanceof Error;');
 
-    expect(declinesFinding(lines, 2, [])).toBe(false);
+    expect(suppressesFinding(lines, 2, [])).toBe(false);
   });
 });
 
 // region | Helpers
 
-/** Parts a source into the lines `declinesFinding` reads. */
+/** Parts a source into the lines `suppressesFinding` reads. */
 function linesOf(source: string): readonly string[] {
   return source.split('\n');
 }

--- a/packages/readyup/src/run/check-return.ts
+++ b/packages/readyup/src/run/check-return.ts
@@ -35,12 +35,12 @@ export function isFindingOutcome(raw: unknown): raw is FindingOutcome {
  * Returns a check's return value with a set of findings resolved into an outcome, and any other value as
  * it came.
  *
- * Which pragmas decline a finding is settled against the check's ids, so the resolution belongs to the run
+ * Which pragmas suppress a finding is settled against the check's ids, so the resolution belongs to the run
  * rather than to the check. The runner and the skip diagnosis both read a verdict off the result, and one
  * resolution between them is what keeps a diagnosed skip agreeing with the run it stands in for.
  *
  * A ledger reaches the resolution where the caller keeps one, which is how a run records what its checks
- * examined and declined while a diagnosis, passing none, leaves no trace of a check that did not run.
+ * examined and suppressed while a diagnosis, passing none, leaves no trace of a check that did not run.
  */
 export function resolveCheckReturn(
   raw: unknown,

--- a/packages/readyup/src/run/listPragmaSites.ts
+++ b/packages/readyup/src/run/listPragmaSites.ts
@@ -7,7 +7,7 @@ export interface PragmaSite {
   /** The 1-based line the token sits on. */
   readonly line: number;
 
-  /** The 1-based line the pragma declines a finding on. */
+  /** The 1-based line the pragma suppresses a finding on. */
   readonly coveredLine: number;
 
   /** The token as written, which is what a report names it by. */
@@ -25,10 +25,10 @@ export function isJsFamilyPath(path: string): boolean {
 /**
  * Returns the pragmas a source anchors to a comment's opening delimiter.
  *
- * A token qualifies where it sits inside a comment and nothing but whitespace and `*` parts it from the `//` or
- * `/*` that opened one. That is stricter than declining, which matches the token in raw text wherever it appears:
- * a report naming a site has to be sure the comment is a pragma rather than prose quoting one, so a token
- * following anything else in its comment, or a second token on a line, is withheld rather than guessed at.
+ * A token qualifies where it sits inside a comment and nothing but whitespace and `*` parts it from the `//` or `/*`
+ * that opened one. That is stricter than suppression, which matches the token in raw text wherever it appears: a report
+ * naming a site has to be sure the comment is a pragma rather than prose quoting one, so a token following anything
+ * else in its comment, or a second token on a line, is withheld rather than guessed at.
  *
  * `blankComments` is the comment oracle, no second tokenizer being needed to answer a question it already answers.
  * It preserves its input's length, so an offset found in the raw text reads the blanked text at the same place.

--- a/packages/readyup/src/run/pragma-report.ts
+++ b/packages/readyup/src/run/pragma-report.ts
@@ -6,17 +6,17 @@ import type { RaisedWarning } from '../schemas/common.ts';
 import { isJsFamilyPath, listPragmaSites, type PragmaSite } from './listPragmaSites.ts';
 import type { PragmaLedger } from './PragmaLedger.ts';
 
-/** One pragma that declined nothing, named the way the warning about it prints. */
+/** One pragma that suppressed nothing, named the way the warning about it prints. */
 interface UnusedPragma extends PragmaSite {
   /** The path relative to `cwd`, the form findings print in. */
   displayPath: string;
 }
 
 /**
- * Emits an advisory stderr warning for each pragma that declined nothing, and returns the entries.
+ * Emits an advisory stderr warning for each pragma that suppressed nothing, and returns the entries.
  *
  * The evidence is what the run's checks read: a pragma is reported only where some check examined the file
- * holding it, by sweeping it or by declaring it, and no check declined a finding on the line it covers. A file
+ * holding it, by sweeping it or by declaring it, and no check suppressed a finding on the line it covers. A file
  * no check examined yields nothing, because the run holds no evidence either way about the pragmas in it.
  *
  * Each examined file is read and scanned once however many checks examined it, and only a JS-family source is
@@ -43,7 +43,7 @@ function byPathThenLine(a: UnusedPragma, b: UnusedPragma): number {
   return a.line - b.line;
 }
 
-/** Returns every pragma the run's examined sources carry against which no check declined a finding. */
+/** Returns every pragma the run's examined sources carry against which no check suppressed a finding. */
 function listUnusedPragmas(ledger: PragmaLedger): UnusedPragma[] {
   const unused: UnusedPragma[] = [];
 
@@ -56,7 +56,7 @@ function listUnusedPragmas(ledger: PragmaLedger): UnusedPragma[] {
     if (text === undefined) continue;
 
     for (const site of listPragmaSites(text)) {
-      if (!ledger.hasDeclined(scannedPath, site.coveredLine)) unused.push({ ...site, displayPath });
+      if (!ledger.hasSuppressed(scannedPath, site.coveredLine)) unused.push({ ...site, displayPath });
     }
   }
 

--- a/packages/readyup/src/run/pragma-report.ts
+++ b/packages/readyup/src/run/pragma-report.ts
@@ -67,7 +67,7 @@ function listUnusedPragmas(ledger: PragmaLedger): UnusedPragma[] {
 function toWarning(pragma: UnusedPragma): RaisedWarning {
   return {
     code: 'pragma-unused',
-    message: `\`${pragma.token}\` pragma at ${pragma.displayPath}:${pragma.line} declined no finding in this run.`,
+    message: `\`${pragma.token}\` pragma at ${pragma.displayPath}:${pragma.line} suppressed no finding in this run.`,
     remedy: 'Remove the pragma, or run the kit whose check it was written for.',
   };
 }

--- a/packages/readyup/src/run/pragma-token.ts
+++ b/packages/readyup/src/run/pragma-token.ts
@@ -7,7 +7,7 @@
  *
  * A fresh matcher per scan, because a global regular expression carries a `lastIndex` its readers all share: one
  * `test` or `exec` anywhere would leave it set, and every later `matchAll` would skip the text before that offset
- * and answer that a pragma declining a finding is not there.
+ * and answer that a pragma suppressing a finding is not there.
  */
 export function createIgnorePragmaMatcher(): RegExp {
   return /(?<![\w-])rdy-ignore(-next-line)?(?![\w-])/g;

--- a/packages/readyup/src/run/resolveFindingOutcome.ts
+++ b/packages/readyup/src/run/resolveFindingOutcome.ts
@@ -1,17 +1,17 @@
 import { readSourceText } from '../check-utils/project/readTrackedSources.ts';
 import type { CheckOutcome, FindingOutcome, OutcomeFinding } from '../kits/types.ts';
-import { declinesFinding } from './declinesFinding.ts';
 import type { PragmaLedger } from './PragmaLedger.ts';
+import { suppressesFinding } from './suppressesFinding.ts';
 
 /**
- * Returns a check's verdict, reason, and fraction, the findings a pragma declined for it having been dropped.
+ * Returns a check's verdict, reason, and fraction, the findings a pragma suppressed for it having been dropped.
  *
  * The denominator counts every surviving site, reported or not, so the checks of one run share a denominator
- * the reader can compare across them, and a declined site leaves both halves of it. `adoptedCount` is the
+ * the reader can compare across them, and a suppressed site leaves both halves of it. `adoptedCount` is the
  * numerator; omitted, the outcome carries no progress at all.
  *
- * A ledger, where one is passed, is told which sites the check's pragmas declined, and the paths it declared in
- * `scanned`. A sweep read through `readTrackedSources` reports itself, so what arrives here is the reading a
+ * A ledger, where one is passed, is told which sites the check's pragmas suppressed, and the paths it declared
+ * in `scanned`. A sweep read through `readTrackedSources` reports itself, so what arrives here is the reading a
  * check did some other way. A caller wanting the run to hold no record of a check passes none.
  */
 export function resolveFindingOutcome(
@@ -21,7 +21,7 @@ export function resolveFindingOutcome(
 ): CheckOutcome {
   if (outcome.scanned !== undefined) ledger?.recordScanned(outcome.scanned);
 
-  const surviving = excludeDeclined(outcome.findings, checkIds, ledger);
+  const surviving = excludeSuppressed(outcome.findings, checkIds, ledger);
   const reported = surviving.filter((finding) => finding.reported);
 
   const { adoptedCount } = outcome;
@@ -43,12 +43,12 @@ function describeFinding(finding: OutcomeFinding): string {
 }
 
 /**
- * Drops the findings a source declined with an `rdy-ignore` pragma naming this check or naming no check.
+ * Drops the findings a source suppressed with an `rdy-ignore` pragma naming this check or naming no check.
  *
  * Each path is parted into lines once, so a file holding ten findings costs one read and one split between
- * them. A path holding no readable text declines nothing.
+ * them. A path holding no readable text suppresses nothing.
  */
-function excludeDeclined(
+function excludeSuppressed(
   findings: readonly OutcomeFinding[],
   checkIds: readonly string[],
   ledger: PragmaLedger | undefined,
@@ -60,9 +60,9 @@ function excludeDeclined(
     }
 
     const lines = linesByPath.get(finding.path);
-    const isDeclined = lines !== undefined && declinesFinding(lines, finding.line, checkIds);
-    if (isDeclined) ledger?.recordDeclined(finding.path, finding.line);
-    return !isDeclined;
+    const isSuppressed = lines !== undefined && suppressesFinding(lines, finding.line, checkIds);
+    if (isSuppressed) ledger?.recordSuppressed(finding.path, finding.line);
+    return !isSuppressed;
   });
 }
 

--- a/packages/readyup/src/run/runRdy.ts
+++ b/packages/readyup/src/run/runRdy.ts
@@ -36,7 +36,7 @@ export interface RunRdyOptions {
   provenance?: KitProvenance | undefined;
 
   /**
-   * The invocation's record of what its checks examined and declined, which the unused-pragma report reads.
+   * The invocation's record of what its checks examined and suppressed, which the unused-pragma report reads.
    *
    * One ledger spans every kit of an invocation, so a file two kits both examined is reported once. A run
    * passing none records nothing and reports nothing.
@@ -58,7 +58,7 @@ interface PendingDiagnosis {
 interface RunContext {
   defaultSeverity: Severity;
 
-  /** The invocation's record of what its checks examined and declined, absent where nothing reads one. */
+  /** The invocation's record of what its checks examined and suppressed, absent where nothing reads one. */
   pragmaLedger: PragmaLedger | undefined;
 
   /** Where the kit came from, read for every check's ids and for nothing else. */

--- a/packages/readyup/src/run/suppressesFinding.ts
+++ b/packages/readyup/src/run/suppressesFinding.ts
@@ -10,24 +10,24 @@ const LEADING_COMMA = /^[ \t]*,/;
 const PRAGMA_TOKENS = new Set(['rdy-ignore', 'rdy-ignore-next-line']);
 
 /**
- * Reports whether a source declines a finding on a line for a check `checkIds` names: an `rdy-ignore` sits on
+ * Reports whether a source suppresses a finding on a line for a check `checkIds` names: an `rdy-ignore` sits on
  * that line, or an `rdy-ignore-next-line` on the one above it.
  *
- * A pragma naming no check declines whatever the check. One naming checks declines only where an id names a
- * member of `checkIds`, so a check declaring no id, which reaches here with none, is declined by the unqualified
- * form alone. Every pragma covering the line is read until one declines.
+ * A pragma naming no check suppresses whatever the check. One naming checks suppresses only where an id names a
+ * member of `checkIds`, so a check declaring no id, which reaches here with none, is suppressed by the
+ * unqualified form alone. Every pragma covering the line is read until one suppresses.
  *
  * Lines are the source's raw text rather than blanked code, so a detector that blanks comments before it scans
  * cannot erase a pragma first.
  */
-export function declinesFinding(lines: readonly string[], line: number, checkIds: readonly string[]): boolean {
+export function suppressesFinding(lines: readonly string[], line: number, checkIds: readonly string[]): boolean {
   return carriesPragma(lines[line - 1], 'line', checkIds) || carriesPragma(lines[line - 2], 'next-line', checkIds);
 }
 
 // region | Helpers
 
 /**
- * Reports whether a line carries a pragma covering the named scope and declining for `checkIds`. A line past
+ * Reports whether a line carries a pragma covering the named scope and suppressing for `checkIds`. A line past
  * either end of the source carries none.
  */
 function carriesPragma(line: string | undefined, scope: 'line' | 'next-line', checkIds: readonly string[]): boolean {


### PR DESCRIPTION
## What

Renames readyup's pragma vocabulary from `decline` to `suppress` across `packages/readyup`: the `rdy-ignore` prose in the README and the kit rulebook, the run layer's identifiers and doc comments, and the `pragma-unused` warning, which had not yet been released. Where the same word described a check that skipped, in the ⚪ legend of both documents, it becomes "does not apply".

## Why

Saying a pragma "declines" a finding claims someone weighed the finding and turned it down. An unqualified `rdy-ignore` copied in from another file does no such thing: it removes whatever lands on its line, whoever wrote it and whenever. "Suppress" is what comparable tools call this, so a reader arrives already knowing the word, where "decline" otherwise means refusing an invitation or going down and has to be reconstructed from context.

## Details

### ♻️ Refactoring

- `declinesFinding` becomes `suppressesFinding`, with its file renamed to match, and `resolveFindingOutcome`'s `excludeDeclined` helper becomes `excludeSuppressed`.
- `PragmaLedger` exposes `hasSuppressed` and `recordSuppressed` in place of `hasDeclined` and `recordDeclined`, and its internal set follows.
- The `pragma-unused` warning now reads `` `rdy-ignore` pragma at src/a.ts:3 suppressed no finding in this run. `` The `pragma-unused` code is unchanged, so `schemas/report.v1.json` needs no regeneration.
- Doc comments in `kits/types.ts`, `runRdy.ts`, `listPragmaSites.ts`, `check-return.ts`, `pragma-token.ts`, and `buildFindingReport.ts` follow the identifiers.
- Nothing crosses the package boundary: neither `PragmaLedger` nor the predicate is exported from `src/index.ts`.

### 🧪 Tests

- `qualifiedDeclining.wiring.unit.test.ts` becomes `qualifiedSuppression.wiring.unit.test.ts`, a noun phrase matching its `pragmaRecording` sibling, and its temporary-directory prefix follows.
- Test names were reworded rather than pattern-replaced, because the subject differs between them: some read "declines the named check", where the pragma is the subject, and others "a pragma declining", where it is a clause.
- `pragma-report.unit.test.ts` keeps the full warning message pinned rather than loosening to an identifying substring, since the wording is that module's product and this is the only place it is verified.

### ⚙️ Tooling

- `eslint.config.ts`'s per-file override names the renamed test file. The override is matched by path, so leaving it behind would silently stop relaxing `vitest/consistent-test-it` and `vitest/require-hook` for that file.

### 📚 Documentation

- The README's `### Declining a finding` heading becomes `### Suppressing a finding`, and the three links to its anchor move with it.
- The kit rulebook adopts the vocabulary its own "Suppression is readyup's rather than yours" paragraph was already using, so `declinable` becomes `suppressible`. It publishes to consumers as the `consult-readyup-kits` skill.
- `packages/compositor` keeps its own `declined`, which names a config tier opting a source out. That is a decision by an author, so the word is correct there and is untouched.

Closes #386
