### PR TITLE
#256 Adopt region folds for overlay's module-level helpers

### DIFF
--- a/packages/overlay/src/__tests__/overlay.tool.test.ts
+++ b/packages/overlay/src/__tests__/overlay.tool.test.ts
@@ -9,21 +9,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { MIN_CHEZMOI_VERSION, parseVersion } from '../chezmoi/version.ts';
 import { overlay } from '../overlay.ts';
 
-/** Detects a chezmoi binary on PATH meeting the minimum version, so these tests skip cleanly when absent. */
-function detectChezmoi(): boolean {
-  try {
-    const output = execFileSync('chezmoi', ['--version'], { encoding: 'utf8' });
-    const installed = parseVersion(output);
-    const minimum = parseVersion(MIN_CHEZMOI_VERSION);
-    if (installed === undefined || minimum === undefined) return false;
-    if (installed.major !== minimum.major) return installed.major > minimum.major;
-    if (installed.minor !== minimum.minor) return installed.minor > minimum.minor;
-    return installed.patch >= minimum.patch;
-  } catch {
-    return false;
-  }
-}
-
 const hasChezmoi = detectChezmoi();
 
 const NEW_CONTENT = 'hello new\n';
@@ -117,3 +102,22 @@ describe.skipIf(!hasChezmoi)('overlay against real chezmoi', () => {
     await writeFile(path.join(target, '.planted'), 'planted\n');
   }
 });
+
+// region | Helpers
+
+/** Detects a chezmoi binary on PATH meeting the minimum version, so these tests skip cleanly when absent. */
+function detectChezmoi(): boolean {
+  try {
+    const output = execFileSync('chezmoi', ['--version'], { encoding: 'utf8' });
+    const installed = parseVersion(output);
+    const minimum = parseVersion(MIN_CHEZMOI_VERSION);
+    if (installed === undefined || minimum === undefined) return false;
+    if (installed.major !== minimum.major) return installed.major > minimum.major;
+    if (installed.minor !== minimum.minor) return installed.minor > minimum.minor;
+    return installed.patch >= minimum.patch;
+  } catch {
+    return false;
+  }
+}
+
+// endregion | Helpers

