### PR TITLE
#103 Expose a mode-aware outcome label for rendering OverlayResult previews

### DIFF
--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -62,7 +62,7 @@ Each mode is computed from the **second (apply-side) column** of `chezmoi status
 
 ### `--verify`
 
-Read-only. Drift is any `A`/`M`/`D` row; overlay exits `1` if any exists, `0` otherwise. Pending `R` scripts are reported as "N script(s) would run" but never make verify fail. A differing file also draws the `--force` fix-it hint, phrased in the conditional because nothing was written.
+Read-only. Drift is any `A`/`M`/`D` row; overlay exits `1` if any exists, `0` otherwise. In the structured result every action tally is `0`, `conflicts` included, and the drift is counted in `pending`. Pending `R` scripts are reported as "N script(s) would run" but never make verify fail. A differing file also draws the `--force` fix-it hint, phrased in the conditional because nothing was written.
 
 `--verify` confirms **file convergence, not script execution.** It cannot know what a `run_` script would do to the target, so it reports the script as pending and moves on.
 

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -62,7 +62,7 @@ Each mode is computed from the **second (apply-side) column** of `chezmoi status
 
 ### `--verify`
 
-Read-only. Drift is any `A`/`M`/`D` row; overlay exits `1` if any exists, `0` otherwise. Pending `R` scripts are reported as "N script(s) would run" but never make verify fail.
+Read-only. Drift is any `A`/`M`/`D` row; overlay exits `1` if any exists, `0` otherwise. Pending `R` scripts are reported as "N script(s) would run" but never make verify fail. A differing file also draws the `--force` fix-it hint, phrased in the conditional because nothing was written.
 
 `--verify` confirms **file convergence, not script execution.** It cannot know what a `run_` script would do to the target, so it reports the script as pending and moves on.
 
