### PR TITLE
#316 Anchor a kit's compile on its own package root

### DIFF
--- a/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
@@ -110,7 +110,7 @@ function compareToRecordedInputs(inputs: ManifestInput[]): CheckOutcome {
  * Compares what was hashed against the hash recorded for it, and reports how it differs.
  *
  * `verb` names what the digest covers: an inline input's is over the projection substituted into the
- * bundle, not over the bytes of the file holding it.
+ * bundle, not over the contents of the file holding it.
  */
 function describeHashDrift(filePath: string, hashed: string, expected: string, verb: string): string | undefined {
   const actual = computeHash(hashed).slice(0, expected.length);

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -448,7 +448,7 @@ Two consequences follow from the value being resolved at compile time:
 
 ### TypeScript settings
 
-Kits compile with no `tsconfig.json`. Whatever config sits above a kit is ignored, so the same source compiles to the same bytes in any repository and a published bundle is the one its author built.
+Kits compile with no `tsconfig.json`. Whatever config sits above a kit is ignored, so the same source compiles to the same bundle in any repository and a published bundle is the one its author built.
 
 Kits are bundled by esbuild, and its defaults apply, with two settings declared:
 
@@ -633,7 +633,7 @@ FAIL  Total: 1 error, 1 passed, 1 skipped (151ms)
 == @acme/release-kit@2.1.0 / npm-auto-publish / repo
 ```
 
-Once a style is named explicitly, output is byte-identical to a terminal or a pipe. `--style` is independent of `--json`: the JSON document never changes.
+Once a style is named explicitly, output is identical to a terminal or a pipe. `--style` is independent of `--json`: the JSON document never changes.
 
 ### Suppressing a finding
 
@@ -1031,7 +1031,7 @@ Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `fa
 | `sourceHash`          | Hash of that source, read back out of its own `inputs` record                               |
 | `targetHash`          | Hash of the compiled bundle                                                                 |
 
-`inputs` is the compile's input closure: every module the bundle inlined past the entry, and every JSON file [`pickJson`](#inlining-json-at-compile-time) projected. A module records the hash of its bytes. An inlined JSON file records the hash of the projection that was substituted, with the path specifier that produced it, so an edit to a field the kit did not pick is not staleness.
+`inputs` is the compile's input closure: every module the bundle inlined past the entry, and every JSON file [`pickJson`](#inlining-json-at-compile-time) projected. A module records the hash of its contents. An inlined JSON file records the hash of the projection that was substituted, with the path specifier that produced it, so an edit to a field the kit did not pick is not staleness.
 
 The closure stops at `node_modules`. A dependency's contents are pinned by the lockfile and read exactly by [`rdy verify --rebuild`](#verifying-by-recompiling), while recording them would size a committed, per-compile-rewritten manifest to the dependency tree rather than to the kit: one `import zod` inlines 79 files.
 
@@ -1208,7 +1208,9 @@ The verdict is `ok`, `mismatch`, `failed` (the source no longer compiles), or `m
 
 Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`, plus `rebuildCompiledWith` when the bundle was built by a different readyup, `rebuildEsbuild` (the recorded esbuild against the rebuild's) whenever the entry records one, and `rebuildDependencyChanges` when at least one bundled package's version moved; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
 
-Three things to know before wiring it into CI: It requires esbuild, which a repository that compiles kits already has. The readyup version forms part of a bundle's hash, so a readyup upgrade makes every kit mismatch until recompiled; an esbuild or dependency upgrade mismatches wherever it changes a bundle's bytes, and the mismatch clause names it. And it must not run after a step that recompiles kits, because recompilation would defeat the comparison.
+Three things to know before wiring it into CI: It requires esbuild, which a repository that compiles kits already has. The readyup version forms part of a bundle's hash, so a readyup upgrade makes every kit mismatch until recompiled; an esbuild or dependency upgrade mismatches wherever it changes a bundle, and the mismatch clause names it. And it must not run after a step that recompiles kits, because recompilation would defeat the comparison.
+
+The directory the command runs in is not one of them. The same source in the same package always compiles to the same bundle, so `rdy verify --rebuild` returns the same verdict from anywhere in the repository.
 
 ```yaml
 - run: npx rdy verify --rebuild

--- a/packages/readyup/src/check-utils/git/run-git.ts
+++ b/packages/readyup/src/check-utils/git/run-git.ts
@@ -10,7 +10,7 @@ export async function runGit(path: string, ...args: string[]): Promise<string> {
 }
 
 /**
- * Runs a git command in the given directory and returns its stdout byte for byte.
+ * Runs a git command in the given directory and returns its stdout unaltered.
  *
  * Reach for this where a path is part of the output: trimming strips a leading space or tab from the first path of a
  * listing, and the file it names then reads as missing.

--- a/packages/readyup/src/compile/CompiledInput.ts
+++ b/packages/readyup/src/compile/CompiledInput.ts
@@ -7,7 +7,7 @@ import type { JsonPathSpec } from './extractJsonPaths.ts';
  * already does for a kit's `path` and `source`. Kept distinct from the manifest's own record so that
  * neither type means two different things about its own `path`.
  *
- * A `module` record's hash is over the file's bytes. An `inline` record's is over the projection that was
+ * A `module` record's hash is over the file's contents. An `inline` record's is over the projection that was
  * substituted into the bundle, which is why it alone carries the specifier that produced it.
  */
 export type CompiledInput =
@@ -17,7 +17,7 @@ export type CompiledInput =
  * Returns a recorded input's identity, which is its path and its kind together.
  *
  * A JSON file a kit both imports and projects is two inputs, not one, because the two record different
- * bytes about it.
+ * content from it.
  */
 export function identifyInput(kind: CompiledInput['kind'], filePath: string): string {
   return `${kind}\u{0}${filePath}`;

--- a/packages/readyup/src/compile/__tests__/buildBundle.closure.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.closure.tool.test.ts
@@ -26,6 +26,9 @@ describe('buildBundle input closure', () => {
 
   beforeAll(async () => {
     treeRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'closure-')));
+    // Anchors the compile on the fixture's own root rather than on whichever ancestor of the OS
+    // temporary directory happens to hold a manifest.
+    writeFileSync(path.join(treeRoot, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0' }));
     writeFileSync(path.join(treeRoot, 'kit.ts'), KIT_SOURCE);
     writeFileSync(path.join(treeRoot, 'helper.ts'), HELPER_SOURCE);
     writeFileSync(path.join(treeRoot, 'data.json'), DATA_JSON);

--- a/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
@@ -26,6 +26,9 @@ describe('buildBundle bundled dependencies', () => {
 
   beforeAll(async () => {
     treeRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'dependencies-')));
+    // Anchors the compile on the fixture's own root rather than on whichever ancestor of the OS
+    // temporary directory happens to hold a manifest.
+    writeFileSync(path.join(treeRoot, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0' }));
     writeFileSync(path.join(treeRoot, 'kit.ts'), KIT_SOURCE);
 
     writePackage(path.join(treeRoot, 'node_modules', 'tiny-dep'), { name: 'tiny-dep', version: '1.0.0' }, [

--- a/packages/readyup/src/compile/__tests__/buildBundle.reproducibility.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.reproducibility.tool.test.ts
@@ -1,0 +1,80 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { BundleResult } from '../buildBundle.ts';
+import { buildBundle } from '../buildBundle.ts';
+
+const KIT_SOURCE = [
+  `import { pickJson } from '${path.resolve(import.meta.dirname, '../pickJson.ts')}';`,
+  `import { helper } from './helper.ts';`,
+  `import { tiny } from 'tiny-dep';`,
+  '',
+  `export const meta = pickJson('./data.json', ['version']);`,
+  'export const kit = { helper, meta, tiny };',
+].join('\n');
+
+/**
+ * Compiles one kit from directories that are neither its own nor each other's, which is the property
+ * `rdy verify --rebuild` rests on: it recompiles in whatever directory the verification runs in.
+ */
+describe('buildBundle reproducibility', () => {
+  let treeRoot: string;
+  let kitPath: string;
+  let fromRepo: BundleResult;
+  let fromKitsDir: BundleResult;
+  const originalCwd = process.cwd();
+
+  beforeAll(async () => {
+    treeRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'reproducibility-')));
+    // Anchors the compile on the fixture's own root rather than on whichever ancestor of the OS
+    // temporary directory happens to hold a manifest.
+    writeFileSync(path.join(treeRoot, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0' }));
+
+    const kitsDir = path.join(treeRoot, 'kits');
+    mkdirSync(kitsDir, { recursive: true });
+    kitPath = path.join(kitsDir, 'kit.ts');
+    writeFileSync(kitPath, KIT_SOURCE);
+    writeFileSync(path.join(kitsDir, 'helper.ts'), "export const helper = 'helper';\n");
+    writeFileSync(path.join(kitsDir, 'data.json'), JSON.stringify({ name: 'fixture', version: '1.0.0' }));
+
+    const dependencyDir = path.join(treeRoot, 'node_modules', 'tiny-dep');
+    mkdirSync(dependencyDir, { recursive: true });
+    writeFileSync(path.join(dependencyDir, 'package.json'), JSON.stringify({ name: 'tiny-dep', version: '1.0.0' }));
+    writeFileSync(path.join(dependencyDir, 'index.js'), 'export const tiny = 1;\n');
+
+    fromRepo = await buildBundle(kitPath);
+
+    process.chdir(kitsDir);
+    try {
+      fromKitsDir = await buildBundle(kitPath);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  afterAll(() => {
+    rmSync(treeRoot, { recursive: true, force: true });
+  });
+
+  it('produces identical bytes whatever directory the compile runs in', () => {
+    expect(fromKitsDir.bytes.equals(fromRepo.bytes)).toBe(true);
+  });
+
+  it('records the same input closure', () => {
+    expect(fromKitsDir.inputs).toStrictEqual(fromRepo.inputs);
+  });
+
+  it('records the same bundled dependencies', () => {
+    expect(fromKitsDir.bundledDependencies).toStrictEqual(fromRepo.bundledDependencies);
+  });
+
+  it("names each bundled module against the kit's package root", () => {
+    // The bundle is identical under any anchor derived from the kit, so this is what pins the anchor to
+    // the one every committed bundle was compiled under.
+    expect(fromRepo.bytes.toString('utf8')).toContain('// kits/kit.ts');
+  });
+});

--- a/packages/readyup/src/compile/__tests__/compileConfig.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileConfig.unit.test.ts
@@ -1,5 +1,5 @@
+import { realpathSync } from 'node:fs';
 import path from 'node:path';
-import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -18,12 +18,18 @@ vi.mock(import('../loadEsbuild.ts'), () => ({
   loadEsbuild: mockLoadEsbuild,
 }));
 
-vi.mock(import('node:fs'), () => ({
+// Spreads the original so that `realpathSync`, which the compile root is resolved through, stays real.
+vi.mock(import('node:fs'), async (importOriginal) => ({
+  ...(await importOriginal()),
   existsSync: mockExistsSync,
   mkdirSync: mockMkdirSync,
   readFileSync: mockReadFileSync,
   writeFileSync: mockWriteFileSync,
 }));
+
+// Names a directory that exists whatever the working directory is, because the compile root is resolved
+// through `realpathSync` of the entry's own directory once `existsSync` reports no `package.json` above it.
+const CONFIG_PATH = path.join(import.meta.dirname, 'readyup.config.ts');
 
 describe(compileConfig, () => {
   beforeEach(() => {
@@ -45,11 +51,13 @@ describe(compileConfig, () => {
     mockBuild.mockResolvedValue(buildResult('compiled'));
     mockExistsSync.mockReturnValue(false);
 
-    await compileConfig('config/readyup.config.ts');
+    await compileConfig(CONFIG_PATH);
 
     expect(mockBuild).toHaveBeenCalledWith({
-      entryPoints: [path.resolve('config/readyup.config.ts')],
-      absWorkingDir: process.cwd(),
+      entryPoints: [CONFIG_PATH],
+      // `existsSync` reports no `package.json` anywhere, so the compile root falls back to the source's
+      // own directory.
+      absWorkingDir: realpathSync(import.meta.dirname),
       bundle: true,
       format: 'esm',
       platform: 'node',
@@ -67,7 +75,7 @@ describe(compileConfig, () => {
     mockBuild.mockResolvedValue(buildResult('compiled'));
     mockExistsSync.mockReturnValue(false);
 
-    await compileConfig('config/readyup.config.ts');
+    await compileConfig(CONFIG_PATH);
 
     expect(mockBuild).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -80,7 +88,7 @@ describe(compileConfig, () => {
     mockBuild.mockResolvedValue(buildResult('compiled'));
     mockExistsSync.mockReturnValue(false);
 
-    const result = await compileConfig('config/readyup.config.ts');
+    const result = await compileConfig(CONFIG_PATH);
 
     expect(result.esbuildVersion).toBe('0.99.0-test');
   });
@@ -89,7 +97,7 @@ describe(compileConfig, () => {
     mockBuild.mockResolvedValue(buildResult('compiled'));
     mockExistsSync.mockReturnValue(false);
 
-    const result = await compileConfig('config/readyup.config.ts');
+    const result = await compileConfig(CONFIG_PATH);
 
     expect(result.bundledDependencies).toStrictEqual({});
   });
@@ -98,16 +106,16 @@ describe(compileConfig, () => {
     mockBuild.mockResolvedValue(buildResult('compiled'));
     mockExistsSync.mockReturnValue(false);
 
-    const result = await compileConfig('config/readyup.config.ts');
+    const result = await compileConfig(CONFIG_PATH);
 
-    expect(result.outputPath).toBe(path.resolve('config/readyup.config.js'));
+    expect(result.outputPath).toBe(path.join(import.meta.dirname, 'readyup.config.js'));
   });
 
   it('uses a custom output path when provided', async () => {
     mockBuild.mockResolvedValue(buildResult('compiled'));
     mockExistsSync.mockReturnValue(false);
 
-    const result = await compileConfig('config/readyup.config.ts', 'dist/bundle.js');
+    const result = await compileConfig(CONFIG_PATH, 'dist/bundle.js');
 
     expect(result.outputPath).toBe(path.resolve('dist/bundle.js'));
   });

--- a/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { resolveCompileRoot } from '../resolveCompileRoot.ts';
+
+const MANIFEST = JSON.stringify({ name: 'fixture', version: '1.0.0' });
+
+describe(resolveCompileRoot, () => {
+  let treeRoot: string;
+
+  beforeAll(() => {
+    treeRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'compile-root-')));
+
+    // Two cases below assert that a walk reaching the filesystem root finds nothing, which only holds
+    // where no directory above the fixture carries a manifest of its own.
+    const ancestorManifest = findAncestorManifest(treeRoot);
+    assert.ok(
+      ancestorManifest === undefined,
+      `${ancestorManifest} sits above the fixture, so the unpackaged cases cannot be tested here`,
+    );
+
+    writePackage(path.join(treeRoot, 'outer'));
+    writePackage(path.join(treeRoot, 'outer', 'inner'));
+    mkdirSync(path.join(treeRoot, 'outer', 'inner', 'kits'), { recursive: true });
+    mkdirSync(path.join(treeRoot, 'outer', 'deep', 'kits'), { recursive: true });
+    mkdirSync(path.join(treeRoot, 'unpackaged', 'kits'), { recursive: true });
+
+    symlinkSync(path.join(treeRoot, 'outer'), path.join(treeRoot, 'link'), 'dir');
+  });
+
+  afterAll(() => {
+    rmSync(treeRoot, { recursive: true, force: true });
+  });
+
+  it('answers with the nearest ancestor holding a package.json', () => {
+    const root = resolveCompileRoot(path.join(treeRoot, 'outer', 'inner', 'kits', 'kit.ts'));
+
+    expect(root).toBe(path.join(treeRoot, 'outer', 'inner'));
+  });
+
+  it('walks past ancestors holding none', () => {
+    const root = resolveCompileRoot(path.join(treeRoot, 'outer', 'deep', 'kits', 'kit.ts'));
+
+    expect(root).toBe(path.join(treeRoot, 'outer'));
+  });
+
+  it("answers with the source's own directory when no ancestor holds a package.json", () => {
+    const kitsDir = path.join(treeRoot, 'unpackaged', 'kits');
+
+    expect(resolveCompileRoot(path.join(kitsDir, 'kit.ts'))).toBe(kitsDir);
+  });
+
+  it('answers with a real path for a source reached through a symlinked ancestor', () => {
+    const root = resolveCompileRoot(path.join(treeRoot, 'link', 'inner', 'kits', 'kit.ts'));
+
+    expect(root).toBe(path.join(treeRoot, 'outer', 'inner'));
+  });
+
+  it('answers for a source that does not exist, leaving the failure to the bundler', () => {
+    const kitsDir = path.join(treeRoot, 'unpackaged', 'absent');
+
+    expect(resolveCompileRoot(path.join(kitsDir, 'kit.ts'))).toBe(kitsDir);
+  });
+});
+
+// region | Helpers
+
+/** Returns the nearest directory at or above `fromDir` holding a `package.json`, or nothing where none does. */
+function findAncestorManifest(fromDir: string): string | undefined {
+  for (let directory = fromDir; ; directory = path.dirname(directory)) {
+    if (existsSync(path.join(directory, 'package.json'))) return directory;
+    if (path.dirname(directory) === directory) return undefined;
+  }
+}
+
+/** Creates a directory and the minimal `package.json` that makes it a package root. */
+function writePackage(directory: string): void {
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(path.join(directory, 'package.json'), MANIFEST);
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
-import process from 'node:process';
 
 import { describeError } from '@williamthorsen/toolbelt.errors';
 
@@ -12,6 +11,7 @@ import { identifyInput } from './CompiledInput.ts';
 import { createCompileRecorder } from './createCompileRecorder.ts';
 import { loadEsbuild } from './loadEsbuild.ts';
 import { pickJsonPlugin } from './pickJsonPlugin.ts';
+import { resolveCompileRoot } from './resolveCompileRoot.ts';
 
 /**
  * Directory whose contents stay out of a kit's recorded closure.
@@ -28,10 +28,10 @@ export const KIT_COMPILE_TARGET = 'es2025';
 /**
  * TypeScript settings kits compile under.
  *
- * Supplying this at all is what stops esbuild searching for a `tsconfig.json` above the kit, so a kit's
- * bytes are a function of its own sources rather than of whatever configuration the host repo happens to
- * keep above it. The two settings are the ones esbuild derives rather than fixes; stating them keeps a
- * version bump from moving kit semantics quietly. Everything else stays at esbuild's default.
+ * Supplying this at all is what stops esbuild searching for a `tsconfig.json` above the kit, so a kit compiles
+ * from its own sources rather than from whatever configuration the host repo happens to keep above it. The two
+ * settings are the ones esbuild derives rather than fixes; stating them keeps a version bump from moving kit
+ * semantics quietly. Everything else stays at esbuild's default.
  *
  * `target` is left undeclared, which is what keeps class-field semantics independent of
  * `KIT_COMPILE_TARGET`: esbuild derives `useDefineForClassFields` from the TypeScript `target`, so
@@ -59,8 +59,8 @@ const UNRESOLVED_SPECIFIER_HINT =
  *
  * Includes an exported `__readyupVersion` constant so the runner can detect skew between the
  * readyup version a kit was compiled against and the runner's own version at execution time. The
- * constant is part of the bundle's bytes, so a kit rebuilt under a different readyup differs from
- * the one on disk even when its source has not moved.
+ * constant is part of the bundle, so a kit rebuilt under a different readyup differs from the one on
+ * disk even when its source has not moved.
  */
 const GENERATED_HEADER = [
   '/** @noformat — @generated. Do not edit. Compiled by rdy. */',
@@ -69,7 +69,7 @@ const GENERATED_HEADER = [
   '',
 ].join('\n');
 
-/** A kit's compiled bytes and the closure of files the compile read to produce them. */
+/** A kit's compiled bundle and the closure of files the compile read to produce it. */
 export interface BundleResult {
   /** Every package the bundle inlined, by name, with the version its `package.json` declares. */
   bundledDependencies: Record<string, string>;
@@ -84,7 +84,7 @@ export interface BundleResult {
 }
 
 /**
- * Bundles a TypeScript checklist file into a self-contained ESM bundle and returns its bytes.
+ * Bundles a TypeScript checklist file into a self-contained ESM bundle and returns it.
  *
  * Node built-in modules and the `readyup` package (including `readyup/*` subpaths) are kept
  * external; all other imports are inlined. The externalized `readyup` specifiers are resolved at
@@ -96,16 +96,17 @@ export interface BundleResult {
  * compile would have produced -- a property that holds by construction rather than by two option
  * objects being kept in agreement.
  *
- * Takes no output path, because none can reach the result: esbuild is invoked without `outfile`. The bytes
- * are a function of the entry point, the plugin, and the working directory, against which esbuild renders
- * each bundled module's path into the output.
+ * Takes no output path, because none can reach the result: esbuild is invoked without `outfile`. The bundle
+ * is determined by the entry point and the plugin. esbuild renders each bundled module's path into the
+ * output against the working directory, which `resolveCompileRoot` derives from the kit itself, so the
+ * directory the compile was invoked from does not reach the bundle.
  *
  * The one place a compile's input closure is known, which is why it returns the closure alongside the
- * bytes rather than leaving a later reader to reconstruct it.
+ * bundle rather than leaving a later reader to reconstruct it.
  */
 export async function buildBundle(inputPath: string): Promise<BundleResult> {
   const resolvedInput = path.resolve(inputPath);
-  const workingDir = process.cwd();
+  const workingDir = resolveCompileRoot(resolvedInput);
 
   let esbuild: typeof import('esbuild');
   try {
@@ -190,7 +191,7 @@ function collectBundledDependencies(metafileKeys: string[], workingDir: string):
  *
  * A recorded read wins over the metafile's account of the same file, because only the recorder knows an
  * inline input's path specifier. The metafile keys are relative to the working directory esbuild ran
- * under, which is pinned rather than defaulted so that resolving them cannot drift.
+ * under, which is the kit's own compile root rather than the invocation's, so resolving them cannot drift.
  *
  * Sorted so that recompiling a kit whose inputs have not moved rewrites the manifest identically.
  */

--- a/packages/readyup/src/compile/compileConfig.ts
+++ b/packages/readyup/src/compile/compileConfig.ts
@@ -27,7 +27,7 @@ export interface CompileResult {
  * Bundles a TypeScript checklist file and writes the result to disk.
  *
  * The bundle itself is `buildBundle`'s; this adds the destination. Writing is skipped when the
- * bytes already on disk are identical, so a compile that changes nothing leaves the file's mtime
+ * file already on disk is identical, so a compile that changes nothing leaves the file's mtime
  * alone.
  */
 export async function compileConfig(inputPath: string, outputPath?: string): Promise<CompileResult> {

--- a/packages/readyup/src/compile/createCompileRecorder.ts
+++ b/packages/readyup/src/compile/createCompileRecorder.ts
@@ -18,7 +18,7 @@ export interface CompileRecorder {
   /** Every file read so far, one record per path and kind, in the order the reads happened. */
   readonly inputs: CompiledInput[];
 
-  /** Reads a module and records its bytes. */
+  /** Reads a module and records its contents. */
   readModule(filePath: string): string;
 
   /**

--- a/packages/readyup/src/compile/projectJsonFile.ts
+++ b/packages/readyup/src/compile/projectJsonFile.ts
@@ -15,8 +15,8 @@ import { JsonProjectionError } from './JsonProjectionError.ts';
  * projection's serialization is hashed it is a format, so a second implementation of it would drift and
  * the two would disagree about a file neither had changed.
  *
- * Returns the serialized form rather than the projected object, which is what makes the bytes a compile
- * hashes the bytes it substitutes.
+ * Returns the serialized form rather than the projected object, so a compile hashes exactly what it
+ * substitutes.
  */
 export function projectJsonFile(filePath: string, paths: JsonPathSpec): string {
   let contents: string;

--- a/packages/readyup/src/compile/resolveCompileRoot.ts
+++ b/packages/readyup/src/compile/resolveCompileRoot.ts
@@ -1,0 +1,45 @@
+import { existsSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+
+/** Marker naming the directory a kit belongs to, and the unit a published package ships as. */
+const PACKAGE_MANIFEST = 'package.json';
+
+/**
+ * Returns the directory a kit compiles under: the nearest ancestor holding a `package.json`, or the
+ * source's own directory where no ancestor holds one.
+ *
+ * esbuild renders every bundled module's path against the working directory and writes it into the
+ * output, so this decides what a kit compiles to. Anchoring on the package root is what makes a bundle
+ * reproducible from any directory, and it keeps a bundle's paths naming the kit's place in the package
+ * that ships it.
+ *
+ * Answers with a real path. esbuild reports the paths it resolved modules to, and a compile resolves
+ * the metafile's keys against this directory, so an answer reached through a symlink would record a
+ * closure whose paths no reader of it can match.
+ */
+export function resolveCompileRoot(inputPath: string): string {
+  const sourceDir = path.dirname(path.resolve(inputPath));
+
+  for (let directory = sourceDir; ; directory = path.dirname(directory)) {
+    if (existsSync(path.join(directory, PACKAGE_MANIFEST))) return toRealPath(directory);
+    if (path.dirname(directory) === directory) return toRealPath(sourceDir);
+  }
+}
+
+// region | Helpers
+
+/**
+ * Returns a directory's real path, or the directory itself where it cannot be read.
+ *
+ * A source that does not exist has no real directory to answer with, and is left to fail where the
+ * bundler reports it rather than as an `ENOENT` raised on the way there.
+ */
+function toRealPath(directory: string): string {
+  try {
+    return realpathSync(directory);
+  } catch {
+    return directory;
+  }
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -6,7 +6,7 @@ const JsonPathSpecSchema = z.array(z.union([z.string(), z.array(z.string())]));
 /**
  * Schema for one file the compile read to produce a kit's bundle.
  *
- * `kind` decides what the hash covers. A `module` records the file's bytes; an `inline` records the
+ * `kind` decides what the hash covers. A `module` records the file's contents; an `inline` records the
  * projection `pickJson` substituted, so an edit to a field the kit did not pick is not staleness. Only
  * an inline record carries `paths`, which is the specifier that produced the projection and so what a
  * reader needs to reproduce it.

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -97,7 +97,7 @@ export const RebuildDependencyChangeSchema = z
  * consumer pinned to this schema still validates a payload from a readyup that predates either.
  *
  * `rebuildStatus` and its fields appear only under `--rebuild`, so a run without the flag emits the
- * payload it always did. `rebuildExpected` is the hash of the recompiled bytes and `rebuildActual`
+ * payload it always did. `rebuildExpected` is the hash of the recompiled bundle and `rebuildActual`
  * the hash of the bundle on disk, both present only on `mismatch`; `rebuildError` carries the
  * compile failure on `failed`. `rebuildCompiledWith` names the readyup a mismatched bundle was
  * built by, present only when it differs from the running one, which is what separates a mismatch

--- a/packages/readyup/src/verify/__tests__/checkRebuild.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkRebuild.unit.test.ts
@@ -186,7 +186,7 @@ function kit() {
   return { name: 'demo', path: 'demo.js', source: 'demo.ts' };
 }
 
-/** Returns a `buildBundle` result whose bytes mismatch the bundle `writeKitFiles` lays down. */
+/** Returns a `buildBundle` result that mismatches the bundle `writeKitFiles` lays down. */
 function rebuildResult(overrides: { esbuildVersion?: string; bundledDependencies?: Record<string, string> } = {}) {
   return {
     bundledDependencies: {},

--- a/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
@@ -49,10 +49,12 @@ describe('verifyCommand --rebuild', () => {
     tempDir = mkdtempSync(path.join(tmpdir(), 'verify-rebuild-'));
     writeFileSync(path.join(tempDir, 'data.json'), JSON.stringify({ name: 'demo', version: '1.0.0' }));
     writeFileSync(path.join(tempDir, 'kit.ts'), KIT_SOURCE);
+    // Anchors the compile on the fixture's own root rather than on whichever ancestor of the OS
+    // temporary directory happens to hold a manifest.
+    writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'fixture', version: '1.0.0' }));
 
     originalCwd = process.cwd();
-    // esbuild renders each module's path against the working directory, so the fixture is compiled from
-    // the directory it is verified from, as a real project is.
+    // `runVerify` names the manifest by a relative path, as a real project's invocation does.
     process.chdir(tempDir);
 
     // Record the manifest from a real compile, so its hashes are the ones the pipeline produces.
@@ -87,6 +89,18 @@ describe('verifyCommand --rebuild', () => {
 
   it('passes an untouched tree', async () => {
     const { exitCode, stdout } = await runVerify();
+
+    expect(exitCode).toBe(0);
+    expect(readPayload(stdout)).toMatchObject({
+      passed: true,
+      kits: [{ name: 'demo', status: 'ok', sourceStatus: 'ok', rebuildStatus: 'ok' }],
+    });
+  });
+
+  it('passes an untouched tree from a directory other than the one the kit was compiled in', async () => {
+    process.chdir(originalCwd);
+
+    const { exitCode, stdout } = await runVerify({ manifestPath: path.join(tempDir, 'manifest.json') });
 
     expect(exitCode).toBe(0);
     expect(readPayload(stdout)).toMatchObject({
@@ -234,7 +248,7 @@ function readPayload(stdout: string): JsonVerifyOutput {
 }
 
 /**
- * Rewrites the bundle's version stamp and re-records the manifest against the restamped bytes.
+ * Rewrites the bundle's version stamp and re-records the manifest against the restamped bundle.
  *
  * The stamp, the recorded `targetHash`, and the recorded `readyupVersion` all name the earlier
  * readyup, which is the state a version bump leaves behind.
@@ -254,11 +268,11 @@ function restampBundle(tempDir: string, version: string): void {
  * Runs `verify` over the tempdir's manifest with JSON output on and the rebuild check on unless waived,
  * returning its exit code alongside what it wrote.
  */
-async function runVerify({ rebuild = true }: { rebuild?: boolean } = {}) {
+async function runVerify({ rebuild = true, manifestPath = 'manifest.json' } = {}) {
   using io = captureStdio();
 
   const rebuildFlag = rebuild ? ['--rebuild'] : [];
-  const exitCode = await verifyCommand(['--manifest', 'manifest.json', ...rebuildFlag, '--json']);
+  const exitCode = await verifyCommand(['--manifest', manifestPath, ...rebuildFlag, '--json']);
 
   return { exitCode, stdout: io.stdout };
 }

--- a/packages/readyup/src/verify/checkRebuild.ts
+++ b/packages/readyup/src/verify/checkRebuild.ts
@@ -49,7 +49,7 @@ export interface EsbuildComparison {
  * mismatch compares the entry's recorded `esbuildVersion` and `bundledDependencies` against the
  * rebuild's own record to name which versions changed.
  *
- * Compares against the on-disk bytes and never against `targetHash`, so the verdict is independent
+ * Compares against the bundle on disk and never against `targetHash`, so the verdict is independent
  * of the manifest's bookkeeping and can contradict it. A kit whose recorded hash has gone wrong
  * reports drift and a passing rebuild together, which is how the two verdicts distinguish a corrupt
  * bundle from corrupt bookkeeping.
@@ -92,7 +92,7 @@ export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Pr
   }
 
   // The generated banner embeds the compiling readyup's version, so a version move alone makes an
-  // untouched source rebuild to different bytes. Carry the recorded version to keep that cause
+  // untouched source rebuild to a different bundle. Carry the recorded version to keep that cause
   // distinguishable from a hand edit.
   const compiledWith = kit.readyupVersion !== VERSION ? kit.readyupVersion : undefined;
 

--- a/packages/readyup/src/verify/targetHash.ts
+++ b/packages/readyup/src/verify/targetHash.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 /** Length of the hex prefix stored in the manifest's `targetHash` field. */
 const HASH_PREFIX_LENGTH = 8;
 
-/** Return the first 8 hex chars of the SHA-256 digest of in-memory bytes. */
+/** Return the first 8 hex chars of the SHA-256 digest of a buffer. */
 export function hashBytes(bytes: Buffer): string {
   return createHash('sha256').update(bytes).digest('hex').slice(0, HASH_PREFIX_LENGTH);
 }


### PR DESCRIPTION
## What

Fixes an issue where `rdy verify --rebuild` reported a mismatch for an unchanged kit whenever it ran from a directory other than the one the kit was compiled in. `rdy compile` now anchors a kit on the nearest package root above its source, so the same source in the same package always compiles to the same bundle.

Committed bundles are unchanged: The package root is the anchor they were already compiled under.

## Why

`rdy verify --rebuild` exists to answer whether a committed bundle still reproduces from its source. A repository that wired it into CI got a trustworthy answer from one directory only; from anywhere else the command failed the build on every kit, which makes it unusable as a gate unless the job's working directory happens to match the one the kits were compiled from.

## Details

### 🐛 Bug fixes

- `buildBundle` pinned esbuild's `absWorkingDir` to `process.cwd()`. esbuild renders every bundled module's path against that directory and writes it into the output, so recompiling a kit somewhere else produced a different bundle, a different `targetHash`, and a different `--rebuild` verdict.
- A new `resolveCompileRoot` decides the anchor from the kit's source path alone: the nearest ancestor holding a `package.json`, falling back to the source's own directory. `buildBundle` derives it internally rather than accepting it as a parameter, so `compileConfig` and `checkRebuild` cannot supply different anchors, and the bundle a verification recompiles is the bundle a compile would have produced by construction.
- The anchor is a real path. `collectInputs` resolves the metafile's keys against it and `deriveClosureFields` matches the entry by its real path, so an anchor reached through a symlink -- a pnpm workspace link, or a macOS temporary directory -- would record a closure no reader of it can match.
- The anchor is deliberately not `identifyPackage`, which is bounded to `node_modules` and climbs past a manifest that fails to declare both `name` and `version`, nor `resolveWorkspaceAnchor`, which keys on `pnpm-workspace.yaml` and `.git`; neither survives into a published tarball, and the latter would have changed every committed bundle.

### 🧪 Tests

- `resolveCompileRoot.unit.test.ts` covers the anchor rule: nearest ancestor wins, the walk passes ancestors holding no manifest, a source under none resolves to its own directory, a symlinked ancestor resolves to a real path, and a nonexistent source returns a directory rather than raising `ENOENT`.
- `buildBundle.reproducibility.tool.test.ts` compiles one kit under two working directories and asserts that the two bundles are identical, along with their `inputs` and `bundledDependencies`. A separate case asserts the rendered path of a bundled module, which is what pins the anchor to the package root: any anchor derived from the kit yields identical bundles, so equality alone would pass with an anchor that changes every committed bundle.
- `verifyCommand.rebuild.tool.test.ts` adds the end-to-end case, verifying a kit from a directory other than the one it was compiled in.
- Each touched fixture writes a root `package.json`, so the anchor comes from the rule rather than from whichever ancestor of the OS temporary directory happens to hold one.

### 📚 Documentation

- The README's `--rebuild` section states the guarantee alongside the caveats it already lists for wiring the command into CI.

Closes #316
