### PR TITLE
#397 Report the repo root in every discoverWorkspaces() result

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1329,11 +1329,16 @@ const findings = discoverWorkspaces().flatMap(({ dir, packageJson }) => {
 
 ### Workspaces
 
-`discoverWorkspaces()` returns a uniform `Workspace[]` collapsing pnpm, npm, and yarn monorepo conventions -- and single-workspace repos -- into one iteration shape. Each entry carries `dir` (relative to `cwd`; `'.'` for a single-workspace repo), `absolutePath`, `name`, `isPackage` (`package.json.private !== true`), and the parsed `packageJson`.
+`discoverWorkspaces()` returns a uniform `Workspace[]` collapsing pnpm, npm, and yarn monorepo conventions -- and single-workspace repos -- into one iteration shape. Each entry carries `dir` (relative to `cwd`; `'.'` for the repo root), `absolutePath`, `name`, `isPackage` (`package.json.private !== true`), `isRoot`, and the parsed `packageJson`.
+
+The repo root is reported in every shape, exactly once, so every call shape is a filter over one list rather than a list a caller adds the root to and dedupes.
 
 ```ts
+const members = discoverWorkspaces({ filter: (w) => !w.isRoot });
 const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
 ```
+
+`isRoot` is independent of `isPackage`: a monorepo may publish its root, and a member may be private. A root `package.json` that is missing or unparseable throws, whatever the repo's shape.
 
 `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs using YAML anchors, flow sequences, or negation patterns raise a clear error.
 

--- a/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
@@ -84,8 +84,8 @@ describe(`${discoverWorkspaces.name} memoization`, () => {
   });
 
   it('caches nothing when discovery throws, so a repaired repo is discovered on the next call', ({ temp }) => {
-    expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
-    expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
+    expect(() => discoverWorkspaces()).toThrow(/no readable package\.json at/);
+    expect(() => discoverWorkspaces()).toThrow(/no readable package\.json at/);
 
     temp.writeJson('package.json', { name: 'solo' });
 
@@ -95,7 +95,7 @@ describe(`${discoverWorkspaces.name} memoization`, () => {
 
 // region | Helpers
 
-/** Writes a two-workspace monorepo whose members differ in `private`, so a filter can tell them apart. */
+/** Writes a monorepo with two member packages that differ in `private`, so a filter can tell them apart. */
 function writeMonorepo(temp: TempTree): void {
   temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/*'] });
   temp.writeJson(join('packages/alpha', 'package.json'), { name: 'alpha' });

--- a/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
@@ -49,7 +49,7 @@ describe(`${discoverWorkspaces.name} memoization`, () => {
     const privateWorkspaces = discoverWorkspaces({ filter: (workspace) => !workspace.isPackage });
 
     expect(packages.map((workspace) => workspace.name)).toStrictEqual(['alpha']);
-    expect(privateWorkspaces.map((workspace) => workspace.name)).toStrictEqual(['internal']);
+    expect(privateWorkspaces.map((workspace) => workspace.name)).toStrictEqual(['root', 'internal']);
     // Guards the equality below, which two zeroes would also satisfy.
     expect(walkedForFirstCall).toBeGreaterThan(0);
     expect(readDirectories).toHaveLength(walkedForFirstCall);
@@ -67,7 +67,7 @@ describe(`${discoverWorkspaces.name} memoization`, () => {
 
     const workspaces = discoverWorkspaces();
 
-    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['solo']);
+    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['second', 'solo']);
     expect(readDirectories.length).toBeGreaterThan(walkedForFirstRoot);
   });
 
@@ -77,6 +77,7 @@ describe(`${discoverWorkspaces.name} memoization`, () => {
     discoverWorkspaces().length = 0;
 
     expect(discoverWorkspaces().map((workspace) => workspace.dir)).toStrictEqual([
+      '.',
       'packages/alpha',
       'packages/internal',
     ]);

--- a/packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { discoverWorkspaces, type Workspace } from '../workspaces.ts';
 
 /**
- * The `node:fs` functions a repoint can be armed on: `existsSync` fires on the `pnpm-workspace.yaml` probe,
+ * The `node:fs` functions a repoint can be armed on: `existsSync` fires on the root manifest read,
  * discovery's first filesystem call after it snapshots the cwd, and `readdirSync` on the directory walk.
  */
 type FsTrigger = 'existsSync' | 'readdirSync';
@@ -62,7 +62,7 @@ describe(`${discoverWorkspaces.name} cwd reconciliation`, () => {
 
     const workspaces = discoverWithCwdRepointedAt(decoyDir, 'existsSync');
 
-    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['alpha']);
+    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['root', 'alpha']);
   });
 
   it('reads the single-workspace manifest at the directory it snapshotted', ({ temp }) => {
@@ -82,7 +82,7 @@ describe(`${discoverWorkspaces.name} cwd reconciliation`, () => {
 
     const workspaces = discoverWithCwdRepointedAt(decoyDir, 'readdirSync');
 
-    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['alpha']);
+    expect(workspaces.map((workspace) => workspace.name)).toStrictEqual(['root', 'alpha']);
   });
 });
 

--- a/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
@@ -280,14 +280,14 @@ describe(discoverWorkspaces, () => {
 
   describe('error: unreadable root package.json', () => {
     it('throws with a message that includes the resolved path', ({ temp }) => {
-      expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
+      expect(() => discoverWorkspaces()).toThrow(/no readable package\.json at/);
       expect(() => discoverWorkspaces()).toThrow(temp.dir);
     });
 
     it('throws even when pnpm-workspace.yaml is present', ({ temp }) => {
       writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
 
-      expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
+      expect(() => discoverWorkspaces()).toThrow(/no readable package\.json at/);
     });
 
     it("throws when a workspace-pattern repo's root package.json is unparseable", ({ temp }) => {
@@ -295,7 +295,7 @@ describe(discoverWorkspaces, () => {
       writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
       writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
 
-      expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
+      expect(() => discoverWorkspaces()).toThrow(/no readable package\.json at/);
     });
   });
 
@@ -313,7 +313,7 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('Workspace shape', () => {
-    it('includes absolutePath, name, isPackage, and packageJson for a monorepo workspace', ({ temp }) => {
+    it('includes absolutePath, name, isPackage, isRoot, and packageJson for a monorepo member', ({ temp }) => {
       writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
       writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha', version: '1.2.3' });
 
@@ -384,7 +384,7 @@ describe(discoverWorkspacesAt, () => {
 
     expect(workspaces.map((w) => w.name)).toStrictEqual(['nested-root', 'alpha']);
     // The ambient cwd holds no manifest, so an answer read through it could not be this one.
-    expect(() => discoverWorkspaces()).toThrow(/no package.json found/);
+    expect(() => discoverWorkspaces()).toThrow(/no readable package.json/);
   });
 
   it('resolves a relative directory against the cwd', ({ temp }) => {

--- a/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
@@ -29,15 +29,15 @@ describe(discoverWorkspaces, () => {
 
       const workspaces = discoverWorkspaces();
 
-      expect(workspaces.map((w) => w.dir)).toStrictEqual(['apps/web', 'packages/alpha', 'packages/beta']);
-      expect(workspaces.map((w) => w.name)).toStrictEqual(['web', 'alpha', 'beta']);
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['.', 'apps/web', 'packages/alpha', 'packages/beta']);
+      expect(workspaces.map((w) => w.name)).toStrictEqual(['root', 'web', 'alpha', 'beta']);
     });
 
-    it('returns an empty array when a pattern expands to zero directories', ({ temp }) => {
+    it('returns the root alone when a pattern expands to zero directories', ({ temp }) => {
       writeRootPackageJson(temp, { name: 'root', private: true });
       writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
 
-      expect(discoverWorkspaces()).toStrictEqual([]);
+      expect(discoverWorkspaces().map((w) => w.dir)).toStrictEqual(['.']);
     });
 
     it('falls through to npm/single detection when `packages` key is absent', ({ temp }) => {
@@ -52,6 +52,7 @@ describe(discoverWorkspaces, () => {
           absolutePath: temp.dir,
           name: 'root',
           isPackage: true,
+          isRoot: true,
           packageJson: { name: 'root', version: '1.0.0' },
         },
       ]);
@@ -73,7 +74,7 @@ describe(discoverWorkspaces, () => {
 
       const workspaces = discoverWorkspaces();
 
-      expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha', 'packages/beta']);
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['.', 'packages/alpha', 'packages/beta']);
     });
 
     it('discovers workspaces when `workspaces.packages` is a string array', ({ temp }) => {
@@ -87,7 +88,7 @@ describe(discoverWorkspaces, () => {
 
       const workspaces = discoverWorkspaces();
 
-      expect(workspaces.map((w) => w.dir)).toStrictEqual(['apps/web', 'packages/alpha']);
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['.', 'apps/web', 'packages/alpha']);
     });
 
     it('returns isPackage: false for a discovered workspace with `private: true`', ({ temp }) => {
@@ -98,7 +99,7 @@ describe(discoverWorkspaces, () => {
       const workspaces = discoverWorkspaces();
       const byDir = Object.fromEntries(workspaces.map((w) => [w.dir, w.isPackage]));
 
-      expect(byDir).toStrictEqual({ 'packages/alpha': true, 'packages/internal': false });
+      expect(byDir).toStrictEqual({ '.': false, 'packages/alpha': true, 'packages/internal': false });
     });
   });
 
@@ -114,6 +115,7 @@ describe(discoverWorkspaces, () => {
           absolutePath: temp.dir,
           name: 'solo',
           isPackage: true,
+          isRoot: true,
           packageJson: { name: 'solo', version: '1.0.0' },
         },
       ]);
@@ -150,6 +152,36 @@ describe(discoverWorkspaces, () => {
     });
   });
 
+  describe('repo root', () => {
+    it('reports the root once, flagged, alongside the members of a workspace-pattern repo', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.filter((w) => w.isRoot).map((w) => w.dir)).toStrictEqual(['.']);
+      expect(workspaces.map((w) => w.isRoot)).toStrictEqual([true, false]);
+    });
+
+    it('flags the sole workspace of a single-package repo as the root', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'solo' });
+
+      expect(discoverWorkspaces().map((w) => w.isRoot)).toStrictEqual([true]);
+    });
+
+    it('reports `isRoot` independently of `isPackage`, for a published root and a private member', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/internal', { name: 'internal', private: true });
+
+      const workspaces = discoverWorkspaces();
+
+      expect(workspaces.map((w) => [w.isRoot, w.isPackage])).toStrictEqual([
+        [true, true],
+        [false, false],
+      ]);
+    });
+  });
+
   describe('filter option', () => {
     it('excludes workspaces for which the filter returns false', ({ temp }) => {
       writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
@@ -159,6 +191,16 @@ describe(discoverWorkspaces, () => {
       const workspaces = discoverWorkspaces({ filter: (w) => w.isPackage });
 
       expect(workspaces.map((w) => w.name)).toStrictEqual(['alpha']);
+    });
+
+    it('yields the members alone when the filter excludes the root', ({ temp }) => {
+      writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
+      writeWorkspacePackage(temp, 'packages/beta', { name: 'beta' });
+
+      const members = discoverWorkspaces({ filter: (w) => !w.isRoot });
+
+      expect(members.map((w) => w.dir)).toStrictEqual(['packages/alpha', 'packages/beta']);
     });
   });
 
@@ -170,7 +212,7 @@ describe(discoverWorkspaces, () => {
 
       const workspaces = discoverWorkspaces();
 
-      expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha']);
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['.', 'packages/alpha']);
     });
 
     it('skips a matched directory with an unparseable package.json', ({ temp }) => {
@@ -180,7 +222,7 @@ describe(discoverWorkspaces, () => {
 
       const workspaces = discoverWorkspaces();
 
-      expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha']);
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['.', 'packages/alpha']);
     });
 
     it('does not traverse into node_modules', ({ temp }) => {
@@ -206,13 +248,13 @@ describe(discoverWorkspaces, () => {
   });
 
   describe('pattern shapes', () => {
-    it('does not report the repo root as a workspace under a `**` pattern', ({ temp }) => {
+    it('reports the repo root exactly once under a `**` pattern, which matches its own manifest', ({ temp }) => {
       writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['**'] });
       writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
 
       const workspaces = discoverWorkspaces();
 
-      expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha']);
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['.', 'packages/alpha']);
     });
 
     it('resolves a trailing-slash pattern to the same set as its bare form', ({ temp }) => {
@@ -222,7 +264,7 @@ describe(discoverWorkspaces, () => {
 
       const workspaces = discoverWorkspaces();
 
-      expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha', 'packages/beta']);
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['.', 'packages/alpha', 'packages/beta']);
     });
 
     it('resolves a pattern that names its directory literally', ({ temp }) => {
@@ -232,11 +274,11 @@ describe(discoverWorkspaces, () => {
 
       const workspaces = discoverWorkspaces();
 
-      expect(workspaces.map((w) => w.dir)).toStrictEqual(['tools/formatter']);
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['.', 'tools/formatter']);
     });
   });
 
-  describe('error: missing root package.json', () => {
+  describe('error: unreadable root package.json', () => {
     it('throws with a message that includes the resolved path', ({ temp }) => {
       expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
       expect(() => discoverWorkspaces()).toThrow(temp.dir);
@@ -244,6 +286,14 @@ describe(discoverWorkspaces, () => {
 
     it('throws even when pnpm-workspace.yaml is present', ({ temp }) => {
       writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
+
+      expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
+    });
+
+    it("throws when a workspace-pattern repo's root package.json is unparseable", ({ temp }) => {
+      temp.write('package.json', '{ not valid json');
+      writePnpmWorkspaceYaml(temp, ['packages:', '  - packages/*', ''].join('\n'));
+      writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
 
       expect(() => discoverWorkspaces()).toThrow(/no package\.json found at/);
     });
@@ -258,7 +308,7 @@ describe(discoverWorkspaces, () => {
 
       const workspaces = discoverWorkspaces();
 
-      expect(workspaces.map((w) => w.dir)).toStrictEqual(['packages/alpha', 'packages/mu', 'packages/zeta']);
+      expect(workspaces.map((w) => w.dir)).toStrictEqual(['.', 'packages/alpha', 'packages/mu', 'packages/zeta']);
     });
   });
 
@@ -267,13 +317,14 @@ describe(discoverWorkspaces, () => {
       writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['packages/*'] });
       writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha', version: '1.2.3' });
 
-      const [workspace] = discoverWorkspaces();
+      const workspace = discoverWorkspaces().find((w) => w.dir === 'packages/alpha');
 
       expect(workspace).toStrictEqual({
         dir: 'packages/alpha',
         absolutePath: join(temp.dir, 'packages/alpha'),
         name: 'alpha',
         isPackage: true,
+        isRoot: false,
         packageJson: { name: 'alpha', version: '1.2.3' },
       });
     });
@@ -331,7 +382,7 @@ describe(discoverWorkspacesAt, () => {
 
     const workspaces = discoverWorkspacesAt(temp.resolve('nested'));
 
-    expect(workspaces.map((w) => w.name)).toStrictEqual(['alpha']);
+    expect(workspaces.map((w) => w.name)).toStrictEqual(['nested-root', 'alpha']);
     // The ambient cwd holds no manifest, so an answer read through it could not be this one.
     expect(() => discoverWorkspaces()).toThrow(/no package.json found/);
   });
@@ -341,6 +392,7 @@ describe(discoverWorkspacesAt, () => {
     writeWorkspacePackage(temp, 'nested/packages/beta', { name: 'beta' });
 
     expect(discoverWorkspacesAt('nested').map((w) => w.absolutePath)).toStrictEqual([
+      temp.resolve('nested'),
       temp.resolve('nested/packages/beta'),
     ]);
   });

--- a/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
@@ -45,14 +45,14 @@ describe(`${discoverWorkspaces.name} directory walk`, () => {
   it('reads every readable directory when none fails', ({ temp }) => {
     writeMonorepo(temp);
 
-    expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['alpha', 'locked', 'inner']);
+    expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['root', 'alpha', 'locked', 'inner']);
   });
 
   it('drops a directory it cannot read for a benign reason along with its subtree, keeping the rest', ({ temp }) => {
     writeMonorepo(temp);
     failures.set(join(temp.dir, 'packages/locked'), 'EACCES');
 
-    expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['alpha']);
+    expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['root', 'alpha']);
   });
 
   it('propagates a systemic read failure rather than answering with a partial walk', ({ temp }) => {

--- a/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
@@ -150,7 +150,7 @@ describe(buildFindingReport, () => {
 
 // region | Helpers
 
-/** Writes a two-workspace repo in which `packages/errors` publishes the package the fixtures name. */
+/** Writes a monorepo with two member packages, of which `packages/errors` publishes the package the fixtures name. */
 function writeMonorepo(temp: TempTree): void {
   temp.writeJson('package.json', { name: 'root', private: true });
   temp.write('pnpm-workspace.yaml', ['packages:', '  - packages/*', ''].join('\n'));

--- a/packages/readyup/src/check-utils/project/__tests__/listOwnImplementationSpans.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listOwnImplementationSpans.unit.test.ts
@@ -183,6 +183,18 @@ describe(listOwnImplementationSpans, () => {
     });
   });
 
+  describe('in a monorepo whose root manifest publishes the package', () => {
+    it('exempts a defining declaration in any workspace, the root being the whole repo', ({ temp }) => {
+      writeMonorepoPublishingFromRoot(temp);
+      const path = 'packages/app/src/describeError.ts';
+      const own = buildOwnImplementation([{ path, text: 'export function describeError(error: unknown) {}' }]);
+
+      expect(listOwnImplementationSpans(path, own)).toStrictEqual([
+        { endLine: 1, name: 'describeError', startLine: 1 },
+      ]);
+    });
+  });
+
   describe('in a single-package repo', () => {
     it('exempts the defining declaration alone, not the repo', ({ temp }) => {
       writeSinglePackage(temp);
@@ -214,11 +226,18 @@ function buildOwnImplementation(sources: readonly ProjectSource[]): OwnImplement
   return { exportNames: EXPORT_NAMES, packageName: PACKAGE_NAME, sources };
 }
 
-/** Writes a two-workspace repo in which `packages/errors` publishes the package under test. */
+/** Writes a monorepo with two member packages, of which `packages/errors` publishes the package under test. */
 function writeMonorepo(temp: TempTree): void {
   temp.writeJson('package.json', { name: 'root', private: true });
   temp.write('pnpm-workspace.yaml', ['packages:', '  - packages/*', ''].join('\n'));
   temp.writeJson('packages/errors/package.json', { name: PACKAGE_NAME, version: '1.0.0' });
+  temp.writeJson('packages/app/package.json', { name: '@scope/app', version: '1.0.0' });
+}
+
+/** Writes a monorepo whose root manifest publishes the package under test, alongside a member that does not. */
+function writeMonorepoPublishingFromRoot(temp: TempTree): void {
+  temp.writeJson('package.json', { name: PACKAGE_NAME, version: '1.0.0' });
+  temp.write('pnpm-workspace.yaml', ['packages:', '  - packages/*', ''].join('\n'));
   temp.writeJson('packages/app/package.json', { name: '@scope/app', version: '1.0.0' });
 }
 

--- a/packages/readyup/src/check-utils/project/listOwnImplementationSpans.ts
+++ b/packages/readyup/src/check-utils/project/listOwnImplementationSpans.ts
@@ -24,10 +24,11 @@ export interface OwnImplementation {
  * file exports under one of the package's recommended names, in a file inside the workspace publishing the package.
  *
  * Every narrowing is required. A repo publishing the package is where the idiom is supposed to live, but the workspace
- * is the whole repository in a single-package project, so a workspace-wide rule would turn the check off there, and in
- * any repo it would silence a second file hand-rolling the idiom instead of importing the local implementation. The
- * argument carries one step further, to the declaration: the reasoning reaches a wrapper of the idiom its own kit
- * detects, which cannot adopt itself, while its neighbours in the same file are ordinary code.
+ * is the whole repository wherever the root manifest declares the name, as a single-package project's always does, so a
+ * workspace-wide rule would turn the check off there, and in any repo it would silence a second file hand-rolling the
+ * idiom instead of importing the local implementation. The argument carries one step further, to the declaration: the
+ * reasoning reaches a wrapper of the idiom its own kit detects, which cannot adopt itself, while its neighbours in the
+ * same file are ordinary code.
  *
  * The declaration is read from the file's text, so a detector reporting sites that declare nothing is exempted on the
  * same terms as one reporting a declaration. A file the sweep never read cannot be shown to declare anything, and a

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -85,7 +85,7 @@ function buildWorkspaces(rootDir: string): Workspace[] {
   const rootPackageJsonPath = join(rootDir, 'package.json');
   const rootPackageJson = readJsonFile(rootPackageJsonPath);
   if (rootPackageJson === undefined) {
-    throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
+    throw new Error(`Workspace discovery: no readable package.json at ${rootPackageJsonPath}`);
   }
   const rootWorkspace = buildWorkspaceFromPackageJson('.', rootDir, rootPackageJson);
 

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -7,9 +7,9 @@ import { walkDirectories } from '../portable/walkDirectories.ts';
 import { readJsonFile } from './json.ts';
 import { readPnpmWorkspacePackages } from './pnpmWorkspaceYaml.ts';
 
-/** A monorepo workspace, or the single workspace of a single-workspace repo. */
+/** A repo's root, or one of a monorepo's members. */
 export interface Workspace {
-  /** Workspace directory, relative to the directory discovery was anchored to. `'.'` for a single-workspace repo. */
+  /** Workspace directory, relative to the directory discovery was anchored to. `'.'` for the repo root. */
   readonly dir: string;
   /** Absolute filesystem path to the workspace directory. */
   readonly absolutePath: string;
@@ -17,6 +17,8 @@ export interface Workspace {
   readonly name: string | undefined;
   /** True iff `package.json.private !== true`. (Equivalently: "this workspace is a package".) */
   readonly isPackage: boolean;
+  /** True for the repo root, which every repo shape reports. Independent of `isPackage`: a root may publish. */
+  readonly isRoot: boolean;
   /** Parsed `package.json` contents, validated to be a record. */
   readonly packageJson: Readonly<Record<string, unknown>>;
 }
@@ -36,6 +38,9 @@ const workspacesByDir = new Map<string, Workspace[]>();
  * Discovers the workspaces of the current repo.
  * Detects pnpm (`pnpm-workspace.yaml`), then npm/yarn (`package.json.workspaces`),
  * and falls back to a single-workspace repo using the root `package.json`.
+ *
+ * The repo root is reported in every shape, once, flagged `isRoot`, so a caller wanting the members alone
+ * filters `!isRoot` rather than reconstructing the distinction from `dir`.
  *
  * Memoized per directory for the life of the process: repeated calls in one run share a single directory walk
  * and the frozen `Workspace` objects it built, and none of them observes a filesystem change made since the first.
@@ -74,30 +79,23 @@ function applyFilter(workspaces: Workspace[], filter: DiscoverWorkspacesOptions[
   return workspaces.filter(filter);
 }
 
-/** Builds the unfiltered workspace list for the repo at `rootDir`. */
+/** Builds the unfiltered workspace list for the repo at `rootDir`, the root entry leading it. */
 function buildWorkspaces(rootDir: string): Workspace[] {
+  // The root is reported in every repo shape, so its manifest MUST be readable in every shape.
   const rootPackageJsonPath = join(rootDir, 'package.json');
-
-  const patternResult = resolveWorkspacePatterns(rootDir);
-
-  if (patternResult === null) {
-    // Single-workspace fallback uses the root package.json, which MUST exist.
-    const rootPackageJson = readJsonFile(rootPackageJsonPath);
-    if (rootPackageJson === undefined) {
-      throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
-    }
-    return [buildWorkspaceFromPackageJson('.', rootDir, rootPackageJson)];
-  }
-
-  // Monorepo path: still require a root package.json (both pnpm and npm workspaces do).
-  if (!existsSync(rootPackageJsonPath)) {
+  const rootPackageJson = readJsonFile(rootPackageJsonPath);
+  if (rootPackageJson === undefined) {
     throw new Error(`Workspace discovery: no package.json found at ${rootPackageJsonPath}`);
   }
+  const rootWorkspace = buildWorkspaceFromPackageJson('.', rootDir, rootPackageJson);
 
-  // `matchedDirs` is already sorted ascending by `expandPatterns`, and each workspace's
-  // `dir` equals its entry in that list, so the result is sorted without an extra pass.
+  const patternResult = resolveWorkspacePatterns(rootDir, rootPackageJson);
+  if (patternResult === null) return [rootWorkspace];
+
+  // `matchedDirs` is already sorted ascending by `expandPatterns` and holds no `.`, and each workspace's
+  // `dir` equals its entry in that list, so the root leads a sorted result without an extra pass.
   const matchedDirs = expandPatterns(rootDir, patternResult.patterns, patternResult.source);
-  const workspaces: Workspace[] = [];
+  const workspaces: Workspace[] = [rootWorkspace];
   for (const relDir of matchedDirs) {
     const workspace = buildWorkspace(rootDir, relDir);
     if (workspace !== undefined) {
@@ -109,10 +107,13 @@ function buildWorkspaces(rootDir: string): Workspace[] {
 }
 
 /**
- * Resolves the workspace pattern list for the repo at `rootDir`.
+ * Resolves the workspace pattern list for the repo at `rootDir`, whose parsed root manifest is `rootPackageJson`.
  * Returns `null` to signal single-workspace fallback, or `{ patterns, source }` for a monorepo.
  */
-function resolveWorkspacePatterns(rootDir: string): { patterns: string[]; source: WorkspacePatternSource } | null {
+function resolveWorkspacePatterns(
+  rootDir: string,
+  rootPackageJson: Record<string, unknown>,
+): { patterns: string[]; source: WorkspacePatternSource } | null {
   const pnpmWorkspacePath = join(rootDir, 'pnpm-workspace.yaml');
   if (existsSync(pnpmWorkspacePath)) {
     const patterns = readPnpmWorkspacePackages(pnpmWorkspacePath);
@@ -122,13 +123,9 @@ function resolveWorkspacePatterns(rootDir: string): { patterns: string[]; source
     // `packages` key absent — fall through to npm/single detection.
   }
 
-  const rootPackageJson = readJsonFile(join(rootDir, 'package.json'));
-  if (rootPackageJson !== undefined) {
-    const workspaces = rootPackageJson['workspaces'];
-    const npmPatterns = extractNpmWorkspacePatterns(workspaces);
-    if (npmPatterns !== null) {
-      return { patterns: npmPatterns, source: 'package.json' };
-    }
+  const npmPatterns = extractNpmWorkspacePatterns(rootPackageJson['workspaces']);
+  if (npmPatterns !== null) {
+    return { patterns: npmPatterns, source: 'package.json' };
   }
 
   return null;
@@ -176,7 +173,8 @@ function expandPatterns(rootDir: string, patterns: string[], source: WorkspacePa
 
   const match = patterns.map((pattern) => `${normalizePattern(pattern)}/package.json`);
 
-  // The root is not a workspace, and a pattern of `**` translates to a glob matching its own manifest.
+  // A pattern of `**` translates to a glob matching the root's own manifest; `buildWorkspaces` reports the
+  // root in its own right, so dropping it here is what leaves exactly one entry for it.
   return walkDirectories({ root: rootDir, match }).filter((relDir) => relDir !== '.');
 }
 
@@ -208,7 +206,7 @@ function buildWorkspaceFromPackageJson(
   const isPackage = packageJson['private'] !== true;
   // One call's mutation would otherwise reach every later call, which shares these objects.
   deepFreeze(packageJson);
-  return Object.freeze({ dir: relDir, absolutePath, name, isPackage, packageJson });
+  return Object.freeze({ dir: relDir, absolutePath, name, isPackage, isRoot: relDir === '.', packageJson });
 }
 
 // endregion | Helpers


### PR DESCRIPTION
## What

Reports the repo root in every `discoverWorkspaces()` result, flagged by a new `isRoot` field on each `Workspace`, so a kit selects what it needs by filtering one uniform list rather than by the repo's shape. `isRoot` is independent of `isPackage`: A monorepo may publish its root, and a member may be private.

Migration: The returned array now includes the monorepo root, so a caller must filter on `!isRoot` to get only the members. A repo whose root `package.json` is missing or unparseable now throws.

## Why

Whether `discoverWorkspaces()` included the repo root was decided by the repo's shape, and nothing on the returned workspaces said which rule had applied. A caller wanting the root added it and deduped, because it was sometimes already there; a caller wanting it out compared `dir === '.'`. The cost of getting that wrong is silent: a kit that lists directories to check and omits the root reports a clean pass over less than it claims, and nothing errors.

## Details

### 🎉 Features

- 🚨 **Breaking:** `discoverWorkspaces()` returns the repo root as the first entry in both single-package and workspace-pattern repos. A monorepo's result previously held its members alone, so a caller relying on that exclusion sees a new entry.
- `Workspace` gains `isRoot`, derived from the workspace's directory inside the builder so the two construction paths cannot disagree.
- 🚨 **Breaking:** a workspace-pattern repo whose root `package.json` is missing or unparseable now throws, on the same terms as a single-package repo. The monorepo path previously only checked that the file existed, and returned its members when the manifest could not be parsed.

### 🐛 Bug fixes

- A root `package.json` that exists but does not parse was reported as `no package.json found at {path}`, sending the reader to look for a file that is plainly there. The message now reads `no readable package.json at {path}`, which holds for all three conditions the reader collapses: absent, unparseable, and valid JSON that is not an object.

### ♻️ Refactoring

- `buildWorkspaces` reads the root manifest once through `readJsonFile` and hands the parsed record to `resolveWorkspacePatterns`, which previously re-read it on the npm branch. The root entry is prepended, so the result stays sorted ascending without a sort pass.
- `expandPatterns` keeps its `'.'` filter, now as a dedupe: a `**` pattern matches the root's own manifest, and dropping it there is what leaves exactly one root entry.
- Neither internal caller gains a root-excluding filter. Both `findPublishingWorkspaceDirs` and `resolveWorkspaceRoot` match a workspace by declared name, and a root declaring the package name is a workspace publishing it, so in such a repo `listOwnImplementationSpans` now exempts the whole repository.

### 🧪 Tests

- Every monorepo expectation in the four workspace suites names the root explicitly rather than being loosened to tolerate it. The cwd suite gains strength from the change: its `existsSync` arming now fires on the root manifest read, so the expected root name proves that read hit the snapshotted directory rather than the decoy.
- New cases cover the root reported exactly once under a `**` pattern, `isRoot` across a published root and a private member, the member-only `!isRoot` filter, and a workspace-pattern repo whose root manifest is unparseable.
- `listOwnImplementationSpans` gains a case for a monorepo whose root manifest declares the package name, pinning the repo-wide exemption that follows from it.

### 📚 Documentation

- The README's Workspaces section describes one uniform list, names `isRoot` and its independence from `isPackage`, and shows the `!isRoot` member filter.

Closes #397