--- a/packages/overlay/src/chezmoi/__tests__/runChezmoi.unit.test.ts
+++ b/packages/overlay/src/chezmoi/__tests__/runChezmoi.unit.test.ts
@@ -14,15 +14,6 @@ const { runChezmoiCaptured, runChezmoiStreamed } = await import('../runChezmoi.t
 
 const context = { source: '/abs/source', target: '/abs/target' };
 
-/** Signature of the Node-style callback the promisified `execFile` drives. */
-type ExecFileCallback = (error: unknown, result?: { stdout: string; stderr: string }) => void;
-
-/** A minimal stand-in for the spawned child process, registering close/error handlers. */
-interface ChildStub {
-  handlers: Map<string, (value: unknown) => void>;
-  on: (event: string, handler: (value: unknown) => void) => ChildStub;
-}
-
 describe(runChezmoiCaptured, () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -33,7 +24,7 @@ describe(runChezmoiCaptured, () => {
 
     await runChezmoiCaptured(context, ['status']);
 
-    const args = firstExecFileArgs();
+    const args = readFirstExecFileArgs();
     expect(execFileMock.mock.calls[0]?.[0]).toBe('chezmoi');
     expect(args).toContain('--source=/abs/source');
     expect(args).toContain('--destination=/abs/target');
@@ -97,18 +88,12 @@ describe(runChezmoiStreamed, () => {
   });
 });
 
-/** Drive the promisified `execFile` callback with a successful result. */
-function resolveExecFile(stdout: string): void {
-  execFileMock.mockImplementation((_cmd: string, _args: string[], callback: ExecFileCallback) => {
-    callback(null, { stdout, stderr: '' });
-  });
-}
+// region | Helpers
 
-/** Drive the promisified `execFile` callback with a rejection carrying captured streams. */
-function rejectExecFile(error: Record<string, unknown>): void {
-  execFileMock.mockImplementation((_cmd: string, _args: string[], callback: ExecFileCallback) => {
-    callback(error);
-  });
+/** A minimal stand-in for the spawned child process, registering close/error handlers. */
+interface ChildStub {
+  handlers: Map<string, (value: unknown) => void>;
+  on: (event: string, handler: (value: unknown) => void) => ChildStub;
 }
 
 /** Create a child stub and arrange for `spawn` to return it and emit `event` with `value` on the next microtask. */
@@ -129,7 +114,7 @@ function arrangeSpawn(event: string, value: unknown): ChildStub {
 }
 
 /** Read the args array passed to the first `execFile` call. */
-function firstExecFileArgs(): string[] {
+function readFirstExecFileArgs(): string[] {
   const call = execFileMock.mock.calls[0];
   const args: unknown = call?.[1];
   if (!Array.isArray(args)) return [];
@@ -143,3 +128,22 @@ function readStdio(options: unknown): unknown {
   }
   return undefined;
 }
+
+/** Signature of the Node-style callback the promisified `execFile` drives. */
+type ExecFileCallback = (error: unknown, result?: { stdout: string; stderr: string }) => void;
+
+/** Drive the promisified `execFile` callback with a rejection carrying captured streams. */
+function rejectExecFile(error: Record<string, unknown>): void {
+  execFileMock.mockImplementation((_cmd: string, _args: string[], callback: ExecFileCallback) => {
+    callback(error);
+  });
+}
+
+/** Drive the promisified `execFile` callback with a successful result. */
+function resolveExecFile(stdout: string): void {
+  execFileMock.mockImplementation((_cmd: string, _args: string[], callback: ExecFileCallback) => {
+    callback(null, { stdout, stderr: '' });
+  });
+}
+
+// endregion | Helpers

--- a/packages/overlay/src/chezmoi/__tests__/version.unit.test.ts
+++ b/packages/overlay/src/chezmoi/__tests__/version.unit.test.ts
@@ -56,7 +56,11 @@ describe(assertChezmoiVersion, () => {
   });
 });
 
+// region | Helpers
+
 /** Stub `chezmoi --version` to return the given stdout and exit code. */
 function mockVersionOutput(stdout: string, code = 0): void {
   vi.spyOn(runChezmoiModule, 'runChezmoiCaptured').mockResolvedValue({ stdout, stderr: '', code });
 }
+
+// endregion | Helpers

--- a/packages/overlay/src/chezmoi/parseStatus.ts
+++ b/packages/overlay/src/chezmoi/parseStatus.ts
@@ -29,6 +29,10 @@ export function parseStatus(stdout: string): StatusEntry[] {
   return entries;
 }
 
+// region | Helpers
+
 function isStatusCode(value: string): value is StatusCode {
   return APPLY_CODES.has(value);
 }
+
+// endregion | Helpers

--- a/packages/overlay/src/chezmoi/runChezmoi.ts
+++ b/packages/overlay/src/chezmoi/runChezmoi.ts
@@ -21,44 +21,6 @@ export interface ChezmoiContext {
 }
 
 /**
- * Build the chezmoi arguments shared by every invocation.
- *
- * Injects `--source`/`--destination`, the throwaway `--persistent-state` and empty `--config` paths, and `--no-tty`,
- * then the caller's own arguments.
- */
-function buildArgs(context: ChezmoiContext, persistentStatePath: string, configPath: string, args: string[]): string[] {
-  return [
-    `--source=${context.source}`,
-    `--destination=${context.target}`,
-    `--persistent-state=${persistentStatePath}`,
-    `--config=${configPath}`,
-    '--no-tty',
-    ...args,
-  ];
-}
-
-/**
- * Run a chezmoi command inside a throwaway state/config sandbox, invoking `body` with the fully-assembled argument
- * list. The sandbox is removed in a `finally`.
- */
-async function withSandbox<T>(
-  context: ChezmoiContext,
-  args: string[],
-  body: (fullArgs: string[]) => Promise<T>,
-): Promise<T> {
-  const sandboxDir = await mkdtemp(path.join(tmpdir(), 'overlay-chezmoi-'));
-  const persistentStatePath = path.join(sandboxDir, 'state.boltdb');
-  const configPath = path.join(sandboxDir, 'chezmoi.toml');
-  try {
-    await writeFile(configPath, '');
-    const fullArgs = buildArgs(context, persistentStatePath, configPath, args);
-    return await body(fullArgs);
-  } finally {
-    await rm(sandboxDir, { recursive: true, force: true });
-  }
-}
-
-/**
  * Run chezmoi and capture its output. Used for read-only commands (`status`, `--version`) where overlay needs the
  * text rather than live streaming.
  *
@@ -90,6 +52,25 @@ export async function runChezmoiStreamed(context: ChezmoiContext, args: string[]
   });
 }
 
+// region | Helpers
+
+/**
+ * Build the chezmoi arguments shared by every invocation.
+ *
+ * Injects `--source`/`--destination`, the throwaway `--persistent-state` and empty `--config` paths, and `--no-tty`,
+ * then the caller's own arguments.
+ */
+function buildArgs(context: ChezmoiContext, persistentStatePath: string, configPath: string, args: string[]): string[] {
+  return [
+    `--source=${context.source}`,
+    `--destination=${context.target}`,
+    `--persistent-state=${persistentStatePath}`,
+    `--config=${configPath}`,
+    '--no-tty',
+    ...args,
+  ];
+}
+
 /** Translate an `execFile` rejection into a `CapturedResult`, surfacing a missing binary as a clear error. */
 function interpretExecFileError(error: unknown): CapturedResult {
   if (isExecFileError(error)) {
@@ -115,3 +96,26 @@ interface ExecFileError {
 function isExecFileError(error: unknown): error is ExecFileError {
   return typeof error === 'object' && error !== null && 'code' in error;
 }
+
+/**
+ * Run a chezmoi command inside a throwaway state/config sandbox, invoking `body` with the fully-assembled argument
+ * list. The sandbox is removed in a `finally`.
+ */
+async function withSandbox<T>(
+  context: ChezmoiContext,
+  args: string[],
+  body: (fullArgs: string[]) => Promise<T>,
+): Promise<T> {
+  const sandboxDir = await mkdtemp(path.join(tmpdir(), 'overlay-chezmoi-'));
+  const persistentStatePath = path.join(sandboxDir, 'state.boltdb');
+  const configPath = path.join(sandboxDir, 'chezmoi.toml');
+  try {
+    await writeFile(configPath, '');
+    const fullArgs = buildArgs(context, persistentStatePath, configPath, args);
+    return await body(fullArgs);
+  } finally {
+    await rm(sandboxDir, { recursive: true, force: true });
+  }
+}
+
+// endregion | Helpers

--- a/packages/overlay/src/chezmoi/version.ts
+++ b/packages/overlay/src/chezmoi/version.ts
@@ -8,10 +8,7 @@ interface SemverParts {
 }
 
 /** Minimum chezmoi version whose `status`-column semantics overlay relies on. */
-const MINIMUM: SemverParts = { major: 2, minor: 46, patch: 0 };
-
-/** Minimum chezmoi version as a display string (e.g. `2.46.0`). */
-export const MIN_CHEZMOI_VERSION = formatVersion(MINIMUM);
+const MINIMUM_VERSION: SemverParts = { major: 2, minor: 46, patch: 0 };
 
 /**
  * Verify chezmoi is installed and meets `MIN_CHEZMOI_VERSION`.
@@ -28,10 +25,13 @@ export async function assertChezmoiVersion(context: ChezmoiContext): Promise<voi
   if (installed === undefined) {
     throw new Error(`could not determine chezmoi version from: ${stdout.trim()}`);
   }
-  if (compareVersions(installed, MINIMUM) < 0) {
+  if (compareVersions(installed, MINIMUM_VERSION) < 0) {
     throw new Error(`chezmoi ${MIN_CHEZMOI_VERSION} or later is required; found ${formatVersion(installed)}`);
   }
 }
+
+/** Minimum chezmoi version as a display string (e.g. `2.46.0`). */
+export const MIN_CHEZMOI_VERSION = formatVersion(MINIMUM_VERSION);
 
 /** Extract the first `major.minor.patch` triple from chezmoi's version string. */
 export function parseVersion(text: string): SemverParts | undefined {
@@ -42,6 +42,8 @@ export function parseVersion(text: string): SemverParts | undefined {
   return { major: Number(major), minor: Number(minor), patch: Number(patch) };
 }
 
+// region | Helpers
+
 function compareVersions(a: SemverParts, b: SemverParts): number {
   if (a.major !== b.major) return a.major - b.major;
   if (a.minor !== b.minor) return a.minor - b.minor;
@@ -51,3 +53,5 @@ function compareVersions(a: SemverParts, b: SemverParts): number {
 function formatVersion(parts: SemverParts): string {
   return `${parts.major}.${parts.minor}.${parts.patch}`;
 }
+
+// endregion | Helpers

--- a/packages/overlay/src/modes/__tests__/create.unit.test.ts
+++ b/packages/overlay/src/modes/__tests__/create.unit.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as runChezmoiModule from '../../chezmoi/runChezmoi.ts';
 import { runCreate } from '../create.ts';
+import { mockCapturedStatus, mockStreamedRun } from '../test-utils/chezmoi-mocks.ts';
 
 const context = { source: '/src', target: '/target' };
 
@@ -11,8 +12,8 @@ describe(runCreate, () => {
   });
 
   it('applies A and D entries by absolute target path', async () => {
-    mockStatus(' A .new\n D .gone\n');
-    const streamed = mockStreamed(0);
+    mockCapturedStatus(' A .new\n D .gone\n');
+    const streamed = mockStreamedRun(0);
 
     const result = await runCreate(context);
 
@@ -28,8 +29,8 @@ describe(runCreate, () => {
   });
 
   it('reports a differing file as a conflict and never includes it in the apply call', async () => {
-    mockStatus(' A .new\n M .diff\n');
-    const streamed = mockStreamed(0);
+    mockCapturedStatus(' A .new\n M .diff\n');
+    const streamed = mockStreamedRun(0);
 
     const result = await runCreate(context);
 
@@ -40,8 +41,8 @@ describe(runCreate, () => {
   });
 
   it('skips the targeted apply entirely when there are no A/D entries', async () => {
-    mockStatus(' M .diff\n');
-    const streamed = mockStreamed(0);
+    mockCapturedStatus(' M .diff\n');
+    const streamed = mockStreamedRun(0);
 
     const result = await runCreate(context);
 
@@ -51,8 +52,8 @@ describe(runCreate, () => {
   });
 
   it('runs a separate scripts pass when R rows are present', async () => {
-    mockStatus(' A .new\n R normalize.sh\n');
-    const streamed = mockStreamed(0);
+    mockCapturedStatus(' A .new\n R normalize.sh\n');
+    const streamed = mockStreamedRun(0);
 
     await runCreate(context);
 
@@ -61,8 +62,8 @@ describe(runCreate, () => {
   });
 
   it('does not run a scripts pass when no R rows are present', async () => {
-    mockStatus(' A .new\n');
-    const streamed = mockStreamed(0);
+    mockCapturedStatus(' A .new\n');
+    const streamed = mockStreamedRun(0);
 
     await runCreate(context);
 
@@ -71,7 +72,7 @@ describe(runCreate, () => {
   });
 
   it('maps a failing scripts pass to exit 2', async () => {
-    mockStatus(' A .new\n R failing.sh\n');
+    mockCapturedStatus(' A .new\n R failing.sh\n');
     vi.spyOn(runChezmoiModule, 'runChezmoiStreamed').mockImplementation((_context, args) =>
       Promise.resolve(args.includes('--include=scripts') ? 1 : 0),
     );
@@ -83,8 +84,8 @@ describe(runCreate, () => {
   });
 
   it('maps a failing file-apply pass to exit 2 without masking it as drift', async () => {
-    mockStatus(' A .new\n M .diff\n');
-    mockStreamed(1);
+    mockCapturedStatus(' A .new\n M .diff\n');
+    mockStreamedRun(1);
 
     const result = await runCreate(context);
 
@@ -93,7 +94,7 @@ describe(runCreate, () => {
   });
 
   it('short-circuits before the scripts pass when the file-apply fails', async () => {
-    mockStatus(' A .new\n R normalize.sh\n');
+    mockCapturedStatus(' A .new\n R normalize.sh\n');
     const streamed = vi.spyOn(runChezmoiModule, 'runChezmoiStreamed').mockResolvedValue(1);
 
     const result = await runCreate(context);
@@ -105,13 +106,3 @@ describe(runCreate, () => {
     expect(streamed).not.toHaveBeenCalledWith(context, ['apply', '--include=scripts']);
   });
 });
-
-/** Stub `chezmoi status` to return the given stdout with a zero exit code. */
-function mockStatus(stdout: string): void {
-  vi.spyOn(runChezmoiModule, 'runChezmoiCaptured').mockResolvedValue({ stdout, stderr: '', code: 0 });
-}
-
-/** Stub every streamed `chezmoi apply` to resolve with the given exit code. */
-function mockStreamed(code: number): ReturnType<typeof vi.spyOn> {
-  return vi.spyOn(runChezmoiModule, 'runChezmoiStreamed').mockResolvedValue(code);
-}

--- a/packages/overlay/src/modes/__tests__/create.unit.test.ts
+++ b/packages/overlay/src/modes/__tests__/create.unit.test.ts
@@ -95,7 +95,7 @@ describe(runCreate, () => {
 
   it('short-circuits before the scripts pass when the file-apply fails', async () => {
     mockCapturedStatus(' A .new\n R normalize.sh\n');
-    const streamed = vi.spyOn(runChezmoiModule, 'runChezmoiStreamed').mockResolvedValue(1);
+    const streamed = mockStreamedRun(1);
 
     const result = await runCreate(context);
 

--- a/packages/overlay/src/modes/__tests__/force.unit.test.ts
+++ b/packages/overlay/src/modes/__tests__/force.unit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import * as runChezmoiModule from '../../chezmoi/runChezmoi.ts';
 import { runForce } from '../force.ts';
+import { mockCapturedStatus, mockStreamedRun } from '../test-utils/chezmoi-mocks.ts';
 
 const context = { source: '/src', target: '/target' };
 
@@ -11,8 +11,8 @@ describe(runForce, () => {
   });
 
   it('runs a full apply and reports M rows as forced, exiting 0 on success', async () => {
-    mockStatus(' A .new\n M .diff\n D .gone\n R normalize.sh\n');
-    const apply = mockApply(0);
+    mockCapturedStatus(' A .new\n M .diff\n D .gone\n R normalize.sh\n');
+    const apply = mockStreamedRun(0);
 
     const result = await runForce(context);
 
@@ -23,8 +23,8 @@ describe(runForce, () => {
   });
 
   it('maps a non-zero apply (script failure) to exit 2', async () => {
-    mockStatus(' R failing.sh\n');
-    mockApply(1);
+    mockCapturedStatus(' R failing.sh\n');
+    mockStreamedRun(1);
 
     const result = await runForce(context);
 
@@ -33,8 +33,8 @@ describe(runForce, () => {
   });
 
   it('never reports conflicts under force', async () => {
-    mockStatus(' M .diff\n');
-    mockApply(0);
+    mockCapturedStatus(' M .diff\n');
+    mockStreamedRun(0);
 
     const result = await runForce(context);
 
@@ -42,13 +42,3 @@ describe(runForce, () => {
     expect(result.entries.every((entry) => entry.outcome !== 'conflict')).toBe(true);
   });
 });
-
-/** Stub `chezmoi status` to return the given stdout with a zero exit code. */
-function mockStatus(stdout: string): void {
-  vi.spyOn(runChezmoiModule, 'runChezmoiCaptured').mockResolvedValue({ stdout, stderr: '', code: 0 });
-}
-
-/** Stub the streamed `chezmoi apply` to resolve with the given exit code. */
-function mockApply(code: number): ReturnType<typeof vi.spyOn> {
-  return vi.spyOn(runChezmoiModule, 'runChezmoiStreamed').mockResolvedValue(code);
-}

--- a/packages/overlay/src/modes/__tests__/verify.unit.test.ts
+++ b/packages/overlay/src/modes/__tests__/verify.unit.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import * as runChezmoiModule from '../../chezmoi/runChezmoi.ts';
+import { mockCapturedStatus } from '../test-utils/chezmoi-mocks.ts';
 import { runVerify } from '../verify.ts';
 
 const context = { source: '/src', target: '/target' };
@@ -11,7 +11,7 @@ describe(runVerify, () => {
   });
 
   it('exits 0 with no entries when status is clean', async () => {
-    mockStatus('');
+    mockCapturedStatus('');
 
     const result = await runVerify(context);
 
@@ -21,7 +21,7 @@ describe(runVerify, () => {
   });
 
   it('reports A/M/D rows as drift and exits 1', async () => {
-    mockStatus(' A .new\n M .diff\n D .gone\n');
+    mockCapturedStatus(' A .new\n M .diff\n D .gone\n');
 
     const result = await runVerify(context);
 
@@ -35,7 +35,7 @@ describe(runVerify, () => {
   });
 
   it('ignores R rows for the verdict and exits 0 when only scripts are pending', async () => {
-    mockStatus(' R normalize.sh\n R seed.sh\n');
+    mockCapturedStatus(' R normalize.sh\n R seed.sh\n');
 
     const result = await runVerify(context);
 
@@ -45,7 +45,7 @@ describe(runVerify, () => {
   });
 
   it('surfaces pending scripts while still failing on file drift', async () => {
-    mockStatus(' A .new\n R normalize.sh\n');
+    mockCapturedStatus(' A .new\n R normalize.sh\n');
 
     const result = await runVerify(context);
 
@@ -54,8 +54,3 @@ describe(runVerify, () => {
     expect(result.counts.pending).toBe(1);
   });
 });
-
-/** Stub `chezmoi status` to return the given stdout with a zero exit code. */
-function mockStatus(stdout: string): void {
-  vi.spyOn(runChezmoiModule, 'runChezmoiCaptured').mockResolvedValue({ stdout, stderr: '', code: 0 });
-}

--- a/packages/overlay/src/modes/create.ts
+++ b/packages/overlay/src/modes/create.ts
@@ -59,8 +59,12 @@ export async function runCreate(context: ChezmoiContext): Promise<OverlayResult>
   };
 }
 
+// region | Helpers
+
 function computeExitCode(ok: boolean, conflicts: number): 0 | 1 | 2 {
   if (!ok) return 2;
   if (conflicts > 0) return 1;
   return 0;
 }
+
+// endregion | Helpers

--- a/packages/overlay/src/modes/test-utils/chezmoi-mocks.ts
+++ b/packages/overlay/src/modes/test-utils/chezmoi-mocks.ts
@@ -1,0 +1,13 @@
+import { vi } from 'vitest';
+
+import * as runChezmoiModule from '../../chezmoi/runChezmoi.ts';
+
+/** Stubs `chezmoi status` to return the given stdout with a zero exit code. */
+export function mockCapturedStatus(stdout: string): void {
+  vi.spyOn(runChezmoiModule, 'runChezmoiCaptured').mockResolvedValue({ stdout, stderr: '', code: 0 });
+}
+
+/** Stubs every streamed chezmoi invocation to resolve with the given exit code. */
+export function mockStreamedRun(code: number): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(runChezmoiModule, 'runChezmoiStreamed').mockResolvedValue(code);
+}

--- a/packages/overlay/src/reporting/__tests__/formatReport.unit.test.ts
+++ b/packages/overlay/src/reporting/__tests__/formatReport.unit.test.ts
@@ -86,6 +86,8 @@ describe(formatReport, () => {
   });
 });
 
+// region | Helpers
+
 /** Build an `OverlayResult` from a converged-verify baseline, applying the given overrides. */
 function buildResult(overrides: Partial<OverlayResult>): OverlayResult {
   return {
@@ -97,3 +99,5 @@ function buildResult(overrides: Partial<OverlayResult>): OverlayResult {
     ...overrides,
   };
 }
+
+// endregion | Helpers

--- a/packages/overlay/src/reporting/formatReport.ts
+++ b/packages/overlay/src/reporting/formatReport.ts
@@ -30,6 +30,8 @@ const OUTCOME_LABELS: Record<EntryOutcome, string> = {
   conflict: 'conflict',
 };
 
+// region | Helpers
+
 /** Build the counts line, phrased as pending drift under verify and as actions taken otherwise. */
 function summarizeCounts(result: OverlayResult): string {
   if (result.mode === 'verify') {
@@ -57,3 +59,5 @@ function summarizeScripts(result: OverlayResult): string {
   const status = result.scripts.ok ? '' : ' (a script failed)';
   return `${pluralizeWithCount(result.scripts.ran, 'script')} ${verb}${status}.`;
 }
+
+// endregion | Helpers


### PR DESCRIPTION
## What

Adopts the repo's declaration-order and naming conventions throughout `packages/overlay/src/`. Also deduplicates the chezmoi stubs.

## Why

Overlay carried one `// region | Helpers` block against 114 in `readyup` and 95 in `compositor`, so a reader moving between packages could not rely on where a module's helpers sit. It was also the only package with no `test-utils/` directory, which left three mode tests each maintaining their own copy of the same two chezmoi stubs and one of them drifting to a different name.

## Details

### ♻️ Refactoring

- Nine modules take a `// region | Helpers` block, bringing `packages/overlay/src` from one to ten.
- `chezmoi/runChezmoi.ts` moves `buildArgs` and `withSandbox` below the two exports they serve.
- `chezmoi/version.ts` leads with `assertChezmoiVersion`, its only production-consumed export, ahead of `MIN_CHEZMOI_VERSION` and `parseVersion`, which are reached only from tests.
- A non-exported type used only by helpers moves into the region beside its consumer: `ExecFileError`, `ChildStub`, and `ExecFileCallback`. `SemverParts` stays above, where the exported `parseVersion` returns it.
- `MINIMUM` takes the kind tail its type calls for, and `firstExecFileArgs` takes a verb-led name.

### 🧪 Tests

- `mockCapturedStatus` and `mockStreamedRun` replace the copies of `mockStatus` in `create`, `force`, and `verify`, and the single stub that `create` called `mockStreamed` and `force` called `mockApply`. `test-utils/` sits inside the coverage tree, where nmr's compiler drops it as a build entry point, so the module is measured without shipping.
- `__tests__/overlay.tool.test.ts` moves `detectChezmoi` below its `describe`; the module-level `const hasChezmoi = detectChezmoi()` above it still resolves, because function declarations hoist.
- `create.unit.test.ts` routes its last inline `runChezmoiStreamed` spy through `mockStreamedRun`, keeping its direct spy for the one case that needs an argument-dependent `mockImplementation`.

Closes #256