@@ -106,3 +106,25 @@ const result = await overlay({ source: './scaffold', target: './repo', mode: 'cr
 ```
 
 `overlay(options)` returns a structured `OverlayResult` — never printed text — so other TypeScript code can compose with it.
+
+### Rendering an entry outcome
+
+Each entry's `outcome` is **mode-relative**: under `--verify` an addition is still tagged `created`, meaning "would be created". `describeOutcome` maps an outcome and a mode to a human label, so a consumer composing its own report reuses overlay's wording rather than re-deriving the preview-vs-applied mapping:
+
+```ts
+import { describeOutcome, overlay } from '@williamthorsen/overlay';
+
+const result = await overlay({ source: './scaffold', target: './repo' });
+for (const entry of result.entries) {
+  console.log(`${describeOutcome(entry.outcome, result.mode)} ${entry.path}`);
+}
+```
+
+| Outcome    | `verify`          | `create` / `force` |
+| ---------- | ----------------- | ------------------ |
+| `created`  | `would create`    | `created`          |
+| `deleted`  | `would delete`    | `deleted`          |
+| `forced`   | `would overwrite` | `overwritten`      |
+| `conflict` | `would conflict`  | `conflict`         |
+
+Labels name the entry's resulting state rather than an action overlay took, and every `verify` label carries a `would ` prefix, so a consumer can tell a read-only run from an applied one. `--verify` never produces a `forced` entry (a differing file reads as `conflict`), so that cell exists only for totality. Labels are unpadded; aligning a column is the caller's job.

--- a/packages/overlay/src/index.ts
+++ b/packages/overlay/src/index.ts
@@ -7,3 +7,4 @@ export type {
   ScriptsSummary,
 } from './modes/types.ts';
 export { overlay, type OverlayOptions } from './overlay.ts';
+export { describeOutcome } from './reporting/describeOutcome.ts';

--- a/packages/overlay/src/modes/types.ts
+++ b/packages/overlay/src/modes/types.ts
@@ -20,8 +20,9 @@ export interface ScriptsSummary {
 }
 
 /**
- * Mode-relative tallies. Under `verify` they count pending drift; under `create`/`force` they count what was actually
- * done. `conflicts` is always `0` under `force`.
+ * Mode-relative tallies. Under `create`/`force` they count what was actually done, and `conflicts` is always `0`
+ * under `force`. Under `verify` every action tally is `0` and all drift lands in `pending`; a differing file is
+ * visible only as an entry whose outcome is `conflict`.
  */
 export interface OverlayCounts {
   created: number;

--- a/packages/overlay/src/reporting/__tests__/describeOutcome.unit.test.ts
+++ b/packages/overlay/src/reporting/__tests__/describeOutcome.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { EntryOutcome, OverlayMode } from '../../modes/types.ts';
+import type { EntryOutcome } from '../../modes/types.ts';
 import { describeOutcome } from '../describeOutcome.ts';
 
 describe(describeOutcome, () => {
@@ -21,20 +21,5 @@ describe(describeOutcome, () => {
   ])('phrases %s as a resulting state under create and force', (outcome, label) => {
     expect(describeOutcome(outcome, 'create')).toBe(label);
     expect(describeOutcome(outcome, 'force')).toBe(label);
-  });
-
-  it('prefixes every verify label with "would " so a consumer can detect a read-only run', () => {
-    const outcomes: EntryOutcome[] = ['created', 'deleted', 'forced', 'conflict'];
-
-    expect(outcomes.every((outcome) => describeOutcome(outcome, 'verify').startsWith('would '))).toBe(true);
-  });
-
-  it('prefixes no applied label with "would "', () => {
-    const applied: OverlayMode[] = ['create', 'force'];
-    const outcomes: EntryOutcome[] = ['created', 'deleted', 'forced', 'conflict'];
-
-    const labels = applied.flatMap((mode) => outcomes.map((outcome) => describeOutcome(outcome, mode)));
-
-    expect(labels.some((label) => label.startsWith('would '))).toBe(false);
   });
 });

--- a/packages/overlay/src/reporting/__tests__/describeOutcome.unit.test.ts
+++ b/packages/overlay/src/reporting/__tests__/describeOutcome.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EntryOutcome, OverlayMode } from '../../modes/types.ts';
+import { describeOutcome } from '../describeOutcome.ts';
+
+describe(describeOutcome, () => {
+  it.each<[EntryOutcome, string]>([
+    ['created', 'would create'],
+    ['deleted', 'would delete'],
+    ['forced', 'would overwrite'],
+    ['conflict', 'would conflict'],
+  ])('phrases %s as a preview under verify', (outcome, label) => {
+    expect(describeOutcome(outcome, 'verify')).toBe(label);
+  });
+
+  it.each<[EntryOutcome, string]>([
+    ['created', 'created'],
+    ['deleted', 'deleted'],
+    ['forced', 'overwritten'],
+    ['conflict', 'conflict'],
+  ])('phrases %s as a resulting state under create and force', (outcome, label) => {
+    expect(describeOutcome(outcome, 'create')).toBe(label);
+    expect(describeOutcome(outcome, 'force')).toBe(label);
+  });
+
+  it('prefixes every verify label with "would " so a consumer can detect a read-only run', () => {
+    const outcomes: EntryOutcome[] = ['created', 'deleted', 'forced', 'conflict'];
+
+    expect(outcomes.every((outcome) => describeOutcome(outcome, 'verify').startsWith('would '))).toBe(true);
+  });
+
+  it('prefixes no applied label with "would "', () => {
+    const applied: OverlayMode[] = ['create', 'force'];
+    const outcomes: EntryOutcome[] = ['created', 'deleted', 'forced', 'conflict'];
+
+    const labels = applied.flatMap((mode) => outcomes.map((outcome) => describeOutcome(outcome, mode)));
+
+    expect(labels.some((label) => label.startsWith('would '))).toBe(false);
+  });
+});

--- a/packages/overlay/src/reporting/__tests__/formatReport.unit.test.ts
+++ b/packages/overlay/src/reporting/__tests__/formatReport.unit.test.ts
@@ -11,21 +11,69 @@ describe(formatReport, () => {
   });
 
   it('lists drift entries and a drift count under verify', () => {
+    const report = formatReport(buildDriftResult());
+
+    expect(report).toContain('would create   .new');
+    expect(report).toContain('would conflict .diff');
+    expect(report).toContain('Drift: 2 entries.');
+  });
+
+  it('phrases every entry as a preview under verify', () => {
     const report = formatReport(
       buildResult({
         mode: 'verify',
         entries: [
           { path: '.new', outcome: 'created' },
-          { path: '.diff', outcome: 'conflict' },
+          { path: '.gone', outcome: 'deleted' },
         ],
         counts: { created: 0, deleted: 0, forced: 0, conflicts: 0, pending: 2 },
         exitCode: 1,
       }),
     );
 
-    expect(report).toContain('.new');
-    expect(report).toContain('.diff');
-    expect(report).toContain('Drift: 2 entries.');
+    expect(report).toContain('would create .new');
+    expect(report).toContain('would delete .gone');
+  });
+
+  it('phrases every entry as a resulting state under create', () => {
+    const report = formatReport(
+      buildResult({
+        mode: 'create',
+        entries: [
+          { path: '.new', outcome: 'created' },
+          { path: '.diff', outcome: 'conflict' },
+        ],
+        counts: { created: 1, deleted: 0, forced: 0, conflicts: 1, pending: 0 },
+        exitCode: 1,
+      }),
+    );
+
+    expect(report).toContain('created  .new');
+    expect(report).toContain('conflict .diff');
+    expect(report).not.toContain('would ');
+  });
+
+  it('phrases an overwritten entry as a resulting state under force', () => {
+    const report = formatReport(
+      buildResult({
+        mode: 'force',
+        entries: [{ path: '.diff', outcome: 'forced' }],
+        counts: { created: 0, deleted: 0, forced: 1, conflicts: 0, pending: 0 },
+      }),
+    );
+
+    expect(report).toContain('overwritten .diff');
+  });
+
+  it('pads labels to the widest one present so the paths align', () => {
+    const report = formatReport(buildDriftResult());
+
+    const columns = report
+      .split('\n')
+      .filter((line) => line.startsWith('  '))
+      .map((line) => line.indexOf('.'));
+
+    expect(new Set(columns).size).toBe(1);
   });
 
   it('phrases pending scripts as "would run" under verify', () => {
@@ -71,6 +119,20 @@ describe(formatReport, () => {
     expect(report).toContain('overlay --force');
   });
 
+  it('includes a conditional fix-it hint when a verify run reports a differing file', () => {
+    const report = formatReport(
+      buildResult({
+        mode: 'verify',
+        entries: [{ path: '.diff', outcome: 'conflict' }],
+        counts: { created: 0, deleted: 0, forced: 0, conflicts: 0, pending: 1 },
+        exitCode: 1,
+      }),
+    );
+
+    expect(report).toContain('would be left untouched by `--create`');
+    expect(report).toContain('overlay --force');
+  });
+
   it('omits the fix-it hint when there are no conflicts', () => {
     const report = formatReport(
       buildResult({ mode: 'force', counts: { created: 1, deleted: 0, forced: 0, conflicts: 0, pending: 0 } }),
@@ -88,7 +150,20 @@ describe(formatReport, () => {
 
 // region | Helpers
 
-/** Build an `OverlayResult` from a converged-verify baseline, applying the given overrides. */
+/** Builds a verify result holding one addition and one differing file. */
+function buildDriftResult(): OverlayResult {
+  return buildResult({
+    mode: 'verify',
+    entries: [
+      { path: '.new', outcome: 'created' },
+      { path: '.diff', outcome: 'conflict' },
+    ],
+    counts: { created: 0, deleted: 0, forced: 0, conflicts: 0, pending: 2 },
+    exitCode: 1,
+  });
+}
+
+/** Builds an `OverlayResult` from a converged-verify baseline, applying the given overrides. */
 function buildResult(overrides: Partial<OverlayResult>): OverlayResult {
   return {
     mode: 'verify',

--- a/packages/overlay/src/reporting/__tests__/formatReport.unit.test.ts
+++ b/packages/overlay/src/reporting/__tests__/formatReport.unit.test.ts
@@ -13,8 +13,8 @@ describe(formatReport, () => {
   it('lists drift entries and a drift count under verify', () => {
     const report = formatReport(buildDriftResult());
 
-    expect(report).toContain('would create   .new');
-    expect(report).toContain('would conflict .diff');
+    expect(report).toContain('.new');
+    expect(report).toContain('.diff');
     expect(report).toContain('Drift: 2 entries.');
   });
 
@@ -65,15 +65,19 @@ describe(formatReport, () => {
     expect(report).toContain('overwritten .diff');
   });
 
-  it('pads labels to the widest one present so the paths align', () => {
-    const report = formatReport(buildDriftResult());
+  it('pads labels to the widest one present, so a run of equal-width labels gets no dead whitespace', () => {
+    const mixedWidths = formatReport(buildDriftResult());
+    const equalWidths = formatReport(
+      buildResult({
+        mode: 'verify',
+        entries: [{ path: '.new', outcome: 'created' }],
+        counts: { created: 0, deleted: 0, forced: 0, conflicts: 0, pending: 1 },
+        exitCode: 1,
+      }),
+    );
 
-    const columns = report
-      .split('\n')
-      .filter((line) => line.startsWith('  '))
-      .map((line) => line.indexOf('.'));
-
-    expect(new Set(columns).size).toBe(1);
+    expect(mixedWidths).toContain('would create   .new');
+    expect(equalWidths).toContain('would create .new');
   });
 
   it('phrases pending scripts as "would run" under verify', () => {

--- a/packages/overlay/src/reporting/describeOutcome.ts
+++ b/packages/overlay/src/reporting/describeOutcome.ts
@@ -1,0 +1,25 @@
+import type { EntryOutcome, OverlayMode } from '../modes/types.ts';
+
+/**
+ * Describes an entry outcome as a human label, phrased for the mode that produced it.
+ *
+ * `verify` yields a preview (`would create`); `create` and `force` yield the resulting state (`created`). Consumers
+ * composing their own report reuse this instead of re-deriving the preview-vs-applied wording from a mode-relative
+ * outcome. Labels are unpadded: aligning a column belongs to whoever renders one.
+ */
+export function describeOutcome(outcome: EntryOutcome, mode: OverlayMode): string {
+  const labels = OUTCOME_LABELS[outcome];
+  return mode === 'verify' ? labels.preview : labels.applied;
+}
+
+/**
+ * The `verify` and `create`/`force` label for each outcome. Labels name the entry's resulting state rather than an
+ * action overlay took, which is the frame `conflict` fits: `forced` reads as `overwritten` because `--force` permits
+ * the write rather than describing what happened to the path.
+ */
+const OUTCOME_LABELS: Record<EntryOutcome, { preview: string; applied: string }> = {
+  created: { preview: 'would create', applied: 'created' },
+  deleted: { preview: 'would delete', applied: 'deleted' },
+  forced: { preview: 'would overwrite', applied: 'overwritten' },
+  conflict: { preview: 'would conflict', applied: 'conflict' },
+};

--- a/packages/overlay/src/reporting/formatReport.ts
+++ b/packages/overlay/src/reporting/formatReport.ts
@@ -1,38 +1,54 @@
-import type { EntryOutcome, OverlayResult } from '../modes/types.ts';
+import type { OverlayResult } from '../modes/types.ts';
 import { pluralizeWithCount } from '../portable/pluralize.ts';
+import { describeOutcome } from './describeOutcome.ts';
 
 /**
- * Render an `OverlayResult` as human-readable report text for stdout.
+ * Renders an `OverlayResult` as human-readable report text for stdout.
  *
- * Lists per-entry outcomes, a counts summary, the scripts summary (phrased "would run" under verify, "ran"
- * otherwise), and — when conflicts exist — a fix-it hint to re-run with `--force`. Built entirely from the structured
- * result; chezmoi's own output never reaches stdout.
+ * Lists per-entry outcomes in an aligned label column, a counts summary, the scripts summary (phrased "would run"
+ * under verify, "ran" otherwise), and a fix-it hint to re-run with `--force` whenever any entry conflicts. Built
+ * entirely from the structured result; chezmoi's own output never reaches stdout.
  */
 export function formatReport(result: OverlayResult): string {
-  const lines: string[] = Array.from(result.entries, (entry) => `  ${OUTCOME_LABELS[entry.outcome]} ${entry.path}`);
+  const lines: string[] = listEntries(result);
   if (result.entries.length > 0) {
     lines.push('');
   }
 
   lines.push(summarizeCounts(result), summarizeScripts(result));
 
-  if (result.counts.conflicts > 0) {
-    lines.push('', 'Conflicts left untouched. Re-run with `overlay --force` to overwrite differing files.');
+  if (result.entries.some((entry) => entry.outcome === 'conflict')) {
+    lines.push('', hintAtForce(result));
   }
 
   return lines.join('\n');
 }
 
-const OUTCOME_LABELS: Record<EntryOutcome, string> = {
-  created: 'create ',
-  deleted: 'delete ',
-  forced: 'force  ',
-  conflict: 'conflict',
-};
-
 // region | Helpers
 
-/** Build the counts line, phrased as pending drift under verify and as actions taken otherwise. */
+/**
+ * Builds the fix-it hint, phrased in the conditional under verify, which reports a differing file without having
+ * written anything.
+ */
+function hintAtForce(result: OverlayResult): string {
+  if (result.mode === 'verify') {
+    return 'Differing files would be left untouched by `--create`. Re-run with `overlay --force` to overwrite them.';
+  }
+  return 'Conflicts left untouched. Re-run with `overlay --force` to overwrite differing files.';
+}
+
+/** Builds the entry lines, padding each label to the widest one present so the paths align in a single column. */
+function listEntries(result: OverlayResult): string[] {
+  const labeled = Array.from(result.entries, (entry) => ({
+    label: describeOutcome(entry.outcome, result.mode),
+    path: entry.path,
+  }));
+  const width = Math.max(0, ...labeled.map(({ label }) => label.length));
+
+  return labeled.map(({ label, path }) => `  ${label.padEnd(width)} ${path}`);
+}
+
+/** Builds the counts line, phrased as pending drift under verify and as actions taken otherwise. */
 function summarizeCounts(result: OverlayResult): string {
   if (result.mode === 'verify') {
     if (result.counts.pending === 0) {
@@ -53,7 +69,7 @@ function summarizeCounts(result: OverlayResult): string {
   return parts.join(', ') + '.';
 }
 
-/** Build the scripts-summary line, phrased "would run" under verify and "ran" otherwise. */
+/** Builds the scripts-summary line, phrased "would run" under verify and "ran" otherwise. */
 function summarizeScripts(result: OverlayResult): string {
   const verb = result.mode === 'verify' ? 'would run' : 'ran';
   const status = result.scripts.ok ? '' : ' (a script failed)';


### PR DESCRIPTION
## What

Fixes an issue where an overlay run gave no sign whether it had previewed or applied. `overlay --verify` described drift in the same words an applied run used, so a read-only run read as though it had written the files, and a differing file came with no route to `--force`. Verify now reports what it would do, and offers the route.

Adds `describeOutcome`, the same wording as a published export, so a consumer composing its own report from an `OverlayResult` draws the preview-versus-applied distinction rather than re-deriving it.

## Why

A consumer of `overlay()` cannot tell a preview from an applied run without re-deriving the distinction itself. Entries carry the outcome they would have under `--create` whatever mode produced them, so rendering them directly reports a read-only run as work that was done. The `thrive-replit-overlay` wrapper hit exactly this, printing `created .envrc` under `--verify` with no signal that the run wrote nothing.

Overlay's own CLI showed the same defect from the other side: it had the wording that would have fixed this and kept it internal, while its own report drew no distinction between a run it had applied and one it had only inspected.

## Details

### 🎉 Features

- `describeOutcome(outcome, mode)` is exported from the package root and returns a label for each of the eight outcome-by-mode combinations. Labels name the entry's resulting state rather than an action overlay took, which is why `forced` reads as `overwritten`: `--force` permits the write rather than describing what happened to the path.
- Labels are returned unpadded and typed as `string` rather than a union of the label values, so aligning a column stays with the caller and rewording is not a breaking type change.

### 🐛 Bug fixes

- `formatReport` sources every entry label from `describeOutcome`, so verify output is distinguishable from create and force output at a glance.
- The `--force` fix-it hint was gated on `counts.conflicts`, which `runVerify` always leaves at `0`. It now fires whenever an entry's outcome is `conflict`, which is the only predicate true in every mode that produces one, and is worded in the conditional under verify.
- Entry labels pad to the widest label present in the run, so paths align in a single column and a run of equal-width labels carries no dead whitespace.

### 🧪 Tests

- All eight outcome-by-mode combinations are asserted against literal labels, including the `forced` under `--verify` cell that no end-to-end run reaches, since `runVerify` maps a differing file to `conflict`.
- `formatReport` gains per-mode label coverage, a case for the verify fix-it hint, and a case contrasting a mixed-width run against an equal-width one so the column-width rule fails on its own name.

### 📚 Documentation

- The README's programmatic-use section gains "Rendering an entry outcome", covering the export, a worked loop, and the full label table.
- `OverlayCounts` and the README's `--verify` section now name the zero tallies under verify alongside the `--force` one, and point a caller at the entry outcome as the only place a differing file is visible under verify.

Closes #103
