### PR TITLE
#350 Remove readyup's last sub-barrel and enforce barrel placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ From the repo root, `pnpm exec rdy run --packages` runs the default kit of every
 
 Lefthook's pre-commit hook formats staged files with Prettier and restages them, so a commit can carry bytes you did not write.
 
+The root suite's `barrel-placement` test flags every `index.ts` under a package's `src/` whose compiled target that package's `exports` map does not name, so a barrel is admitted only where it backs a published entry point.
+
 ## Commit conventions
 
 The scope values this repo uses are `compositor`, `overlay`, `readyup`, and `root`, mirroring the `scope:*` labels in `.config/release-kit.config.ts`.

--- a/__tests__/barrel-placement.unit.test.ts
+++ b/__tests__/barrel-placement.unit.test.ts
@@ -44,7 +44,8 @@ function collectUnpublishedBarrels(): string[] {
   const manifests = globSync('packages/*/package.json', { cwd: repoRoot });
   for (const manifest of manifests) {
     const packageDir = toPosix(path.dirname(manifest));
-    // Matching is exact: no wildcard entry here targets `dist/`, so a barrel published only by a wildcard escapes.
+    // Matching is exact, so a wildcard entry targeting `dist/` would leave the barrels it publishes reported as
+    // offenders. No entry here uses one.
     const published = collectExportTargets(readExports(manifest));
     for (const barrel of findBarrels(packageDir)) {
       if (!published.has(deriveCompiledTarget(packageDir, barrel))) unpublished.push(barrel);

--- a/__tests__/barrel-placement.unit.test.ts
+++ b/__tests__/barrel-placement.unit.test.ts
@@ -1,0 +1,80 @@
+import { globSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+
+// Directories under `src/` that hold test code rather than shipped source.
+const NON_SOURCE_DIRS = new Set(['__fixtures__', '__mocks__', '__tests__', 'test-utils']);
+
+// A barrel is permitted only where it backs a published entry point, so an `index.ts` the `exports` map does not name
+// is one every importer of a single symbol pays for by loading the whole directory.
+describe('barrel placement', () => {
+  it('every index.ts under a package src backs an entry in that package exports map', () => {
+    const unpublished = collectUnpublishedBarrels();
+
+    expect(unpublished).toStrictEqual([]);
+  });
+});
+
+// region | Helpers
+
+/**
+ * Collects every string anywhere in an `exports` value, which is the set of paths the manifest publishes.
+ *
+ * Reading the strings rather than the keys covers the bare-string form and the conditional-object form alike, and
+ * needs no list of the condition names a manifest may use.
+ */
+function collectExportTargets(value: unknown, targets = new Set<string>()): Set<string> {
+  if (typeof value === 'string') {
+    targets.add(value);
+  } else if (Array.isArray(value)) {
+    for (const entry of value) collectExportTargets(entry, targets);
+  } else if (typeof value === 'object' && value !== null) {
+    const nested: unknown[] = Object.values(value);
+    for (const entry of nested) collectExportTargets(entry, targets);
+  }
+  return targets;
+}
+
+/** Returns the repo-relative path of every source barrel no `exports` entry publishes, in sorted order. */
+function collectUnpublishedBarrels(): string[] {
+  const unpublished: string[] = [];
+  const manifests = globSync('packages/*/package.json', { cwd: repoRoot });
+  for (const manifest of manifests) {
+    const packageDir = toPosix(path.dirname(manifest));
+    // Matching is exact: no wildcard entry here targets `dist/`, so a barrel published only by a wildcard escapes.
+    const published = collectExportTargets(readExports(manifest));
+    for (const barrel of findBarrels(packageDir)) {
+      if (!published.has(deriveCompiledTarget(packageDir, barrel))) unpublished.push(barrel);
+    }
+  }
+  return unpublished.toSorted();
+}
+
+/** Returns the `exports` target a barrel compiles to, which is the path an entry must name to publish it. */
+function deriveCompiledTarget(packageDir: string, barrel: string): string {
+  const withinSrc = toPosix(path.relative(path.join(packageDir, 'src'), barrel));
+  return `./dist/esm/${withinSrc.replace(/\.ts$/, '.js')}`;
+}
+
+/** Returns the repo-relative path of every barrel in a package's shipped source. */
+function findBarrels(packageDir: string): string[] {
+  const found = globSync(`${packageDir}/src/**/index.ts`, { cwd: repoRoot });
+  return found.map(toPosix).filter((file) => file.split('/').every((segment) => !NON_SOURCE_DIRS.has(segment)));
+}
+
+/** Reads a manifest's `exports` value, or undefined where it declares none. */
+function readExports(manifest: string): unknown {
+  const parsed: unknown = JSON.parse(readFileSync(path.join(repoRoot, manifest), 'utf8'));
+  if (typeof parsed !== 'object' || parsed === null || !('exports' in parsed)) return undefined;
+  return parsed.exports;
+}
+
+/** Rewrites a path to POSIX separators, so a comparison against a manifest's forward-slash targets holds. */
+function toPosix(file: string): string {
+  return file.split('\\').join('/');
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/check-utils/git/index.ts
+++ b/packages/readyup/src/check-utils/git/index.ts
@@ -1,5 +1,0 @@
-export { compareLocalRefs } from './compare-local-refs.ts';
-export { compareRefToRemote } from './compare-ref-to-remote.ts';
-export { makeLocalRefSyncCheck, makeRemoteRefSyncCheck } from './factories.ts';
-export { isAtRepoRoot, isGitRepo } from './repo-predicates.ts';
-export { expandHome, runGit } from './run-git.ts';

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -10,16 +10,11 @@ export { readEnginesNodeFloor, satisfiesNodeFloor } from './engines.ts';
 export type { EsYear } from './es-year.ts';
 export { esYearForNodeMajor } from './es-year.ts';
 export { commandExists, fileContains, fileDoesNotContain, fileExists, filesExist, readFile } from './filesystem.ts';
-export {
-  compareLocalRefs,
-  compareRefToRemote,
-  expandHome,
-  isAtRepoRoot,
-  isGitRepo,
-  makeLocalRefSyncCheck,
-  makeRemoteRefSyncCheck,
-  runGit,
-} from './git/index.ts';
+export { compareLocalRefs } from './git/compare-local-refs.ts';
+export { compareRefToRemote } from './git/compare-ref-to-remote.ts';
+export { makeLocalRefSyncCheck, makeRemoteRefSyncCheck } from './git/factories.ts';
+export { isAtRepoRoot, isGitRepo } from './git/repo-predicates.ts';
+export { expandHome, runGit } from './git/run-git.ts';
 export { computeHash, fileMatchesHash } from './hashing.ts';
 export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json.ts';
 export { getJsonValue, hasJsonValue } from './json-value.ts';


### PR DESCRIPTION
## What

Removes `readyup`'s last internal barrel file and adds a repo-wide test disallowing the use of a barrel file other than for a published entry point.

## Why

A barrel that no entry point publishes makes every importer of a single symbol load the whole directory, and the sibling `check-utils/project/` directory already reached its modules directly, so the two read as different conventions. Nothing enforced the rule, so the drift persisted unnoticed.

## Details

### ♻️ Refactoring

- Deletes `check-utils/git/index.ts` and replaces the grouped re-export block in `check-utils/index.ts` with five per-module `export` statements, which occupy the same alphabetical slot.
- Leaves `runGitRaw` and `isRefMissingError` internal, as they were; the deleted barrel never published them.
- Requires no importer changes: `check-utils/index.ts` was the barrel's only consumer, and the git modules, their tests, and `project/listTrackedFiles.ts` already imported by defining module.

### 🧪 Tests

- Adds `__tests__/barrel-placement.unit.test.ts`, which globs `packages/*/package.json`, collects every string anywhere in each `exports` value, and reports any barrel whose derived `./dist/esm/…` target is absent from that set.
- Collects export targets by walking the `exports` value recursively, so the bare-string form and the conditional-object form are both handled without naming the condition keys.
- Treats a package declaring no `exports` map as publishing nothing, and skips `__fixtures__`, `__mocks__`, `__tests__`, and `test-utils` under `src/`.
- Matches targets exactly rather than expanding wildcards, so a wildcard entry targeting `dist/` would leave the barrels it publishes reported as offenders. No entry uses one.

### 🤖 Agentic support

- Records the `barrel-placement` invariant in `AGENTS.md` under `### Code quality`, beside the tier-infix rule it sits with.

Closes #350
