### PR TITLE
#389 Resolve a configured package through the workspace when `node_modules` misses

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -108,6 +108,7 @@ const config = defineConfig([
       'packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts',
       'packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts',
       'packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts',
+      'packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts',
       'packages/readyup/src/list/__tests__/listCommand.packages.unit.test.ts',
       'packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts',
       'packages/readyup/src/list/__tests__/listCommand.recursivePackages.unit.test.ts',

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1086,7 +1086,7 @@ A listed package that is absent, or that publishes no kits at all, fails the run
 
 Where `node_modules` misses, a configured name matching one of the project's own workspaces resolves to that workspace's directory, and its kits are read from there as for any installed package. A monorepo therefore runs its own packages' kits over itself without declaring a dependency on them purely to make them findable. The workspace matches by the `name` its manifest declares, `private: true` included, and resolution is anchored to the directory whose config named the package, so a `--recursive` sweep reads each project's own workspaces.
 
-Two limitations follow from resolving through `node_modules`, and neither reaches a workspace, which never resolves through it. A package that is not a workspace must be a **direct** dependency: a strict pnpm layout links nothing else into the project, so a transitive package is genuinely unreachable. And Yarn Plug'n'Play keeps no `node_modules` on disk, so package sources do not resolve under it.
+Two limitations follow from resolving through `node_modules`, and neither can withhold a workspace, which the fallback reaches wherever the walk misses. A package that is not a workspace must be a **direct** dependency: a strict pnpm layout links nothing else into the project, so a transitive package is genuinely unreachable. And Yarn Plug'n'Play keeps no `node_modules` on disk, so package sources do not resolve under it.
 
 A published version other than the installed one is not yet reachable through `npm:` -- naming one says so. Use `--url` with the published address in the meantime:
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -788,7 +788,7 @@ Kits from configured packages get their own section, each named package-first so
 
 The hint above each block is what marks the package. A package the config names is headed by `rdy run --packages`, which is exactly the run that would reach it; one the config omits is headed by the source that names it directly, and reads `not listed in the readyup config`. Every kit listed is therefore runnable by the command above it, and learning what an unconfigured package holds no longer means a `--from npm:` listing per package.
 
-Configured packages are resolved through `node_modules` rather than through the project's declared dependencies, so one that is installed without being declared is reported here as it is under a plain `rdy list`; one that is not installed warns and is omitted. On its own, `--packages` reads the working directory, and it is not combinable with `--from` or `--manifest`. Pairing it with `--recursive` sweeps the whole repository, which [Listing a repository's dependencies](#listing-a-repositorys-dependencies) covers.
+Configured packages are resolved through `node_modules` rather than through the project's declared dependencies, so one that is installed without being declared is reported here as it is under a plain `rdy list`; where that misses, a name matching one of the project's own workspaces resolves to that workspace, and a name matching neither warns and is omitted. On its own, `--packages` reads the working directory, and it is not combinable with `--from` or `--manifest`. Pairing it with `--recursive` sweeps the whole repository, which [Listing a repository's dependencies](#listing-a-repositorys-dependencies) covers.
 
 `--manifest` reports each kit's compile-time ReadyUp version and description:
 
@@ -1084,7 +1084,9 @@ That rule is how an author holds a kit back from a routine `--packages` run: pub
 
 A listed package that is absent, or that publishes no kits at all, fails the run and names itself; `rdy list` warns instead and reports the rest, then names any installed dependency publishing kits the list omits.
 
-Two limitations follow from resolving through `node_modules`. A package must be a **direct** dependency: a strict pnpm layout links nothing else into the project, so a transitive package is genuinely unreachable. And Yarn Plug'n'Play keeps no `node_modules` on disk, so package sources do not resolve under it.
+Where `node_modules` misses, a configured name matching one of the project's own workspaces resolves to that workspace's directory, and its kits are read from there as for any installed package. A monorepo therefore runs its own packages' kits over itself without declaring a dependency on them purely to make them findable. The workspace matches by the `name` its manifest declares, `private: true` included, and resolution is anchored to the directory whose config named the package, so a `--recursive` sweep reads each project's own workspaces.
+
+Two limitations follow from resolving through `node_modules`, and neither reaches a workspace, which never resolves through it. A package that is not a workspace must be a **direct** dependency: a strict pnpm layout links nothing else into the project, so a transitive package is genuinely unreachable. And Yarn Plug'n'Play keeps no `node_modules` on disk, so package sources do not resolve under it.
 
 A published version other than the installed one is not yet reachable through `npm:` -- naming one says so. Use `--url` with the published address in the meantime:
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1086,7 +1086,7 @@ A listed package that is absent, or that publishes no kits at all, fails the run
 
 Where `node_modules` misses, a configured name matching one of the project's own workspaces resolves to that workspace's directory, and its kits are read from there as for any installed package. A monorepo therefore runs its own packages' kits over itself without declaring a dependency on them purely to make them findable. The workspace matches by the `name` its manifest declares, `private: true` included, and resolution is anchored to the directory whose config named the package, so a `--recursive` sweep reads each project's own workspaces.
 
-Two limitations follow from resolving through `node_modules`, and neither can withhold a workspace, which the fallback reaches wherever the walk misses. A package that is not a workspace must be a **direct** dependency: a strict pnpm layout links nothing else into the project, so a transitive package is genuinely unreachable. And Yarn Plug'n'Play keeps no `node_modules` on disk, so package sources do not resolve under it.
+Two limitations follow from resolving through `node_modules`, and neither applies to a workspace, because a configured package that `node_modules` does not contain is still resolved through the workspace fallback. A package that is not a workspace must be a **direct** dependency: a strict pnpm layout links nothing else into the project, so a transitive package is genuinely unreachable. And Yarn Plug'n'Play keeps no `node_modules` on disk, so package sources do not resolve under it.
 
 A published version other than the installed one is not yet reachable through `npm:` -- naming one says so. Use `--url` with the published address in the meantime:
 

--- a/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
@@ -5,7 +5,7 @@ import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
 import { describe, expect, test } from 'vitest';
 
-import { discoverWorkspaces } from '../workspaces.ts';
+import { discoverWorkspaces, discoverWorkspacesAt } from '../workspaces.ts';
 
 const it = test.extend(
   'temp',
@@ -324,6 +324,28 @@ describe(discoverWorkspaces, () => {
   });
 });
 
+describe(discoverWorkspacesAt, () => {
+  it('reads the repo at the directory it is handed rather than the ambient cwd', ({ temp }) => {
+    writeWorkspacePackage(temp, 'nested', { name: 'nested-root', private: true, workspaces: ['packages/*'] });
+    writeWorkspacePackage(temp, 'nested/packages/alpha', { name: 'alpha' });
+
+    const workspaces = discoverWorkspacesAt(temp.resolve('nested'));
+
+    expect(workspaces.map((w) => w.name)).toStrictEqual(['alpha']);
+    // The ambient cwd holds no manifest, so an answer read through it could not be this one.
+    expect(() => discoverWorkspaces()).toThrow(/no package.json found/);
+  });
+
+  it('resolves a relative directory against the cwd', ({ temp }) => {
+    writeWorkspacePackage(temp, 'nested', { name: 'nested-root', private: true, workspaces: ['packages/*'] });
+    writeWorkspacePackage(temp, 'nested/packages/beta', { name: 'beta' });
+
+    expect(discoverWorkspacesAt('nested').map((w) => w.absolutePath)).toStrictEqual([
+      temp.resolve('nested/packages/beta'),
+    ]);
+  });
+});
+
 // region | Helpers
 
 /** Writes the root manifest that declares the workspace globs. */
@@ -331,7 +353,7 @@ function writeRootPackageJson(temp: TempTree, content: Record<string, unknown>):
   temp.writeJson('package.json', content);
 }
 
-/** Writes a workspace member's manifest at a root-relative directory. */
+/** Writes a package manifest at a root-relative directory. */
 function writeWorkspacePackage(temp: TempTree, relDir: string, content: Record<string, unknown>): void {
   temp.writeJson(join(relDir, 'package.json'), content);
 }

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -53,7 +53,7 @@ export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspa
  * ambient answer is the one a kit author wants.
  */
 export function discoverWorkspacesAt(dir: string, options?: DiscoverWorkspacesOptions): Workspace[] {
-  // Resolved before it keys the memo, so a relative path and its absolute form share one discovery.
+  // Resolve before keying the memo, so a relative path and its absolute form share one discovery.
   const rootDir = resolve(dir);
 
   let workspaces = workspacesByDir.get(rootDir);

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -9,7 +9,7 @@ import { readPnpmWorkspacePackages } from './pnpmWorkspaceYaml.ts';
 
 /** A monorepo workspace, or the single workspace of a single-workspace repo. */
 export interface Workspace {
-  /** Workspace directory, relative to `cwd`. `'.'` for a single-workspace repo. */
+  /** Workspace directory, relative to the directory discovery was anchored to. `'.'` for a single-workspace repo. */
   readonly dir: string;
   /** Absolute filesystem path to the workspace directory. */
   readonly absolutePath: string;
@@ -29,26 +29,38 @@ export interface DiscoverWorkspacesOptions {
 
 type WorkspacePatternSource = 'pnpm-workspace.yaml' | 'package.json';
 
-/** Discovered workspaces by the `cwd` they were resolved against, held for the life of the process. */
-const workspacesByCwd = new Map<string, Workspace[]>();
+/** Discovered workspaces by the directory they were resolved against, held for the life of the process. */
+const workspacesByDir = new Map<string, Workspace[]>();
 
 /**
  * Discovers the workspaces of the current repo.
  * Detects pnpm (`pnpm-workspace.yaml`), then npm/yarn (`package.json.workspaces`),
  * and falls back to a single-workspace repo using the root `package.json`.
  *
- * Memoized per `cwd` for the life of the process: repeated calls in one run share a single directory walk
+ * Memoized per directory for the life of the process: repeated calls in one run share a single directory walk
  * and the frozen `Workspace` objects it built, and none of them observes a filesystem change made since the first.
  * `options.filter` applies per call, so it selects from the memoized list rather than being memoized with it.
  */
 export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspace[] {
-  const cwd = process.cwd();
+  return discoverWorkspacesAt(process.cwd(), options);
+}
 
-  let workspaces = workspacesByCwd.get(cwd);
+/**
+ * Discovers the workspaces of the repo rooted at `dir`, which a relative path names against `cwd`.
+ *
+ * The directory-taking half of `discoverWorkspaces`, for a caller resolving against a project other than the
+ * one it is running in. It stays out of `check-utils`'s exports: a kit runs in the project it checks, so the
+ * ambient answer is the one a kit author wants.
+ */
+export function discoverWorkspacesAt(dir: string, options?: DiscoverWorkspacesOptions): Workspace[] {
+  // Resolved before it keys the memo, so a relative path and its absolute form share one discovery.
+  const rootDir = resolve(dir);
+
+  let workspaces = workspacesByDir.get(rootDir);
   if (workspaces === undefined) {
     // Build before storing, so a discovery that throws leaves nothing behind and the next call retries it.
-    workspaces = buildWorkspaces(cwd);
-    workspacesByCwd.set(cwd, workspaces);
+    workspaces = buildWorkspaces(rootDir);
+    workspacesByDir.set(rootDir, workspaces);
   }
 
   return applyFilter(workspaces, options?.filter);
@@ -62,11 +74,11 @@ function applyFilter(workspaces: Workspace[], filter: DiscoverWorkspacesOptions[
   return workspaces.filter(filter);
 }
 
-/** Builds the unfiltered workspace list for the repo at `cwd`. */
-function buildWorkspaces(cwd: string): Workspace[] {
-  const rootPackageJsonPath = join(cwd, 'package.json');
+/** Builds the unfiltered workspace list for the repo at `rootDir`. */
+function buildWorkspaces(rootDir: string): Workspace[] {
+  const rootPackageJsonPath = join(rootDir, 'package.json');
 
-  const patternResult = resolveWorkspacePatterns(cwd);
+  const patternResult = resolveWorkspacePatterns(rootDir);
 
   if (patternResult === null) {
     // Single-workspace fallback uses the root package.json, which MUST exist.
@@ -74,7 +86,7 @@ function buildWorkspaces(cwd: string): Workspace[] {
     if (rootPackageJson === undefined) {
       throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
     }
-    return [buildWorkspaceFromPackageJson('.', cwd, rootPackageJson)];
+    return [buildWorkspaceFromPackageJson('.', rootDir, rootPackageJson)];
   }
 
   // Monorepo path: still require a root package.json (both pnpm and npm workspaces do).
@@ -84,10 +96,10 @@ function buildWorkspaces(cwd: string): Workspace[] {
 
   // `matchedDirs` is already sorted ascending by `expandPatterns`, and each workspace's
   // `dir` equals its entry in that list, so the result is sorted without an extra pass.
-  const matchedDirs = expandPatterns(cwd, patternResult.patterns, patternResult.source);
+  const matchedDirs = expandPatterns(rootDir, patternResult.patterns, patternResult.source);
   const workspaces: Workspace[] = [];
   for (const relDir of matchedDirs) {
-    const workspace = buildWorkspace(cwd, relDir);
+    const workspace = buildWorkspace(rootDir, relDir);
     if (workspace !== undefined) {
       workspaces.push(workspace);
     }
@@ -97,11 +109,11 @@ function buildWorkspaces(cwd: string): Workspace[] {
 }
 
 /**
- * Resolves the workspace pattern list for the repo at `cwd`.
+ * Resolves the workspace pattern list for the repo at `rootDir`.
  * Returns `null` to signal single-workspace fallback, or `{ patterns, source }` for a monorepo.
  */
-function resolveWorkspacePatterns(cwd: string): { patterns: string[]; source: WorkspacePatternSource } | null {
-  const pnpmWorkspacePath = join(cwd, 'pnpm-workspace.yaml');
+function resolveWorkspacePatterns(rootDir: string): { patterns: string[]; source: WorkspacePatternSource } | null {
+  const pnpmWorkspacePath = join(rootDir, 'pnpm-workspace.yaml');
   if (existsSync(pnpmWorkspacePath)) {
     const patterns = readPnpmWorkspacePackages(pnpmWorkspacePath);
     if (patterns !== null) {
@@ -110,7 +122,7 @@ function resolveWorkspacePatterns(cwd: string): { patterns: string[]; source: Wo
     // `packages` key absent — fall through to npm/single detection.
   }
 
-  const rootPackageJson = readJsonFile(join(cwd, 'package.json'));
+  const rootPackageJson = readJsonFile(join(rootDir, 'package.json'));
   if (rootPackageJson !== undefined) {
     const workspaces = rootPackageJson['workspaces'];
     const npmPatterns = extractNpmWorkspacePatterns(workspaces);
@@ -147,7 +159,7 @@ function extractNpmWorkspacePatterns(workspaces: unknown): string[] | null {
  * Each pattern is rewritten to name the `package.json` inside the directories it matches, so
  * `walkDirectories` yields those directories.
  */
-function expandPatterns(cwd: string, patterns: string[], source: WorkspacePatternSource): string[] {
+function expandPatterns(rootDir: string, patterns: string[], source: WorkspacePatternSource): string[] {
   if (patterns.length === 0) return [];
 
   // Check for negation patterns up front — the pnpm reader already rejects these in YAML,
@@ -165,7 +177,7 @@ function expandPatterns(cwd: string, patterns: string[], source: WorkspacePatter
   const match = patterns.map((pattern) => `${normalizePattern(pattern)}/package.json`);
 
   // The root is not a workspace, and a pattern of `**` translates to a glob matching its own manifest.
-  return walkDirectories({ root: cwd, match }).filter((relDir) => relDir !== '.');
+  return walkDirectories({ root: rootDir, match }).filter((relDir) => relDir !== '.');
 }
 
 /**
@@ -178,8 +190,8 @@ function normalizePattern(pattern: string): string {
 }
 
 /** Builds a `Workspace` for a relative directory; returns undefined if its `package.json` is missing or malformed. */
-function buildWorkspace(cwd: string, relDir: string): Workspace | undefined {
-  const absoluteDir = resolve(cwd, relDir);
+function buildWorkspace(rootDir: string, relDir: string): Workspace | undefined {
+  const absoluteDir = resolve(rootDir, relDir);
   const packageJson = readJsonFile(join(absoluteDir, 'package.json'));
   if (packageJson === undefined) return undefined;
   return buildWorkspaceFromPackageJson(relDir, absoluteDir, packageJson);

--- a/packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts
@@ -89,13 +89,13 @@ describe(collectKitPackageGroups, () => {
   });
 
   // Listing is read-only, so a dependency nobody can read costs its own group rather than the answer.
-  it('warns and omits a configured package that is not installed', ({ temp }) => {
+  it('warns and omits a configured package that cannot be resolved', ({ temp }) => {
     using io = captureStdio();
 
     const groups = collectKitPackageGroups({ configuredPackages: ['absent-package'], fromDir: temp.dir });
 
     expect(groups.map((group) => group.packageName)).not.toContain('absent-package');
-    expect(io.stderr).toContain('Configured package "absent-package" is not installed');
+    expect(io.stderr).toContain('Configured package "absent-package" was not found');
   });
 
   it('warns and omits a configured package that publishes no kits', ({ temp }) => {

--- a/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts
@@ -82,9 +82,9 @@ describe(expandConfiguredPackages, () => {
     ]);
   });
 
-  it('names the package when it is not installed', ({ temp }) => {
+  it('names the package when it is neither installed nor a workspace', ({ temp }) => {
     expect(() => expandConfiguredPackages(['absent-package'], '.js', temp.dir)).toThrow(
-      /Configured package "absent-package" is not installed/,
+      /Configured package "absent-package" was not found/,
     );
   });
 

--- a/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts
@@ -26,7 +26,7 @@ describe(`${expandConfiguredPackages.name} workspace fallback`, () => {
     ]);
   });
 
-  it('expands a private workspace, which publication to a registry is what `private` withholds', ({ temp }) => {
+  it('expands a private workspace, since `private` withholds publication rather than discovery', ({ temp }) => {
     temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/*'] });
     writeKitPackage(temp, 'packages/sealed', { name: 'sealed', private: true, version: '1.2.0' }, 'default');
 

--- a/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts
@@ -1,0 +1,91 @@
+import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, test } from 'vitest';
+
+import { expandConfiguredPackages } from '../expandConfiguredPackages.ts';
+
+const it = test.extend(
+  'temp',
+  // A tree per test: workspace discovery holds its answer for the life of the process, keyed by directory.
+  makeFixture(() => createTempTree({}, { prefix: 'expand-packages-workspaces-' })),
+);
+
+describe(`${expandConfiguredPackages.name} workspace fallback`, () => {
+  it('expands a workspace the project declares no dependency on', ({ temp }) => {
+    temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/*'] });
+    writeKitPackage(temp, 'packages/kit-workspace', { name: 'kit-workspace', version: '3.0.0' }, 'default');
+
+    expect(expandConfiguredPackages(['kit-workspace'], '.js', temp.dir)).toStrictEqual([
+      {
+        packageName: 'kit-workspace',
+        version: '3.0.0',
+        kitName: 'default',
+        description: undefined,
+        path: temp.resolve('packages/kit-workspace/.readyup/kits/default.js'),
+      },
+    ]);
+  });
+
+  it('expands a private workspace, which publication to a registry is what `private` withholds', ({ temp }) => {
+    temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/*'] });
+    writeKitPackage(temp, 'packages/sealed', { name: 'sealed', private: true, version: '1.2.0' }, 'default');
+
+    expect(expandConfiguredPackages(['sealed'], '.js', temp.dir).map((kit) => kit.version)).toStrictEqual(['1.2.0']);
+  });
+
+  it('prefers the installed copy where a package is both installed and a workspace', ({ temp }) => {
+    temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/*'] });
+    writeKitPackage(temp, 'packages/dual', { name: 'dual', version: '9.9.9' }, 'default');
+    writeKitPackage(temp, 'node_modules/dual', { name: 'dual', version: '1.0.0' }, 'default');
+
+    expect(expandConfiguredPackages(['dual'], '.js', temp.dir)).toStrictEqual([
+      {
+        packageName: 'dual',
+        version: '1.0.0',
+        kitName: 'default',
+        description: undefined,
+        path: temp.resolve('node_modules/dual/.readyup/kits/default.js'),
+      },
+    ]);
+  });
+
+  // This suite runs in a repo whose own workspaces include `readyup`, so an answer read through the
+  // ambient cwd would resolve the name the directory under test does not hold.
+  it('reads the workspaces of the directory it is handed, not those of the ambient cwd', ({ temp }) => {
+    temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/*'] });
+    writeKitPackage(temp, 'packages/other', { name: 'other', version: '1.0.0' }, 'default');
+
+    expect(() => expandConfiguredPackages(['readyup'], '.js', temp.dir)).toThrow(
+      /Configured package "readyup" was not found/,
+    );
+  });
+
+  it('names the configured package where the project has no manifest to discover workspaces from', ({ temp }) => {
+    expect(() => expandConfiguredPackages(['kit-workspace'], '.js', temp.dir)).toThrow(
+      /Configured package "kit-workspace" was not found/,
+    );
+  });
+
+  it('names the configured package where the workspace globs cannot be expanded', ({ temp }) => {
+    temp.writeJson('package.json', {
+      name: 'root',
+      private: true,
+      workspaces: ['packages/*', '!packages/deprecated/*'],
+    });
+    writeKitPackage(temp, 'packages/kit-workspace', { name: 'kit-workspace', version: '3.0.0' }, 'default');
+
+    expect(() => expandConfiguredPackages(['kit-workspace'], '.js', temp.dir)).toThrow(
+      /Configured package "kit-workspace" was not found/,
+    );
+  });
+});
+
+// region | Helpers
+
+/** Writes a package manifest and one compiled kit beside it, at a root-relative directory. */
+function writeKitPackage(temp: TempTree, relDir: string, packageJson: Record<string, unknown>, kitName: string): void {
+  temp.writeJson(`${relDir}/package.json`, packageJson);
+  temp.write(`${relDir}/.readyup/kits/${kitName}.js`, 'export default {};\n');
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/installed-packages/collectKitPackageGroups.ts
+++ b/packages/readyup/src/installed-packages/collectKitPackageGroups.ts
@@ -22,8 +22,9 @@ interface KitPackageGroupOptions {
  * Groups every kit-publishing dependency with the kits it publishes, sorted by package name.
  *
  * The set unions the installed direct dependencies discovery names with the packages the config names.
- * Discovery reads the project's declared dependencies, while package resolution walks `node_modules`
- * upward, so a configured package installed without being declared is one only the config half reports.
+ * Discovery reads the project's declared dependencies, while package resolution walks `node_modules` upward
+ * and falls back to the project's workspaces, so a configured package that is installed without being declared,
+ * or published by a workspace, is one only the config half reports.
  *
  * Configured membership arrives as an argument rather than being read here, which leaves the answer a
  * function of a directory and a list: a caller sweeping a repository already holds each project's config.

--- a/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
+++ b/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
@@ -6,6 +6,7 @@ import { enumerateKits } from '../list/enumerateKits.ts';
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { readPackageVersion, resolvePackageRoot } from './resolvePackageRoot.ts';
+import { resolveWorkspaceRoot } from './resolveWorkspaceRoot.ts';
 
 /** A kit published by an installed package, carrying the provenance its output is labelled with. */
 export interface PackageKit {
@@ -37,12 +38,13 @@ export function expandConfiguredPackages(packageNames: string[], extension: stri
 
 /** Expands one configured package into the kits it publishes. */
 function expandOnePackage(packageName: string, extension: string, fromDir: string | undefined): PackageKit[] {
-  const root = resolvePackageRoot(packageName, fromDir);
+  // `node_modules` answers first, so an installed package resolves as it does without a workspace to fall back on.
+  const root = resolvePackageRoot(packageName, fromDir) ?? resolveWorkspaceRoot(packageName, fromDir);
   if (root === undefined) {
     // Only a configured name reaches this: a discovered one resolved through this same call before it was
     // named, so the config is the one place the reader can act on.
     throw configError(
-      `Configured package "${packageName}" is not installed; it must be a direct dependency of this project.`,
+      `Configured package "${packageName}" was not found; it must be a direct dependency of this project or one of its workspaces.`,
     );
   }
 

--- a/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
+++ b/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
@@ -38,7 +38,7 @@ export function expandConfiguredPackages(packageNames: string[], extension: stri
 
 /** Expands one configured package into the kits it publishes. */
 function expandOnePackage(packageName: string, extension: string, fromDir: string | undefined): PackageKit[] {
-  // `node_modules` answers first, so an installed package resolves as it does without a workspace to fall back on.
+  // Search `node_modules` first, so a package that is both installed and a workspace resolves to the installed copy.
   const root = resolvePackageRoot(packageName, fromDir) ?? resolveWorkspaceRoot(packageName, fromDir);
   if (root === undefined) {
     // Only a configured name reaches this: a discovered one resolved through this same call before it was

--- a/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
+++ b/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
@@ -41,8 +41,8 @@ function expandOnePackage(packageName: string, extension: string, fromDir: strin
   // Search `node_modules` first, so a package that is both installed and a workspace resolves to the installed copy.
   const root = resolvePackageRoot(packageName, fromDir) ?? resolveWorkspaceRoot(packageName, fromDir);
   if (root === undefined) {
-    // Only a configured name reaches this: a discovered one resolved through this same call before it was
-    // named, so the config is the one place the reader can act on.
+    // Only a configured package name can be unresolved here: A discovered name has already been located
+    // through `resolvePackageRoot`, so the config is what the reader must correct.
     throw configError(
       `Configured package "${packageName}" was not found; it must be a direct dependency of this project or one of its workspaces.`,
     );

--- a/packages/readyup/src/installed-packages/resolveWorkspaceRoot.ts
+++ b/packages/readyup/src/installed-packages/resolveWorkspaceRoot.ts
@@ -6,7 +6,7 @@ import { discoverWorkspacesAt, type Workspace } from '../check-utils/workspaces.
 /**
  * Locates the root directory of the workspace publishing `packageName`, or `undefined` when no workspace does.
  *
- * The fallback behind `resolvePackageRoot`, for a project whose own workspaces publish kits: a monorepo
+ * The fallback behind `resolvePackageRoot`, for a project whose own workspaces publish kits: A monorepo
  * declares no dependency on them at its root, so nothing links them into `node_modules` and the upward walk
  * does not find them. A workspace matches by the `name` its manifest declares, `private: true` included,
  * because `private` prevents publication to a registry and has no bearing on discovery inside the repo.

--- a/packages/readyup/src/installed-packages/resolveWorkspaceRoot.ts
+++ b/packages/readyup/src/installed-packages/resolveWorkspaceRoot.ts
@@ -6,12 +6,13 @@ import { discoverWorkspacesAt, type Workspace } from '../check-utils/workspaces.
 /**
  * Locates the root directory of the workspace publishing `packageName`, or `undefined` when no workspace does.
  *
- * The second answer behind `resolvePackageRoot`, for a project whose own workspaces publish kits: a monorepo
- * declares no dependency on them at its root, so nothing links them into `node_modules` and the walk misses.
- * A workspace matches by the `name` its manifest declares, `private: true` included, since privacy governs
- * publication to a registry rather than discovery inside the repo.
+ * The fallback behind `resolvePackageRoot`, for a project whose own workspaces publish kits: a monorepo
+ * declares no dependency on them at its root, so nothing links them into `node_modules` and the upward walk
+ * does not find them. A workspace matches by the `name` its manifest declares, `private: true` included,
+ * because `private` prevents publication to a registry and has no bearing on discovery inside the repo.
  *
- * Answers with the real path, matching what the `node_modules` walk reports for a workspace linked into it.
+ * Returns the real path, so the result matches what `resolvePackageRoot` returns for a workspace that is
+ * linked into `node_modules`.
  */
 export function resolveWorkspaceRoot(packageName: string, fromDir: string = process.cwd()): string | undefined {
   const workspaces = discoverWorkspacesOrNone(fromDir);
@@ -24,11 +25,11 @@ export function resolveWorkspaceRoot(packageName: string, fromDir: string = proc
 // region | Helpers
 
 /**
- * Discovers the workspaces of the project at `fromDir`, answering with none where discovery cannot.
+ * Discovers the workspaces of the project at `fromDir`, returning an empty list where discovery fails.
  *
- * Discovery throws for a project with no root manifest and for workspace globs readyup cannot expand. Both
- * mean the same thing here -- no workspace answers to this name -- and letting either escape would replace
- * the caller's actionable "configured package was not found" with a diagnostic about the repository's shape.
+ * Discovery throws for a project with no root manifest and for workspace globs readyup cannot expand. In
+ * both cases no workspace can match the requested name, and propagating the error would replace the
+ * caller's actionable "configured package was not found" with a diagnostic about the repository's layout.
  */
 function discoverWorkspacesOrNone(fromDir: string): Workspace[] {
   try {

--- a/packages/readyup/src/installed-packages/resolveWorkspaceRoot.ts
+++ b/packages/readyup/src/installed-packages/resolveWorkspaceRoot.ts
@@ -1,0 +1,41 @@
+import { realpathSync } from 'node:fs';
+import process from 'node:process';
+
+import { discoverWorkspacesAt, type Workspace } from '../check-utils/workspaces.ts';
+
+/**
+ * Locates the root directory of the workspace publishing `packageName`, or `undefined` when no workspace does.
+ *
+ * The second answer behind `resolvePackageRoot`, for a project whose own workspaces publish kits: a monorepo
+ * declares no dependency on them at its root, so nothing links them into `node_modules` and the walk misses.
+ * A workspace matches by the `name` its manifest declares, `private: true` included, since privacy governs
+ * publication to a registry rather than discovery inside the repo.
+ *
+ * Answers with the real path, matching what the `node_modules` walk reports for a workspace linked into it.
+ */
+export function resolveWorkspaceRoot(packageName: string, fromDir: string = process.cwd()): string | undefined {
+  const workspaces = discoverWorkspacesOrNone(fromDir);
+  const match = workspaces.find((workspace) => workspace.name === packageName);
+  if (match === undefined) return undefined;
+
+  return realpathSync(match.absolutePath);
+}
+
+// region | Helpers
+
+/**
+ * Discovers the workspaces of the project at `fromDir`, answering with none where discovery cannot.
+ *
+ * Discovery throws for a project with no root manifest and for workspace globs readyup cannot expand. Both
+ * mean the same thing here -- no workspace answers to this name -- and letting either escape would replace
+ * the caller's actionable "configured package was not found" with a diagnostic about the repository's shape.
+ */
+function discoverWorkspacesOrNone(fromDir: string): Workspace[] {
+  try {
+    return discoverWorkspacesAt(fromDir);
+  } catch {
+    return [];
+  }
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/list/__tests__/listCommand.packages.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.packages.unit.test.ts
@@ -112,13 +112,13 @@ describe('list --packages', () => {
       expect(stdout).not.toContain('Available');
     });
 
-    it('warns and omits a configured package that is not installed', async () => {
+    it('warns and omits a configured package that cannot be resolved', async () => {
       configurePackages(['absent-package']);
 
       const { exitCode, stdout, stderr } = await list(['--packages']);
 
       expect(exitCode).toBe(0);
-      expect(stderr).toContain('Configured package "absent-package" is not installed');
+      expect(stderr).toContain('Configured package "absent-package" was not found');
       expect(stdout).not.toContain('absent-package');
     });
   });


### PR DESCRIPTION
## What

Resolves a configured package through the running project's own workspaces when the package is not present in `node_modules`, so a monorepo can run its own packages' kits over itself without declaring a dependency on them purely to make them resolvable. The fallback applies to both `rdy run --packages` and `rdy list --packages`.

`node_modules` is still searched first, so an installed package resolves exactly as before. When a configured name matches neither an installed package nor a workspace, readyup now reports `Configured package "X" was not found; it must be a direct dependency of this project or one of its workspaces.`

## Why

A monorepo whose own workspaces publish kits declares no dependency on them at the root, so pnpm links none of them into `node_modules` and `rdy run --packages` failed outright: a repo could not run the kits its own packages publish over itself. The workaround was to declare each kit-publishing workspace as a root dependency purely to make it resolvable. That entry served no other purpose, and it made the workspace importable from root code, where the import resolves to a `dist/` the root has no reason to have built.

## Details

### 🎉 Features

- A configured package whose name matches the `name` in a workspace's manifest resolves to that workspace's directory, and its kits are read from there as for any installed package. `private: true` does not disqualify a workspace: `private` prevents publication to a registry and has no bearing on discovery inside the repo.
- Resolution is anchored to the directory whose config named the package, so `rdy list --recursive --packages` reads the workspaces of each project it sweeps rather than those of the invoking directory.
- Where workspace discovery fails, for want of a root manifest or through workspace globs readyup cannot expand, readyup reports the configured-package error above instead of a workspace-discovery error.
- `--from npm:<name>` is unchanged, since that prefix names an installed package; its "is not installed" error keeps its wording.

### ♻️ Refactoring

- `discoverWorkspaces` splits into a directory-taking `discoverWorkspacesAt(dir, options?)` and a wrapper that passes `process.cwd()`. The memo is now keyed by the resolved directory instead of the cwd. `discoverWorkspacesAt` is not exported from `readyup/check-utils`: A kit runs in the project it checks, so `discoverWorkspaces` remains the function a kit author needs.

### 🧪 Tests

- A new `expandConfiguredPackages.workspaces.unit.test.ts` suite covers the fallback, the precedence of an installed copy over a workspace, a private workspace, and both discovery-failure paths. Its anchoring case configures `readyup` against a temp tree containing no such workspace, so the assertion fails if resolution reads the cwd instead of the directory it is given.

### ⚙️ Tooling

- The new suite is added to the `vitest/consistent-test-it` exemption list in `eslint.config.ts`.

### 📚 Documentation

- The `rdy list --packages` passage and the package-hosted-kits limitations passage in `packages/readyup/README.md` describe the fallback, and neither still implies that a configured package must be an installed dependency.

Closes #389
