### PR TITLE
#144 Apply the comment standard across the readyup package

### DIFF
--- a/packages/readyup/src/__tests__/packaging.tool.test.ts
+++ b/packages/readyup/src/__tests__/packaging.tool.test.ts
@@ -6,7 +6,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 const packageDir = path.resolve(import.meta.dirname, '../..');
 
 /**
- * Guards what the published tarball carries.
+ * Guards what the published tarball includes.
  *
  * This is the only check that exercises `files`: every other check here resolves readyup's guidance through a
  * `workspace:*` self-link to the live source tree, so a dropped `agents` entry breaks registry installs alone.

--- a/packages/readyup/src/__tests__/readyupResolverHook.unit.test.ts
+++ b/packages/readyup/src/__tests__/readyupResolverHook.unit.test.ts
@@ -5,7 +5,7 @@ import { initialize, resolve } from '../readyupResolverHook.ts';
 const READYUP_PARENT_URL = 'file:///runner/node_modules/readyup/dist/esm/bin/rdy.js';
 const KIT_PARENT_URL = 'file:///tmp/rdy-XYZ/kit.js';
 
-/** Build the minimal `context` object Node passes to a resolve hook. */
+/** Returns the minimal `context` object Node passes to a resolve hook. */
 function buildContext(overrides: Partial<{ parentURL: string; conditions: string[] }> = {}) {
   return {
     conditions: overrides.conditions ?? ['node', 'import'],
@@ -14,7 +14,7 @@ function buildContext(overrides: Partial<{ parentURL: string; conditions: string
   };
 }
 
-/** Default `nextResolve` stub that returns a synthetic URL. */
+/** Stands in for `nextResolve`, returning a synthetic URL. */
 function buildNextResolve() {
   return vi.fn().mockReturnValue({ url: 'file:///resolved.js', shortCircuit: true });
 }

--- a/packages/readyup/src/__tests__/sideEffectFreeSrc.app.unit.test.ts
+++ b/packages/readyup/src/__tests__/sideEffectFreeSrc.app.unit.test.ts
@@ -12,7 +12,7 @@ const SRC_ROOT = join(thisFileDir, '..');
 const PACKAGE_JSON_PATH = join(thisFileDir, '..', '..', 'package.json');
 
 /**
- * Files in `src/` that intentionally carry top-level side effects (CLI entry points, etc.).
+ * Files in `src/` that intentionally have top-level side effects, such as CLI entry points.
  * Each entry is a src-relative POSIX path. The corresponding compiled output MUST appear in
  * package.json's `sideEffects` array so bundlers don't tree-shake it.
  */

--- a/packages/readyup/src/bin/__tests__/route.compiledWithReporting.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.compiledWithReporting.unit.test.ts
@@ -74,7 +74,7 @@ describe('compile-time readyup version in the run report', () => {
 
 // region | Helpers
 
-/** Builds a kit source carrying the version stamp `rdy compile` embeds in a bundle. */
+/** Builds a kit source with the version stamp `rdy compile` embeds in a bundle. */
 function buildStampedKit(version: string): string {
   return `export const __readyupVersion = '${version}';\n${KIT_BODY}`;
 }

--- a/packages/readyup/src/bin/__tests__/route.detailProjection.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.detailProjection.unit.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from 'vitest';
 
 import { routeCommand } from '../route.ts';
 
-/** A kit with one passing check and one failing check that carries a fix. */
+/** A kit with one passing check and one failing check that has a fix. */
 const MIXED_KIT =
   `export default { checklists: [{ name: 'main', checks: [\n` +
   `  { name: 'clean', check: () => true },\n` +

--- a/packages/readyup/src/bin/exitCodes.ts
+++ b/packages/readyup/src/bin/exitCodes.ts
@@ -3,7 +3,7 @@
  *
  * The code answers "can I retry this invocation?": 1 means the invocation was well-formed
  * and the repo has problems to fix; 2 means rdy could not complete the invocation at all.
- * `rdy list` and `rdy init` produce only 0 and 2 — neither can find problems to report.
+ * `rdy list` and `rdy init` produce only 0 and 2 -- neither can find problems to report.
  */
 
 /** Ran to completion and found no problems. */

--- a/packages/readyup/src/bin/rdy.ts
+++ b/packages/readyup/src/bin/rdy.ts
@@ -15,8 +15,8 @@ try {
   // `readyup`/`readyup/*` imports in compiled kits are routed through this hook to
   // the runner's own readyup installation, sidestepping filesystem walk-up from
   // the kit's location. The hook sits one directory up from this file in both
-  // layouts — `src/readyupResolverHook.ts` under tsx, `dist/esm/readyupResolverHook.js`
-  // in the compiled build — so `resolveHookSpecifier` derives the extension from this
+  // layouts -- `src/readyupResolverHook.ts` under tsx, `dist/esm/readyupResolverHook.js`
+  // in the compiled build -- so `resolveHookSpecifier` derives the extension from this
   // runner's own URL rather than hardcoding one. (nmr-compile rewrites specifiers only
   // in import/export/`import()` positions, never a `module.register()` argument, so the
   // extension cannot be deferred to the build.) Wrapping this call in the runner's error

--- a/packages/readyup/src/bin/resolveHookSpecifier.ts
+++ b/packages/readyup/src/bin/resolveHookSpecifier.ts
@@ -1,6 +1,6 @@
 /**
  * Resolves the readyup resolver-hook specifier for `module.register`, choosing the extension
- * from the runner's own URL — `.ts` under tsx, `.js` in the compiled build — so registration
+ * from the runner's own URL -- `.ts` under tsx, `.js` in the compiled build -- so registration
  * works identically from `src` and from `dist/esm`.
  */
 export function resolveHookSpecifier(runnerUrl: string): string {

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -31,7 +31,7 @@ import { hasJsonFlag } from './hasJsonFlag.ts';
 /** Command names a mistyped bare word is matched against, including the implicit `run`. */
 export const COMMAND_NAMES = ['compile', 'help', 'init', 'list', 'run', 'verify'];
 
-/** Extensions a kit file can carry, in the order `run` would resolve them. */
+/** Extensions a kit file can take, in the order `run` would resolve them. */
 const KIT_EXTENSIONS = ['.js', '.ts'];
 
 /** Flags naming where a kit comes from, each of which resolves it somewhere the local probe cannot see. */
@@ -42,7 +42,7 @@ const SOURCE_FLAGS = new Set(['--file', '-f', '--from', '--internal', '--url']);
  *
  * Returns a numeric exit code. Every failure that prevents the invocation from completing
  * is rendered here — as prose on stderr, or as the JSON error envelope on stdout when
- * `--json` is in argv — so no command carries its own error-reporting path.
+ * `--json` is in argv -- so no command needs an error-reporting path of its own.
  */
 export async function routeCommand(args: string[]): Promise<number> {
   const json = hasJsonFlag(args);
@@ -207,7 +207,7 @@ function handleInit(flags: string[]): number {
 }
 
 /**
- * Returns `argv` without a leading `--style` and the value it carries.
+ * Returns `argv` without a leading `--style` and the value beside it.
  *
  * Command selection reads the first argument, so a style named ahead of the command would otherwise be
  * taken for a kit name. `routeCommand` has already read the value, so nothing downstream needs the

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -38,11 +38,10 @@ const KIT_EXTENSIONS = ['.js', '.ts'];
 const SOURCE_FLAGS = new Set(['--file', '-f', '--from', '--internal', '--url']);
 
 /**
- * Routes CLI arguments to the appropriate subcommand.
+ * Routes CLI arguments to the appropriate subcommand, returning the exit code it produced.
  *
- * Returns a numeric exit code. Every failure that prevents the invocation from completing
- * is rendered here — as prose on stderr, or as the JSON error envelope on stdout when
- * `--json` is in argv -- so no command needs an error-reporting path of its own.
+ * Every failure that prevents the invocation from completing is rendered here -- as prose on stderr, or as the JSON
+ * error envelope on stdout when `--json` is in argv -- so no command needs an error-reporting path of its own.
  */
 export async function routeCommand(args: string[]): Promise<number> {
   const json = hasJsonFlag(args);
@@ -140,7 +139,7 @@ async function handleRun(flags: string[], json: boolean): Promise<number> {
 
   const parsed = parseRunArgs(flags);
 
-  // Skip config when an external source flag is active — external modes don't use config values.
+  // Skip config when an external source flag is active -- external modes don't use config values.
   // `--packages` is not one of them: the config is where the packages it runs are named.
   const hasExternalSource =
     parsed.filePath !== undefined || parsed.fromValue !== undefined || parsed.urlValue !== undefined;

--- a/packages/readyup/src/check-utils/__tests__/tsconfig.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/tsconfig.unit.test.ts
@@ -220,7 +220,7 @@ describe(readTsconfigLanguageLevel, () => {
     });
 
     expect(readTsconfigLanguageLevel('packages/alpha/tsconfig.json')).toStrictEqual({
-      // `target` is undeclared in the package config, so the root's value carries through.
+      // `target` is undeclared in the package config, so the root's value applies.
       lib: ['es2022'],
       target: 'es2025',
       chain: ['packages/alpha/tsconfig.json', 'tsconfig.json'],

--- a/packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts
@@ -105,7 +105,7 @@ function discoverWithCwdRepointedAt(decoyDir: string, fsFunction: FsTrigger): Wo
 }
 
 /**
- * Writes a second repo root whose manifests all carry the name `decoy`, at the same relative paths as the real
+ * Writes a second repo root whose manifests all use the name `decoy`, at the same relative paths as the real
  * root's, so a helper reading through the ambient cwd reports a wrong name rather than an empty result.
  */
 function writeDecoyRoot(temp: TempTree): string {

--- a/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
@@ -228,7 +228,7 @@ describe(discoverWorkspaces, () => {
     it('does not traverse into node_modules', ({ temp }) => {
       writeRootPackageJson(temp, { name: 'root', private: true, workspaces: ['**/*'] });
       writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha' });
-      // A fake workspace hiding inside node_modules — must not appear in results.
+      // A fake workspace hiding inside node_modules -- must not appear in results.
       writeWorkspacePackage(temp, 'node_modules/sneaky', { name: 'sneaky' });
 
       const workspaces = discoverWorkspaces();

--- a/packages/readyup/src/check-utils/discoverKitPackages.ts
+++ b/packages/readyup/src/check-utils/discoverKitPackages.ts
@@ -7,7 +7,7 @@ import { KITS_DIR } from '../kits/kitsDir.ts';
 import { enumerateKits } from '../list/enumerateKits.ts';
 import { isRecord } from '../portable/isRecord.ts';
 
-/** Manifest fields a kit-carrying dependency can be declared in. */
+/** Manifest fields a kit-publishing dependency can be declared in. */
 const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies'];
 
 /**
@@ -29,7 +29,7 @@ export function discoverKitPackages(fromDir: string = process.cwd()): string[] {
 
 // region | Helpers
 
-/** Reports whether an installed package carries at least one compiled kit. */
+/** Reports whether an installed package contains at least one compiled kit. */
 function publishesKits(packageName: string, fromDir: string): boolean {
   const root = resolvePackageRoot(packageName, fromDir);
   if (root === undefined) return false;

--- a/packages/readyup/src/check-utils/engines.ts
+++ b/packages/readyup/src/check-utils/engines.ts
@@ -45,7 +45,7 @@ export function satisfiesNodeFloor(version: string, floor: string): boolean | un
 
 // region | Helpers
 
-/** Trims a version string and strips the leading `v` that Node's own version carries. */
+/** Trims a version string and strips the leading `v` on Node's own version. */
 function normalizeVersion(version: string): string {
   const trimmed = version.trim();
   return trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;

--- a/packages/readyup/src/check-utils/engines.ts
+++ b/packages/readyup/src/check-utils/engines.ts
@@ -33,7 +33,7 @@ export function readEnginesNodeFloor(manifest: Record<string, unknown>): Engines
 
 /**
  * Reports whether a Node version is at or above a floor, and undefined when either argument is not a
- * dotted numeric version — the shape `.tool-versions` tokens such as `lts` and `system` do not take.
+ * dotted numeric version -- the shape `.tool-versions` tokens such as `lts` and `system` do not take.
  * A leading `v` is tolerated on either argument, so `process.version` can be passed as it comes.
  */
 export function satisfiesNodeFloor(version: string, floor: string): boolean | undefined {

--- a/packages/readyup/src/check-utils/git/__tests__/compare-ref-to-remote.unit.test.ts
+++ b/packages/readyup/src/check-utils/git/__tests__/compare-ref-to-remote.unit.test.ts
@@ -156,7 +156,7 @@ describe(compareRefToRemote, () => {
 
 // region | Helpers
 
-/** Stub `runGit` to route calls by git subcommand and arguments. */
+/** Stubs `runGit` to route calls by git subcommand and arguments. */
 function stubRunGit(routes: Record<string, string | Error>): void {
   runGit.mockImplementation((_path: string, ...args: string[]) => {
     const key = args.join(' ');

--- a/packages/readyup/src/check-utils/git/compare-local-refs.ts
+++ b/packages/readyup/src/check-utils/git/compare-local-refs.ts
@@ -1,7 +1,7 @@
 import type { LocalRefsCompareResult } from '../../kits/types.ts';
 import { isRefMissingError, runGit } from './run-git.ts';
 
-/** Compare two local git refs and return a discriminated-union result. */
+/** Returns how two local git refs relate, as a discriminated union. */
 export async function compareLocalRefs(path: string, refA: string, refB: string): Promise<LocalRefsCompareResult> {
   const missingRef = await findMissingRef(path, refA, refB);
   if (missingRef !== undefined) {
@@ -19,7 +19,7 @@ export async function compareLocalRefs(path: string, refA: string, refB: string)
   return { status: 'mismatch', shaA, shaB, ...(aheadBehind && { aheadBehind }) };
 }
 
-/** Return the name of the first ref that does not exist, or undefined if both exist. */
+/** Returns the name of the first ref that does not exist, or undefined where both exist. */
 async function findMissingRef(path: string, refA: string, refB: string): Promise<string | undefined> {
   const [existsA, existsB] = await Promise.all([refExists(path, refA), refExists(path, refB)]);
   if (!existsA) return refA;
@@ -27,7 +27,7 @@ async function findMissingRef(path: string, refA: string, refB: string): Promise
   return undefined;
 }
 
-/** Check whether a ref exists in the repository. Rethrow non-ref-missing errors. */
+/** Reports whether a ref exists in the repository, rethrowing errors that mean anything else. */
 async function refExists(path: string, ref: string): Promise<boolean> {
   try {
     await runGit(path, 'rev-parse', '--verify', ref);
@@ -38,7 +38,7 @@ async function refExists(path: string, ref: string): Promise<boolean> {
   }
 }
 
-/** Compute ahead/behind counts between two refs. Return undefined on failure. */
+/** Returns the ahead/behind counts between two refs, or undefined where they cannot be computed. */
 async function resolveAheadBehind(
   path: string,
   refA: string,

--- a/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
+++ b/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
@@ -2,7 +2,7 @@ import type { RemoteRefCompareResult } from '../../kits/types.ts';
 import { toError } from '../../portable/toError.ts';
 import { isRefMissingError, runGit } from './run-git.ts';
 
-/** Compare a local ref to its counterpart on a remote. Uses `ls-remote` (no fetch). */
+/** Returns how a local ref relates to its counterpart on a remote, read via `ls-remote` without fetching. */
 export async function compareRefToRemote(
   path: string,
   ref: string,
@@ -33,7 +33,7 @@ export async function compareRefToRemote(
   return { status: 'out-of-sync', localSha, remoteSha, ...(aheadBehind && { aheadBehind }) };
 }
 
-/** Resolve a local ref to its SHA, or undefined if it doesn't exist. Rethrow non-ref-missing errors. */
+/** Returns a local ref's SHA, or undefined where the ref does not exist, rethrowing errors that mean anything else. */
 async function resolveLocalRef(path: string, ref: string): Promise<string | undefined> {
   try {
     return await runGit(path, 'rev-parse', '--verify', ref);
@@ -43,7 +43,7 @@ async function resolveLocalRef(path: string, ref: string): Promise<string | unde
   }
 }
 
-/** Resolve a remote ref to its SHA via ls-remote. Return undefined if the ref doesn't exist. Throw on network errors. */
+/** Returns a remote ref's SHA via `ls-remote`, or undefined where the ref does not exist. Throws on a network error. */
 async function resolveRemoteRef(path: string, ref: string, remote: string): Promise<string | undefined> {
   const output = await runGit(path, 'ls-remote', remote, ref);
   if (!output) return undefined;
@@ -51,7 +51,7 @@ async function resolveRemoteRef(path: string, ref: string, remote: string): Prom
   return sha;
 }
 
-/** Compute ahead/behind from the local tracking ref. Return undefined on failure. */
+/** Returns the ahead/behind counts from the local tracking ref, or undefined where they cannot be computed. */
 async function resolveAheadBehind(
   path: string,
   ref: string,

--- a/packages/readyup/src/check-utils/git/factories.ts
+++ b/packages/readyup/src/check-utils/git/factories.ts
@@ -32,7 +32,7 @@ interface RemoteRefSyncCheckOptions {
   severity?: Severity;
 }
 
-/** Create a check that verifies two local refs point to the same commit. */
+/** Returns a check that verifies two local refs point at the same commit. */
 export function makeLocalRefSyncCheck(options: LocalRefSyncCheckOptions): RdyCheck {
   const { name, path, refA, refB, fix: customFix, severity } = options;
 
@@ -49,7 +49,12 @@ export function makeLocalRefSyncCheck(options: LocalRefSyncCheckOptions): RdyChe
   return check;
 }
 
-/** Create a check that verifies a local ref matches its remote counterpart. Uses a closure-cached probe so the network call runs at most once. */
+/**
+ * Returns a check that verifies a local ref matches its remote counterpart.
+ *
+ * A closure-cached probe holds the comparison, so the network call runs at most once however many
+ * times the check is evaluated.
+ */
 export function makeRemoteRefSyncCheck(options: RemoteRefSyncCheckOptions): RdyCheck {
   const { name, path, ref, remote = 'origin', fix: customFix, severity } = options;
 
@@ -86,7 +91,7 @@ export function makeRemoteRefSyncCheck(options: RemoteRefSyncCheckOptions): RdyC
   return rdyCheck;
 }
 
-/** Format a human-readable detail message for a local ref comparison failure. */
+/** Returns a human-readable detail message for a local ref comparison failure. */
 function formatLocalResult(
   result: Exclude<LocalRefsCompareResult, { status: 'match' }>,
   refA: string,
@@ -112,7 +117,7 @@ function formatLocalResult(
   return `${refA} is ahead of ${refB} by ${ahead} commit${ahead === 1 ? '' : 's'} in ${path}`;
 }
 
-/** Format a human-readable detail message for a remote ref comparison failure. */
+/** Returns a human-readable detail message for a remote ref comparison failure. */
 function formatRemoteResult(
   result: Exclude<RemoteRefCompareResult, { status: 'in-sync' }>,
   ref: string,

--- a/packages/readyup/src/check-utils/git/repo-predicates.ts
+++ b/packages/readyup/src/check-utils/git/repo-predicates.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 
 import { expandHome, runGit } from './run-git.ts';
 
-/** Check whether `path` is inside a git working tree (subdirectories and worktrees count). */
+/** Reports whether `path` is inside a git working tree, counting subdirectories and worktrees. */
 export async function isGitRepo(path: string): Promise<boolean> {
   const resolved = expandHome(path);
   if (!existsSync(resolved)) return false;
@@ -14,7 +14,7 @@ export async function isGitRepo(path: string): Promise<boolean> {
   }
 }
 
-/** Check whether `path` is the top of a git working tree. Subdirectories return false. */
+/** Reports whether `path` is the top of a git working tree, so a subdirectory yields false. */
 export async function isAtRepoRoot(path: string): Promise<boolean> {
   const resolved = expandHome(path);
   if (!existsSync(resolved)) return false;

--- a/packages/readyup/src/check-utils/git/run-git.ts
+++ b/packages/readyup/src/check-utils/git/run-git.ts
@@ -4,7 +4,7 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-/** Run a git command in the given directory and return trimmed stdout. */
+/** Returns a git command's stdout, trimmed, from a run in the given directory. */
 export async function runGit(path: string, ...args: string[]): Promise<string> {
   return (await runGitRaw(path, ...args)).trim();
 }
@@ -12,8 +12,8 @@ export async function runGit(path: string, ...args: string[]): Promise<string> {
 /**
  * Runs a git command in the given directory and returns its stdout unaltered.
  *
- * Reach for this where a path is part of the output: trimming strips a leading space or tab from the first path of a
- * listing, and the file it names then reads as missing.
+ * Trimming strips a leading space or tab from the first path of a listing, and the file it names then
+ * reads as missing, so output containing paths needs this variant.
  */
 export async function runGitRaw(path: string, ...args: string[]): Promise<string> {
   const resolved = expandHome(path);
@@ -22,10 +22,10 @@ export async function runGitRaw(path: string, ...args: string[]): Promise<string
 }
 
 /**
- * Determine whether an error from a git command represents a missing ref.
- * Exit code 128 is ambiguous: git uses it for missing refs, invalid paths,
- * and "not a git repo". Inspect stderr to distinguish ref-missing from
- * infrastructure failures.
+ * Reports whether an error from a git command means the ref was missing.
+ *
+ * Exit code 128 is ambiguous: git uses it for a missing ref, an invalid path, and "not a git repo"
+ * alike, so stderr is what separates a missing ref from an infrastructure failure.
  */
 export function isRefMissingError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
@@ -42,7 +42,7 @@ export function isRefMissingError(error: unknown): boolean {
   );
 }
 
-/** Expand leading `~` or `~/` to the user's home directory. */
+/** Returns `path` with a leading `~` or `~/` expanded to the user's home directory. */
 export function expandHome(path: string): string {
   if (path === '~' || path === '~/') return homedir();
   if (path.startsWith('~/')) return homedir() + path.slice(1);

--- a/packages/readyup/src/check-utils/json-value.ts
+++ b/packages/readyup/src/check-utils/json-value.ts
@@ -1,6 +1,6 @@
 import { isRecord } from '../portable/isRecord.ts';
 
-/** Extract a nested value from a parsed object by traversing the key path. */
+/** Returns the value at a key path in a parsed object, traversing one key at a time. */
 export function getJsonValue(obj: Record<string, unknown>, ...keys: string[]): unknown {
   let current: unknown = obj;
   for (const key of keys) {
@@ -10,7 +10,7 @@ export function getJsonValue(obj: Record<string, unknown>, ...keys: string[]): u
   return current;
 }
 
-/** Check whether a non-nullish value exists at the key path in a parsed object. */
+/** Reports whether a non-nullish value exists at a key path in a parsed object. */
 export function hasJsonValue(obj: Record<string, unknown>, ...keys: string[]): boolean {
   const value = getJsonValue(obj, ...keys);
   return value !== undefined && value !== null;

--- a/packages/readyup/src/check-utils/missingFrom.ts
+++ b/packages/readyup/src/check-utils/missingFrom.ts
@@ -1,6 +1,6 @@
 import type { CheckOutcome, FractionProgress } from '../kits/types.ts';
 
-/** Build a `CheckOutcome` with `FractionProgress` from expected vs. actual arrays. */
+/** Returns a `CheckOutcome` whose `FractionProgress` counts how many expected entries the actual list holds. */
 export function missingFrom(category: string, expected: string[], actual: string[]): CheckOutcome {
   const actualSet = new Set(actual);
   const missing = expected.filter((item) => !actualSet.has(item));

--- a/packages/readyup/src/check-utils/package-json.ts
+++ b/packages/readyup/src/check-utils/package-json.ts
@@ -10,17 +10,17 @@ const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml';
 /** Leading range operators and the `v` prefix, stripped before a version is parsed from the start of a specifier. */
 const RANGE_PREFIX = /^[\s^~=<>v]+/;
 
-/** Read and parse the root package.json. Return undefined if it doesn't exist or isn't an object. */
+/** Returns the parsed root package.json, or undefined where it does not exist or is not an object. */
 export function readPackageJson(): Record<string, unknown> | undefined {
   return readJsonFile('package.json');
 }
 
-/** Check whether package.json has a field, optionally with a specific value. */
+/** Reports whether package.json has a field, optionally holding a specific value. */
 export function hasPackageJsonField(field: string, expectedValue?: string): boolean {
   return hasJsonField('package.json', field, expectedValue);
 }
 
-/** Check whether a dev dependency is present in package.json. */
+/** Reports whether package.json declares a dev dependency. */
 export function hasDevDependency(name: string): boolean {
   const pkg = readJsonFile('package.json');
   if (pkg === undefined) return false;
@@ -72,7 +72,7 @@ function extractVersion(specifier: string): string | undefined {
   // `compareVersions` pads a short version against the floor.
   const fromStart = /^\d+(?:\.\d+)*/.exec(specifier.replace(RANGE_PREFIX, ''))?.[0];
   if (fromStart !== undefined) return fromStart;
-  // A specifier carrying its version elsewhere, such as the `npm:` alias protocol, still yields a three-segment match.
+  // A specifier with its version elsewhere, such as the `npm:` alias protocol, still yields a three-segment match.
   return /\d+\.\d+\.\d+/.exec(specifier)?.[0];
 }
 

--- a/packages/readyup/src/check-utils/pnpmWorkspaceYaml.ts
+++ b/packages/readyup/src/check-utils/pnpmWorkspaceYaml.ts
@@ -44,8 +44,8 @@ export function findPnpmCatalogVersion(
  * Returns the pattern strings in a `pnpm-workspace.yaml` file's `packages` block-sequence, or `null`
  * when the `packages` key is absent.
  *
- * Throws a pathful, line-pointing error on YAML features outside the supported subset: anchors, flow
- * sequences, tags, and negation patterns.
+ * Throws a pathful, line-pointing error on any YAML construct outside the block-sequence subset it
+ * reads, anchors, flow sequences, tags, and negation patterns among them.
  */
 export function readPnpmWorkspacePackages(absolutePath: string): string[] | null {
   const content = readFileSync(absolutePath, 'utf8');

--- a/packages/readyup/src/check-utils/pnpmWorkspaceYaml.ts
+++ b/packages/readyup/src/check-utils/pnpmWorkspaceYaml.ts
@@ -41,10 +41,11 @@ export function findPnpmCatalogVersion(
 }
 
 /**
- * Read the `packages` block-sequence from a `pnpm-workspace.yaml` file.
- * Returns the list of pattern strings, or `null` when the `packages` key is absent.
- * Throws on YAML features outside the supported subset (anchors, flow sequences,
- * tags, negation patterns, etc.) with a pathful, line-pointing error.
+ * Returns the pattern strings in a `pnpm-workspace.yaml` file's `packages` block-sequence, or `null`
+ * when the `packages` key is absent.
+ *
+ * Throws a pathful, line-pointing error on YAML features outside the supported subset: anchors, flow
+ * sequences, tags, and negation patterns.
  */
 export function readPnpmWorkspacePackages(absolutePath: string): string[] | null {
   const content = readFileSync(absolutePath, 'utf8');
@@ -67,7 +68,7 @@ export function readPnpmWorkspacePackages(absolutePath: string): string[] | null
 
 // region | Helpers
 
-/** Reject whole-file features (multi-document streams, anchors/aliases/tags appearing anywhere). */
+/** Rejects whole-file features (multi-document streams, anchors/aliases/tags appearing anywhere). */
 function rejectGlobalUnsupportedFeatures(absolutePath: string, lines: string[]): void {
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? '';
@@ -143,8 +144,8 @@ function collectBlockEntries(lines: string[], keyLineIndex: number): { index: nu
 
 /**
  * Splits a `key: value` mapping line into its parts, or returns undefined when the line is not one or
- * carries a value this reader cannot follow. The key may be quoted, as a scoped package name in a
- * catalog is; the value keeps any `:` it carries, so a `workspace:*` entry survives.
+ * has a value this reader cannot follow. The key may be quoted, as a scoped package name in a
+ * catalog is; the value keeps any `:` it contains, so a `workspace:*` entry survives.
  */
 function parseMappingEntry(text: string): { key: string; value: string } | undefined {
   const match = /^(?:('[^']*')|("[^"]*")|([^:#]+?))\s*:(.*)$/.exec(text.trim());
@@ -158,7 +159,7 @@ function parseMappingEntry(text: string): { key: string; value: string } | undef
   return { key: stripQuotes(rawKey), value: stripQuotes(rawValue) };
 }
 
-/** Return the trimmed value after a `key:` on the same line, or null if there's no inline value. */
+/** Returns the trimmed value after a `key:` on the same line, or null where there is no inline value. */
 function extractInlineValue(line: string): string | null {
   const colonIndex = line.indexOf(':');
   if (colonIndex === -1) return null;
@@ -168,7 +169,7 @@ function extractInlineValue(line: string): string | null {
   return trimmed;
 }
 
-/** Collect block-sequence items below the `packages:` line. */
+/** Returns the block-sequence items below the `packages:` line. */
 function collectSequenceItems(absolutePath: string, lines: string[], packagesLineIndex: number): string[] {
   const items: string[] = [];
   let sequenceIndent: number | null = null;
@@ -216,7 +217,7 @@ function collectSequenceItems(absolutePath: string, lines: string[], packagesLin
   return items;
 }
 
-/** Reject per-item unsupported YAML features before quote-stripping. */
+/** Rejects per-item unsupported YAML features before quote-stripping. */
 function rejectItemLevelUnsupportedFeatures(
   absolutePath: string,
   lineIndex: number,
@@ -259,10 +260,7 @@ function stripQuotes(value: string): string {
   return value;
 }
 
-/**
- * Strip an inline `#` comment, respecting single- and double-quoted scalars so a `#`
- * inside quotes is treated as part of the value.
- */
+/** Strips an inline `#` comment, keeping a `#` inside a single- or double-quoted scalar as part of the value. */
 function stripInlineComment(text: string): string {
   let inSingle = false;
   let inDouble = false;
@@ -284,20 +282,20 @@ function stripInlineComment(text: string): string {
   return text;
 }
 
-/** True if a line is blank or a full-line comment. */
+/** Reports whether a line is blank or a full-line comment. */
 function isBlankOrComment(line: string): boolean {
   const trimmed = line.trim();
   return trimmed === '' || trimmed.startsWith('#');
 }
 
-/** Count leading space characters on a line. */
+/** Returns the number of leading space characters on a line. */
 function countLeadingSpaces(line: string): number {
   let count = 0;
   while (count < line.length && line[count] === ' ') count += 1;
   return count;
 }
 
-/** Throw a pathful, line-pointing error for an unsupported YAML feature. */
+/** Throws a pathful, line-pointing error for an unsupported YAML feature. */
 function throwUnsupported(absolutePath: string, lineIndex: number, line: string, feature: string): never {
   const lineNumber = lineIndex + 1;
   const message =
@@ -308,7 +306,7 @@ function throwUnsupported(absolutePath: string, lineIndex: number, line: string,
   throw new Error(message);
 }
 
-/** Throw a pathful, line-pointing error for a negation pattern. */
+/** Throws a pathful, line-pointing error for a negation pattern. */
 function throwNegationUnsupported(absolutePath: string, lineIndex: number, line: string, pattern: string): never {
   const lineNumber = lineIndex + 1;
   const message =

--- a/packages/readyup/src/check-utils/project/buildFindingReport.ts
+++ b/packages/readyup/src/check-utils/project/buildFindingReport.ts
@@ -68,7 +68,7 @@ function isLineInSpans(line: number, spans: readonly DeclarationSpan[]): boolean
   return spans.some((span) => span.startLine <= line && line <= span.endLine);
 }
 
-/** Returns a finding as the runner reads it, carrying whether the reporting check names it. */
+/** Returns a finding as the runner reads it, with whether the reporting check names it. */
 function toOutcomeFinding(finding: Finding, reported: boolean): OutcomeFinding {
   const { line, path, symbol } = finding;
   return symbol === undefined ? { line, path, reported } : { line, path, reported, symbol };

--- a/packages/readyup/src/check-utils/project/listOwnImplementationSpans.ts
+++ b/packages/readyup/src/check-utils/project/listOwnImplementationSpans.ts
@@ -26,7 +26,7 @@ export interface OwnImplementation {
  * Every narrowing is required. A repo publishing the package is where the idiom is supposed to live, but the workspace
  * is the whole repository wherever the root manifest declares the name, as a single-package project's always does, so a
  * workspace-wide rule would turn the check off there, and in any repo it would silence a second file hand-rolling the
- * idiom instead of importing the local implementation. The argument carries one step further, to the declaration: the
+ * idiom instead of importing the local implementation. The argument extends one step further, to the declaration: the
  * reasoning reaches a wrapper of the idiom its own kit detects, which cannot adopt itself, while its neighbours in the
  * same file are ordinary code.
  *
@@ -89,7 +89,7 @@ function findPublishingWorkspaceDirs(packageName: string): string[] {
  * of the same name, which is a hand-roll the check exists to report. A clause exporting the name under a different one
  * exports something else, and matches neither pattern.
  *
- * A clause carrying `from` declares nothing local, so a re-exporting barrel names no binding here and exempts no
+ * A clause with `from` declares nothing local, so a re-exporting barrel names no binding here and exempts no
  * lines.
  */
 function listLocalExportNames(code: string, exportNames: readonly string[]): Set<string> {

--- a/packages/readyup/src/check-utils/project/test-utils/sweep-recording.ts
+++ b/packages/readyup/src/check-utils/project/test-utils/sweep-recording.ts
@@ -1,6 +1,6 @@
 import type { SweepRecorder } from '../sweepRecorder.ts';
 
-/** A recorder paired with the sweeps reported to it, in the order they arrived. */
+/** Returns a recorder paired with the sweeps reported to it, in the order they arrived. */
 export function createRecorder(): { recorder: SweepRecorder; scanned: (readonly string[])[] } {
   const scanned: (readonly string[])[] = [];
   return {

--- a/packages/readyup/src/check-utils/semver.ts
+++ b/packages/readyup/src/check-utils/semver.ts
@@ -1,4 +1,4 @@
-/** Compare two semver version strings. Return negative if a < b, 0 if equal, positive if a > b. */
+/** Returns a negative number where `a` sorts below `b`, zero where they are equal, and a positive number otherwise. */
 export function compareVersions(a: string, b: string): number {
   const partsA = a.split('.').map(Number);
   const partsB = b.split('.').map(Number);

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -188,8 +188,8 @@ function resolvePackageDefaultConfig(packageName: string, configDir: string): st
 
   const manifest = readJsonFile(resolve(packageRoot, 'package.json'));
   if (manifest === undefined) return undefined;
-  // An `exports` map is exhaustive, so it answers for the package or nothing does. A null map has no
-  // entries to answer with, and TypeScript reads it as no map at all.
+  // An `exports` map is exhaustive, so it resolves the package or nothing does. A null map has no
+  // entries to resolve from, and TypeScript reads it as no map at all.
   if ('exports' in manifest && manifest['exports'] !== null) {
     return resolveThroughNodeResolver(packageName, configDir);
   }
@@ -218,7 +218,7 @@ function resolvePathSpecifier(specifier: string, baseDir: string): string | unde
 
 /**
  * Resolves a package specifier through Node's resolver anchored at the extending config, so `exports`
- * governs what is reachable and a pnpm symlink answers with the directory the package occupies.
+ * governs what is reachable and a pnpm symlink resolves to the directory the package occupies.
  *
  * Resolution runs under the `require` condition, which is the condition TypeScript resolves `extends`
  * under, so a specifier this reaches is a specifier `tsc` reaches.
@@ -231,7 +231,7 @@ function resolveThroughNodeResolver(specifier: string, configDir: string): strin
   } catch {
     return undefined;
   }
-  // A core module such as `"fs/promises"` answers with its own name rather than with a path.
+  // A core module such as `"fs/promises"` resolves to its own name rather than to a path.
   if (!isAbsolute(resolved)) return undefined;
   // TypeScript resolves `extends` under a JSON-only extension set, so a package's entry point is not a config.
   return resolved.endsWith('.json') ? resolved : undefined;

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -120,7 +120,7 @@ function resolveWorkspacePatterns(
     if (patterns !== null) {
       return { patterns, source: 'pnpm-workspace.yaml' };
     }
-    // `packages` key absent — fall through to npm/single detection.
+    // `packages` key absent -- fall through to npm/single detection.
   }
 
   const npmPatterns = extractNpmWorkspacePatterns(rootPackageJson['workspaces']);
@@ -159,7 +159,7 @@ function extractNpmWorkspacePatterns(workspaces: unknown): string[] | null {
 function expandPatterns(rootDir: string, patterns: string[], source: WorkspacePatternSource): string[] {
   if (patterns.length === 0) return [];
 
-  // Check for negation patterns up front — the pnpm reader already rejects these in YAML,
+  // Check for negation patterns up front -- the pnpm reader already rejects these in YAML,
   // but npm `workspaces` entries come through untouched.
   for (const pattern of patterns) {
     if (pattern.startsWith('!')) {

--- a/packages/readyup/src/compile/CompiledInput.ts
+++ b/packages/readyup/src/compile/CompiledInput.ts
@@ -8,7 +8,7 @@ import type { JsonPathSpec } from './extractJsonPaths.ts';
  * neither type means two different things about its own `path`.
  *
  * A `module` record's hash is over the file's contents. An `inline` record's is over the projection that was
- * substituted into the bundle, which is why it alone carries the specifier that produced it.
+ * substituted into the bundle, which is why it alone records the specifier that produced it.
  */
 export type CompiledInput =
   { hash: string; kind: 'inline'; path: string; paths: JsonPathSpec } | { hash: string; kind: 'module'; path: string };

--- a/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
@@ -102,12 +102,12 @@ function compileResult(
   };
 }
 
-/** Returns the `inputs` an entry carries when its compile read only the entry point, stated against the manifest. */
+/** Returns the `inputs` an entry has when its compile read only the entry point, stated against the manifest. */
 function recordedEntry(relativePath: string, hash: string = SOURCE_HASH) {
   return [{ hash, kind: 'module', path: relativePath }];
 }
 
-/** Metadata as `validateCompiledOutput` returns it, defaulting to a kit with no checklists to record. */
+/** Returns metadata as `validateCompiledOutput` yields it, defaulting to a kit with no checklists to record. */
 function kitMetadata(overrides: Partial<KitMetadata> = {}): KitMetadata {
   return { checklists: [], ...overrides };
 }

--- a/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
@@ -514,7 +514,7 @@ describe(compileCommand, () => {
   });
 
   describe('sweep completion', () => {
-    /** A two-kit batch whose first kit fails to compile and whose second succeeds. */
+    /** Arranges a two-kit batch whose first kit fails to compile and whose second succeeds. */
     function arrangeMixedBatch(): void {
       mockLoadConfig.mockResolvedValue({
         compile: { srcDir: '.readyup/kits', outDir: '.readyup/kits', include: undefined },
@@ -775,7 +775,7 @@ describe(compileCommand, () => {
     expect(mockWriteManifest).toHaveBeenCalledWith(expect.any(String), { version: 1, kits: [] });
   });
 
-  /** A two-kit batch in which both kits compile successfully. */
+  /** Arranges a two-kit batch in which both kits compile successfully. */
   function arrangeTwoKitBatch(hashes: { alphaHash?: string; betaHash?: string } = {}): void {
     mockLoadConfig.mockResolvedValue({
       compile: { srcDir: SRC_DIR, outDir: SRC_DIR, include: undefined },

--- a/packages/readyup/src/compile/__tests__/externalReadyup.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/externalReadyup.tool.test.ts
@@ -21,7 +21,7 @@ interface SpawnResult {
   stderr: string;
 }
 
-/** Spawn `node` with the given arguments and collect stdio. */
+/** Spawns `node` with the given arguments and returns its collected stdio. */
 function spawnNode(args: string[]): Promise<SpawnResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });

--- a/packages/readyup/src/compile/__tests__/fixtures/discoverWorkspaces-fixture.ts
+++ b/packages/readyup/src/compile/__tests__/fixtures/discoverWorkspaces-fixture.ts
@@ -12,7 +12,7 @@ export default defineRdyKit({
           check: () => {
             // Reference `discoverWorkspaces` (a value, not just a type) so esbuild
             // cannot dead-code-eliminate the externalized `readyup` import. We
-            // verify the binding is a function rather than invoking it — calling
+            // verify the binding is a function rather than invoking it -- calling
             // `discoverWorkspaces()` reads from `process.cwd()`, which couples
             // the resolution signal to the subprocess's filesystem state. The
             // sentinel on stdout signals successful module resolution alone.

--- a/packages/readyup/src/compile/__tests__/pickJsonPlugin.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/pickJsonPlugin.unit.test.ts
@@ -16,7 +16,7 @@ import { pickJsonPlugin } from '../pickJsonPlugin.ts';
 
 type OnLoadCallback = Parameters<esbuild.PluginBuild['onLoad']>[1];
 
-/** Minimal `PluginBuild` stub; only `onLoad` is exercised by these tests. */
+/** Returns a minimal `PluginBuild` stub, which exercises `onLoad` alone. */
 function stubBuild(onLoad: esbuild.PluginBuild['onLoad']): esbuild.PluginBuild {
   return {
     initialOptions: {},
@@ -30,7 +30,7 @@ function stubBuild(onLoad: esbuild.PluginBuild['onLoad']): esbuild.PluginBuild {
   };
 }
 
-/** Capture the onLoad callback registered by the plugin, reading through a real recorder. */
+/** Returns the onLoad callback the plugin registered, read back through a real recorder. */
 function captureOnLoad(recorder: CompileRecorder = createCompileRecorder()): OnLoadCallback {
   let captured: OnLoadCallback | undefined;
   const plugin = pickJsonPlugin(recorder);
@@ -45,7 +45,7 @@ function captureOnLoad(recorder: CompileRecorder = createCompileRecorder()): OnL
   return captured;
 }
 
-/** Invoke the captured onLoad for a source path and return its synchronous result. */
+/** Returns the synchronous result of invoking the captured onLoad for a source path. */
 function runOnLoad(onLoad: OnLoadCallback, path: string): esbuild.OnLoadResult | null | undefined {
   const result = onLoad({ path, namespace: 'file', suffix: '', pluginData: undefined, with: {} });
   if (result instanceof Promise) {

--- a/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
@@ -16,7 +16,7 @@ describe(resolveCompileRoot, () => {
     treeRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'compile-root-')));
 
     // Two cases below assert that a walk reaching the filesystem root finds nothing, which only holds
-    // where no directory above the fixture carries a manifest of its own.
+    // where no directory above the fixture has a manifest of its own.
     const ancestorManifest = findAncestorManifest(treeRoot);
     assert.ok(
       ancestorManifest === undefined,

--- a/packages/readyup/src/compile/__tests__/validateCompiledOutput.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/validateCompiledOutput.unit.test.ts
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { validateCompiledOutput } from '../validateCompiledOutput.ts';
 
-/** Create a temporary ESM bundle that exports the given kit fields. */
+/** Returns the path to a temporary ESM bundle exporting the given kit fields. */
 function writeTempKit(dir: string, filename: string, kitFields: Record<string, unknown>): string {
   mkdirSync(dir, { recursive: true });
   const filePath = join(dir, filename);
@@ -81,7 +81,7 @@ describe(validateCompiledOutput, () => {
   });
 
   // A check is serialized to JSON here, so `check` arrives as a string rather than a function: the
-  // same authoring mistake a hand-edited bundle would carry, and one compile must not let through.
+  // same authoring mistake a hand-edited bundle would have, and one compile must not let through.
   it('rejects a kit whose check is not a function, naming the offending location', async () => {
     const outputPath = writeTempKit(testDir, 'bad-check.mjs', {
       checklists: [{ name: 'test', checks: [{ name: 'a', check: 'nope' }] }],

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -218,7 +218,7 @@ function collectInputs(recorded: CompiledInput[], metafileKeys: string[], workin
 }
 
 /**
- * Reports whether an esbuild failure carries an import esbuild could not resolve.
+ * Reports whether an esbuild failure names an import esbuild could not resolve.
  *
  * Reads the failure's own error list rather than its rendered message, and matches on message text
  * because esbuild leaves the machine-readable `id` empty on a resolve error.

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -46,11 +46,7 @@ const compileHints: Record<string, string> = {
   '--output': '--output requires a path argument',
 };
 
-/**
- * Handle the `compile` subcommand: parse arguments, invoke the bundler, and report the result.
- *
- * Returns a numeric exit code.
- */
+/** Runs the `compile` subcommand, returning the exit code its parse, bundle, and report produced. */
 export async function compileCommand(args: string[]): Promise<number> {
   let parsed;
   try {
@@ -102,7 +98,7 @@ interface CompileSingleArgs {
   json: boolean;
 }
 
-/** Compile a single explicit input file, applying the drift gate before overwriting. */
+/** Compiles a single explicit input file, applying the drift gate before overwriting. */
 async function compileSingle(args: CompileSingleArgs): Promise<number> {
   const { inputPath, outputPath, skipManifest, force, manifestPath, json } = args;
   const manifestDir = path.dirname(manifestPath);
@@ -160,7 +156,7 @@ async function compileSingle(args: CompileSingleArgs): Promise<number> {
 }
 
 /**
- * Emit the compile payload under `--json` and reduce the run's per-kit statuses to an exit code.
+ * Emits the compile payload under `--json` and reduces the run's per-kit statuses to an exit code.
  *
  * A kit left alone because it drifted counts against the run just as a failed one does: both mean
  * the compiled output on disk is not what the source says it should be.
@@ -176,12 +172,12 @@ function finishCompile(kits: JsonCompileKitEntry[], json: boolean): number {
   return passed ? EXIT_OK : EXIT_PROBLEMS_FOUND;
 }
 
-/** Describe a drift skip for the JSON payload, where there is no formatted line to read. */
+/** Returns a drift skip described for the JSON payload, where there is no formatted line to read. */
 function formatDriftReason(status: Extract<DriftStatus, { kind: 'drift' }>): string {
   return `Compiled output has drifted from the manifest (expected ${status.expected}, got ${status.actual})`;
 }
 
-/** Resolve the manifest output path from the optional `--manifest` flag. */
+/** Returns the manifest output path, taken from `--manifest` where that flag was given. */
 function resolveManifestPath(flagValue: string | undefined): string {
   return path.resolve(process.cwd(), flagValue ?? DEFAULT_MANIFEST_PATH);
 }
@@ -195,11 +191,11 @@ interface CompileBatchArgs {
 }
 
 /**
- * Compile all matching `.ts` files from the config-driven source directory.
+ * Compiles every matching `.ts` file in the config-driven source directory.
  *
  * The sweep runs to completion: a kit that fails to compile is reported and the next one is tried,
  * so one broken kit cannot hide the state of every kit that sorts after it. Failures on the way to
- * the sweep — an unreadable config, an unwritable manifest — still throw, because they say nothing
+ * the sweep -- an unreadable config, an unwritable manifest -- still throw, because they say nothing
  * about any individual kit.
  */
 async function compileBatch(args: CompileBatchArgs): Promise<number> {
@@ -285,7 +281,7 @@ async function compileBatch(args: CompileBatchArgs): Promise<number> {
       kitResults.push({ name: kitName, status: 'compiled' });
     } catch (error: unknown) {
       // A kit that fails to compile is a problem with the kit, not with the invocation, so the sweep
-      // carries on. The sweep replaces the whole manifest, so a prior record has to be pushed back to
+      // goes on. The sweep replaces the whole manifest, so a prior record has to be pushed back to
       // survive, and it still describes the tree: an esbuild failure leaves the previous output and
       // its hash intact, and a validation failure deletes the output for `verify` to report missing.
       const existingKit = existingKitsByName.get(kitName);
@@ -408,7 +404,7 @@ function relativizeInput(input: CompiledInput, manifestDir: string): RdyManifest
     : { hash: input.hash, kind: 'module', path: relativePath };
 }
 
-/** Read an existing manifest (if any), upsert a kit entry, and write back. */
+/** Upserts a kit entry into the manifest at `manifestPath`, writing the result back. */
 function upsertManifest(
   manifestPath: string,
   kitName: string,
@@ -450,7 +446,12 @@ function upsertManifest(
   writeManifest(manifestPath, { version: 1, kits });
 }
 
-/** Read the manifest and index its kits by name. Missing manifest is expected (first compile); other failures are surfaced on stderr and treated as a no-op drift gate. */
+/**
+ * Returns the manifest's kits indexed by name, or an empty index where the manifest is missing.
+ *
+ * A missing manifest is the normal state of a first compile. Any other failure is written to stderr
+ * and leaves the drift gate a no-op.
+ */
 function loadExistingKitsByName(manifestPath: string): Map<string, RdyManifestKit> {
   const map = new Map<string, RdyManifestKit>();
   try {
@@ -482,8 +483,8 @@ interface DriftSkip {
 }
 
 /**
- * Evaluate the drift gate for a single kit. Returns the drift status and the manifest entry
- * to preserve when a skip is warranted, or undefined when the kit should proceed to compile.
+ * Returns a single kit's drift status alongside the manifest entry to preserve, or undefined where
+ * the kit should proceed to compile.
  */
 function detectDrift(args: DetectDriftArgs): DriftSkip | undefined {
   const { skipManifest, force, existingKit, manifestDir } = args;

--- a/packages/readyup/src/compile/extractJsonPaths.ts
+++ b/packages/readyup/src/compile/extractJsonPaths.ts
@@ -5,7 +5,7 @@ import { isRecord } from '../portable/isRecord.ts';
 /**
  * A `pickJson` path specifier list: a top-level key as a string, a nested one as an array of keys.
  *
- * Mirrors `pickJson`'s second argument, and is the form a recorded inline input carries so a later reader
+ * Mirrors `pickJson`'s second argument, and is the form a recorded inline input takes so a later reader
  * can reproduce the projection the compile inlined.
  */
 export type JsonPathSpec = Array<string | Array<string>>;
@@ -23,10 +23,10 @@ export class JsonPathNotFoundError extends Error {
 }
 
 /**
- * Extract selected paths from a parsed JSON object, preserving original nesting structure.
+ * Returns the selected paths from a parsed JSON object, preserving the original nesting.
  *
- * Each path is either a single string (top-level key) or an array of strings (nested key path).
- * Throws if any requested path does not exist in the source object.
+ * Each path is a single string naming a top-level key, or an array of strings naming a nested one.
+ * Throws where a requested path does not exist in the source object.
  */
 export function extractJsonPaths(obj: Record<string, unknown>, paths: JsonPathSpec): Record<string, unknown> {
   const result: Record<string, unknown> = {};

--- a/packages/readyup/src/compile/pickJson.ts
+++ b/packages/readyup/src/compile/pickJson.ts
@@ -1,9 +1,9 @@
 /**
- * Declare selected JSON paths for compile-time inlining.
+ * Declares selected JSON paths for compile-time inlining.
  *
- * This function exists only for type-checking in kit source files. At compile time, the
- * `pickJsonPlugin` replaces every call with an object literal containing only the requested
- * fields. If this function executes at runtime, it means the kit was not compiled.
+ * The declaration exists for type-checking in kit source files alone: `pickJsonPlugin` replaces every
+ * call with an object literal holding only the requested fields, so reaching this body at runtime
+ * means the kit was never compiled.
  */
 export function pickJson(_relativePath: string, _paths: Array<string | Array<string>>): Record<string, unknown> {
   throw new Error('pickJson is a compile-time-only function. Compile the kit with `rdy compile` before running it.');

--- a/packages/readyup/src/compile/pickJsonPlugin.ts
+++ b/packages/readyup/src/compile/pickJsonPlugin.ts
@@ -120,7 +120,7 @@ function parsePickJsonArgs(argsText: string): { relativePath: string; paths: Jso
 
   let parsed: unknown;
   try {
-    // JSON.parse requires double quotes — replace single-quote delimiters only (not interior chars).
+    // JSON.parse requires double quotes -- replace single-quote delimiters only (not interior chars).
     // Path keys must be plain identifiers (no embedded quotes or special characters).
     const jsonText = rest.replace(/'([^']*?)'/g, '"$1"');
     parsed = JSON.parse(jsonText);

--- a/packages/readyup/src/compile/pickJsonPlugin.ts
+++ b/packages/readyup/src/compile/pickJsonPlugin.ts
@@ -19,11 +19,11 @@ import { JsonProjectionError } from './JsonProjectionError.ts';
 const PICK_JSON_RE = /\bpickJson\s*\((?<args>[^)]+)\)/g;
 
 /**
- * Create an esbuild plugin that replaces `pickJson(...)` calls with inlined object literals.
+ * Returns an esbuild plugin that replaces `pickJson(...)` calls with inlined object literals.
  *
- * The plugin intercepts TypeScript file loads, scans for `pickJson` calls, resolves
- * the referenced JSON file relative to the source file, extracts the requested paths,
- * and substitutes the call with a static object expression.
+ * The plugin intercepts TypeScript file loads, scans for `pickJson` calls, resolves each referenced
+ * JSON file relative to its source file, extracts the requested paths, and substitutes the call with
+ * a static object expression.
  *
  * Every read goes through `recorder`, which is what puts the module and the JSON file it projected into
  * the compile's input closure. This module imports no filesystem API of its own, so a read it performs
@@ -95,10 +95,10 @@ function isStringArray(value: unknown): value is string[] {
 }
 
 /**
- * Parse the static arguments from a `pickJson(...)` call's argument string.
+ * Returns the static arguments in a `pickJson(...)` call's argument string.
  *
- * Expects a JSON file path string and an array of path specifiers (strings or string arrays).
- * Only static literals are supported; expressions or template literals produce an error.
+ * Expects a JSON file path string and an array of path specifiers, each a string or an array of
+ * strings. Only a static literal is supported; an expression or a template literal is an error.
  */
 function parsePickJsonArgs(argsText: string): { relativePath: string; paths: JsonPathSpec } {
   // Trim and strip potential trailing comma.

--- a/packages/readyup/src/compile/resolveCompileRoot.ts
+++ b/packages/readyup/src/compile/resolveCompileRoot.ts
@@ -13,8 +13,8 @@ const PACKAGE_MANIFEST = 'package.json';
  * reproducible from any directory, and it keeps a bundle's paths naming the kit's place in the package
  * that ships it.
  *
- * Answers with a real path. esbuild reports the paths it resolved modules to, and a compile resolves
- * the metafile's keys against this directory, so an answer reached through a symlink would record a
+ * The path is real. esbuild reports the paths it resolved modules to, and a compile resolves
+ * the metafile's keys against this directory, so a path reached through a symlink would record a
  * closure whose paths no reader of it can match.
  */
 export function resolveCompileRoot(inputPath: string): string {

--- a/packages/readyup/src/compile/resolveCompileRoot.ts
+++ b/packages/readyup/src/compile/resolveCompileRoot.ts
@@ -31,7 +31,7 @@ export function resolveCompileRoot(inputPath: string): string {
 /**
  * Returns a directory's real path, or the directory itself where it cannot be read.
  *
- * A source that does not exist has no real directory to answer with, and is left to fail where the
+ * A source that does not exist has no real directory to resolve to, and is left to fail where the
  * bundler reports it rather than as an `ENOENT` raised on the way there.
  */
 function toRealPath(directory: string): string {

--- a/packages/readyup/src/compile/validateCompiledOutput.ts
+++ b/packages/readyup/src/compile/validateCompiledOutput.ts
@@ -17,10 +17,9 @@ export interface KitMetadata {
 }
 
 /**
- * Import a compiled kit bundle and run semantic validation.
+ * Imports a compiled kit bundle, validates it semantically, and returns the metadata it yields.
  *
- * Returns metadata extracted from the validated kit. Deletes the output file when validation
- * fails so the user isn't left with an invalid bundle.
+ * A validation failure deletes the output file, so no invalid bundle is left on disk.
  */
 export async function validateCompiledOutput(outputPath: string): Promise<KitMetadata> {
   const fileUrl = `${pathToFileURL(outputPath).href}?t=${Date.now()}`;

--- a/packages/readyup/src/config/loadConfig.ts
+++ b/packages/readyup/src/config/loadConfig.ts
@@ -108,7 +108,7 @@ function resolveConfigPath(fromDir: string, overridePath: string | undefined): s
 /**
  * Fills every key the config file left out with its default.
  *
- * The guards are redundant at runtime — Zod validated the shape already — but they narrow `raw`, which
+ * The guards are redundant at runtime -- Zod validated the shape already -- but they narrow `raw`, which
  * is `Record<string, unknown> & RdyConfig` after the assertion.
  */
 function applyDefaults(raw: Record<string, unknown> & RdyConfig): ResolvedRdyConfig {

--- a/packages/readyup/src/config/loadConfig.ts
+++ b/packages/readyup/src/config/loadConfig.ts
@@ -42,7 +42,7 @@ const RdyConfigSchema = z.looseObject({
   packages: z.array(z.string()).optional(),
 });
 
-/** Validate that a raw value has the expected RdyConfig shape. */
+/** Validates that a raw value has the expected RdyConfig shape. */
 function assertIsRdyConfig(raw: unknown): asserts raw is RdyConfig {
   RdyConfigSchema.parse(raw);
 }
@@ -56,10 +56,10 @@ export interface LoadConfigOptions {
 }
 
 /**
- * Load readyup config from the filesystem.
+ * Returns the readyup config read from the filesystem, or the defaults where there is none.
  *
- * Checks `.config/readyup.config.ts` and returns defaults if not found.
- * An explicit override path skips the lookup chain.
+ * `.config/readyup.config.ts` is the file the lookup chain checks, and an explicit override path
+ * skips that chain.
  */
 export async function loadConfig(options: LoadConfigOptions = {}): Promise<ResolvedRdyConfig> {
   const { fromDir = process.cwd(), overridePath } = options;

--- a/packages/readyup/src/errors/RdyError.ts
+++ b/packages/readyup/src/errors/RdyError.ts
@@ -5,11 +5,11 @@ import { extractHint } from './error-handling.ts';
 /**
  * Diagnosis of a failure that prevented rdy from completing an invocation.
  *
- * - `usage`: the invocation is malformed — an unknown flag, a missing value, an impossible
+ * - `usage`: the invocation is malformed -- an unknown flag, a missing value, an impossible
  *   combination of arguments.
  * - `config`: repo configuration or a kit manifest could not be read, written, or parsed.
  * - `kit-load`: a kit could not be resolved, fetched, or evaluated.
- * - `internal`: anything else — a defect in rdy or an unexpected environment failure.
+ * - `internal`: anything else -- a defect in rdy or an unexpected environment failure.
  */
 export type RdyErrorCode = 'config' | 'internal' | 'kit-load' | 'usage';
 

--- a/packages/readyup/src/errors/RdyError.ts
+++ b/packages/readyup/src/errors/RdyError.ts
@@ -25,10 +25,10 @@ export interface RdyErrorOptions {
  * A failure that prevented rdy from completing the invocation.
  *
  * Every code maps to the same exit status, because the exit code answers "can I retry this
- * invocation?" while `code` carries the diagnosis.
+ * invocation?" while `code` holds the diagnosis.
  *
  * `hint` stays out of `message` so the two travel separately: human output renders the hint on its
- * own line through the selected style, and `--json` carries it as its own envelope field.
+ * own line through the selected style, and `--json` reports it as its own envelope field.
  */
 export class RdyError extends Error {
   readonly code: RdyErrorCode;
@@ -66,7 +66,7 @@ export function internalError(message: string, options?: RdyErrorOptions): RdyEr
  * Coerces an unknown thrown value into an `RdyError`.
  *
  * Anything not already classified is `internal`: escaping the command boundary undiagnosed
- * is itself the definition of a defect rather than a known failure mode. A hint the value carries
+ * is itself the definition of a defect rather than a known failure mode. A hint the value holds
  * survives the coercion, so a throw site can attach one without every boundary between it and the
  * output having to forward it.
  */

--- a/packages/readyup/src/errors/error-handling.ts
+++ b/packages/readyup/src/errors/error-handling.ts
@@ -1,7 +1,7 @@
 import { isError } from '@williamthorsen/toolbelt.errors';
 
 /**
- * Extract a remediation hint from an unknown thrown value, or `undefined` when it carries none.
+ * Returns the remediation hint on an unknown thrown value, or `undefined` where it has none.
  *
  * Reads the property off any error rather than off `RdyError` alone, so a boundary that re-wraps a
  * failure forwards the hint with one extra argument instead of a branch per throwing module.

--- a/packages/readyup/src/errors/parse-args-error.ts
+++ b/packages/readyup/src/errors/parse-args-error.ts
@@ -1,7 +1,7 @@
 import { describeError, isError } from '@williamthorsen/toolbelt.errors';
 
 /**
- * Translate a caught `node:util.parseArgs` error into a user-facing message.
+ * Returns a caught `node:util.parseArgs` error as a user-facing message.
  *
  * An unknown option is reported against `command`, pointing at the help that lists what the command
  * accepts. For a string flag missing its value (`--flag`, `--flag=`, or `--flag --other`), returns

--- a/packages/readyup/src/help/helpText.ts
+++ b/packages/readyup/src/help/helpText.ts
@@ -8,7 +8,7 @@ const TOPIC_LINES = Object.entries(TOPICS)
 /**
  * Where help output sends a reader for anything it does not cover.
  *
- * Help lists the surface; the README explains it, and the skill carries the authoring judgment neither states. The
+ * Help lists the surface; the README explains it, and the skill holds the authoring judgment neither states. The
  * installed path leads because a reader in a consuming repo can open it without a fetch; the repository URL follows
  * for a global install, where no such path exists.
  */

--- a/packages/readyup/src/help/readmeSection.ts
+++ b/packages/readyup/src/help/readmeSection.ts
@@ -32,7 +32,7 @@ export function readReadmeSection(heading: string): string {
 
 /**
  * Returns a level-2 section, from its heading through the line before the next level-2 heading, or
- * `undefined` when the markdown carries no such heading.
+ * `undefined` where the markdown has no such heading.
  *
  * Deeper headings are content rather than boundaries, so a `###` subsection comes back with its
  * parent. Headings inside a fenced code block are text, and neither open a section nor close one.

--- a/packages/readyup/src/init/__tests__/initCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/init/__tests__/initCommand.wiring.unit.test.ts
@@ -30,7 +30,7 @@ vi.mock(import('../../installed-packages/isPackageInstalled.ts'), () => ({
 
 import { initCommand } from '../initCommand.ts';
 
-/** Build a scaffold result with both files having the same outcome. */
+/** Returns a scaffold result whose two files share one outcome. */
 function makeScaffoldResult(outcome: string) {
   return {
     configResult: { filePath: '.config/readyup.config.ts', outcome },
@@ -172,7 +172,7 @@ describe(`${initCommand.name} next steps`, () => {
   });
 });
 
-/** Join everything written to `console.info` into one string. */
+/** Returns everything written to `console.info` joined into one string. */
 function printedSteps(infoSpy: MockInstance): string {
   return infoSpy.mock.calls.map((call) => String(call[0])).join('\n');
 }

--- a/packages/readyup/src/init/__tests__/templates.unit.test.ts
+++ b/packages/readyup/src/init/__tests__/templates.unit.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { rdyKitTemplate } from '../templates.ts';
 
 describe('rdyKitTemplate', () => {
-  // One of two pointers at the skill; the help output carries the other, pinned in `route.unit.test.ts`.
+  // One of two pointers at the skill; the help output holds the other, pinned in `route.unit.test.ts`.
   it('points at the authoring skill', () => {
     expect(rdyKitTemplate).toContain('consult-readyup-kits');
   });

--- a/packages/readyup/src/init/initCommand.ts
+++ b/packages/readyup/src/init/initCommand.ts
@@ -58,7 +58,7 @@ export function initCommand({ dryRun, force }: InitOptions): number {
 }
 
 /**
- * Compose the numbered next steps printed after scaffolding.
+ * Returns the numbered next steps printed after scaffolding.
  *
  * The install step leads when readyup does not resolve from the project, because every later step
  * depends on it: compiling a kit resolves the kit's readyup import, and running one loads the CLI.

--- a/packages/readyup/src/init/scaffold.ts
+++ b/packages/readyup/src/init/scaffold.ts
@@ -15,7 +15,7 @@ interface ScaffoldResult {
   kitResult: WriteResult;
 }
 
-/** Scaffold the rdy config and starter kit files. */
+/** Scaffolds the rdy config and starter kit files. */
 export function scaffoldConfig({ dryRun, force }: ScaffoldOptions): ScaffoldResult {
   const configResult = writeFileWithCheck(CONFIG_PATH, rdyConfigTemplate, { dryRun, overwrite: force });
   const kitResult = writeFileWithCheck(KIT_PATH, rdyKitTemplate, {

--- a/packages/readyup/src/installed-packages/__tests__/resolvePackageRoot.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/resolvePackageRoot.unit.test.ts
@@ -44,7 +44,7 @@ describe(resolvePackageRoot, () => {
 
     beforeAll(() => {
       // Resolve the real path up front: macOS reports `/var/...` for a temp dir that is really `/private/var/...`,
-      // and the walk answers with real paths.
+      // and the walk yields real paths.
       fixtureRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'resolve-package-root-')));
       nestedDir = path.join(fixtureRoot, 'packages', 'nested');
       mkdirSync(nestedDir, { recursive: true });
@@ -53,7 +53,7 @@ describe(resolvePackageRoot, () => {
       mkdirSync(installed, { recursive: true });
       writeFileSync(path.join(installed, 'package.json'), '{"name":"@acme/kitpkg","version":"1.0.0"}\n');
 
-      // A directory that occupies the name but carries no manifest, which is not a package.
+      // A directory that occupies the name but has no manifest, which is not a package.
       mkdirSync(path.join(fixtureRoot, 'node_modules', 'readyup-fixture-manifestless'), { recursive: true });
     });
 

--- a/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
+++ b/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
@@ -8,7 +8,7 @@ import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts
 import { readPackageVersion, resolvePackageRoot } from './resolvePackageRoot.ts';
 import { resolveWorkspaceRoot } from './resolveWorkspaceRoot.ts';
 
-/** A kit published by an installed package, carrying the provenance its output is labelled with. */
+/** A kit published by an installed package, with the provenance its output is labelled with. */
 export interface PackageKit {
   packageName: string;
   version: string | undefined;

--- a/packages/readyup/src/installed-packages/isPackageInstalled.ts
+++ b/packages/readyup/src/installed-packages/isPackageInstalled.ts
@@ -5,8 +5,8 @@ import { resolvePackageRoot } from './resolvePackageRoot.ts';
  *
  * Resolution is anchored to the current directory rather than to this module, so the answer describes
  * the project being worked on and not readyup's own installation. It also asks the filesystem rather
- * than the module resolver, which keeps ESM-only packages — whose entry points no `require` condition
- * reaches — from reading as absent.
+ * than the module resolver, which keeps ESM-only packages -- whose entry points no `require` condition
+ * reaches -- from reading as absent.
  */
 export function isPackageInstalled(packageName: string): boolean {
   return resolvePackageRoot(packageName) !== undefined;

--- a/packages/readyup/src/installed-packages/resolvePackageRoot.ts
+++ b/packages/readyup/src/installed-packages/resolvePackageRoot.ts
@@ -13,7 +13,7 @@ import { isRecord } from '../portable/isRecord.ts';
  * ESM-only packages do not publish. A package directory is also precisely what `exports` exists to hide,
  * so no specifier can name one.
  *
- * Answers with the real path, so a pnpm store symlink resolves to the directory the package occupies and
+ * Returns the real path, so a pnpm store symlink resolves to the directory the package occupies and
  * a workspace link resolves to its source checkout.
  */
 export function resolvePackageRoot(packageName: string, fromDir: string = process.cwd()): string | undefined {

--- a/packages/readyup/src/installed-packages/resolveWorkspaceRoot.ts
+++ b/packages/readyup/src/installed-packages/resolveWorkspaceRoot.ts
@@ -9,7 +9,7 @@ import { discoverWorkspacesAt, type Workspace } from '../check-utils/workspaces.
  * The fallback behind `resolvePackageRoot`, for a project whose own workspaces publish kits: A monorepo
  * declares no dependency on them at its root, so nothing links them into `node_modules` and the upward walk
  * does not find them. A workspace matches by the `name` its manifest declares, `private: true` included,
- * because `private` prevents publication to a registry and has no bearing on discovery inside the repo.
+ * because `private` prevents publication to a registry and does not affect discovery inside the repo.
  *
  * Returns the real path, so the result matches what `resolvePackageRoot` returns for a workspace that is
  * linked into `node_modules`.

--- a/packages/readyup/src/kitImports/__tests__/listRunnerExports.unit.test.ts
+++ b/packages/readyup/src/kitImports/__tests__/listRunnerExports.unit.test.ts
@@ -7,7 +7,7 @@ import { isRecord } from '../../portable/isRecord.ts';
 import { listRunnerExports, listRunnerSpecifiers } from '../listRunnerExports.ts';
 
 /**
- * The specifiers this package's `exports` map serves as JavaScript.
+ * Returns the specifiers this package's `exports` map serves as JavaScript.
  *
  * A JSON subpath is excluded: it has no named exports for the table to account for.
  */

--- a/packages/readyup/src/kitImports/scanReadyupImports.ts
+++ b/packages/readyup/src/kitImports/scanReadyupImports.ts
@@ -12,7 +12,7 @@ export interface ReadyupImport {
  * Lists the `readyup` and `readyup/*` imports a compiled bundle makes.
  *
  * Scans the whole bundle rather than its head: esbuild emits each inlined module's external imports inside that
- * module's section, so a kit's later sections carry imports of their own.
+ * module's section, so a kit's later sections have imports of their own.
  *
  * A form whose bindings cannot be read statically -- a namespace import, a default import, a dynamic import, a
  * side-effect import, a star re-export -- yields an entry with no names, so its specifier is still reported while
@@ -53,7 +53,7 @@ const BRACED_GROUP_PATTERN = /\{([\s\S]*)\}/;
 /**
  * The imported name leading one entry of a braced clause, ahead of any `as` rename.
  *
- * Both spellings the grammar allows for the name: a bare identifier, and the quoted form that carries a module-export
+ * Both spellings the grammar allows for the name: a bare identifier, and the quoted form that holds a module-export
  * name an identifier cannot express.
  */
 const LEADING_NAME_PATTERN = /^\s*(?:"([^"]*)"|'([^']*)'|([A-Za-z_$][\w$]*))/;

--- a/packages/readyup/src/kits/KitProvenance.ts
+++ b/packages/readyup/src/kits/KitProvenance.ts
@@ -2,7 +2,7 @@
  * Where a kit came from, absent only for a kit resolved from the local kits directory.
  *
  * Three kinds where `--from` accepts six: the six collapse onto three roles a heading can name, and a
- * distinction no reader ever sees is one nothing should carry. A source kind added later joins this
+ * distinction no reader ever sees is one nothing should record. A source kind added later joins this
  * union and the branch that renders it.
  */
 export type KitProvenance =

--- a/packages/readyup/src/kits/__tests__/assertIsRdyKit.unit.test.ts
+++ b/packages/readyup/src/kits/__tests__/assertIsRdyKit.unit.test.ts
@@ -34,7 +34,7 @@ describe(assertIsRdyKit, () => {
       );
     });
 
-    // `isFlatChecklist` discriminates on key presence, so a checklist carrying either key explicitly
+    // `isFlatChecklist` discriminates on key presence, so a checklist with either key explicitly
     // set to `undefined` is classified by that key whatever its value, and the collection the runner
     // then iterates is not there.
     it.each([

--- a/packages/readyup/src/kits/__tests__/loadRdyKit.unit.test.ts
+++ b/packages/readyup/src/kits/__tests__/loadRdyKit.unit.test.ts
@@ -300,7 +300,7 @@ describe(loadRdyKit, () => {
   });
 });
 
-/** Build the `withFileTypes` entries `readdirSync` returns for a set of regular files. */
+/** Returns the `withFileTypes` entries `readdirSync` yields for a set of regular files. */
 function buildDirents(...names: string[]): Array<{ name: string; isFile: () => boolean }> {
   return names.map((name) => ({ name, isFile: () => true }));
 }

--- a/packages/readyup/src/kits/__tests__/validateKit.unit.test.ts
+++ b/packages/readyup/src/kits/__tests__/validateKit.unit.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { RdyKit } from '../types.ts';
 import { validateKit } from '../validateKit.ts';
 
-/** Build a minimal valid kit for testing. */
+/** Returns a minimal valid kit. */
 function makeKit(overrides?: Partial<RdyKit>): RdyKit {
   return {
     checklists: [

--- a/packages/readyup/src/kits/assertIsRdyKit.ts
+++ b/packages/readyup/src/kits/assertIsRdyKit.ts
@@ -25,13 +25,13 @@ const FunctionSchema = z.custom<(...args: never[]) => unknown>((value) => typeof
   error: (issue) => `expected a function, got ${describeType(issue.input)}`,
 });
 
-/** Schema for the name every check and checklist must carry. */
+/** Schema for the name every check and checklist must have. */
 const NameSchema = z.string('expected a non-empty string').min(1, 'expected a non-empty string');
 
 /**
  * Schema for a single check, recursing into its dependent checks through a getter.
  *
- * `looseObject` lets unknown keys through: a kit authored against a later readyup, or carrying an
+ * `looseObject` lets unknown keys through: a kit authored against a later readyup, or with an
  * annotation this version knows nothing about, is not thereby broken.
  *
  * `looseObject` reads every own enumerable key in order to pass unknown ones through, so removing
@@ -74,7 +74,7 @@ const ChecklistShapeSchema = z.looseObject({
 });
 
 /**
- * A checklist carrying exactly one of `checks` and `groups`.
+ * A checklist with exactly one of `checks` and `groups`.
  *
  * The two clauses test different things, and each has to. `isFlatChecklist` discriminates on key
  * presence, so the exclusivity clause does too: a checklist whose `checks` is present but explicitly
@@ -99,7 +99,7 @@ const RdyKitSchema = z.looseObject({
 });
 
 /**
- * Validate that a raw value conforms to the RdyKit shape, checks included.
+ * Validates that a raw value conforms to the RdyKit shape, checks included.
  *
  * Every check is validated wherever it appears, so a typo'd severity or a non-function `check`
  * fails at load rather than silently changing what the run reports. jiti and esbuild type-check
@@ -115,7 +115,7 @@ export function assertIsRdyKit(raw: unknown, source?: string): asserts raw is Rd
   throw new Error(formatValidationError(result.error, source));
 }
 
-/** Compose a heading plus one sentence per issue from a failed kit parse. */
+/** Returns a heading plus one sentence per issue from a failed kit parse. */
 function formatValidationError(error: ZodError, source: string | undefined): string {
   const heading = source === undefined ? 'Invalid kit:' : `Invalid kit at ${source}:`;
   const lines = error.issues.map((issue) => `  ${formatIssuePath(issue.path)}: ${issue.message}`);
@@ -144,7 +144,7 @@ function formatIssuePath(path: ReadonlyArray<PropertyKey>): string {
  *
  * A getter is deferred to the failure that renders it, so validation must not read one. Hiding it
  * behind a copy that has no `fix` at all is what defers it; a data property passes through untouched.
- * The copy carries descriptors rather than values, so no other accessor on the check is invoked by
+ * The copy holds descriptors rather than values, so no other accessor on the check is invoked by
  * building it.
  */
 function hideAccessorFix(value: unknown): unknown {

--- a/packages/readyup/src/kits/authoring.ts
+++ b/packages/readyup/src/kits/authoring.ts
@@ -1,28 +1,28 @@
 import type { RdyChecklist, RdyConfig, RdyKit, RdyStagedChecklist } from './types.ts';
 
-/** Type-safe identity function for defining repo-level rdy settings. */
+/** Returns repo-level rdy settings unchanged, so their literal is type-checked where it is written. */
 export function defineRdyConfig(config: RdyConfig): RdyConfig {
   return config;
 }
 
-/** Type-safe identity function for defining a rdy kit in a config file. */
+/** Returns a rdy kit unchanged, so its literal is type-checked where it is written in a config file. */
 export function defineRdyKit(kit: RdyKit): RdyKit {
   return kit;
 }
 
-/** Type-safe identity function for defining an array of checklists in a config file. */
+/** Returns an array of checklists unchanged, so its literal is type-checked where it is written. */
 export function defineChecklists(
   checklists: Array<RdyChecklist | RdyStagedChecklist>,
 ): Array<RdyChecklist | RdyStagedChecklist> {
   return checklists;
 }
 
-/** Type-safe identity function for defining a flat checklist. */
+/** Returns a flat checklist unchanged, so its literal is type-checked where it is written. */
 export function defineRdyChecklist(checklist: RdyChecklist): RdyChecklist {
   return checklist;
 }
 
-/** Type-safe identity function for defining a staged checklist. */
+/** Returns a staged checklist unchanged, so its literal is type-checked where it is written. */
 export function defineRdyStagedChecklist(checklist: RdyStagedChecklist): RdyStagedChecklist {
   return checklist;
 }

--- a/packages/readyup/src/kits/buildKitFilename.ts
+++ b/packages/readyup/src/kits/buildKitFilename.ts
@@ -1,4 +1,4 @@
-/** Build a kit filename from a kit name, optional infix, and extension. */
+/** Returns a kit filename built from a kit name, an optional infix, and an extension. */
 export function buildKitFilename(kitName: string, infix: string | undefined, extension: string): string {
   if (infix !== undefined) {
     return `${kitName}.${infix}${extension}`;

--- a/packages/readyup/src/kits/kitsDir.ts
+++ b/packages/readyup/src/kits/kitsDir.ts
@@ -11,7 +11,7 @@ export const READYUP_DIR = '.readyup';
  */
 export const KITS_DIR = `${READYUP_DIR}/kits`;
 
-/** Resolve the home directory the `global` kit source is rooted at, across platforms. */
+/** Returns the home directory the `global` kit source is rooted at, on any platform. */
 export function resolveHomeDir(): string {
   return process.env['HOME'] ?? process.env['USERPROFILE'] ?? '~';
 }

--- a/packages/readyup/src/kits/loadRdyKit.ts
+++ b/packages/readyup/src/kits/loadRdyKit.ts
@@ -11,7 +11,7 @@ import { resolveKitExports } from './resolveKitExports.ts';
 import type { RdyKit } from './types.ts';
 import { validateKit } from './validateKit.ts';
 
-/** The extension a kit's counterpart carries, keyed by the extension that was requested. */
+/** The extension a kit's counterpart takes, keyed by the extension that was requested. */
 const SIBLING_EXTENSIONS: Record<string, string> = { '.js': '.ts', '.ts': '.js' };
 
 /** Result of loading a rdy kit: the validated kit plus the compile-time readyup version, if embedded. */
@@ -61,7 +61,7 @@ export async function loadRdyKit(kitPath: string): Promise<LoadedRdyKit> {
 }
 
 /**
- * Compose the error message for a kit path that does not exist.
+ * Returns the error message for a kit path that does not exist.
  *
  * Each branch names the remedy that applies to the state actually found on disk: a source
  * awaiting compilation, a compiled kit requested as source, a project that was never
@@ -93,7 +93,7 @@ function diagnoseMissingKit(resolvedPath: string): string {
   return `Kit "${name}" not found at ${toDisplayPath(resolvedPath)}. ${availability}`;
 }
 
-/** List the kit names beside a missing kit, treating an unreadable directory as holding none. */
+/** Returns the kit names beside a missing kit, treating an unreadable directory as holding none. */
 function listAvailableKits(dir: string, extension: string): string[] {
   try {
     return enumerateKits({ dir, extension });
@@ -102,7 +102,7 @@ function listAvailableKits(dir: string, extension: string): string[] {
   }
 }
 
-/** Narrow `__readyupVersion` from an imported module namespace to a string, or undefined. */
+/** Narrows `__readyupVersion` in an imported module namespace to a string, or undefined. */
 function readCompileTimeVersion(moduleRecord: Record<string, unknown>): string | undefined {
   const value = moduleRecord['__readyupVersion'];
   return typeof value === 'string' ? value : undefined;

--- a/packages/readyup/src/kits/resolveKitExports.ts
+++ b/packages/readyup/src/kits/resolveKitExports.ts
@@ -1,12 +1,11 @@
 import { isRecord } from '../portable/isRecord.ts';
 
 /**
- * Extract all recognized kit fields from an imported module namespace.
+ * Returns every recognized kit field in an imported module namespace, as a plain record.
  *
- * Extracts `checklists` (required), and optionally `defaultSeverity`, `description`, `failOn`,
- * `fixLocation`, `reportOn`, and `suites`. Supports both `export default defineRdyKit({...})`
- * and the named-export convention (`export const checklists = ...`). Returns a plain record
- * suitable for passing to `assertIsRdyKit`.
+ * `checklists` is required; `defaultSeverity`, `description`, `failOn`, `fixLocation`, `reportOn`,
+ * and `suites` are optional. Both `export default defineRdyKit({...})` and the named-export form,
+ * `export const checklists = ...`, are recognized.
  */
 export function resolveKitExports(moduleRecord: Record<string, unknown>): Record<string, unknown> {
   // Unwrap default export when present (e.g., `export default defineRdyKit({...})`)

--- a/packages/readyup/src/kits/types.ts
+++ b/packages/readyup/src/kits/types.ts
@@ -98,12 +98,12 @@ export interface PercentProgress {
 /** Union of progress representations, discriminated by `type`. */
 export type Progress = FractionProgress | PercentProgress;
 
-/** Return true if a progress value uses the percentage representation. */
+/** Reports whether a progress value uses the percentage representation. */
 export function isPercentProgress(progress: Progress): progress is PercentProgress {
   return progress.type === 'percent';
 }
 
-/** Structured outcome from a check, carrying diagnostic data alongside the pass/fail status. */
+/** Structured outcome from a check, with diagnostic data alongside the pass/fail status. */
 export interface CheckOutcome {
   /** Whether the check's claim holds. */
   ok: boolean;
@@ -259,7 +259,7 @@ export interface FailedResult extends RdyResultBase {
 
   /**
    * Remediation message, resolved from the check definition as the failure is built. Only a failure
-   * carries one, because a `fix` may be an accessor and nothing else renders it.
+   * has one, because a `fix` may be an accessor and nothing else renders it.
    */
   fix: string | null;
 }
@@ -322,7 +322,7 @@ export interface RdyReport {
  * `worstSeverity` is the highest-severity failed bucket (`null` when nothing failed).
  *
  * This is the runner's internal tally, shared by the human report and the combined-summary table.
- * The JSON layer nests the six numeric fields under `counts` and carries `worstSeverity` beside
+ * The JSON layer nests the six numeric fields under `counts` and places `worstSeverity` beside
  * them; see `schemas/common.ts`, which is the source of truth for the wire shape.
  */
 export interface SummaryCounts {
@@ -366,7 +366,7 @@ export interface RdyStagedChecklist {
   fixLocation?: FixLocation | undefined;
 }
 
-/** Distinguish a flat checklist from a staged checklist by the presence of `checks`. */
+/** Reports whether a checklist is flat rather than staged, which the presence of `checks` decides. */
 export function isFlatChecklist(checklist: RdyChecklist | RdyStagedChecklist): checklist is RdyChecklist {
   return 'checks' in checklist;
 }

--- a/packages/readyup/src/kits/validateKit.ts
+++ b/packages/readyup/src/kits/validateKit.ts
@@ -1,11 +1,11 @@
 import type { RdyKit } from './types.ts';
 
 /**
- * Check semantic invariants on a structurally valid kit.
+ * Checks the semantic invariants of a structurally valid kit, throwing a descriptive message on a
+ * violation.
  *
- * Enforces two rules: (1) no suite name may collide with a checklist name,
- * and (2) every entry in a suite must reference an existing checklist name.
- * Throws on violation with a descriptive message.
+ * Two rules hold: no suite name collides with a checklist name, and every entry in a suite names an
+ * existing checklist.
  */
 export function validateKit(kit: RdyKit): void {
   const { suites } = kit;

--- a/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
@@ -216,7 +216,7 @@ describe('formatBreadcrumb', () => {
     expect(engine.formatBreadcrumb([{ role: 'checklist', text: 'repo' }], 'kit')).toBe('\u{2501}\u{2501} 📋 repo');
   });
 
-  // The spacing is the only segment boundary a glyphless style offers, and segment texts carry slashes
+  // The spacing is the only segment boundary a glyphless style offers, and segment texts contain slashes
   // of their own, so a bare separator would leave nothing to read the breadcrumb by.
   it('keeps the separator spaced where a role has no glyph', () => {
     const plain = createLayoutEngine(plainFormatter);
@@ -364,7 +364,7 @@ describe('formatSummaryTable', () => {
     expect(lines).toHaveLength(6);
   });
 
-  // The run's writer parts one block from the next, so a table carrying its own blanks would double the gap.
+  // The run's writer separates one block from the next, so a table with its own blanks would double the gap.
   it('carries no blank line of its own', () => {
     expect(engine.formatSummaryTable(input)).not.toContain('');
   });

--- a/packages/readyup/src/layout/formatter.ts
+++ b/packages/readyup/src/layout/formatter.ts
@@ -33,7 +33,7 @@ export type HeadingLevel = 'kit' | 'section';
 
 /** A vocabulary of status tokens and heading rule characters, from which the layout engine derives geometry. */
 export interface Formatter {
-  /** Character parting a check's name from its inline detail. The engine supplies the spaces around it. */
+  /** Character separating a check's name from its inline detail. The engine supplies the spaces around it. */
   detailSeparator: string;
 
   /** Columns from the start of a status token to the start of the name beside it. Exceeds every token's width. */

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -9,9 +9,9 @@ const DURATION_FLOOR_MS = 100;
 const HEADING_SIGIL_WIDTH = 2;
 
 /**
- * Text parting one breadcrumb segment from the next.
+ * Text separating one breadcrumb segment from the next.
  *
- * Spaced on both sides because a segment's own text carries slashes -- a scoped package name, a relative
+ * Spaced on both sides because a segment's own text contains slashes -- a scoped package name, a relative
  * path -- and under a style whose roles have no glyph, that spacing is the only boundary a reader gets.
  */
 export const SEGMENT_SEPARATOR = ' / ';
@@ -30,7 +30,7 @@ const TOTAL_LABEL = 'Total:';
 /** Heading over the combined summary table. */
 const SUMMARY_HEADING = 'Summary';
 
-/** Text parting one count from the next. */
+/** Text separating one count from the next. */
 const COUNT_SEPARATOR = ', ';
 
 /** Statement a count line makes when there is nothing at all to report. */
@@ -112,10 +112,9 @@ export interface LayoutEngine {
 /** Returns string builders bound to `formatter`, each deriving its spacing from the formatter's gutter. */
 export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   /**
-   * Returns `segments` as one heading, each behind its role's glyph and parted by the segment separator.
+   * Returns `segments` as one heading, each behind its role's glyph and separated by the segment separator.
    *
-   * A role the formatter gives no glyph closes up rather than carrying the space that would have
-   * followed one.
+   * A role the formatter gives no glyph closes up, with no space where the glyph would sit.
    */
   function formatBreadcrumb(segments: BreadcrumbSegment[], level: HeadingLevel, detail?: string): string {
     const rendered = segments.map((segment) => `${inlineGlyph(segment.role)}${segment.text}`);
@@ -149,10 +148,10 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   }
 
   /**
-   * Returns `name` behind a two-character rule whose weight comes from `level`, carrying `detail` behind
+   * Returns `name` behind a two-character rule whose weight comes from `level`, with `detail` behind
    * the formatter's separator where there is one.
    *
-   * A heading carries no blank line of its own. Separation is a property of the sequence a heading sits
+   * A heading has no blank line of its own. Separation is a property of the sequence a heading sits
    * in, which only the code emitting that sequence can see: a heading deciding for itself is how two
    * adjacent ones each contribute a blank and open a gap neither intended.
    */
@@ -169,7 +168,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   /**
    * Returns each reason indented to the name column of a check at `depth`, one gutter further in.
    *
-   * A reason carrying its own line breaks -- a bundler's rendered diagnostic, say -- is indented on
+   * A reason with its own line breaks -- a bundler's rendered diagnostic, say -- is indented on
    * every line, so it reads as one block rather than falling back to the left margin partway through.
    * Blank lines within it stay blank rather than becoming trailing whitespace.
    */
@@ -188,7 +187,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
    *
    * Names are padded and durations right-aligned, so every row's counts begin at the same column. Both
    * rules span the widest line they enclose, the total included. A row names itself by its breadcrumb
-   * without the role glyphs the matching heading carries, because padding counts characters while the
+   * without the role glyphs the matching heading adds, because padding counts characters while the
    * terminal lays out display width, and a glyph makes the two disagree.
    */
   function formatSummaryTable({ rows, totalDurationMs, totals }: SummaryTableInput): string[] {
@@ -226,8 +225,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   /**
    * Returns a token's glyph and one trailing space, for placement mid-sentence rather than at a line's head.
    *
-   * A formatter that gives the token no glyph returns nothing, so the sentence closes up instead of
-   * carrying the space that would have followed one.
+   * A formatter that gives the token no glyph returns nothing, so the sentence closes up with no space.
    */
   function inlineGlyph(name: TokenName): string {
     const { glyph } = formatter.tokens[name];
@@ -242,7 +240,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
 
   // -- Helpers --
 
-  /** Returns everything a count line carries after its leading token. */
+  /** Returns everything a count line shows after its leading token. */
   function buildCountBody(counts: SummaryCounts, durationMs: number): string {
     return `${TOTAL_LABEL} ${formatCounts(counts)} (${formatDuration(durationMs)})`;
   }
@@ -263,7 +261,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   };
 }
 
-/** Returns `segments` parted as a heading parts them, carrying none of the role glyphs a heading adds. */
+/** Returns `segments` separated as a heading separates them, without the role glyphs a heading adds. */
 function formatBreadcrumbLabel(segments: BreadcrumbSegment[]): string {
   return segments.map((segment) => segment.text).join(SEGMENT_SEPARATOR);
 }

--- a/packages/readyup/src/layout/plainFormatter.ts
+++ b/packages/readyup/src/layout/plainFormatter.ts
@@ -7,7 +7,7 @@ import type { Formatter } from './formatter.ts';
  * terminal with no emoji font. Each status token is a word rather than a symbol, which is what makes
  * `grep FAIL` find a failure.
  *
- * The role tokens carry no glyph. They name what a thing is rather than reporting an outcome, and an
+ * The role tokens have no glyph. They name what a thing is rather than reporting an outcome, and an
  * uppercase word in the status column would read as a status; position already says which role a name
  * plays, whether it is a heading's segment or a listed row. Declaring zero width still reserves the
  * gutter, so names hold the same column as every status line.

--- a/packages/readyup/src/layout/resolveStyle.ts
+++ b/packages/readyup/src/layout/resolveStyle.ts
@@ -11,7 +11,7 @@ export type StyleSetting = (typeof STYLE_SETTINGS)[number];
 /** Flag naming the style for one invocation. */
 export const STYLE_FLAG = '--style';
 
-/** Environment variable carrying a standing style preference. */
+/** Environment variable holding a standing style preference. */
 export const STYLE_ENV_VAR = 'RDY_STYLE';
 
 /** The accepted settings widened to strings, so an arbitrary input can be tested for membership. */
@@ -23,7 +23,7 @@ export interface InvalidStyle {
   value: string;
 }
 
-/** A style to render with, alongside the complaint the inputs earned. */
+/** A style to render with, alongside any complaint the inputs provoked. */
 export interface StyleResolution {
   style: Style;
   invalid?: InvalidStyle;
@@ -97,7 +97,7 @@ function readStyleFlag(argv: string[]): string | undefined {
 /**
  * Returns the style the environment implies: plain wherever the output is not a person's terminal.
  *
- * Both signals carry their own weight. `CI` catches a runner that allocates a pseudo-terminal, where the
+ * Both signals matter on their own. `CI` catches a runner that allocates a pseudo-terminal, where the
  * terminal check alone would emit emoji into a log nobody can grep; the terminal check catches an
  * interactive pipe into `grep`, where `CI` is unset. `CI` is also not universal -- Jenkins does not set
  * it. An explicit `CI=false` is honored as a denial, which is how the wider ecosystem reads it.

--- a/packages/readyup/src/layout/richFormatter.ts
+++ b/packages/readyup/src/layout/richFormatter.ts
@@ -3,7 +3,7 @@ import type { Formatter } from './formatter.ts';
 /**
  * A formatter whose tokens are emoji.
  *
- * Every glyph carries `Emoji_Presentation=Yes`, so it occupies two terminal cells without a U+FE0F
+ * Every glyph has `Emoji_Presentation=Yes`, so it occupies two terminal cells without a U+FE0F
  * variation selector. A glyph lacking that property renders one cell wide in some terminals and two in
  * others, so its declared width would be wrong somewhere.
  */

--- a/packages/readyup/src/list/__tests__/formatList.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/formatList.unit.test.ts
@@ -84,7 +84,7 @@ describe(formatOwnerView, () => {
     expect(lines[2]).toBe(`${INTERNAL} deploy`);
   });
 
-  // A blank parts one section from the next, and the first section opens the output with no blank at all.
+  // A blank separates one section from the next, and the first section opens the output with no blank at all.
   it('parts one section from the next with a blank line, opening with none', () => {
     const lines = formatOwnerView({
       internalKits: ['deploy'],

--- a/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
@@ -30,7 +30,7 @@ describe('listCommand wiring', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  /** Create a kit directory holding compiled kits, with no manifest beside them. */
+  /** Creates a kit directory holding compiled kits, with no manifest beside them. */
   function writeKitsDir(dirName: string, kitNames: string[]): string {
     const dir = path.join(tempDir, dirName);
     mkdirSync(dir, { recursive: true });

--- a/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
@@ -12,7 +12,7 @@ import { listCommand } from '../listCommand.ts';
 /**
  * Exercises `listCommand` against real directories, without mocking the manifest reader or the
  * filesystem enumerator. The unit tests cover each mode's branches; this locks in the wiring the
- * manifest-less fallback depends on — that `list --from` looks where `run --from` loads.
+ * manifest-less fallback depends on -- that `list --from` looks where `run --from` loads.
  */
 describe('listCommand wiring', () => {
   let tempDir: string;

--- a/packages/readyup/src/list/enumerateKits.ts
+++ b/packages/readyup/src/list/enumerateKits.ts
@@ -9,10 +9,11 @@ interface EnumerateKitsOptions {
 }
 
 /**
- * Return sorted base names (extension stripped) of files in `dir` matching `extension`.
+ * Returns the sorted base names, extension stripped, of the files in `dir` matching `extension`, or
+ * `[]` where `dir` does not exist.
  *
- * Non-recursive. Hidden files (starting with `.`) are excluded. Returns `[]` when
- * `dir` does not exist; rethrows other filesystem errors (e.g., `EACCES`).
+ * The listing is not recursive, and a hidden file, meaning one whose name starts with `.`, is
+ * excluded. A filesystem error that is not a missing directory, such as `EACCES`, is rethrown.
  */
 export function enumerateKits({ dir, extension }: EnumerateKitsOptions): string[] {
   let entries;
@@ -31,7 +32,7 @@ export function enumerateKits({ dir, extension }: EnumerateKitsOptions): string[
     .toSorted();
 }
 
-/** Type guard for Node.js filesystem errors with a `code` property. */
+/** Reports whether an error is a Node.js filesystem error, which is one with a `code` property. */
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return isError(error) && 'code' in error;
 }

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -5,7 +5,7 @@ import { KITS_DIR } from '../kits/kitsDir.ts';
 import { getLayout } from '../layout/engine.ts';
 import type { TokenName } from '../layout/formatter.ts';
 
-/** Blank line parting one listed section from the next. A section supplies none of its own. */
+/** Blank line separating one listed section from the next. A section supplies none of its own. */
 const SECTION_SEPARATOR = '\n\n';
 
 /** Detail marking a package the readyup config does not name. */
@@ -55,7 +55,7 @@ interface OwnerViewOptions {
 }
 
 /**
- * Format the owner-mode output showing internal and compiled kit sections.
+ * Returns the owner-mode output, showing the internal and compiled kit sections.
  *
  * Empty sections are omitted. Returns the empty-owner message when both lists are empty.
  *
@@ -119,7 +119,7 @@ interface ConsumerViewOptions {
 }
 
 /**
- * Format the consumer-mode output showing compiled kits at a local path.
+ * Returns the consumer-mode output, showing the compiled kits at a local path.
  *
  * Returns the empty-consumer message when the kit list is empty.
  */
@@ -143,7 +143,7 @@ interface PackagesViewOptions {
  *
  * Configured and unconfigured packages interleave in one alphabetical list rather than splitting into
  * sections, so a reader asking what their dependencies publish reads one answer. What separates them is
- * the hint each block carries, which names the command that runs that package's kits.
+ * the hint each block shows, which names the command that runs that package's kits.
  *
  * A sweep with no groups returns the empty-packages message.
  */
@@ -153,7 +153,7 @@ export function formatPackagesView({ groups }: PackagesViewOptions): string {
 
 // -- Recursive view --
 
-/** One kit a recursive listing reports, carrying the description its project's manifest records. */
+/** One kit a recursive listing reports, with the description its project's manifest records. */
 export interface RecursiveKitView {
   name: string;
   description?: string | undefined;
@@ -216,7 +216,7 @@ export function formatRecursivePackagesView({ projects }: RecursivePackagesViewO
 
 // -- Empty messages --
 
-/** Format the "no kits found" message appropriate to the given mode. */
+/** Returns the "no kits found" message that suits the given mode. */
 export function formatEmpty(
   mode: 'owner' | 'consumer' | 'packages' | 'recursive' | 'recursive-packages',
   kitsDir?: string,
@@ -246,7 +246,7 @@ interface ManifestViewOptions {
 /**
  * Returns a heading naming the manifest, then one line per kit.
  *
- * A kit's line carries its version as a parenthetical and its description as inline detail, each present
+ * A kit's line shows its version as a parenthetical and its description as inline detail, each present
  * only when the manifest records it. The `readyup` label distinguishes the runner's version from a
  * version the kit might declare for itself.
  */
@@ -320,7 +320,7 @@ function buildProjectPrefix(dir: string): string {
  * Returns the indented line naming the command that runs the kits beneath it.
  *
  * The label is what separates the line from the kit rows sharing its column: the role glyphs those rows
- * carry are empty in plain style, so without it the command reads as one more kit.
+ * show are empty in plain style, so without it the command reads as one more kit.
  */
 function buildRunLine(command: string, depth = 1): string {
   return `${getLayout().indent(depth)}To run: ${command}`;
@@ -330,7 +330,7 @@ function buildRunLine(command: string, depth = 1): string {
  * Returns the section naming installed packages that publish kits the config does not list.
  *
  * Its line heads the section with what to do about those packages rather than a command to run, so it
- * carries no `To run:` label.
+ * has no `To run:` label.
  */
 function formatAvailableSection(availablePackages: string[]): string {
   const instruction = `${getLayout().indent(1)}Add to "packages" in the readyup config`;
@@ -393,7 +393,7 @@ function formatProjectBlock(project: RecursiveProjectView): string {
  * Returns one project's directory line, then a block per kit-publishing dependency beneath it.
  *
  * The directory sits directly above its first package, which is what makes the blank lines within the
- * block read as parting one package from the next rather than the directory from what it heads.
+ * block read as separating one package from the next rather than the directory from what it heads.
  */
 function formatProjectPackagesBlock(project: ProjectPackagesView): string {
   const directory = getLayout().formatCheckLine({ token: 'sourceDirectory', name: `${project.dir}/` });
@@ -407,9 +407,9 @@ function formatProjectPackagesBlock(project: ProjectPackagesView): string {
  * Returns a titled section: the title, `hintLine` beneath it, then the kits.
  *
  * `hintLine` arrives indented, because a section headed by a command and one headed by an instruction are
- * built differently and only the caller knows which it holds. Nothing inside is parted by a blank line:
+ * built differently and only the caller knows which it holds. Nothing inside is separated by a blank line:
  * the hint sits against the title so it reads as part of the heading, the kits sit against the hint, and
- * the blank parting one section from the next belongs to whoever assembles them.
+ * the blank separating one section from the next belongs to whoever assembles them.
  */
 function formatSection(title: string, hintLine: string, kits: string[], token: TokenName): string {
   const items = kits.map((name) => getLayout().formatCheckLine({ token, name }));

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -98,7 +98,7 @@ export function formatOwnerView({
   }
 
   if (packageKits.length > 0) {
-    // The rows stay every published kit — discovery is not run selection — so the bracketed optional keeps
+    // The rows stay every published kit -- discovery is not run selection -- so the bracketed optional keeps
     // the promise that every kit listed is reachable by the command above it.
     sections.push(formatSection('Packages', buildRunLine('rdy run --packages [<name>]'), packageKits, 'sourcePackage'));
   }

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -56,11 +56,7 @@ const listOptions = {
   style: { type: 'string' },
 } as const;
 
-/**
- * Handle the `list` subcommand: enumerate kits from the manifest and filesystem, then print their names.
- *
- * Returns a numeric exit code.
- */
+/** Runs the `list` subcommand, returning the exit code its enumeration of manifest and filesystem kits produced. */
 export async function listCommand(args: string[]): Promise<number> {
   let parsed;
   try {
@@ -129,7 +125,7 @@ export async function listCommand(args: string[]): Promise<number> {
   return runOwnerMode(json);
 }
 
-/** Display kits from a manifest file. */
+/** Displays the kits a manifest file declares. */
 function runManifestMode(manifestArg: string, json: boolean): number {
   const manifestPath = path.resolve(process.cwd(), manifestArg);
   const manifest = readManifestOrThrow(manifestPath);
@@ -143,7 +139,7 @@ function runManifestMode(manifestArg: string, json: boolean): number {
   );
 }
 
-/** Resolve the manifest path for a `--from` source and display its kits. */
+/** Resolves the manifest path for a `--from` source and displays its kits. */
 async function runFromMode(fromArg: string, json: boolean): Promise<number> {
   let source;
   try {
@@ -207,7 +203,7 @@ function listLocalDirectory(manifestPath: string, kitsDir: string, fromArg: stri
   return finishList(entries, json);
 }
 
-/** Fetch and display kits from a remote manifest URL, authenticating where the host is one readyup knows. */
+/** Fetches and displays the kits at a remote manifest URL, authenticating where the host is one readyup knows. */
 async function runRemoteFromMode({ url, json }: { url: string; json: boolean }): Promise<number> {
   const provider = resolveRemoteProvider(url);
   const headers = resolveRemoteAuthHeaders(provider);
@@ -229,7 +225,7 @@ async function runRemoteFromMode({ url, json }: { url: string; json: boolean }):
   );
 }
 
-/** Enumerate kits using the project config. */
+/** Enumerates the kits the project config names. */
 async function runOwnerMode(json: boolean): Promise<number> {
   const cwd = process.cwd();
   const config = await loadListingConfig();
@@ -434,7 +430,7 @@ function collectConfiguredPackageKits(packageNames: string[]): PackageKit[] {
 /**
  * Labels a package kit, its package first, so a kit reads the same here as in the heading a run gives it.
  *
- * The row's own token supplies the package glyph, so the label carries only what follows it.
+ * The row's own token supplies the package glyph, so the label holds only what follows it.
  */
 function describePackageKit(kit: PackageKit): string {
   const version = kit.version === undefined ? '' : `@${kit.version}`;
@@ -482,7 +478,7 @@ async function loadListingConfig(): Promise<ResolvedRdyConfig> {
   }
 }
 
-/** Emit the list payload under `--json`. Listing succeeds whenever its source could be read. */
+/** Emits the list payload under `--json`, succeeding whenever the listing's source could be read. */
 function finishList(kits: JsonListKitEntry[], json: boolean, availablePackages: string[] = []): number {
   if (json) {
     const output: JsonListOutput = {
@@ -495,16 +491,16 @@ function finishList(kits: JsonListKitEntry[], json: boolean, availablePackages: 
   return EXIT_OK;
 }
 
-/** Build the rows a manifest declares, rebasing each recorded path onto the current directory. */
+/** Returns the rows a manifest declares, rebasing each recorded path onto the current directory. */
 function manifestEntries(manifest: RdyManifest, manifestPath: string): JsonListKitEntry[] {
   return manifest.kits.map((kit) => buildManifestEntry(kit, path.dirname(manifestPath)));
 }
 
 /**
- * Build a kit row from a manifest entry.
+ * Returns a kit row built from a manifest entry.
  *
  * Every field but `name` and `kind` comes from the manifest, so a kit compiled by an older readyup
- * simply carries fewer of them. `checklists` is read here rather than from the kit itself: listing
+ * simply has fewer of them. `checklists` is read here rather than from the kit itself: listing
  * kits never imports a compiled bundle, so it never runs kit code.
  *
  * `manifestDir` rebases the recorded path onto the current directory, so a consumer can hand it
@@ -528,17 +524,17 @@ function buildManifestEntry(kit: RdyManifestKit, manifestDir: string | undefined
   return entry;
 }
 
-/** Build a kit row for a TypeScript source awaiting compilation. */
+/** Returns a kit row for a TypeScript source awaiting compilation. */
 function buildInternalEntry(name: string, dir: string, extension: string): JsonListKitEntry {
   return { name, kind: 'internal', path: path.relative(process.cwd(), path.join(dir, `${name}${extension}`)) };
 }
 
 /**
- * Enumerate the compiled kits in a directory, for a source that has no manifest beside it.
+ * Enumerates the compiled kits in a directory, for a source that has no manifest beside it.
  *
  * `run --from` resolves a kit by filename alone, so a directory it can run from is one `list` must
- * be able to describe. The rows carry only what the filesystem knows: everything else — description,
- * checklist names, the readyup version a kit was built against — lives in the manifest that is absent.
+ * be able to describe. The rows hold only what the filesystem knows: everything else -- description,
+ * checklist names, the readyup version a kit was built against -- lives in the manifest that is absent.
  *
  * A source with neither a manifest nor a kit directory is still an error. Reporting "no kits" for a
  * path that does not exist would turn a mistyped `--from` into a clean, empty answer.
@@ -564,7 +560,7 @@ function enumerateCompiledKits(kitsDir: string, manifestPath: string): JsonListK
   }));
 }
 
-/** Read a manifest, returning undefined when there is none and reporting any other failure. */
+/** Reads a manifest, returning undefined where there is none and reporting any other failure. */
 function readLocalManifestIfPresent(manifestPath: string): RdyManifest | undefined {
   try {
     return readManifest(manifestPath);
@@ -583,7 +579,7 @@ function readManifestOrThrow(manifestPath: string): RdyManifest {
   }
 }
 
-/** Resolve the manifest path for a parsed local `--from` source. */
+/** Returns the manifest path for a parsed local `--from` source. */
 function resolveFromManifestPath(source: LocalFromSource): string {
   if (source.type === 'global') {
     return path.join(resolveHomeDir(), '.readyup/manifest.json');
@@ -597,7 +593,7 @@ function resolveFromManifestPath(source: LocalFromSource): string {
   return path.join(path.resolve(source.path), '.readyup/manifest.json');
 }
 
-/** Resolve the directory a local `--from` source keeps its compiled kits in, matching `run --from`. */
+/** Returns the directory a local `--from` source keeps its compiled kits in, matching `run --from`. */
 function resolveFromKitsDir(source: LocalFromSource): string {
   if (source.type === 'global') {
     return path.join(resolveHomeDir(), KITS_DIR);

--- a/packages/readyup/src/list/test-utils/findPackageCommand.ts
+++ b/packages/readyup/src/list/test-utils/findPackageCommand.ts
@@ -3,7 +3,7 @@
  *
  * Reading that line positionally is the assertion: a command fused into the heading would still satisfy a
  * `toContain` over the whole output. The heading rule anchors the search, since an unconfigured package's
- * heading carries a trailing detail and a kit line could otherwise hold the same text.
+ * heading has a trailing detail and a kit line could otherwise hold the same text.
  */
 export function findPackageCommand(output: string, label: string): string | undefined {
   const lines = output.split('\n');

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -8,7 +8,7 @@ const JsonPathSpecSchema = z.array(z.union([z.string(), z.array(z.string())]));
  *
  * `kind` decides what the hash covers. A `module` records the file's contents; an `inline` records the
  * projection `pickJson` substituted, so an edit to a field the kit did not pick is not staleness. Only
- * an inline record carries `paths`, which is the specifier that produced the projection and so what a
+ * an inline record has `paths`, which is the specifier that produced the projection and so what a
  * reader needs to reproduce it.
  *
  * Paths are relative to the manifest directory, as `path` and `source` are.
@@ -40,7 +40,7 @@ const ManifestInputSchema = z.discriminatedUnion('kind', [
  * Neither field is covered by `inputs`, whose closure stops at `node_modules`; `rdy verify
  * --rebuild` reads both to name which versions changed when a rebuild mismatches. Each is
  * optional on the same terms `checklists` is, and `bundledDependencies` is additionally absent
- * when the kit bundles nothing, so `esbuildVersion` is the marker that an entry carries the
+ * when the kit bundles nothing, so `esbuildVersion` is the marker that an entry has the
  * record at all.
  */
 const ManifestKitSchema = z.object({

--- a/packages/readyup/src/manifest/readManifest.ts
+++ b/packages/readyup/src/manifest/readManifest.ts
@@ -15,9 +15,10 @@ export class ManifestNotFoundError extends Error {
 }
 
 /**
- * Read and validate a manifest file from disk.
+ * Returns a manifest file read from disk and validated.
  *
- * Throws `ManifestNotFoundError` for missing files, or a plain `Error` for invalid JSON / schema failures.
+ * Throws `ManifestNotFoundError` for a missing file, or a plain `Error` for invalid JSON or a schema
+ * failure.
  */
 export function readManifest(manifestPath: string): RdyManifest {
   let raw: string;

--- a/packages/readyup/src/manifest/writeManifest.ts
+++ b/packages/readyup/src/manifest/writeManifest.ts
@@ -5,9 +5,10 @@ import type { RdyManifest } from './manifestSchema.ts';
 import { ManifestSchema } from './manifestSchema.ts';
 
 /**
- * Validate and write a manifest to disk as formatted JSON.
+ * Validates a manifest and writes it to disk as formatted JSON, creating parent directories as
+ * needed.
  *
- * Creates parent directories as needed. Throws on invalid manifest data.
+ * Throws on invalid manifest data.
  */
 export function writeManifest(manifestPath: string, manifest: RdyManifest): void {
   const result = ManifestSchema.safeParse(manifest);

--- a/packages/readyup/src/output/terminal.ts
+++ b/packages/readyup/src/output/terminal.ts
@@ -12,7 +12,7 @@ interface WriteLine {
   reason?: string;
 }
 
-/** Writes `message` to stdout as a section heading, parted from whatever precedes it by a blank line. */
+/** Writes `message` to stdout as a section heading, separated from whatever precedes it by a blank line. */
 export function printStep(message: string): void {
   console.info(`\n${getLayout().formatHeading(message, 'section')}`);
 }
@@ -20,7 +20,7 @@ export function printStep(message: string): void {
 /**
  * Writes a check line for `result`, naming the file and then its outcome.
  *
- * An outcome that failed carries its cause in a block beneath and goes to stderr; the rest go to stdout.
+ * An outcome that failed shows its cause in a block beneath and goes to stderr; the rest go to stdout.
  */
 export function reportWriteResult(result: WriteResult, dryRun: boolean): void {
   const { claim, detail, reason, token } = describeWriteResult(result, dryRun);
@@ -38,7 +38,7 @@ export function reportWriteResult(result: WriteResult, dryRun: boolean): void {
 /**
  * Returns the token and text for a write outcome, phrasing `dryRun` outcomes as what would happen.
  *
- * A skip carries a warning token only when an unreadable file left the outcome undetermined.
+ * A skip takes a warning token only when an unreadable file left the outcome undetermined.
  */
 function describeWriteResult(result: WriteResult, dryRun: boolean): WriteLine {
   const { error, filePath, outcome } = result;

--- a/packages/readyup/src/output/writeHuman.ts
+++ b/packages/readyup/src/output/writeHuman.ts
@@ -3,7 +3,7 @@ import process from 'node:process';
 /**
  * Writes human-readable prose, diverting it to stderr when JSON mode owns stdout.
  *
- * Under `--json`, stdout carries exactly one JSON document, so every header, progress line, and
+ * Under `--json`, stdout contains exactly one JSON document, so every header, progress line, and
  * summary a command would otherwise print has to go somewhere else.
  */
 export function writeHuman(text: string, json: boolean): void {

--- a/packages/readyup/src/portable/__tests__/buildInstallCommand.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/buildInstallCommand.unit.test.ts
@@ -104,7 +104,7 @@ describe(buildInstallCommand, () => {
   });
 });
 
-/** Make `existsSync` answer true for exactly the given paths. */
+/** Makes `existsSync` return true for exactly the given paths. */
 function presentFiles(...paths: string[]): void {
   const present = new Set(paths);
   mockExistsSync.mockImplementation((target: string) => present.has(target));

--- a/packages/readyup/src/portable/blankNonCode.ts
+++ b/packages/readyup/src/portable/blankNonCode.ts
@@ -264,7 +264,7 @@ function readWordToken(word: string, previousToken: string): string {
  */
 function scanCode(scan: Scan, from: number, isInterpolation: boolean): number {
   const { source } = scan;
-  // The token a `/` is classified against: the operand before it where one is complete, so a member name carries its
+  // The token a `/` is classified against: the operand before it where one is complete, so a member name takes its
   // introducing `.` or `#`, a postfix `++` or `--` is one token, and a postfix `!` leaves this untouched.
   let previousToken = '';
   let braceDepth = 0;

--- a/packages/readyup/src/portable/buildInstallCommand.ts
+++ b/packages/readyup/src/portable/buildInstallCommand.ts
@@ -33,7 +33,7 @@ const LOCKFILE_MANAGERS = [
 ] as const;
 
 /**
- * Build the command that installs a package as a dev dependency of the current project.
+ * Returns the command that installs a package as a dev dependency of the current project.
  *
  * The package manager comes from the nearest directory that names one, falling back to npm when
  * none does.
@@ -43,7 +43,7 @@ export function buildInstallCommand(moduleName: string): string {
 }
 
 /**
- * Find the install command for the package manager governing the current directory.
+ * Returns the install command for the package manager governing the current directory.
  *
  * The search walks up from the current directory because in a workspace the lockfile and the
  * `packageManager` declaration sit at the repo root while commands run from a package
@@ -67,7 +67,7 @@ function findInstallCommand(): string | undefined {
   return undefined;
 }
 
-/** Read the package-manager name from a `package.json`, dropping the version Corepack pins. */
+/** Returns the package-manager name in a `package.json`, dropping the version Corepack pins. */
 function readDeclaredManager(packageJsonPath: string): string | undefined {
   if (!existsSync(packageJsonPath)) return undefined;
 
@@ -82,7 +82,7 @@ function readDeclaredManager(packageJsonPath: string): string | undefined {
   return typeof declared === 'string' ? /^[a-z]+/.exec(declared)?.[0] : undefined;
 }
 
-/** List a directory and every directory above it, nearest first. */
+/** Returns a directory and every directory above it, nearest first. */
 function listSelfAndAncestors(from: string): string[] {
   const directories = [from];
   let current = from;

--- a/packages/readyup/src/portable/describe-value.ts
+++ b/packages/readyup/src/portable/describe-value.ts
@@ -2,10 +2,9 @@
 const MAX_PREVIEW_LENGTH = 40;
 
 /**
- * Name the runtime type of a value.
+ * Names the runtime type of a value.
  *
- * Distinguishes `null` and arrays from plain objects, which `typeof` alone collapses together. Used
- * in diagnostics that tell an author what they wrote where a specific type was expected.
+ * Distinguishes `null` and arrays from plain objects, which `typeof` alone collapses together.
  */
 export function describeType(value: unknown): string {
   if (value === null) return 'null';
@@ -14,7 +13,7 @@ export function describeType(value: unknown): string {
 }
 
 /**
- * Render a short, readable preview of a value for a diagnostic message.
+ * Returns a short, readable preview of a value for a diagnostic message.
  *
  * Strings keep their quotes, so `"1"` stays distinguishable from `1`. Anything long is truncated:
  * the preview is there to identify what was written, and the author has the source. A value with no
@@ -22,7 +21,7 @@ export function describeType(value: unknown): string {
  * could tell a reader anyway.
  */
 export function previewValue(value: unknown): string {
-  // The types `JSON.stringify` answers with `undefined` or a throw rather than a rendering.
+  // The types for which `JSON.stringify` yields `undefined` or throws rather than rendering.
   if (value === undefined) return 'undefined';
   if (typeof value === 'function') return 'function';
   if (typeof value === 'symbol') return value.toString();
@@ -39,7 +38,7 @@ export function previewValue(value: unknown): string {
 }
 
 /**
- * Name a value by its type and its content, for a diagnostic that has to convey both.
+ * Names a value by its type and its content, for a diagnostic that has to convey both.
  *
  * The two collapse into one when the preview already names the type, so a value of `undefined`
  * reads as `undefined` rather than `undefined undefined`.

--- a/packages/readyup/src/portable/isRecord.ts
+++ b/packages/readyup/src/portable/isRecord.ts
@@ -1,4 +1,4 @@
-/** Check whether a value is a plain object (non-null, non-array). */
+/** Reports whether a value is a plain object, so neither `null` nor an array. */
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/readyup/src/portable/isSkippableFilesystemError.ts
+++ b/packages/readyup/src/portable/isSkippableFilesystemError.ts
@@ -10,7 +10,7 @@ export function isSkippableFilesystemError(error: unknown): boolean {
 
 // region | Helpers
 
-/** Type guard for Node.js filesystem errors carrying a `code`. */
+/** Reports whether an error is a Node.js filesystem error, which is one with a `code`. */
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return isError(error) && 'code' in error;
 }

--- a/packages/readyup/src/portable/jitiImport.ts
+++ b/packages/readyup/src/portable/jitiImport.ts
@@ -8,13 +8,12 @@ import { toDisplayPath } from './toDisplayPath.ts';
 const NON_PACKAGE_PREFIXES = ['.', '/', '#', 'node:'];
 
 /**
- * Import a TypeScript file via jiti with module-resolution error handling.
+ * Imports a TypeScript file through jiti, returning the plain object it exports.
  *
- * Catches `MODULE_NOT_FOUND` and `ERR_MODULE_NOT_FOUND` errors and rethrows naming the file being
- * evaluated and the caller-provided `moduleErrorDetail`, with the install command carried as a
- * `hint` property beside the message. The hint rides on the error rather than being raised as a
- * typed failure here, because the two callers classify the same failure under different codes.
- * Validates the imported value is a plain object, using `exportNoun` in the error message if not.
+ * A `MODULE_NOT_FOUND` or `ERR_MODULE_NOT_FOUND` failure is rethrown naming the file being evaluated
+ * and `moduleErrorDetail`, with the install command on a `hint` property beside the message. The hint
+ * rides on the error rather than a typed failure, because the same failure is classified under two
+ * different codes. An imported value that is not a plain object raises an error naming `exportNoun`.
  */
 export async function jitiImport(
   resolvedPath: string,
@@ -55,7 +54,7 @@ interface UnresolvedModuleReport {
 }
 
 /**
- * Compose the diagnosis and remediation for a specifier jiti could not resolve.
+ * Returns the diagnosis and remediation for a specifier jiti could not resolve.
  *
  * The install command is offered only for a specifier that names a package: installing a relative
  * import or a builtin is not the remedy, and a specifier jiti did not name cannot be installed at all.
@@ -78,7 +77,7 @@ function describeUnresolvedModule(
   };
 }
 
-/** Report whether a specifier names an installable package rather than a file or a builtin. */
+/** Reports whether a specifier names an installable package rather than a file or a builtin. */
 function isPackageSpecifier(specifier: string): boolean {
   return NON_PACKAGE_PREFIXES.every((prefix) => !specifier.startsWith(prefix));
 }

--- a/packages/readyup/src/portable/listDeclarationSpans.ts
+++ b/packages/readyup/src/portable/listDeclarationSpans.ts
@@ -43,7 +43,7 @@ export interface DeclarationSpan {
   startLine: number;
 }
 
-/** A declaration head found at brace depth 0, carrying the name it introduces where it introduces one. */
+/** A declaration head found at brace depth 0, with the name it introduces where it introduces one. */
 interface Head {
   name?: string | undefined;
   startLine: number;
@@ -65,7 +65,7 @@ interface Head {
  * A statement declaring no name ends the declaration before it and begins none, so an export clause, an import, a
  * destructuring binding, and a control-flow statement each bound the span ahead of them without owning lines of their
  * own. Each is recognized by the keyword it opens with; a statement opening with an identifier, such as a bare call,
- * carries no keyword to recognize it by and is read as part of the declaration before it.
+ * has no keyword to recognize it by and is read as part of the declaration before it.
  *
  * A head is recognized at brace depth 0, and only where a statement could have ended just before it, so a named
  * function or class expression in an initializer, in an argument list, or as an arrow's body reads as the expression

--- a/packages/readyup/src/portable/safeJsonParse.ts
+++ b/packages/readyup/src/portable/safeJsonParse.ts
@@ -1,4 +1,4 @@
-/** Parse a JSON string, returning `undefined` instead of throwing on invalid input. */
+/** Returns a JSON string parsed, or `undefined` where the input is invalid. */
 export function safeJsonParse(content: string): unknown {
   try {
     const parsed: unknown = JSON.parse(content);

--- a/packages/readyup/src/portable/toDisplayPath.ts
+++ b/packages/readyup/src/portable/toDisplayPath.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import process from 'node:process';
 
 /**
- * Render a path for display, relative to the current directory when it sits inside it.
+ * Returns a path rendered for display, relative to the current directory where it sits inside it.
  *
  * A path outside the current directory keeps its absolute form: a chain of `..` segments is
  * harder to act on than the path the reader would have typed.

--- a/packages/readyup/src/portable/toError.ts
+++ b/packages/readyup/src/portable/toError.ts
@@ -1,7 +1,7 @@
 import { describeError, isError } from '@williamthorsen/toolbelt.errors';
 
 /**
- * Coerces a thrown value to an Error, wrapping anything else in an Error carrying its text.
+ * Coerces a thrown value to an Error, wrapping anything else in an Error holding its text.
  *
  * A value with no rendering, such as a null-prototype object, yields a placeholder rather than throwing, so a catch
  * block reporting a failure cannot itself fail.

--- a/packages/readyup/src/portable/walkDirectories.ts
+++ b/packages/readyup/src/portable/walkDirectories.ts
@@ -58,7 +58,7 @@ export function walkDirectories(options: WalkDirectoriesOptions): string[] {
 
 // region | Helpers
 
-/** Everything the recursive sweep carries down, bound once by `walkDirectories`. */
+/** Everything the recursive sweep passes down, bound once by `walkDirectories`. */
 interface SweepContext {
   root: string;
   isMatch: (entryPath: string) => boolean;

--- a/packages/readyup/src/portable/writeFileWithCheck.ts
+++ b/packages/readyup/src/portable/writeFileWithCheck.ts
@@ -13,7 +13,7 @@ export interface WriteResult {
   error?: string;
 }
 
-/** Strip trailing whitespace from each line and from EOF. */
+/** Returns `content` with trailing whitespace stripped from each line and from the end of the file. */
 function normalizeTrailingWhitespace(content: string): string {
   return content
     .split('\n')
@@ -23,12 +23,12 @@ function normalizeTrailingWhitespace(content: string): string {
 }
 
 /**
- * Write a file with existence and content checks.
+ * Writes a file, reporting what the write did to what was already there.
  *
- * Creates parent directories as needed. Compares content using whitespace-normalized comparison
- * to determine whether an existing file is up to date. In dry-run mode, returns the outcome
- * that would happen without performing writes. Filesystem errors are caught and returned as
- * `{ outcome: 'failed' }` rather than thrown.
+ * Parent directories are created as needed, and an existing file counts as up to date when its
+ * content matches once trailing whitespace is normalized. A dry run reports the outcome a real one
+ * would produce and writes nothing. A filesystem error is returned as `{ outcome: 'failed' }` rather
+ * than thrown.
  */
 export function writeFileWithCheck(
   filePath: string,

--- a/packages/readyup/src/projects/project-discovery.ts
+++ b/packages/readyup/src/projects/project-discovery.ts
@@ -103,7 +103,7 @@ function hasKitSources(absolutePath: string, config: ResolvedRdyConfig): boolean
 }
 
 /**
- * Reports whether a directory carries any readyup footprint at all.
+ * Reports whether a directory has any readyup footprint at all.
  *
  * A project with neither falls back to the default config, which points inside `.readyup/`: declaring a
  * source directory anywhere else takes a config file to say so. Testing this before the directory reads

--- a/packages/readyup/src/readyupResolverHook.ts
+++ b/packages/readyup/src/readyupResolverHook.ts
@@ -41,15 +41,13 @@ type NextResolve = (specifier: string, context?: Partial<ResolveContext>) => Res
 
 let readyupParentURL: string | undefined;
 
-/** Determine whether a specifier should be routed through the runner's readyup installation. */
+/** Reports whether a specifier should be routed through the runner's readyup installation. */
 function isReadyupSpecifier(specifier: string): boolean {
   return specifier === 'readyup' || specifier.startsWith('readyup/');
 }
 
 /**
- * Initialize the hook with data passed from `module.register()`.
- *
- * Called exactly once when the hook is registered.
+ * Initializes the hook with the data `module.register()` supplies, which happens exactly once.
  */
 export function initialize(data: ReadyupResolverHookData): void {
   // eslint-disable-next-line unicorn/no-top-level-assignment-in-function -- `module.register()` supplies this once.
@@ -57,12 +55,11 @@ export function initialize(data: ReadyupResolverHookData): void {
 }
 
 /**
- * Resolve hook: routes `readyup` and `readyup/*` specifiers through the runner's
- * own readyup installation by rewriting `parentURL`. All other specifiers are
- * delegated to the default resolver unchanged. Throws if a readyup specifier is
- * encountered before `initialize()` has been called — silently falling back to
- * the original `parentURL` would defeat the hook's purpose and produce an opaque
- * `ERR_MODULE_NOT_FOUND` later.
+ * Routes `readyup` and `readyup/*` specifiers through the runner's own readyup installation by
+ * rewriting `parentURL`, and delegates every other specifier to the default resolver unchanged.
+ *
+ * A readyup specifier arriving before `initialize()` throws: falling back to the original
+ * `parentURL` would defeat the rewrite and surface later as an opaque `ERR_MODULE_NOT_FOUND`.
  */
 export function resolve(
   specifier: string,

--- a/packages/readyup/src/readyupResolverHook.ts
+++ b/packages/readyup/src/readyupResolverHook.ts
@@ -6,7 +6,7 @@
  * Registered by `src/bin/rdy.ts` via `module.register()` before any kit is loaded.
  * Compiled kits leave `readyup` imports as live specifiers (see `compileConfig.ts`
  * external list); this hook ensures those specifiers resolve to the runner's
- * installation regardless of where the kit file lives on disk — making
+ * installation regardless of where the kit file lives on disk -- making
  * `npx readyup` and `rdy run --from ...` work without requiring readyup as a
  * project dependency.
  *

--- a/packages/readyup/src/remote/__tests__/loadRemoteKit.validation.unit.test.ts
+++ b/packages/readyup/src/remote/__tests__/loadRemoteKit.validation.unit.test.ts
@@ -7,7 +7,7 @@ vi.stubGlobal('fetch', mockFetch);
 import { UnresolvableKitImportsError } from '../../kitImports/UnresolvableKitImportsError.ts';
 import { loadRemoteKit } from '../loadRemoteKit.ts';
 
-/** Build a minimal mock Response with the given body and status. */
+/** Returns a minimal mock Response with the given body and status. */
 function mockResponse(
   body: string,
   init?: { status?: number; statusText?: string },

--- a/packages/readyup/src/remote/loadRemoteKit.ts
+++ b/packages/readyup/src/remote/loadRemoteKit.ts
@@ -21,10 +21,9 @@ export interface LoadRemoteKitOptions {
  * embedded `__readyupVersion`, which is undefined for a kit compiled before that field existed or
  * fetched from a third-party source that omits it.
  *
- * Any supplied headers are sent with the request. This has no auth-scheme knowledge of its own, so
- * `Authorization` and anything else, such as a corporate proxy or telemetry header, arrive already
- * formatted. The fetched content is written to a temp file for dynamic import and cleaned up
- * afterwards. Throws `RemoteFetchError` for a non-2xx
+ * Any supplied headers are sent with the request. This has no auth-scheme knowledge of its own, so `Authorization` and
+ * anything else, such as a corporate proxy or telemetry header, arrive already formatted. The fetched content is
+ * written to a temp file for dynamic import and cleaned up afterwards. Throws `RemoteFetchError` for a non-2xx
  * response, and a plain `Error` for a body that is not an evaluable kit.
  */
 export async function loadRemoteKit({ url, headers = {} }: LoadRemoteKitOptions): Promise<LoadedRdyKit> {

--- a/packages/readyup/src/remote/loadRemoteKit.ts
+++ b/packages/readyup/src/remote/loadRemoteKit.ts
@@ -17,13 +17,14 @@ export interface LoadRemoteKitOptions {
 }
 
 /**
- * Fetch a remote `.js` kit bundle, evaluate it, and return a validated RdyKit.
+ * Fetches a remote `.js` kit bundle, evaluates it, and returns the validated RdyKit alongside its
+ * embedded `__readyupVersion`, which is undefined for a kit compiled before that field existed or
+ * fetched from a third-party source that omits it.
  *
- * Sends the supplied headers (if any) with the request; the helper has no auth-scheme knowledge —
- * callers pre-format `Authorization` and any other headers (e.g., proxy/telemetry in corporate environments).
- * Writes the fetched content to a temp file for dynamic import, then cleans up. Returns the kit
- * alongside the embedded `__readyupVersion` (undefined for kits compiled before that field existed
- * or fetched from third-party sources that omit it). Throws `RemoteFetchError` for a non-2xx
+ * Any supplied headers are sent with the request. This has no auth-scheme knowledge of its own, so
+ * `Authorization` and anything else, such as a corporate proxy or telemetry header, arrive already
+ * formatted. The fetched content is written to a temp file for dynamic import and cleaned up
+ * afterwards. Throws `RemoteFetchError` for a non-2xx
  * response, and a plain `Error` for a body that is not an evaluable kit.
  */
 export async function loadRemoteKit({ url, headers = {} }: LoadRemoteKitOptions): Promise<LoadedRdyKit> {

--- a/packages/readyup/src/remote/loadRemoteManifest.ts
+++ b/packages/readyup/src/remote/loadRemoteManifest.ts
@@ -18,12 +18,12 @@ export interface LoadRemoteManifestOptions {
 }
 
 /**
- * Fetch, parse, and schema-validate a manifest from a URL.
+ * Fetches a manifest from a URL and returns it parsed and schema-validated.
  *
- * Sends the supplied headers (if any) with the request; the helper has no auth-scheme knowledge —
- * callers pre-format `Authorization` and any other headers (e.g., proxy/telemetry in corporate environments).
- * Throws `RemoteManifestNotFoundError` for 404 and HTML soft-404 responses, `RemoteFetchError` for
- * other non-2xx responses, and a plain `Error` for malformed JSON and schema-invalid bodies.
+ * Any supplied headers are sent with the request. This has no auth-scheme knowledge of its own, so
+ * `Authorization` and anything else, such as a corporate proxy or telemetry header, arrive already
+ * formatted. Throws `RemoteManifestNotFoundError` for a 404 or an HTML soft-404, `RemoteFetchError`
+ * for any other non-2xx response, and a plain `Error` for malformed JSON or a schema-invalid body.
  */
 export async function loadRemoteManifest({ url, headers = {} }: LoadRemoteManifestOptions): Promise<RdyManifest> {
   const response = await fetch(url, { headers });

--- a/packages/readyup/src/remote/remote-provider.ts
+++ b/packages/readyup/src/remote/remote-provider.ts
@@ -36,7 +36,7 @@ export function resolveRemoteAuthHeaders(provider: RemoteProvider | undefined): 
  *
  * Matching the host rather than the `--from` scheme covers a `--url` aimed at a provider by
  * construction, so the two flags need no separate code path. The comparison is against the parsed
- * host, so a third-party URL carrying a provider's name elsewhere in it does not match.
+ * host, so a third-party URL with a provider's name elsewhere in it does not match.
  */
 export function resolveRemoteProvider(url: string): RemoteProvider | undefined {
   const host = parseHost(url);

--- a/packages/readyup/src/remote/resolveBitbucketToken.ts
+++ b/packages/readyup/src/remote/resolveBitbucketToken.ts
@@ -1,9 +1,9 @@
 /**
- * Resolve a Bitbucket token from ambient sources for authenticating private repo fetches.
+ * Returns a Bitbucket token from ambient sources, for authenticating a private repo fetch, or
+ * `undefined` where none is set.
  *
- * Checks the `BITBUCKET_TOKEN` env var only — there is no widely-deployed Bitbucket CLI
- * with a stable `auth token` equivalent (Atlassian's `acli` is Jira/Confluence-centric).
- * Returns `undefined` when the env var is unset or empty.
+ * The `BITBUCKET_TOKEN` env var is the only source: no Bitbucket CLI is widely deployed with a stable
+ * `auth token` equivalent, Atlassian's `acli` being Jira- and Confluence-centric.
  */
 export function resolveBitbucketToken(): string | undefined {
   const envToken = process.env['BITBUCKET_TOKEN'];

--- a/packages/readyup/src/remote/resolveGitHubToken.ts
+++ b/packages/readyup/src/remote/resolveGitHubToken.ts
@@ -1,10 +1,10 @@
 import { execFileSync } from 'node:child_process';
 
 /**
- * Resolve a GitHub token from ambient sources for authenticating private repo fetches.
+ * Returns a GitHub token from ambient sources, for authenticating a private repo fetch, or
+ * `undefined` where neither source produces one.
  *
- * Checks `GITHUB_TOKEN` env var first, then falls back to `gh auth token`.
- * Returns `undefined` when neither source produces a token.
+ * The `GITHUB_TOKEN` env var is read first, then `gh auth token`.
  */
 export function resolveGitHubToken(): string | undefined {
   const envToken = process.env['GITHUB_TOKEN'];

--- a/packages/readyup/src/remote/toRemoteRdyError.ts
+++ b/packages/readyup/src/remote/toRemoteRdyError.ts
@@ -5,7 +5,7 @@ import { RemoteManifestNotFoundError } from './loadRemoteManifest.ts';
 import type { RemoteProvider } from './remote-provider.ts';
 import { RemoteFetchError } from './RemoteFetchError.ts';
 
-/** Statuses a provider answers with when a credential would have made the difference. */
+/** Statuses a provider returns when a credential would have made the difference. */
 const CREDENTIAL_STATUSES = new Set([401, 403, 404]);
 
 /**
@@ -50,7 +50,7 @@ export function toRemoteRdyError(error: unknown, context: RemoteFailureContext):
     return build(error.message, { cause: error, hint: resolveHint(context, error.status) });
   }
 
-  // A transport failure carries no status to reason about and no URL of its own, so it is never
+  // A transport failure has no status to reason about and no URL of its own, so it is never
   // hinted and needs the URL supplied.
   const message = describeError(error);
   const detail = message.includes(context.url) ? message : `Failed to reach ${context.url}: ${message}`;

--- a/packages/readyup/src/reporting/__tests__/formatCombinedSummary.unit.test.ts
+++ b/packages/readyup/src/reporting/__tests__/formatCombinedSummary.unit.test.ts
@@ -36,7 +36,7 @@ function renderLines(rows: SummaryRow[]): string[] {
 }
 
 describe(formatCombinedSummary, () => {
-  // The run's writer parts one block from the next, so a table carrying its own blank would double the gap.
+  // The run's writer separates one block from the next, so a table with its own blank would double the gap.
   it('carries no separation of its own', () => {
     expect(renderLines([makeRow()])[0]).not.toBe('');
   });

--- a/packages/readyup/src/reporting/__tests__/formatJsonReport.unit.test.ts
+++ b/packages/readyup/src/reporting/__tests__/formatJsonReport.unit.test.ts
@@ -558,7 +558,7 @@ describe(formatJsonReport, () => {
   describe('kits that produced no results', () => {
     const FAILURE = { name: 'release', error: { code: 'kit-load' as const, message: 'Cannot find release.js' } };
 
-    /** A one-check kit that passes in 10ms, for pairing with a failed kit. */
+    /** Returns a one-check kit that passes in 10ms, for pairing with a failed kit. */
     function ranKit(name: string) {
       const report = makeReport({ results: [makePassedResult({ name: 'a' })], passed: true, durationMs: 10 });
       return { name, entries: [{ name: 'check', report }] };

--- a/packages/readyup/src/reporting/__tests__/formatJsonReport.unit.test.ts
+++ b/packages/readyup/src/reporting/__tests__/formatJsonReport.unit.test.ts
@@ -63,7 +63,7 @@ function makeReport(overrides?: Partial<RdyReport> & { results?: RdyResult[] }):
   return { results: [], passed: true, durationMs: 0, ...overrides };
 }
 
-/** Wrap a single checklist report as a single-kit input. */
+/** Wraps a single checklist report as a single-kit input. */
 function singleKit(checklistName: string, report: RdyReport, kitName = 'deploy') {
   return [{ name: kitName, entries: [{ name: checklistName, report }] }];
 }
@@ -219,7 +219,7 @@ describe(formatJsonReport, () => {
   });
 
   describe('per-kit thresholds', () => {
-    /** Two kits under one invocation, the second declaring thresholds of its own. */
+    /** Returns two kits under one invocation, the second declaring thresholds of its own. */
     function mixedThresholdKits() {
       const report = makeReport({
         results: [makeFailedResult({ name: 'warn-fail', severity: 'warn' })],
@@ -423,7 +423,7 @@ describe(formatJsonReport, () => {
       expect(output).not.toContain('worstSeverity');
     });
 
-    // Only a failed result carries a `fix`, so withholding it from a passed one is a type-level
+    // Only a failed result has a `fix`, so withholding it from a passed one is a type-level
     // guarantee rather than a behavior to assert.
     it('emits fix on a failed check', () => {
       const report = makeReport({

--- a/packages/readyup/src/reporting/formatCombinedSummary.ts
+++ b/packages/readyup/src/reporting/formatCombinedSummary.ts
@@ -3,7 +3,7 @@ import { getLayout } from '../layout/engine.ts';
 import type { SummaryRow } from '../layout/layoutEngine.ts';
 import { emptyCounts, mergeCounts } from './reportRdy.ts';
 
-/** Returns the summary table for `rows`, one row each, carrying no separation of its own. */
+/** Returns the summary table for `rows`, one row each, with no separation of its own. */
 export function formatCombinedSummary(rows: SummaryRow[]): string {
   return getLayout()
     .formatSummaryTable({
@@ -16,7 +16,7 @@ export function formatCombinedSummary(rows: SummaryRow[]): string {
 
 // region | Helpers
 
-/** Returns the sum of every row's counts, carrying the worst severity among them. */
+/** Returns the sum of every row's counts, with the worst severity among them. */
 function aggregateCounts(rows: SummaryRow[]): SummaryCounts {
   const totals = emptyCounts();
   for (const row of rows) {

--- a/packages/readyup/src/reporting/formatJsonReport.ts
+++ b/packages/readyup/src/reporting/formatJsonReport.ts
@@ -20,7 +20,7 @@ interface ChecklistEntry {
 }
 
 /**
- * Input for a kit that ran, carrying the reports its checklists produced and the thresholds that
+ * Input for a kit that ran, with the reports its checklists produced and the thresholds that
  * governed them.
  *
  * The thresholds travel with the kit rather than with the run, because a kit may declare its own and
@@ -44,7 +44,7 @@ export interface KitResultInput {
 export type KitInput = JsonKitErrorEntry | KitResultInput;
 
 /**
- * The run settings the report echoes back, plus anything it must carry alongside results.
+ * The run settings the report echoes back, plus anything else it must include alongside results.
  *
  * `failOn` and `reportOn` are what the invocation requested, so each is absent when its flag was not
  * given: a default echoed as though it had been asked for is what made a kit's own threshold
@@ -69,7 +69,7 @@ interface AggregatedKit {
   durationMs: number;
 }
 
-/** Transform kit-grouped checklist results into a JSON-serializable report string. */
+/** Returns kit-grouped checklist results as a JSON-serializable report string. */
 export function formatJsonReport(kitInputs: KitInput[], options: FormatJsonReportOptions): string {
   const { failOn, reportOn, detail, warnings } = options;
   const kits: JsonKitEntry[] = [];
@@ -113,7 +113,7 @@ export function formatJsonReport(kitInputs: KitInput[], options: FormatJsonRepor
   return JSON.stringify(report);
 }
 
-/** Build one kit's entry and the raw figures the report aggregates from it. */
+/** Returns one kit's entry alongside the raw figures the report aggregates from it. */
 function aggregateKit(input: KitResultInput, detail: JsonDetail): AggregatedKit {
   const counts = emptyCounts();
   let durationMs = 0;
@@ -148,7 +148,7 @@ function aggregateKit(input: KitResultInput, detail: JsonDetail): AggregatedKit 
 }
 
 /**
- * Split the runner's internal tally into the wire shape: six numbers under `counts`, worst severity
+ * Splits the runner's internal tally into the wire shape: six numbers under `counts`, worst severity
  * beside them.
  *
  * `worstSeverity` is derived verdict data rather than a count, so it sits outside the object it
@@ -160,10 +160,10 @@ function splitCounts(counts: SummaryCounts): { counts: JsonCounts; worstSeverity
 }
 
 /**
- * Build the `checks` property for a checklist entry, or nothing when the projection leaves it empty.
+ * Returns the `checks` property for a checklist entry, or nothing when the projection leaves it empty.
  *
  * The reporting threshold prunes first and the detail projection second, so `summary` shows the same
- * failures `full` would — just without the checks that passed around them.
+ * failures `full` would, without the checks that passed around them.
  */
 function buildDetailTree(results: RdyResult[], reportOn: Severity, detail: JsonDetail): { checks?: JsonCheckEntry[] } {
   const visibleResults = selectVisibleResults(results, reportOn);
@@ -173,10 +173,10 @@ function buildDetailTree(results: RdyResult[], reportOn: Severity, detail: JsonD
 }
 
 /**
- * Project visible results down to what `--detail summary` carries: the failures and their remedies.
+ * Returns visible results reduced to what `--detail summary` shows: the failures and their remedies.
  *
  * Nesting is dropped along with the checks that passed, because what survives is a work list rather
- * than a trace of the run — the caller wants what to fix, and `full` remains one flag away.
+ * than a trace of the run.
  */
 function buildSummaryEntries(results: RdyResult[]): JsonCheckEntry[] {
   return results
@@ -196,14 +196,12 @@ function buildSummaryEntries(results: RdyResult[]): JsonCheckEntry[] {
 }
 
 /**
- * Reconstruct a tree of check entries from a flat depth-first results slice.
+ * Reconstructs a tree of check entries from a flat depth-first results slice, alongside the index of
+ * the first result it did not consume.
  *
- * Consumes results at `expectedDepth` as siblings, recursing into deeper results
- * as children. Returns the parsed entries and the index of the first unconsumed result.
- *
- * Assumes contiguous, monotonically increasing depths as produced by `runRdy`.
- * A depth gap (e.g., depth 0 followed by depth 2 with no depth 1) will silently
- * promote the deeper result to the nearest parent level.
+ * Results at `expectedDepth` become siblings and deeper ones recurse as their children. Depths must be
+ * contiguous and monotonically increasing; a gap, such as depth 0 followed by depth 2, silently
+ * promotes the deeper result to the nearest parent level.
  */
 function buildCheckEntries(
   results: RdyResult[],
@@ -218,12 +216,10 @@ function buildCheckEntries(
     if (result === undefined) break;
     const depth = result.depth;
 
-    // Stop when we encounter a result shallower than what we expect at this level.
     if (depth < expectedDepth) break;
 
     index++;
 
-    // Recursively collect children (results at depth + 1 and deeper).
     const { entries: children, nextIndex } = buildCheckEntries(results, index, depth + 1);
     index = nextIndex;
 
@@ -234,7 +230,7 @@ function buildCheckEntries(
 }
 
 /**
- * Build a single JSON check entry, omitting every field that carries nothing.
+ * Returns a single JSON check entry, omitting every field that holds nothing.
  *
  * A field is present only when it holds information the consumer could act on: no `null` placeholders,
  * no empty `checks` array, and no `fix` on a check that has nothing to remediate. Durations are whole

--- a/packages/readyup/src/reporting/reportRdy.ts
+++ b/packages/readyup/src/reporting/reportRdy.ts
@@ -41,10 +41,7 @@ export interface ReportRdyOptions {
  * A failed check contributes its claim plus a reason block; every other status contributes one line.
  * `fixLocation` places each fix either in the recap or in its check's reason block. The count line
  * tallies every result in `report`, including those `reportOn` and `quiet` omit from the tree, and it
- * closes the block: the last line a reader meets before the blank parting one block from the next.
- *
- * Reports whether the tree rendered anything, so a caller placing the block in a sequence can decide
- * whether a report that is nothing but its count line has earned its place there.
+ * closes the block: the last line a reader meets before the blank separating one block from the next.
  */
 export function reportRdy(report: RdyReport, options?: ReportRdyOptions): RenderedReport {
   const fixLocation = options?.fixLocation ?? 'end';
@@ -154,7 +151,7 @@ function renderResult(result: RdyResult, fixLocation: FixLocation): string[] {
     name: result.name,
     depth: result.depth,
     durationMs: result.durationMs,
-    // A failed check's detail is its reason, which the block beneath carries.
+    // A failed check's detail is its reason, which the block beneath renders.
     ...(!isFailed && result.detail !== null && { detail: result.detail }),
     // Only a failure names findings, so only a failure gives the reader a pragma to write.
     ...(isFailed && result.id !== null && { checkId: result.id }),
@@ -169,7 +166,7 @@ function renderResult(result: RdyResult, fixLocation: FixLocation): string[] {
 /**
  * Returns a failed result's reasons in reading order: its detail, its error, then its fix.
  *
- * Each is present only when the result carries it, so a result carrying none yields an empty list.
+ * Each is present only when the result has it, so a result with none yields an empty list.
  */
 function collectReasons(result: FailedResult, includeFix: boolean): string[] {
   const reasons: string[] = [];
@@ -179,7 +176,7 @@ function collectReasons(result: FailedResult, includeFix: boolean): string[] {
   return reasons;
 }
 
-/** Returns each failed result's fix paired with the name and severity of the check carrying it. */
+/** Returns each failed result's fix paired with the name and severity of its check. */
 function collectFixes(results: RdyResult[]): AttributedFix[] {
   return results.flatMap((result) =>
     result.status === 'failed' && result.fix !== null

--- a/packages/readyup/src/reporting/test-utils/formatReport.ts
+++ b/packages/readyup/src/reporting/test-utils/formatReport.ts
@@ -12,7 +12,7 @@ export type TestKitInput =
   | (Omit<KitResultInput, 'failOn' | 'reportOn'> & Partial<Pick<KitResultInput, 'failOn' | 'reportOn'>>);
 
 /**
- * Serialize a report the way the CLI would for an invocation carrying the given flags.
+ * Returns a report serialized the way the CLI would for an invocation with the given flags.
  *
  * An override stands in for its CLI flag: it reaches the top level only when supplied, and resolves
  * against the default to give each kit the threshold that governs it. A kit input that names its own

--- a/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
@@ -343,12 +343,12 @@ describe(warnOnKitStaleness, () => {
     });
   }
 
-  /** Tracking whose sole entry describes the kit at `KIT_PATH`. */
+  /** Returns tracking whose sole entry describes the kit at `KIT_PATH`. */
   function defaultTracking(): ManifestTracking {
     return trackingFor([{ name: 'default', path: MANIFEST_KIT_PATH, source: 'kits/default.ts' }]);
   }
 
-  /** Tracking as `readManifestTracking` would have built it, holding the given entries. */
+  /** Returns tracking as `readManifestTracking` would have built it, holding the given entries. */
   function trackingFor(kits: RdyManifestKit[]): ManifestTracking {
     return { manifest: { version: 1, kits }, manifestDir: path.resolve(process.cwd(), '.readyup') };
   }

--- a/packages/readyup/src/run/__tests__/loadKit.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/loadKit.unit.test.ts
@@ -287,7 +287,7 @@ describe(loadKit, () => {
       expect(error.hint).toBeUndefined();
     });
 
-    /** Loads one kit from `url` against a fetch that failed with `status`, and answers with the hint raised. */
+    /** Loads one kit from `url` against a fetch that failed with `status`, returning the hint raised. */
     async function hintFor(url: string, status: number): Promise<string | undefined> {
       mockLoadRemoteKit.mockRejectedValue(new RemoteFetchError(`Failed to fetch remote kit from ${url}`, status));
       const error = await captureError(RdyError, () => loadKit(remoteEntry(url), false));
@@ -308,7 +308,7 @@ function makeKit(): RdyKit {
   return { checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }] };
 }
 
-/** The failure a loader raises for a kit binding a symbol this runner does not export. */
+/** Returns the failure a loader raises for a kit binding a symbol this runner does not export. */
 function missingSymbolError(): UnresolvableKitImportsError {
   return new UnresolvableKitImportsError({
     unknownSubpaths: [],
@@ -316,7 +316,7 @@ function missingSymbolError(): UnresolvableKitImportsError {
   });
 }
 
-/** The failure Node raises for an import that resolves to no installed package. */
+/** Returns the failure Node raises for an import that resolves to no installed package. */
 function moduleNotFoundError(packageName: string): Error {
   return Object.assign(new Error(`Cannot find package '${packageName}'`), { code: 'MODULE_NOT_FOUND' });
 }

--- a/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
@@ -14,7 +14,7 @@ import { runCommand } from '../runCommand.ts';
 /**
  * Joins `--packages` to the kits an installed package publishes, against a real fixture project.
  * The unit tests cover the expansion and the resolver separately; this locks in the seam between them:
- * that a configured package becomes a run entry carrying the provenance the report and the headings render,
+ * that a configured package becomes a run entry with the provenance the report and the headings render,
  * and that the kit name selects which of its kits run.
  */
 describe('--packages run path wiring', () => {

--- a/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
@@ -73,7 +73,7 @@ describe('--packages run path wiring', () => {
     ]);
   });
 
-  // Selection reads names, so the manifest-less path needs no handling of its own — but it has to answer alike.
+  // Selection reads names, so the manifest-less path needs no handling of its own -- but it has to answer alike.
   it('selects by name when a package ships no manifest', () => {
     installPackage('plain-kit', ['default', 'preflight'], { hasManifest: false });
 

--- a/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
@@ -22,7 +22,7 @@ import { runRdy } from '../runRdy.ts';
 const SOURCE_PATH = 'src/a.ts';
 const OTHER_PATH = 'src/b.ts';
 
-/** A source whose first line carries a pragma and whose second does not. */
+/** A source whose first line has a pragma and whose second does not. */
 const SOURCE_TEXT = ['x; // rdy-ignore', 'y;', ''].join('\n');
 
 const it = test.extend(

--- a/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
@@ -74,7 +74,7 @@ describe('a pragma reaching the check ids the runner resolved', () => {
 
 // region | Helpers
 
-/** Two checks reporting a finding on the same line, each addressable by an id of its own. */
+/** Returns two checks reporting a finding on the same line, each addressable by an id of its own. */
 function twoChecksOverOneLine(): RdyChecklist {
   const findings = [{ line: 1, path: SOURCE_PATH, reported: true }];
 

--- a/packages/readyup/src/run/__tests__/resolveRequestedNames.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveRequestedNames.unit.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import type { RdyKit } from '../../kits/types.ts';
 import { resolveRequestedNames } from '../resolveRequestedNames.ts';
 
-/** Build a minimal kit with named checklists and optional suites. */
+/** Returns a minimal kit with named checklists and optional suites. */
 function makeKit(overrides?: Partial<RdyKit>): RdyKit {
   return {
     checklists: [

--- a/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
@@ -62,7 +62,7 @@ import { runHumanMode } from '../runHumanMode.ts';
 import { makeKit, singleKitEntry } from '../test-utils/kit-fixtures.ts';
 
 /**
- * The blank line parting one block from the next, as it reads in concatenated stdout writes.
+ * The blank line separating one block from the next, as it reads in concatenated stdout writes.
  *
  * The count includes the newline terminating the block above, so the gap a reader sees is one blank fewer.
  */
@@ -196,7 +196,7 @@ describe(runHumanMode, () => {
     expect(allOutput).toContain('\u{2501}\u{2501} \u{1F4CB} infra');
   });
 
-  // One blank parts blocks of the same kit, and the summary that tallies them is parted the same way.
+  // One blank separates blocks of the same kit, and the summary that tallies them is separated the same way.
   it('parts one block from the next with a single blank line', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
@@ -210,7 +210,7 @@ describe(runHumanMode, () => {
   });
 
   // A lone local kit running one checklist has no source to name, nothing to be told apart from, and one checklist to
-  // report, so its breadcrumb would carry no segment at all.
+  // report, so its breadcrumb would have no segment at all.
   it('heads nothing at all for a lone local kit running one checklist', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
@@ -240,7 +240,7 @@ describe(runHumanMode, () => {
   });
 
   describe('provenance in the block heading', () => {
-    /** Runs one kit carrying the given provenance, returning everything it wrote to stdout. */
+    /** Runs one kit with the given provenance, returning everything it wrote to stdout. */
     async function headingFor(provenance: KitProvenance): Promise<string> {
       const kit = makeKit({ checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }] });
       mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });

--- a/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
@@ -165,7 +165,7 @@ describe(runJsonMode, () => {
           reportOn: 'recommend',
         },
       ],
-      // The run named no threshold, so the run-level options carry none: the resolved values reach the
+      // The run named no threshold, so the run-level options have none: the resolved values reach the
       // serializer on the kit that they governed.
       { detail: 'full' },
     );

--- a/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
@@ -14,12 +14,12 @@ import { runRdy } from '../runRdy.ts';
  */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
-/** Wrap a value as a check function that returns it. */
+/** Wraps a value as a check function that returns it. */
 function returning(value: unknown): RdyCheck['check'] {
   return () => value as CheckReturnValue;
 }
 
-/** Wrap a value as a skip function that returns it. */
+/** Wraps a value as a skip function that returns it. */
 function skipReturning(value: unknown): NonNullable<RdyCheck['skip']> {
   return () => value as SkipResult;
 }

--- a/packages/readyup/src/run/__tests__/skip-diagnosis.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/skip-diagnosis.unit.test.ts
@@ -71,7 +71,7 @@ describe(warnOnMaskedSkips, () => {
   });
 
   describe('kit identity', () => {
-    // Every kit `--packages` resolves carries the same name, so the package is the only thing that
+    // Every kit `--packages` resolves has the same name, so the package is the only thing that
     // tells one run entry's warnings from another's.
     it('names the publishing package beside the kit', () => {
       const { warnings } = warn([{ name: 'a', verdict: 'masked-pass' }], packagedKit());

--- a/packages/readyup/src/run/__tests__/suppressesFinding.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/suppressesFinding.unit.test.ts
@@ -170,7 +170,7 @@ describe(suppressesFinding, () => {
 
 // region | Helpers
 
-/** Parts a source into the lines `suppressesFinding` reads. */
+/** Splits a source into the lines `suppressesFinding` reads. */
 function linesOf(source: string): readonly string[] {
   return source.split('\n');
 }

--- a/packages/readyup/src/run/kit-staleness.ts
+++ b/packages/readyup/src/run/kit-staleness.ts
@@ -20,7 +20,7 @@ export interface ManifestTracking {
 /**
  * Reads the default manifest for the run's advisories, best effort.
  *
- * Every failure here answers with no manifest at all: a missing one is the normal state of a
+ * Every failure here yields no manifest at all: a missing one is the normal state of a
  * project that never compiled, and an unreadable or unrecognized one says nothing about any kit. A
  * verification tool that refused to run because its own bookkeeping was unreadable would be worse
  * than one that runs and stays quiet. `--jit` runs from source, which the manifest does not

--- a/packages/readyup/src/run/listPragmaSites.ts
+++ b/packages/readyup/src/run/listPragmaSites.ts
@@ -2,7 +2,7 @@ import { blankComments } from '../portable/blankNonCode.ts';
 import { getLineAtOffset } from '../portable/getLineAtOffset.ts';
 import { createIgnorePragmaMatcher } from './pragma-token.ts';
 
-/** One pragma a source carries, and the line it covers. */
+/** One pragma a source holds, and the line it covers. */
 export interface PragmaSite {
   /** The 1-based line the token sits on. */
   readonly line: number;
@@ -25,10 +25,10 @@ export function isJsFamilyPath(path: string): boolean {
 /**
  * Returns the pragmas a source anchors to a comment's opening delimiter.
  *
- * A token qualifies where it sits inside a comment and nothing but whitespace and `*` parts it from the `//` or `/*`
- * that opened one. That is stricter than suppression, which matches the token in raw text wherever it appears: a report
- * naming a site has to be sure the comment is a pragma rather than prose quoting one, so a token following anything
- * else in its comment, or a second token on a line, is withheld rather than guessed at.
+ * A token qualifies where it sits inside a comment and nothing but whitespace and `*` separates it from the `//` or
+ * `/*` that opened one. That is stricter than suppression, which matches the token in raw text wherever it appears: a
+ * report naming a site has to be sure the comment is a pragma rather than prose quoting one, so a token following
+ * anything else in its comment, or a second token on a line, is withheld rather than guessed at.
  *
  * `blankComments` is the comment oracle, no second tokenizer being needed to answer a question it already answers.
  * It preserves its input's length, so an offset found in the raw text reads the blanked text at the same place.
@@ -52,7 +52,7 @@ export function listPragmaSites(text: string): readonly PragmaSite[] {
 
 // region | Helpers
 
-/** Reports whether a token at an offset sits in a comment, parted from its opening delimiter by nothing else. */
+/** Reports whether a token at an offset sits in a comment, separated from its opening delimiter by nothing else. */
 function isCommentAnchored(text: string, blanked: string, offset: number): boolean {
   // A comment blanks whole, its delimiters included, so a blank at the token's own offset is what places it in one.
   if (blanked[offset] !== ' ') return false;

--- a/packages/readyup/src/run/loadKit.ts
+++ b/packages/readyup/src/run/loadKit.ts
@@ -14,7 +14,7 @@ import type { ResolvedKitEntry } from './ResolvedKitEntry.ts';
  * Loads a rdy kit from a path or URL source.
  *
  * Takes the whole entry rather than its source alone: a kit whose readyup imports the runner cannot satisfy is
- * reported with a remedy chosen from the kit's provenance, which the source by itself does not carry.
+ * reported with a remedy chosen from the kit's provenance, which the source by itself does not state.
  */
 export async function loadKit(entry: ResolvedKitEntry, isJit: boolean): Promise<LoadedRdyKit> {
   const { source } = entry;

--- a/packages/readyup/src/run/parseKitSpecifiers.ts
+++ b/packages/readyup/src/run/parseKitSpecifiers.ts
@@ -5,16 +5,16 @@ export interface KitSpecifier {
 }
 
 /**
- * Parse positional arguments in `kit[:checklist,...]` format into structured specifiers.
+ * Returns positional arguments in `kit[:checklist,...]` format as structured specifiers.
  *
- * Splits each positional on the first `:` to separate kit name from comma-separated
- * checklist/suite names. Kit names may contain `/` (e.g., `shared/deploy`).
+ * Each positional splits on its first `:`, separating the kit name from the comma-separated
+ * checklist and suite names. A kit name may itself contain `/`, as `shared/deploy` does.
  */
 export function parseKitSpecifiers(positionals: string[]): KitSpecifier[] {
   return positionals.map(parseOneSpecifier);
 }
 
-/** Parse a single `kit[:checklist,...]` string into a `KitSpecifier`. */
+/** Returns a single `kit[:checklist,...]` string as a `KitSpecifier`. */
 function parseOneSpecifier(arg: string): KitSpecifier {
   const colonIndex = arg.indexOf(':');
   if (colonIndex === -1) {

--- a/packages/readyup/src/run/parseRunArgs.ts
+++ b/packages/readyup/src/run/parseRunArgs.ts
@@ -110,7 +110,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   validateRunFlags(parsed, kitSpecifiers);
 
   // Parse checklists from the flag value. An empty list selects every checklist, so a value that
-  // names none — `,,,` — would invert what an explicit filter asks for.
+  // names none -- `,,,` -- would invert what an explicit filter asks for.
   const checklists = parsed.checklists !== undefined ? parsed.checklists.split(',').filter((s) => s !== '') : undefined;
   if (checklists?.length === 0) {
     throw usageError(CHECKLISTS_HINT);

--- a/packages/readyup/src/run/parseRunArgs.ts
+++ b/packages/readyup/src/run/parseRunArgs.ts
@@ -33,7 +33,7 @@ const VALID_SEVERITIES = new Set<string>(['error', 'warn', 'recommend']);
 /**
  * Options accepted by the `run` subcommand.
  *
- * A letter earns a short flag only when it carries no dominant conflicting meaning in comparable
+ * A letter takes a short flag only when it has no dominant conflicting meaning in comparable
  * tools and means one thing across every `rdy` subcommand. The second clause is why `-f` is
  * `--file` here and nothing anywhere else. Pairs differing only by case are barred outright: a
  * shift-key slip must not be able to change what runs.
@@ -99,7 +99,7 @@ export function parseRunArgs(flags: string[]): ParsedRunArgs {
   };
 
   // Parse kit specifiers from positional args. This precedes validation because `--checklists`
-  // is constrained by how many kits were named and whether the one named carries its own filter.
+  // is constrained by how many kits were named and whether the one named has its own filter.
   let kitSpecifiers: KitSpecifier[];
   try {
     kitSpecifiers = parseKitSpecifiers(positionals);

--- a/packages/readyup/src/run/pragma-report.ts
+++ b/packages/readyup/src/run/pragma-report.ts
@@ -43,7 +43,7 @@ function byPathThenLine(a: UnusedPragma, b: UnusedPragma): number {
   return a.line - b.line;
 }
 
-/** Returns every pragma the run's examined sources carry against which no check suppressed a finding. */
+/** Returns every pragma in the run's examined sources against which no check suppressed a finding. */
 function listUnusedPragmas(ledger: PragmaLedger): UnusedPragma[] {
   const unused: UnusedPragma[] = [];
 

--- a/packages/readyup/src/run/pragma-token.ts
+++ b/packages/readyup/src/run/pragma-token.ts
@@ -5,7 +5,7 @@
  * Both sides are bounded against a word character or a hyphen, so `rdy-ignored` and `rdy-ignore-nextline` are words
  * of their own rather than pragmas, while a token a block comment closes against without a space is a pragma.
  *
- * A fresh matcher per scan, because a global regular expression carries a `lastIndex` its readers all share: one
+ * A fresh matcher per scan, because a global regular expression has a `lastIndex` its readers all share: one
  * `test` or `exec` anywhere would leave it set, and every later `matchAll` would skip the text before that offset
  * and answer that a pragma suppressing a finding is not there.
  */

--- a/packages/readyup/src/run/resolveFindingOutcome.ts
+++ b/packages/readyup/src/run/resolveFindingOutcome.ts
@@ -8,7 +8,7 @@ import { suppressesFinding } from './suppressesFinding.ts';
  *
  * The denominator counts every surviving site, reported or not, so the checks of one run share a denominator
  * the reader can compare across them, and a suppressed site leaves both halves of it. `adoptedCount` is the
- * numerator; omitted, the outcome carries no progress at all.
+ * numerator; omitted, the outcome has no progress at all.
  *
  * A ledger, where one is passed, is told which sites the check's pragmas suppressed, and the paths it declared
  * in `scanned`. A sweep read through `readTrackedSources` reports itself, so what arrives here is the reading a
@@ -45,7 +45,7 @@ function describeFinding(finding: OutcomeFinding): string {
 /**
  * Drops the findings a source suppressed with an `rdy-ignore` pragma naming this check or naming no check.
  *
- * Each path is parted into lines once, so a file holding ten findings costs one read and one split between
+ * Each path is split into lines once, so a file holding ten findings costs one read and one split between
  * them. A path holding no readable text suppresses nothing.
  */
 function excludeSuppressed(

--- a/packages/readyup/src/run/resolveKitSources.ts
+++ b/packages/readyup/src/run/resolveKitSources.ts
@@ -102,7 +102,7 @@ export function resolveKitSources({
 /**
  * Splits a kit URL into the kit's name and the label naming where it was fetched from.
  *
- * The scheme is dropped from the label because every kit URL carries one and it distinguishes nothing.
+ * The scheme is dropped from the label because every kit URL has one and it distinguishes nothing.
  * A URL that does not parse is reported exactly as given, since a value the runner could not read is one
  * the reader needs to see unaltered.
  */

--- a/packages/readyup/src/run/resolveRequestedNames.ts
+++ b/packages/readyup/src/run/resolveRequestedNames.ts
@@ -1,13 +1,12 @@
 import type { RdyKit } from '../kits/types.ts';
 
 /**
- * Resolve positional arguments against checklist names and suite names.
+ * Returns the ordered checklist names that positional arguments name, or every checklist name in kit
+ * order where no argument was given.
  *
- * Processes args left-to-right: suite names expand to their constituent checklists in
- * suite-defined order; checklist names pass through directly. Duplicates are removed by
- * first occurrence. Returns the ordered list of checklist names to run.
- *
- * When no names are given, returns all checklist names in kit order.
+ * Arguments resolve left to right: a suite name expands to its constituent checklists in the order
+ * the suite declares, and a checklist name passes through as itself. A repeated name keeps only its
+ * first occurrence.
  */
 export function resolveRequestedNames(requestedNames: string[], kit: RdyKit): string[] {
   if (requestedNames.length === 0) {

--- a/packages/readyup/src/run/runCommand.ts
+++ b/packages/readyup/src/run/runCommand.ts
@@ -14,7 +14,7 @@ interface RunCommandOptions {
   reportOn?: Severity;
 }
 
-/** Runs rdy checklists across one or more kits. Returns a numeric exit code. */
+/** Runs rdy checklists across one or more kits, returning the exit code they produced. */
 export async function runCommand(
   { kitEntries, json, detail, diagnose, failOn, quiet, reportOn }: RunCommandOptions,
   isJit = false,

--- a/packages/readyup/src/run/runHumanMode.ts
+++ b/packages/readyup/src/run/runHumanMode.ts
@@ -90,7 +90,7 @@ export async function runHumanMode(
 
   // Tallying follows the last kit rather than riding inside one, so a kit that failed to load still leaves
   // the table covering the checklists that did run. A dropped block is reported by its row alone, so one
-  // dropped block earns the table even where a single row is all it has to carry.
+  // dropped block justifies the table even where a single row is all it has to show.
   if (rows.length > 1 || anyBlockDropped) writeBlock(formatCombinedSummary(rows));
 
   // Written after the summary table, the last block a reported pragma's file may have been named in.
@@ -114,11 +114,11 @@ function buildKitSegments(entry: ResolvedKitEntry, isMultiKit: boolean): Breadcr
   return [source, { role: 'kit', text: entry.name }];
 }
 
-/** Writes one block of a run to stdout, parted from the block before it by a blank line. */
+/** Writes one block of a run to stdout, separated from the block before it by a blank line. */
 type BlockWriter = (text: string) => void;
 
 /**
- * Returns a writer that parts each block of a run from the one before with a single blank line.
+ * Returns a writer that separates each block of a run from the one before with a single blank line.
  *
  * Separation lives here rather than in the headings because only a sequence can see what precedes it, and
  * the run's first block needs no blank at all. One width serves every boundary, a kit's included: the
@@ -140,7 +140,7 @@ function createBlockWriter(): BlockWriter {
  *
  * A kit the local kits directory holds has no source, and neither does one whose directory resolves to
  * the working directory: naming the directory the reader is standing in tells them nothing. A package
- * carries its version because the whole point of running a kit from an installed package is that it
+ * states its version because the whole point of running a kit from an installed package is that it
  * matches the version in place, which the reader can only confirm if it is stated.
  */
 function describeKitProvenance(provenance: KitProvenance | undefined): BreadcrumbSegment | undefined {
@@ -185,7 +185,7 @@ async function runKit(
   const checklists = selectChecklists(kit, checklistFilter);
   const thresholds = resolveThresholds(kit, settings.failOn, settings.reportOn);
   const showChecklistSegment = checklists.length > 1;
-  // A block may go unwritten only where the summary table will carry the row it leaves behind. A run of
+  // A block may go unwritten only where the summary table will show the row it leaves behind. A run of
   // one checklist tabulates nothing, so its block stands however little it has to say.
   const willTabulate = isMultiKit || checklists.length > 1;
   const rows: SummaryRow[] = [];

--- a/packages/readyup/src/run/runJsonMode.ts
+++ b/packages/readyup/src/run/runJsonMode.ts
@@ -30,7 +30,7 @@ interface JsonRunSettings {
  * Each iteration is its own error boundary: once the run has dispatched, anything the loop body
  * throws is attributable to that kit alone, so it becomes an entry in the report rather than
  * discarding the kits that already ran. The scope is positional rather than keyed on `RdyErrorCode`
- * — a consumer cannot predict which codes would escape, and a new code would silently pick a branch.
+ * -- a consumer cannot predict which codes would escape, and a new code would silently pick a branch.
  */
 export async function runJsonMode(
   kitEntries: ResolvedKitEntry[],

--- a/packages/readyup/src/run/runJsonMode.ts
+++ b/packages/readyup/src/run/runJsonMode.ts
@@ -78,7 +78,7 @@ export async function runJsonMode(
         reportOn: thresholds.reportOn,
       });
     } catch (error: unknown) {
-      // An entry built here carries no `compiledWith`: a kit that produced no results has nothing
+      // An entry built here has no `compiledWith`: a kit that produced no results has nothing
       // for a compile-time version to explain.
       const { code, hint, message } = toRdyError(error);
       kitInputs.push({

--- a/packages/readyup/src/run/runRdy.ts
+++ b/packages/readyup/src/run/runRdy.ts
@@ -54,7 +54,7 @@ interface PendingDiagnosis {
   result: SkippedResult;
 }
 
-/** What every step of a checklist walk carries with it. */
+/** What every step of a checklist walk holds. */
 interface RunContext {
   defaultSeverity: Severity;
 
@@ -68,7 +68,7 @@ interface RunContext {
    * The checks whose `skip` returned a reason, in the order their skips resolved.
    *
    * Collected unconditionally, because recording a reference executes nothing; only the diagnosis
-   * that reads them is gated on the option. Each carries its result, which is what lets the findings
+   * that reads them is gated on the option. Each holds its result, which is what lets the findings
    * be read back in the report's own order rather than in the order the skips happened to settle.
    */
   pendingDiagnoses: PendingDiagnosis[];
@@ -83,7 +83,7 @@ interface RunContext {
  */
 const AUTHORING_ERROR_SEVERITY: Severity = 'error';
 
-/** Resolve the effective severity for a check. */
+/** Returns the effective severity for a check. */
 function resolveSeverity(check: RdyCheck, defaultSeverity: Severity): Severity {
   return check.severity ?? defaultSeverity;
 }
@@ -104,7 +104,7 @@ function resolveFix(check: RdyCheck): string | null {
     raw = check.fix;
   } catch (error_: unknown) {
     const error = toError(error_);
-    // Quoted so the kit's message stays distinguishable from the sentence carrying it.
+    // Quoted so the kit's message stays distinguishable from the sentence around it.
     return `Unresolvable fix: the accessor threw ${JSON.stringify(error.message)}`;
   }
 
@@ -122,7 +122,7 @@ interface CheckContext {
   depth: number;
 }
 
-/** Gather the fields a check contributes to every result it can produce. */
+/** Returns the fields a check contributes to every result it can produce. */
 function buildCheckContext(check: RdyCheck, run: RunContext, depth: number): CheckContext {
   return {
     name: check.name,
@@ -133,7 +133,7 @@ function buildCheckContext(check: RdyCheck, run: RunContext, depth: number): Che
   };
 }
 
-/** Build a passed result. */
+/** Returns a passed result. */
 function buildPassedResult(
   fields: CheckContext & { detail: string | null; durationMs: number; progress: Progress | null },
 ): PassedResult {
@@ -153,7 +153,7 @@ function buildFailedResult(
   return { ...fields, fix: resolveFix(check), status: 'failed', ok: false };
 }
 
-/** Build a skipped result. */
+/** Returns a skipped result. */
 function buildSkippedResult(
   fields: CheckContext & { detail: string | null; skipReason: 'n/a' | 'precondition' },
 ): SkippedResult {
@@ -161,7 +161,7 @@ function buildSkippedResult(
 }
 
 /**
- * Build the result for a check that is broken rather than failing.
+ * Returns the result for a check that is broken rather than failing.
  *
  * The declared severity is overridden, because a check that never expressed a verdict says nothing
  * about the urgency of its subject.
@@ -183,15 +183,13 @@ function buildAuthoringErrorResult(
 }
 
 /**
- * Execute a single check and recursively process its dependent checks.
- *
- * Returns the check's own result followed by all descendant results in depth-first order.
+ * Runs a check and its dependents, returning the check's own result followed by every descendant
+ * result, in depth-first order.
  */
 async function executeCheck(check: RdyCheck, run: RunContext, depth = 0): Promise<RdyResult[]> {
   const context = buildCheckContext(check, run, depth);
   const children = check.checks ?? [];
 
-  // Evaluate skip condition before running the check.
   if (check.skip !== undefined) {
     const start = performance.now();
     try {
@@ -257,10 +255,10 @@ async function executeCheck(check: RdyCheck, run: RunContext, depth = 0): Promis
 }
 
 /**
- * Collect results from child checks based on the parent's outcome.
+ * Returns the results of a parent's child checks, decided by the parent's own outcome.
  *
- * Passed parents: execute children concurrently, then iterate in declaration order
- * to produce depth-first results. Failed parents: skip all descendants.
+ * A passed parent runs its children concurrently and returns them in depth-first declaration order;
+ * a failed parent skips every descendant.
  */
 async function collectChildResults(
   parentResult: PassedResult | FailedResult,
@@ -278,11 +276,9 @@ async function collectChildResults(
 }
 
 /**
- * Run sibling checks concurrently, then collect results in depth-first declaration order.
+ * Runs sibling checks concurrently and returns their results in depth-first declaration order.
  *
- * All siblings execute concurrently via `Promise.all`, but the returned array
- * preserves declaration order: each sibling's own result is followed by its
- * subtree before the next sibling appears.
+ * Each sibling's own result is followed by its subtree before the next sibling appears.
  */
 async function runSiblingChecks(checks: RdyCheck[], run: RunContext, depth: number): Promise<RdyResult[]> {
   const siblingTrees = await Promise.all(checks.map((c) => executeCheck(c, run, depth)));
@@ -290,10 +286,10 @@ async function runSiblingChecks(checks: RdyCheck[], run: RunContext, depth: numb
 }
 
 /**
- * Recursively skip a check and all its descendants.
+ * Skips a check and every descendant below it.
  *
- * Every skip produced here is a `precondition` skip: an `n/a` skip terminates its own
- * subtree in `executeCheck` and so never reaches this function.
+ * Every skip produced here is a `precondition` skip: an `n/a` skip terminates its own subtree before
+ * reaching this point.
  */
 function skipAllDescendants(checks: RdyCheck[], run: RunContext, depth: number): RdyResult[] {
   const results: RdyResult[] = [];
@@ -306,13 +302,13 @@ function skipAllDescendants(checks: RdyCheck[], run: RunContext, depth: number):
   return results;
 }
 
-/** Mark a check as skipped because a precondition or ancestor check failed. */
+/** Returns a skipped result for a check whose precondition or ancestor check failed. */
 function skipCheck(check: RdyCheck, run: RunContext, depth: number): RdyResult {
   const context = buildCheckContext(check, run, depth);
   return buildSkippedResult({ ...context, skipReason: 'precondition', detail: null });
 }
 
-/** Run preconditions concurrently. Return true if all passed. */
+/** Runs preconditions concurrently, reporting whether every one of them passed. */
 async function runPreconditions(preconditions: RdyCheck[], results: RdyResult[], run: RunContext): Promise<boolean> {
   if (preconditions.length === 0) return true;
 
@@ -325,7 +321,7 @@ async function runPreconditions(preconditions: RdyCheck[], results: RdyResult[],
   return flat.filter((r) => r.depth === 0).every((r) => r.status !== 'failed');
 }
 
-/** Run a flat checklist: all checks concurrently. */
+/** Runs a flat checklist, every check concurrently. */
 async function runFlatChecks(
   checklist: RdyChecklist,
   results: RdyResult[],
@@ -341,7 +337,7 @@ async function runFlatChecks(
   results.push(...checkResults);
 }
 
-/** Run a staged checklist: groups sequentially, checks within each group concurrently. */
+/** Runs a staged checklist: groups sequentially, and the checks within each group concurrently. */
 async function runStagedChecks(
   checklist: RdyStagedChecklist,
   results: RdyResult[],
@@ -390,17 +386,16 @@ function orderByResult(results: RdyResult[], pending: PendingDiagnosis[]): RdyCh
 }
 
 /**
- * Run all checks in a checklist and produce a report.
+ * Runs every check in a checklist and returns the report.
  *
- * Preconditions run first. If any fails, all subsequent checks are skipped; a precondition
- * skipped `n/a` does not gate the checklist.
- * Flat checklists run all checks concurrently. Staged checklists run groups
- * sequentially, bailing on later groups when an earlier group has a failure
- * at or above the failure threshold.
+ * Preconditions run first, and a failure among them skips every check that follows; a precondition
+ * skipped `n/a` does not gate the checklist. A flat checklist runs all its checks concurrently. A
+ * staged checklist runs its groups sequentially, abandoning later groups once an earlier one has a
+ * failure at or above the failure threshold.
  *
  * Diagnosis, when asked for, runs once the duration and the verdict are settled. Observing the run
  * cannot then alter it: no diagnostic check can reach a conclusion that already exists, and none
- * enters the wall clock the report carries.
+ * enters the wall clock the report records.
  */
 export async function runRdy(
   checklist: RdyChecklist | RdyStagedChecklist,

--- a/packages/readyup/src/run/skip-diagnosis.ts
+++ b/packages/readyup/src/run/skip-diagnosis.ts
@@ -52,7 +52,7 @@ export function warnOnMaskedSkips(
  * Names the check a warning is about, down to the checklist that holds it.
  *
  * A masked pass is a property of one check where the staleness advisories are properties of a kit,
- * and one run may carry many of both, so the check's name alone would not say which line to look at.
+ * and one run may have many of both, so the check's name alone would not say which line to look at.
  */
 function describeCheck(entry: ResolvedKitEntry, checklistName: string, name: string): string {
   const kit = `kit "${entry.name}"${describeKitOwner(entry.provenance)}`;
@@ -112,7 +112,7 @@ function toWarning(entry: ResolvedKitEntry, checklistName: string, diagnosis: Sk
   };
 }
 
-/** Trims a reason's trailing period, so the sentence carrying it ends with exactly one. */
+/** Trims a reason's trailing period, so the sentence around it ends with exactly one. */
 function trimTrailingPeriod(reason: string): string {
   return reason.endsWith('.') ? reason.slice(0, -1) : reason;
 }

--- a/packages/readyup/src/run/suppressesFinding.ts
+++ b/packages/readyup/src/run/suppressesFinding.ts
@@ -3,7 +3,7 @@ import { createIgnorePragmaMatcher } from './pragma-token.ts';
 /** Matches one check id at the head of a pragma's tail, with the whitespace leading up to it. */
 const LEADING_CHECK_ID = /^[ \t]*[A-Za-z0-9@][\w@./-]*/;
 
-/** Matches the comma parting one check id from the next. */
+/** Matches the comma separating one check id from the next. */
 const LEADING_COMMA = /^[ \t]*,/;
 
 /** The tokens that open a pragma, which an id list therefore never names. */
@@ -27,8 +27,8 @@ export function suppressesFinding(lines: readonly string[], line: number, checkI
 // region | Helpers
 
 /**
- * Reports whether a line carries a pragma covering the named scope and suppressing for `checkIds`. A line past
- * either end of the source carries none.
+ * Reports whether a line has a pragma covering the named scope and suppressing for `checkIds`. A line past
+ * either end of the source has none.
  */
 function carriesPragma(line: string | undefined, scope: 'line' | 'next-line', checkIds: readonly string[]): boolean {
   if (line === undefined) return false;
@@ -48,7 +48,7 @@ function carriesPragma(line: string | undefined, scope: 'line' | 'next-line', ch
  *
  * The list is comma-separated and ends at the first candidate that is not an id: a `--` opening a reason, the
  * delimiter closing a block comment, either pragma token, or the line's end. Excluding the pragma tokens by name
- * is what keeps a line carrying both of them two unqualified pragmas rather than one naming a check called
+ * is what keeps a line with both of them two unqualified pragmas rather than one naming a check called
  * `rdy-ignore-next-line`.
  */
 function readCheckIds(tail: string): readonly string[] {

--- a/packages/readyup/src/run/validateRunFlags.ts
+++ b/packages/readyup/src/run/validateRunFlags.ts
@@ -63,7 +63,7 @@ export function validateRunFlags(parsed: RunFlagConstraints, kitSpecifiers: KitS
 
 // region | Helpers
 
-/** Names the source flags this invocation gave, alphabetically, as the exclusivity error lists them. */
+/** Names the source flags present in this invocation, alphabetically, as the exclusivity error lists them. */
 function collectSourceFlags(parsed: RunFlagConstraints): string[] {
   const sourceFlags: string[] = [];
   if (parsed.file !== undefined) sourceFlags.push('--file');

--- a/packages/readyup/src/run/validateRunFlags.ts
+++ b/packages/readyup/src/run/validateRunFlags.ts
@@ -63,7 +63,7 @@ export function validateRunFlags(parsed: RunFlagConstraints, kitSpecifiers: KitS
 
 // region | Helpers
 
-/** Names the source flags this invocation carries, alphabetically, as the exclusivity error lists them. */
+/** Names the source flags this invocation gave, alphabetically, as the exclusivity error lists them. */
 function collectSourceFlags(parsed: RunFlagConstraints): string[] {
   const sourceFlags: string[] = [];
   if (parsed.file !== undefined) sourceFlags.push('--file');
@@ -78,7 +78,7 @@ function collectSourceFlags(parsed: RunFlagConstraints): string[] {
  *
  * The flag names checklists within one kit, so it needs exactly one kit and no competing per-kit
  * filter. `--file` and `--url` each name their one kit implicitly; a bare invocation names the
- * default kit. Conflicting selections error rather than merging: an invocation carrying both is a
+ * default kit. Conflicting selections error rather than merging: an invocation giving both is a
  * bug in whatever generated it, and no merge rule for "run `deploy:build`, filtered to `test`" is
  * obviously right.
  */

--- a/packages/readyup/src/schemas/__tests__/fixtures/payloadFixtures.ts
+++ b/packages/readyup/src/schemas/__tests__/fixtures/payloadFixtures.ts
@@ -87,7 +87,7 @@ export const minimalReportPayload = {
 };
 
 /**
- * A report carrying an advisory this readyup does not know about.
+ * A report with an advisory this readyup does not know about.
  *
  * Stands in for a payload from a later version: the open warning-code set is what keeps a consumer
  * pinned to `report.v1.json` validating it rather than rejecting it.

--- a/packages/readyup/src/schemas/buildSchemas.ts
+++ b/packages/readyup/src/schemas/buildSchemas.ts
@@ -40,11 +40,11 @@ const PAYLOADS: Payload[] = [
 ];
 
 /**
- * Render every payload as a JSON Schema document.
+ * Returns every payload rendered as a JSON Schema document.
  *
  * Rendered in `input` mode, which leaves objects open. The evolution policy promises that adding an
  * optional field does not bump `schemaVersion`, and a closed schema would break that promise the
- * first time it was exercised: a consumer pinned to v1 would reject every payload carrying the new
+ * first time it was exercised: a consumer pinned to v1 would reject every payload with the new
  * field. No payload uses a transform or a default, so the input and output renderings are otherwise
  * the same document.
  */
@@ -57,7 +57,7 @@ export function buildSchemaDocuments(): SchemaDocument[] {
   });
 }
 
-/** Write every payload schema into `outDir`, creating it if needed, and return the paths written. */
+/** Writes every payload schema into `outDir`, creating it as needed, and returns the paths written. */
 export function writeSchemaFiles(outDir: string): string[] {
   mkdirSync(outDir, { recursive: true });
 

--- a/packages/readyup/src/schemas/common.ts
+++ b/packages/readyup/src/schemas/common.ts
@@ -12,7 +12,7 @@ export const SeveritySchema = z.enum(['error', 'warn', 'recommend']).meta({ id: 
 export const ErrorCodeSchema = z.enum(['config', 'internal', 'kit-load', 'usage']).meta({ id: 'ErrorCode' });
 
 /**
- * The error body the envelope holds and, verbatim, a per-kit error entry inside a report holds too.
+ * The error body in the envelope and, verbatim, in a per-kit error entry inside a report.
  *
  * `hint` names one action that would clear the failure, present only where the diagnosis alone would
  * not suggest it. It is absent rather than empty when there is nothing to suggest, and never appears
@@ -30,7 +30,7 @@ export const ErrorBodySchema = z
 const CountSchema = z.int().min(0);
 
 /**
- * Result tallies for one scope of a run — the whole report, one kit, or one checklist.
+ * Result tallies for one scope of a run -- the whole report, one kit, or one checklist.
  *
  * `errors`/`warnings`/`recommendations` bucket failures by severity; `blocked` (precondition-skipped)
  * and `optional` (n/a-skipped) bucket skips by reason. Counts nest under their own object so they

--- a/packages/readyup/src/schemas/common.ts
+++ b/packages/readyup/src/schemas/common.ts
@@ -12,7 +12,7 @@ export const SeveritySchema = z.enum(['error', 'warn', 'recommend']).meta({ id: 
 export const ErrorCodeSchema = z.enum(['config', 'internal', 'kit-load', 'usage']).meta({ id: 'ErrorCode' });
 
 /**
- * The error body carried by the envelope and, verbatim, by a per-kit error entry inside a report.
+ * The error body the envelope holds and, verbatim, a per-kit error entry inside a report holds too.
  *
  * `hint` names one action that would clear the failure, present only where the diagnosis alone would
  * not suggest it. It is absent rather than empty when there is nothing to suggest, and never appears
@@ -64,7 +64,7 @@ export const WarningCodeSchema = z.enum([
  *
  * Open where `ErrorCodeSchema` is closed, because the two vocabularies do different jobs. An error
  * code selects a consumer's branch, so an unknown one leaves the consumer with nothing to dispatch
- * on and earns its version bump. A warning labels an advisory whose `message` and `remedy` a
+ * on and justifies its version bump. A warning labels an advisory whose `message` and `remedy` a
  * consumer can display verbatim, so a code it has never heard of must still validate: closing this
  * set would make the first new advisory a breaking change. The union keeps the known values visible
  * in the generated schema's `anyOf` rather than trading them for a bare `string`.

--- a/packages/readyup/src/schemas/compileOutputSchema.ts
+++ b/packages/readyup/src/schemas/compileOutputSchema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 /**
  * Version of the `compile` payload.
  *
- * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ * Bumped when a field is removed, renamed, or re-typed -- never when an optional field is added.
  */
 export const SCHEMA_VERSION = 1;
 

--- a/packages/readyup/src/schemas/compileOutputSchema.ts
+++ b/packages/readyup/src/schemas/compileOutputSchema.ts
@@ -15,7 +15,7 @@ export const SCHEMA_VERSION = 1;
  */
 export const CompileStatusSchema = z.enum(['compiled', 'failed', 'skipped']).meta({ id: 'CompileStatus' });
 
-/** One kit's compile outcome, carrying the reason only when there is a failure to explain. */
+/** One kit's compile outcome, with the reason only when there is a failure to explain. */
 export const CompileKitEntrySchema = z
   .object({
     name: z.string(),

--- a/packages/readyup/src/schemas/errorEnvelopeSchema.ts
+++ b/packages/readyup/src/schemas/errorEnvelopeSchema.ts
@@ -10,7 +10,7 @@ import { ErrorBodySchema } from './common.ts';
 export const SCHEMA_VERSION = 1;
 
 /**
- * The single JSON document stdout carries when an invocation fails before it can produce anything else.
+ * The single JSON document stdout holds when an invocation fails before it can produce anything else.
  *
  * The envelope covers only failures that precede dispatch. Once a run has reached its kits, a kit
  * that fails becomes an entry inside the report rather than replacing it, so a consumer that sees an

--- a/packages/readyup/src/schemas/errorEnvelopeSchema.ts
+++ b/packages/readyup/src/schemas/errorEnvelopeSchema.ts
@@ -5,7 +5,7 @@ import { ErrorBodySchema } from './common.ts';
 /**
  * Version of the error-envelope payload.
  *
- * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ * Bumped when a field is removed, renamed, or re-typed -- never when an optional field is added.
  */
 export const SCHEMA_VERSION = 1;
 

--- a/packages/readyup/src/schemas/listOutputSchema.ts
+++ b/packages/readyup/src/schemas/listOutputSchema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 /**
  * Version of the `list` payload.
  *
- * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ * Bumped when a field is removed, renamed, or re-typed -- never when an optional field is added.
  */
 export const SCHEMA_VERSION = 1;
 
@@ -14,7 +14,7 @@ export const KitKindSchema = z.enum(['compiled', 'internal']).meta({ id: 'KitKin
  * The installed package a listed kit was published by.
  *
  * Present only for a kit reached through a package source. Such a kit keeps `kind: 'compiled'`, because
- * that is what it is — a compiled bundle — and only its provenance is new. Recording provenance here
+ * that is what it is -- a compiled bundle -- and only its provenance is new. Recording provenance here
  * rather than as a third `kind` also keeps the payload additive: widening a closed set would bump
  * `schemaVersion`, while an optional field leaves a `v1` validator accepting these rows.
  *

--- a/packages/readyup/src/schemas/listOutputSchema.ts
+++ b/packages/readyup/src/schemas/listOutputSchema.ts
@@ -35,7 +35,7 @@ export const ListKitOriginSchema = z
  * One kit row.
  *
  * Every field but `name` and `kind` comes from the manifest, so a kit enumerated from the filesystem
- * without one carries only those two plus `path`. `checklists` is read from the manifest rather than
+ * without one has only those two plus `path`. `checklists` is read from the manifest rather than
  * from the kit itself: listing kits never executes kit code.
  */
 export const ListKitEntrySchema = z

--- a/packages/readyup/src/schemas/reportSchema.ts
+++ b/packages/readyup/src/schemas/reportSchema.ts
@@ -9,7 +9,7 @@ import { CountsSchema, ErrorBodySchema, SeveritySchema, WarningSchema } from './
  */
 export const SCHEMA_VERSION = 1;
 
-/** How much of the detail tree a report carries. */
+/** How much of the detail tree a report includes. */
 export const DetailSchema = z.enum(['summary', 'full']).meta({ id: 'Detail' });
 
 /** Progress a check reported alongside its verdict, discriminated by `type`. */
@@ -31,7 +31,7 @@ export const ProgressSchema = z
  * One check result in a checklist's detail tree.
  *
  * `ok` is three-valued rather than optional: `null` is the verdict a skipped check has, not a
- * missing field. Every other optional field is omitted when it carries nothing, so a passed check
+ * missing field. Every other optional field is omitted when it holds nothing, so a passed check
  * with no detail serializes to five keys. Nesting is recursive — `checks` holds the results of
  * checks that ran only because this one passed.
  */
@@ -91,7 +91,7 @@ export const KitOriginSchema = z
  *
  * `compiledWith` is the readyup that built this kit's bundle, read from the stamp the bundle
  * exports. It is present whenever that stamp is, including when it equals the report's own
- * `readyupVersion`, so its absence means the kit carries no stamp: a bundle compiled before the
+ * `readyupVersion`, so its absence means the kit has no stamp: a bundle compiled before the
  * stamp existed, or a `--jit` run that loaded TypeScript source. `rdy verify` reports the same
  * value as `rebuildCompiledWith` under a narrower rule, appearing only where it differs from the
  * running readyup.
@@ -112,7 +112,7 @@ export const KitResultEntrySchema = z
   .meta({ id: 'KitResultEntry' });
 
 /**
- * A kit that produced no results, carrying the same error body as the envelope.
+ * A kit that produced no results, with the same error body as the envelope.
  *
  * Deliberately counts-free and verdict-free: a kit that never ran has no `errors: 0` to report and
  * no verdict to give, and emitting either would misstate the run.

--- a/packages/readyup/src/schemas/reportSchema.ts
+++ b/packages/readyup/src/schemas/reportSchema.ts
@@ -5,7 +5,7 @@ import { CountsSchema, ErrorBodySchema, SeveritySchema, WarningSchema } from './
 /**
  * Version of the run-report payload.
  *
- * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ * Bumped when a field is removed, renamed, or re-typed -- never when an optional field is added.
  */
 export const SCHEMA_VERSION = 1;
 
@@ -32,7 +32,7 @@ export const ProgressSchema = z
  *
  * `ok` is three-valued rather than optional: `null` is the verdict a skipped check has, not a
  * missing field. Every other optional field is omitted when it holds nothing, so a passed check
- * with no detail serializes to five keys. Nesting is recursive — `checks` holds the results of
+ * with no detail serializes to five keys. Nesting is recursive -- `checks` holds the results of
  * checks that ran only because this one passed.
  */
 export const CheckEntrySchema = z

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -15,7 +15,7 @@ export const DriftStatusSchema = z.enum(['drift', 'missing', 'ok', 'unverified']
  *
  * A separate vocabulary from `DriftStatus` rather than a widening of it. The two verdicts answer
  * different questions -- has the bundle been edited, and has the source moved on since it was
- * built -- and a kit can carry a distinct answer to each. Widening the closed `DriftStatus` enum
+ * built -- and a kit can give a distinct answer to each. Widening the closed `DriftStatus` enum
  * would also break a consumer that exhaustively switches on it.
  */
 export const SourceStatusSchema = z.enum(['missing', 'ok', 'stale', 'unverified']).meta({ id: 'SourceStatus' });
@@ -24,7 +24,7 @@ export const SourceStatusSchema = z.enum(['missing', 'ok', 'stale', 'unverified'
  * Outcome of reading one kit's recorded input closure back off disk.
  *
  * A vocabulary of its own rather than a widening of any above, for the reason `SourceStatus`
- * records. One axis carries every kind of input, with `inputFailures` naming which inputs failed
+ * records. One axis covers every kind of input, with `inputFailures` naming which inputs failed
  * and why, so a consumer branches on the cause rather than on a status per kind of input.
  */
 export const InputsStatusSchema = z.enum(['ok', 'stale', 'unverified']).meta({ id: 'InputsStatus' });
@@ -35,9 +35,9 @@ export const InputsStatusSchema = z.enum(['ok', 'stale', 'unverified']).meta({ i
  * `path` is the file as the manifest records it, relative to the manifest directory, and `kind`
  * separates a module the bundle inlined from a JSON projection `pickJson` substituted.
  *
- * Discriminated on `reason` so each cause carries exactly what it compared, as `ManifestInputSchema`
- * discriminates the record this reads back: `changed` carries the hash pair, `missing` carries
- * neither, and `unprojectable` carries a diagnosis instead and is inline-only, since only a
+ * Discriminated on `reason` so each cause states exactly what it compared, as `ManifestInputSchema`
+ * discriminates the record this reads back: `changed` has the hash pair, `missing` has
+ * neither, and `unprojectable` has a diagnosis instead and is inline-only, since only a
  * projection can fail to be reproduced. A consumer generating types from this narrows by `reason`
  * rather than by hand over three fields that are independently optional.
  */
@@ -78,7 +78,7 @@ export const RebuildEsbuildSchema = z
  * One bundled package whose recorded version the rebuild does not reproduce.
  *
  * `recorded` is the version the compile bundled and `rebuilt` the one the rebuild bundled; a side is
- * absent where the package was not bundled then or now. A side carrying several comma-separated
+ * absent where the package was not bundled then or now. A side with several comma-separated
  * versions is a package the bundle inlined at more than one version at once.
  */
 export const RebuildDependencyChangeSchema = z
@@ -92,13 +92,13 @@ export const RebuildDependencyChangeSchema = z
  * are present only on a `drift` verdict, since no other status has two hashes to compare.
  * `sourceExpected` and `sourceActual` are their counterparts for the source, present only on
  * `stale`. `inputFailures` is the same idea for the recorded input closure, present only on a
- * `stale` `inputsStatus` and carrying one entry per input rather than a pair of hashes, since a kit
+ * `stale` `inputsStatus` and holding one entry per input rather than a pair of hashes, since a kit
  * can be stale in several inputs at once. `sourceStatus` and `inputsStatus` are optional so a
  * consumer pinned to this schema still validates a payload from a readyup that predates either.
  *
  * `rebuildStatus` and its fields appear only under `--rebuild`, so a run without the flag emits the
  * payload it always did. `rebuildExpected` is the hash of the recompiled bundle and `rebuildActual`
- * the hash of the bundle on disk, both present only on `mismatch`; `rebuildError` carries the
+ * the hash of the bundle on disk, both present only on `mismatch`; `rebuildError` holds the
  * compile failure on `failed`. `rebuildCompiledWith` names the readyup a mismatched bundle was
  * built by, present only when it differs from the running one, which is what separates a mismatch
  * caused by a readyup upgrade from one caused by an edited bundle.

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 /**
  * Version of the `verify` payload.
  *
- * Bumped when a field is removed, renamed, or re-typed — never when an optional field is added.
+ * Bumped when a field is removed, renamed, or re-typed -- never when an optional field is added.
  */
 export const SCHEMA_VERSION = 1;
 

--- a/packages/readyup/src/severity/meetsThreshold.ts
+++ b/packages/readyup/src/severity/meetsThreshold.ts
@@ -12,7 +12,7 @@ const SEVERITY_RANK: Record<Severity, number> = {
 };
 
 /**
- * Return true if `severity` is at or above (more severe than or equal to) `threshold`.
+ * Reports whether `severity` is as severe as `threshold` or more so.
  *
  * Throws on a value outside the severity enum. Supplying a validated severity is the caller's
  * responsibility, and the throw is what makes that a contract rather than an assumption: an unranked
@@ -27,7 +27,7 @@ export function meetsThreshold(severity: Severity, threshold: Severity): boolean
 
 // region | Helpers
 
-/** Throw when a severity carries no rank, naming the role it was supplied in. */
+/** Throws where a severity has no rank, naming the role it was supplied in. */
 function assertRankedSeverity(severity: Severity, role: string): void {
   if (!Object.hasOwn(SEVERITY_RANK, severity)) {
     throw new Error(`Unknown ${role} "${severity}". Expected one of: error, warn, recommend.`);

--- a/packages/readyup/src/severity/worseSeverity.ts
+++ b/packages/readyup/src/severity/worseSeverity.ts
@@ -1,6 +1,6 @@
 import type { Severity } from '../kits/types.ts';
 
-/** Return the more severe of two severity values. `error` > `warn` > `recommend` > `null`. */
+/** Returns the more severe of two severity values, ranked `error` > `warn` > `recommend` > `null`. */
 export function worseSeverity(current: Severity | null, candidate: Severity | null): Severity | null {
   if (current === 'error' || candidate === 'error') return 'error';
   if (current === 'warn' || candidate === 'warn') return 'warn';

--- a/packages/readyup/src/test-utils/asSeverity.ts
+++ b/packages/readyup/src/test-utils/asSeverity.ts
@@ -1,6 +1,6 @@
 import type { Severity } from '../kits/types.ts';
 
-/** Restate a string as a severity, standing in for a kit that declared one outside the enum. */
+/** Restates a string as a severity, standing in for a kit that declared one outside the enum. */
 export function asSeverity(value: string): Severity {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the value is one the type forbids.
   return value as Severity;

--- a/packages/readyup/src/test-utils/mockResponse.ts
+++ b/packages/readyup/src/test-utils/mockResponse.ts
@@ -1,4 +1,4 @@
-/** Build a minimal mock Response with the given body and status. */
+/** Returns a minimal mock Response with the given body and status. */
 export function mockResponse(
   body: string,
   init?: { status?: number; statusText?: string },

--- a/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
@@ -175,7 +175,7 @@ describe(checkInputDrift, () => {
 
   // region | Helpers
 
-  /** A manifest entry recording the given closure and nothing else this axis reads. */
+  /** Returns a manifest entry recording the given closure and nothing else this axis reads. */
   function kitWith(inputs: RdyManifestInput[]): RdyManifestKit {
     return { inputs, name: 'demo' };
   }

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -142,7 +142,7 @@ describe(verifyCommand, () => {
   });
 
   describe('source verdict', () => {
-    /** A manifest naming one kit, with whatever hashes the caller wants to imply. */
+    /** Arranges a manifest naming one kit, with whatever hashes the caller wants to imply. */
     function arrangeSingleKit(): void {
       mockReadManifest.mockReturnValue({
         version: 1,
@@ -220,7 +220,7 @@ describe(verifyCommand, () => {
   });
 
   describe('inputs verdict', () => {
-    /** A manifest naming one kit whose two hash verdicts both pass, leaving the inputs axis alone to speak. */
+    /** Arranges a manifest naming one kit whose two hash verdicts both pass, leaving the inputs axis alone to speak. */
     function arrangeSingleKit(): void {
       mockReadManifest.mockReturnValue({
         version: 1,
@@ -371,7 +371,7 @@ describe(verifyCommand, () => {
   });
 
   describe('rebuild verdict', () => {
-    /** A manifest naming one fully recorded kit whose two hash verdicts both pass. */
+    /** Arranges a manifest naming one fully recorded kit whose two hash verdicts both pass. */
     function arrangeSingleKit(): void {
       mockReadManifest.mockReturnValue({
         version: 1,

--- a/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
@@ -73,10 +73,11 @@ describe('verifyCommand wiring', () => {
 
   describe('source staleness', () => {
     /**
-     * Write a matching source/output pair and a manifest recording both hashes.
+     * Writes a matching source/output pair and a manifest recording both hashes, returning the
+     * source path.
      *
-     * Returns the source path so a test can edit it, which is the whole scenario: a kit whose
-     * TypeScript moved on while the compiled bundle it was built from stayed put.
+     * Editing that source is the whole scenario: a kit whose TypeScript moved on while the compiled
+     * bundle it was built from stayed put.
      */
     function writeCompiledPair(): string {
       const compiled = Buffer.from('export default { checklists: [] };\n');
@@ -264,7 +265,7 @@ describe('verifyCommand wiring', () => {
   });
 
   describe('--json', () => {
-    /** Write a manifest naming one matching kit, one drifted kit, and one with no recorded hash. */
+    /** Writes a manifest naming one matching kit, one drifted kit, and one with no recorded hash. */
     function writeMixedManifest(): void {
       const clean = Buffer.from('export default { checks: [] };\n');
       writeFileSync(path.join(tempDir, 'clean.js'), clean);

--- a/packages/readyup/src/verify/checkDrift.ts
+++ b/packages/readyup/src/verify/checkDrift.ts
@@ -12,11 +12,11 @@ export type DriftStatus =
   | { kind: 'unverified' };
 
 /**
- * Determine whether a kit's on-disk compiled file matches the manifest's recorded `targetHash`.
+ * Returns whether a kit's on-disk compiled file matches the manifest's recorded `targetHash`.
  *
- * Returns `unverified` when the manifest entry has no hash (predates the feature or was written
- * with `--skip-manifest`), `missing` when the compiled file doesn't exist, `drift` when the hashes
- * differ, and `ok` when they match.
+ * `unverified` where the manifest entry has no hash, which means it predates the feature or was
+ * written with `--skip-manifest`; `missing` where the compiled file does not exist; `drift` where the
+ * hashes differ; and `ok` where they match.
  */
 export function checkDrift(kit: RdyManifestKit, manifestDir: string): DriftStatus {
   if (kit.targetHash === undefined || kit.path === undefined) {

--- a/packages/readyup/src/verify/checkRebuild.ts
+++ b/packages/readyup/src/verify/checkRebuild.ts
@@ -82,7 +82,7 @@ export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Pr
     rebuild = await buildBundle(sourcePath);
   } catch (error: unknown) {
     // A source that no longer compiles is a finding about the kit, not a failure of the invocation,
-    // so the sweep carries on to the kits after it.
+    // so the sweep goes on to the kits after it.
     return { kind: 'failed', message: describeError(error) };
   }
 

--- a/packages/readyup/src/verify/checkSourceDrift.ts
+++ b/packages/readyup/src/verify/checkSourceDrift.ts
@@ -12,13 +12,13 @@ export type SourceStatus =
   | { kind: 'unverified' };
 
 /**
- * Determine whether a kit's on-disk TypeScript source still matches the `sourceHash` the manifest
+ * Returns whether a kit's on-disk TypeScript source still matches the `sourceHash` the manifest
  * recorded when the kit was compiled.
  *
- * Orthogonal to the target verdict: a kit can be stale at the source and drifted at the target at
- * the same time, and neither verdict implies the other. Returns `unverified` when the entry records
- * no source or no hash (it predates the feature, or was written with `--skip-manifest`), `missing`
- * when the recorded source is gone, `stale` when the hashes differ, and `ok` when they match.
+ * `unverified` where the entry records no source or no hash, which means it predates the feature or
+ * was written with `--skip-manifest`; `missing` where the recorded source is gone; `stale` where the
+ * hashes differ; and `ok` where they match. This is orthogonal to the target verdict: a kit can be
+ * stale at the source and drifted at the target at once, and neither verdict implies the other.
  */
 export function checkSourceDrift(kit: RdyManifestKit, manifestDir: string): SourceStatus {
   if (kit.sourceHash === undefined || kit.source === undefined) {

--- a/packages/readyup/src/verify/targetHash.ts
+++ b/packages/readyup/src/verify/targetHash.ts
@@ -4,18 +4,18 @@ import { readFileSync } from 'node:fs';
 /** Length of the hex prefix stored in the manifest's `targetHash` field. */
 const HASH_PREFIX_LENGTH = 8;
 
-/** Return the first 8 hex chars of the SHA-256 digest of a buffer. */
+/** Returns the first 8 hex characters of a buffer's SHA-256 digest. */
 export function hashBytes(bytes: Buffer): string {
   return createHash('sha256').update(bytes).digest('hex').slice(0, HASH_PREFIX_LENGTH);
 }
 
-/** Return the first 8 hex chars of the SHA-256 digest of a file's content. */
+/** Returns the first 8 hex characters of a file's SHA-256 digest. */
 export function hashFile(filePath: string): string {
   return hashBytes(readFileSync(filePath));
 }
 
 /**
- * Returns the hash of a serialized JSON projection, which is what a recorded inline input carries.
+ * Returns the hash of a serialized JSON projection, which is what a recorded inline input stores.
  *
  * The compile and every reader of a recorded input hash the projection through here, so neither can
  * encode it differently and report a file neither changed as stale.

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -46,7 +46,7 @@ const verifyOptions = {
  * Handles the `verify` subcommand: reads the manifest, hashes each kit's source and compiled
  * output, and reports what no longer matches.
  *
- * Each kit carries three independent verdicts, and a fourth under `--rebuild`. Returns 0 when every
+ * Each kit has three independent verdicts, and a fourth under `--rebuild`. Returns 0 when every
  * verdict is `ok` or `unverified`; 1 when any kit has drifted, gone stale, lost a file, or failed
  * to reproduce. An unreadable manifest is a config failure and is thrown rather than reported as
  * drift, as is a `--rebuild` run with no esbuild to rebuild with.
@@ -165,7 +165,7 @@ function isPassingVerdict({ drift, inputs, rebuild, source }: KitVerdicts): bool
   return targetPasses && sourcePasses && inputsPass && rebuildPasses;
 }
 
-/** Builds a kit's JSON entry, carrying what a verdict compared only where it compared something. */
+/** Builds a kit's JSON entry, stating what a verdict compared only where it compared something. */
 function buildVerifyEntry(name: string, { drift, inputs, rebuild, source }: KitVerdicts): JsonVerifyKitEntry {
   return {
     name,
@@ -191,15 +191,15 @@ function buildVerifyEntry(name: string, { drift, inputs, rebuild, source }: KitV
 }
 
 /**
- * Returns a kit's line, carrying whichever of its verdicts has something to report.
+ * Returns a kit's line, showing whichever of its verdicts has something to report.
  *
- * A failing kit carries each verdict on its own line beneath its name; any other kit carries them
- * inline. A kit that passes every verdict carries none, leaving its token to report the outcome.
+ * A failing kit gets each verdict on its own line beneath its name; any other kit gets them inline.
+ * A kit that passes every verdict shows none, leaving its token to report the outcome.
  */
 function formatStatusLine(kit: RdyManifestKit, verdicts: KitVerdicts): string {
   const { drift, inputs, rebuild, source } = verdicts;
   const token = resolveToken(verdicts);
-  // An unverified closure counts as confirmed, so an entry predating it carries the line it always did.
+  // An unverified closure counts as confirmed, so an entry predating it gets the line it always did.
   const hashesConfirmed = drift.kind === 'ok' && source.kind === 'ok' && inputs.kind !== 'stale';
   const clauses = [
     describeDriftStatus(kit, drift),
@@ -290,7 +290,7 @@ function describeInputFailure(failure: InputFailure): string {
  * Returns a clause describing the rebuild verdict, or nothing when there is nothing to add.
  *
  * A passing rebuild is silent only where the hash verdicts already reached `ok` and it would
- * restate them. Anywhere else it speaks, because it then carries the line's strongest answer: over
+ * restate them. Anywhere else it speaks, because it then holds the line's strongest answer: over
  * a failing verdict it says the bundle reproduces and the manifest's record of it is what went
  * wrong, and over an unverified one it supplies the answer the absent hash could not.
  */
@@ -315,7 +315,7 @@ function describeRebuildStatus(status: RebuildStatus | undefined, hashesConfirme
 /**
  * Returns one clause per cause, naming which versions changed between the compile and the rebuild.
  *
- * When the entry carries the toolchain record and nothing in it changed, the single clause says so and
+ * When the entry has the toolchain record and nothing in it changed, the single clause says so and
  * names what the record cannot see: an edited bundle, a changed input, or a dependency whose content
  * changed without a version change.
  */

--- a/packages/readyup/vitest.config.ts
+++ b/packages/readyup/vitest.config.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { defineVitestConfig } from '@williamthorsen/nmr/vitest';
 
 // This package keeps a config of its own, against the general rule that packages inherit the root one. The rule
-// targets configs that merely restate the shared config; this one carries package-scoped settings that have no
+// targets configs that merely restate the shared config; this one holds package-scoped settings that have no
 // root-level expression, since a `project` override at the root would apply to every package.
 //
 // Pinning the style keeps rendering deterministic: left to detection, output would follow whether the runner attached
@@ -11,7 +11,7 @@ import { defineVitestConfig } from '@williamthorsen/nmr/vitest';
 // plain output passes `--style plain`, which outranks this.
 //
 // Restoring a stubbed environment variable is the runner's job rather than a suite's. `unstubEnvs` clears every stub
-// before each test, so a suite that stubs one carries no hook to undo it.
+// before each test, so a suite that stubs one has no hook to undo it.
 //
 // The aliases let a test import this package's own kits, which reach readyup by package name the way a consumer's kit
 // does, without a prior build standing between the test and the source. Longest specifier first: an alias on `readyup`


### PR DESCRIPTION
## What

Rewrites the comments throughout `packages/readyup` to align with repo conventions.

## Why

readyup's comments had drifted into two registers, and the split ran through individual files rather than between them: `runRdy.ts` had `Build a passed result` sitting directly above `Builds a failed result`. Nothing in the source distinguished a file still awaiting the standard from one deliberately left alone, so a reader had no way to tell which form to imitate.

## Details

### 📚 Documentation

**Register.** Every description attached to a function or method leads with a third-person indicative verb. The rule reaches noun-phrase and adjective openers too: `Type-safe identity function for defining a rdy kit` and `True if a line is blank or a full-line comment` named the thing rather than reporting what the function does.

**Shape.** A description that had grown into a paragraph now opens with one summary line and puts its reasoning below. `jitiImport`, `writeFileWithCheck`, `resolveKitExports`, `checkDrift`, `checkSourceDrift`, `readPnpmWorkspacePackages`, and `loadExistingKitsByName` each buried their return value mid-paragraph; each now states it first. Descriptions wrapped at seventy or a hundred columns are rewrapped at the file's own width, which `.editorconfig` sets to 120.

**Plain speech.** `carries`, `bears`, `parts`, `earns`, and `answers with` give way to the clearest verb for each site rather than to a single replacement: a source `holds` a pragma, a writer `separates` one block from the next, an `exports` map `resolves` a package, and a tarball `includes` its files.

**Deletions.** Comments were cut where the declaration could not verify them: `describeType` no longer names the diagnostics that consume it, `runSiblingChecks` no longer names `Promise.all`, and `reportRdy` no longer explains what a caller does with `hasVisibleResults`, which the `RenderedReport` interface already documents. Four inline comments that restated the line beneath them are gone. Descriptions on constants, types, and interfaces survive only where they state something the declaration does not.

**Inline comments** keep the imperative mood the house style gives them, so a step comment still reads `Parse kit specifiers from positional args`.

**Em-dashes** in comments become `--` at 41 sites across 30 files. The substitution is scoped to comment lines, so the two em-dashes in string literals are untouched; one of them is the `@noformat @generated` banner `buildBundle` writes into every compiled kit bundle, where a changed byte would leave the tracked bundles stale against their manifest.

**Out of scope.** `README.md`, `agents/`, test titles, and the `carriesPragma` identifier keep the older vocabulary. Markdown is not a comment, and a title or an identifier is code, so folding either in would forfeit the guarantee that this diff changes no bytes of output. [#408](https://github.com/williamthorsen/workshop/issues/408) covers them.

### 🧪 Tests

No test behavior changed. Test-file comments were audited under the same rules, so helper descriptions moved to third person alongside source, and the reason comments above indirect assertions were rewritten rather than cut.

Behavior-neutrality is checked rather than asserted: each of the 167 changed files produces byte-identical `esbuild --loader=ts --minify` output against `main`. Minification strips comments, so a surviving difference would be a code change.

Closes #144
