### PR TITLE
#291 Take every broad lint glob from the shared config's patterns

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -127,7 +127,7 @@ const config = defineConfig([
   },
   {
     // Config files legitimately mutate and compose configuration objects at module top level.
-    files: ['**/*.config.{cjs,js,mjs,ts}', '**/config/**'],
+    files: [...patterns.codeExtensions.map((extensions) => `**/*.config.${extensions}`), '**/config/**'],
     rules: {
       'unicorn/no-top-level-side-effects': 'off',
     },

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -41,14 +41,6 @@ const config = defineConfig([
     ignores: ['**/*.sh', '**/.claude/**', '**/.readyup/**', '**/coverage/**', '**/dist/**', '**/local/**'],
   },
   {
-    // `prefer-simple-condition-first` reorders conditions to save a property read, at the cost of the reading
-    // order the surrounding error messages use. Its own diagnostic concedes it cannot verify the reorder is safe.
-    files: patterns.typeScriptFiles,
-    rules: {
-      'unicorn/prefer-simple-condition-first': 'off',
-    },
-  },
-  {
     files: patterns.codeFiles,
     rules: {
       'n/no-missing-import': 'off',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,10 +1,11 @@
 import baseConfig, { createConfig, patterns } from '@williamthorsen/eslint-config-typescript';
 import { defineConfig } from 'eslint/config';
 
-// The broad blocks below match on the base config's `patterns`, the same constants it applies its own blocks to.
-// Sharing the constants is what keeps a block here from overriding a base block it does not fully cover, which
-// would drop this file's additions for the extensions it missed. The breadth is the shared config's position on
-// which extensions a project may hold, and says nothing about which ones this repo contains.
+// The broad blocks below match on the base config's `patterns`, the same constants it applies its own blocks to,
+// save `no-restricted-syntax`, whose narrower scope `RESTRICTED_SYNTAX` states. Sharing the constants is what
+// keeps a block here from overriding a base block it does not fully cover, which would drop this file's additions
+// for the extensions it missed. The breadth is the shared config's position on which extensions a project may
+// hold, and says nothing about which ones this repo contains.
 //
 // The layout guards further down are the opposite case and name `.ts` alone: a guard naming an extension asserts
 // that a file of that kind belongs at the path it guards.
@@ -15,6 +16,10 @@ import { defineConfig } from 'eslint/config';
  * Shared because ESLint substitutes a rule's options across config objects instead of merging them, so an object
  * that sets this rule for a narrower glob discards every entry it does not restate. The three statement bans come
  * from the shared config and would be lost the same way.
+ *
+ * The scope is TypeScript alone, though the base block this overrides also covers `patterns.javaScriptFiles`. The
+ * `describeError` entry answers the `unknown` type TypeScript gives a catch binding, which JavaScript has no
+ * equivalent of, so a `.js` file receives the three statement bans without it.
  */
 const RESTRICTED_SYNTAX = [
   'DebuggerStatement',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,6 +1,14 @@
 import baseConfig, { createConfig, patterns } from '@williamthorsen/eslint-config-typescript';
 import { defineConfig } from 'eslint/config';
 
+// The broad blocks below match on the base config's `patterns`, the same constants it applies its own blocks to.
+// Sharing the constants is what keeps a block here from overriding a base block it does not fully cover, which
+// would drop this file's additions for the extensions it missed. The breadth is the shared config's position on
+// which extensions a project may hold, and says nothing about which ones this repo contains.
+//
+// The layout guards further down are the opposite case and name `.ts` alone: a guard naming an extension asserts
+// that a file of that kind belongs at the path it guards.
+
 /**
  * Every `no-restricted-syntax` entry that applies to TypeScript repo-wide.
  *

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,4 @@
-import baseConfig, { createConfig } from '@williamthorsen/eslint-config-typescript';
+import baseConfig, { createConfig, patterns } from '@williamthorsen/eslint-config-typescript';
 import { defineConfig } from 'eslint/config';
 
 /**
@@ -30,20 +30,20 @@ const config = defineConfig([
   {
     // `prefer-simple-condition-first` reorders conditions to save a property read, at the cost of the reading
     // order the surrounding error messages use. Its own diagnostic concedes it cannot verify the reorder is safe.
-    files: ['**/*.ts', '**/*.mts', '**/*.tsx', '**/*.md/*.ts'],
+    files: patterns.typeScriptFiles,
     rules: {
       'unicorn/prefer-simple-condition-first': 'off',
     },
   },
   {
-    files: ['**/*.js', '**/*.cjs', '**/*.mjs', '**/*.ts', '**/*.tsx'],
+    files: patterns.codeFiles,
     rules: {
       'n/no-missing-import': 'off',
       'n/no-unpublished-import': 'off',
     },
   },
   {
-    files: ['**/*.ts', '**/*.mts', '**/*.tsx', '**/*.md/*.ts'],
+    files: patterns.typeScriptFiles,
     languageOptions: {
       parserOptions: {
         // Anchor the project service (enabled by the base config) at the repo root.
@@ -69,7 +69,7 @@ const config = defineConfig([
     },
   },
   defineConfig({
-    files: ['**/*.test.ts', '**/*.test.tsx'],
+    files: patterns.testFiles,
     extends: [await createConfig.vitest()],
   }),
   {
@@ -139,7 +139,7 @@ const config = defineConfig([
     },
   },
   {
-    files: ['**/*.ts', '**/*.mts', '**/*.tsx', '**/*.md/*.ts'],
+    files: patterns.typeScriptFiles,
     rules: {
       'no-restricted-syntax': ['error', ...RESTRICTED_SYNTAX],
     },


### PR DESCRIPTION
## What

Takes every broad glob in `eslint.config.ts` from the `patterns` constants `@williamthorsen/eslint-config-typescript` publishes, replacing the hand-rolled extension list each block had restated. The config now names no file extension of its own.

Removes a block that disabled a lint rule the shared config already disables, and three globs that matched nothing.

## Why

Read as the repo's working definition of a source file, the hand-rolled lists misled a reviewer into recommending a wider directory-scoped guard. They also hid a live defect: ESLint substitutes a rule's options across config objects instead of merging them, so a block narrower than the one it overrides silently drops this repo's own entries.

## Details

### 🐛 Bug fixes

- A `.cts` file received the shared config's three `no-restricted-syntax` statement bans without this repo's `describeError` entry, because the overriding block named `.ts`, `.mts`, and `.tsx` alone. Resolving the override and the block it overrides from `patterns.typeScriptFiles` closes the gap.

### ♻️ Refactoring

- Five broad blocks take `patterns.typeScriptFiles`, `patterns.codeFiles`, or `patterns.testFiles`. The top-level-side-effects block has no published constant to take, so it composes `**/*.config.${extensions}` from `patterns.codeExtensions`; its `'**/config/**'` entry names a directory rather than an extension and is unchanged.
- The vitest block widens from `**/*.test.{ts,tsx}` to `patterns.testFiles`, which also admits `.spec.*` and the JavaScript extensions. No such file exists on this tree.
- The three `**/*.md/*.ts` globs are dropped. No markdown processor is registered here or in the shared config, and `**/*.{ts,cts,mts,tsx}` matches a processor's virtual `README.md/0_0.ts` paths regardless.
- The block disabling `unicorn/prefer-simple-condition-first` is removed. The shared config sets that rule `off` at `codeFiles`, so the block resolved nothing.
- A file-header comment states why the broad blocks take the shared constants and why the layout guards, which name `.ts` alone, do not. The `RESTRICTED_SYNTAX` docblock records that its own scope is TypeScript alone though the shared block it overrides also covers `patterns.javaScriptFiles`: `describeError` answers the `unknown` type TypeScript gives a catch binding.

### 🧪 Tests

- No tests accompany the change. The resolved configuration is what would be asserted, and `eslint --print-config` answers it directly. Across the branch, `eslint .` reports the same 740 files with zero findings as before.


Closes #291
