### PR TITLE
#408 Extend the plain-speech standard to readyup's markdown and test titles

### DIFF
--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -1,4 +1,4 @@
-/** @noformat — @generated. Do not edit. Compiled by rdy. */
+/** @noformat -- @generated. Do not edit. Compiled by rdy. */
 /* eslint-disable */
 export const __readyupVersion = "0.33.0";
 

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -21,7 +21,7 @@
       "readyupVersion": "0.33.0",
       "source": "kits/demo.ts",
       "sourceHash": "33b6ea59",
-      "targetHash": "35c09b44"
+      "targetHash": "f8ba98fb"
     }
   ]
 }

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -559,7 +559,7 @@ A check line reads `token name <separator> detail [progress] (duration)`. The se
 
 **Every block heads itself with a breadcrumb.** A run block is headed `━━`, and its segments read source, then kit, then checklist, separated by a spaced slash. A segment appears only where it distinguishes something: the source where the kit came from anywhere but the local kits directory or the working directory, the kit where the run holds more than one or a source segment is already there, the checklist where the kit runs more than one. A lone local kit running one checklist heads nothing at all. The summary table heads itself at `━━` too, as a peer of the blocks it tallies, and each of its rows repeats the breadcrumb of the block it summarizes, the same segments elided; `Fixes` and each command's own heading stay at `──`, which heads a section and nothing else.
 
-Blank lines part blocks rather than decorate headings: none opens a command's output, follows a heading, or falls inside a block, and exactly one parts one block from the next, a kit boundary included. More than one checklist anywhere in the run adds a summary table:
+Blank lines separate blocks rather than decorate headings: none opens a command's output, follows a heading, or falls inside a block, and exactly one separates one block from the next, a kit boundary included. More than one checklist anywhere in the run adds a summary table:
 
 ```
 ━━ 📋 build
@@ -618,7 +618,7 @@ A run spanning several kits tallies them together, each row naming its source an
 
 `CI` catches a runner that attaches a pseudo-terminal; the terminal check catches an interactive `rdy | grep FAIL`. An explicit `CI=false` is read as a denial. Naming a style that does not exist fails the invocation.
 
-In `plain`, every character is printable ASCII, heading rules and separators included. A role glyph is omitted while keeping its column, so names stay aligned; in a breadcrumb, where there is no column to keep, the spaced separator is what parts one segment from the next:
+In `plain`, every character is printable ASCII, heading rules and separators included. A role glyph is omitted while keeping its column, so names stay aligned; in a breadcrumb, where there is no column to keep, the spaced separator is what separates one segment from the next:
 
 ```
 == integration

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -106,7 +106,7 @@ kit
 
 ### Severities
 
-Every check carries a severity. It decides whether a failure fails the run and whether the result is reported, and it never decides whether that check itself runs. It reaches later work in one place only: a failed check at or above the failure threshold stops the remaining groups of a [staged checklist](#staged-checklists).
+Every check has a severity. It decides whether a failure fails the run and whether the result is reported, and it never decides whether that check itself runs. It reaches later work in one place only: a failed check at or above the failure threshold stops the remaining groups of a [staged checklist](#staged-checklists).
 
 | Severity    | Meaning           |
 | ----------- | ----------------- |
@@ -129,7 +129,7 @@ A check result has one of three statuses -- `passed`, `failed`, or `skipped`. Th
 
 💊 `FIX` marks a remediation hint rather than a result.
 
-Role glyphs are nouns rather than statuses. They name what something is, in a heading segment or beside a listed row, and plain style renders none of them: position carries the meaning instead.
+Role glyphs are nouns rather than statuses. They name what something is, in a heading segment or beside a listed row, and plain style renders none of them: position shows the meaning instead.
 
 | Rich | Names                                                  |
 | ---- | ------------------------------------------------------ |
@@ -202,7 +202,7 @@ See [internal kits](#internal-kits) for what the `internal` keys select, and [pa
 | `preconditions` | `RdyCheck[]`        | --                 | Gating checks                               |
 | `fixLocation`   | `'inline' \| 'end'` | the kit's setting  | Overrides the kit's setting                 |
 
-A checklist carries either `checks` or `groups`, never both.
+A checklist has either `checks` or `groups`, never both.
 
 ### Checks
 
@@ -264,7 +264,7 @@ Neither is a `quiet` check, though it looks like one: its name reaches the reade
 
 ### The detail contract
 
-`detail` answers "why this status" -- not "what this check asserts", which the name already says. On a pass it reports the evidence; on a skip, why the check did not apply; on a failure, what went wrong. Write it as a complete sentence, capitalized and carrying no terminal period -- the register `name` and `fix` already use. A sentence whose subject is a code identifier keeps that identifier's own case, as in `package.json is missing or unreadable`.
+`detail` answers "why this status" -- not "what this check asserts", which the name already says. On a pass it reports the evidence; on a skip, why the check did not apply; on a failure, what went wrong. Write it as a complete sentence, capitalized and with no terminal period -- the register `name` and `fix` already use. A sentence whose subject is a code identifier keeps that identifier's own case, as in `package.json is missing or unreadable`.
 
 | Status  | Where `detail` renders                                  |
 | ------- | ------------------------------------------------------- |
@@ -350,7 +350,7 @@ The second question is a fast check, not the rule. A skip is correct whenever th
 | `code-quality workflow does not use nmr prepush`  | pass                                    | the skip masks a pass                                  |
 | `.github/labels.yaml exists`                      | pass                                    | the skip is correct; release-kit does not own the file |
 
-The last row is the one the fast check alone gets wrong. `.github/labels.yaml` is a filename several label-sync tools write, and release-kit generates it only from a `repoLabels` block, so a repo carrying that file without the block would have passed `fileExists` and still deserves the skip.
+The last row is the one the fast check alone gets wrong. `.github/labels.yaml` is a filename several label-sync tools write, and release-kit generates it only from a `repoLabels` block, so a repo with that file but no such block would have passed `fileExists` and still deserves the skip.
 
 The third row is the failure mode to watch for: `skip` and `check` ran the identical predicate, so the check could never pass. [`rdy run --diagnose`](#run-options) decides that mechanical half, reporting every check its own `skip` turned off that would have passed. It decides nothing about applicability.
 
@@ -364,7 +364,7 @@ The third row is the failure mode to watch for: `skip` and `check` ran the ident
 
 The doctrine above ships as agent guidance too, in a CodeAssembly content root under `agents/` in the installed package. A repo that names `readyup` under `packages` in its `.agents/codeassembly.yaml` and runs `codeassembly sync` gets it as the `consult-readyup-kits` skill, in every harness that repo targets.
 
-The skill carries the judgment a kit author needs while writing; this README stays the reference for everything mechanical.
+The skill holds the judgment a kit author needs while writing; this README stays the reference for everything mechanical.
 
 ### Staged checklists
 
@@ -490,7 +490,7 @@ rdy deploy:fast       # a suite
 rdy deploy release    # two kits
 ```
 
-`--checklists` filters within a single kit, and pairs with one positional kit, with `--file` or `--url`, or with no kit at all. Naming two kits, or one that already carries a `:checklist` filter, is an error rather than a merge.
+`--checklists` filters within a single kit, and pairs with one positional kit, with `--file` or `--url`, or with no kit at all. Naming two kits, or one that already has a `:checklist` filter, is an error rather than a merge.
 
 Kit names may contain `/`, as in `shared/deploy`. To name one that starts with `-`, place it last, after `--`:
 
@@ -518,9 +518,9 @@ rdy run -- "--odd-kit-name"
 
 `--quiet` filters by status where `--report-on` filters by severity, so the two compose rather than override. Both keep the parent checks of anything they show, so a failure nested under passing parents stays reachable.
 
-A checklist either filter empties renders no block at all: its summary-table row states the same counts in a column the reader can compare across the run. A block is withheld only where a table will carry its row, so a run of one checklist reports its block however little it has to say, and a run that withholds one always ends with the table.
+A checklist either filter empties renders no block at all: its summary-table row states the same counts in a column the reader can compare across the run. A block is withheld only where a table will include its row, so a run of one checklist reports its block however little it has to say, and a run that withholds one always ends with the table.
 
-`--diagnose` runs the `check` of every check its own `skip` turned off, and reports the ones that would have passed: a `skip` exists to prevent a wrong failure, and one that suppresses a right pass instead renders as an ordinary white circle that nothing fails. [When a check skips](#when-a-check-skips) carries the judgment this flag cannot decide. It is opt-in because it executes exactly the work a skip was written to avoid, which may reach a network or a registry. What it finds is reported as [advisory warnings](#advisory-warnings), and the statuses, counts, durations, and exit code are those of an undiagnosed run.
+`--diagnose` runs the `check` of every check its own `skip` turned off, and reports the ones that would have passed: a `skip` exists to prevent a wrong failure, and one that suppresses a right pass instead renders as an ordinary white circle that nothing fails. [When a check skips](#when-a-check-skips) holds the judgment this flag cannot decide. It is opt-in because it executes exactly the work a skip was written to avoid, which may reach a network or a registry. What it finds is reported as [advisory warnings](#advisory-warnings), and the statuses, counts, durations, and exit code are those of an undiagnosed run.
 
 A check's own [`quiet`](#checks) is this flag narrowed to that one check, and a kit whose every check declares it renders what `--quiet` renders. It is not `skip`, which reports that the check did not run and why: a quiet check runs, and its pass reaches the count line and the exit code like any other -- only the line is withheld. `--json` is unaffected, so `rdy run --json --detail full` shows a quiet check that passed.
 
@@ -553,11 +553,11 @@ Private repositories use ambient tokens: `GITHUB_TOKEN` (falling back to `gh aut
 
 A check line reads `token name <separator> detail [progress] (duration)`. The separator is `·` in `rich` and `-` in `plain`; progress takes brackets. Durations appear from 100 ms up, never on a check that did not run, and always on a tail or total line.
 
-**A failed line carries only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. Passes and skips keep their detail inline.
+**A failed line states only its claim.** The reason renders beneath it, indented to the name column -- the authored `detail` first, then any thrown exception behind its `Error:` label. Passes and skips keep their detail inline.
 
-**Every block closes with its count line.** A count line is labelled `Total:`, leads with the run's worst severity, and reports counts in a fixed order -- errors, warnings, recommendations, passed, blocked, skipped -- omitting any that is zero, parted by commas. The label is what tells the line from the check lines above it, which lead with a token in the same column. It is the block's last line, following any `Fixes` recap.
+**Every block closes with its count line.** A count line is labelled `Total:`, leads with the run's worst severity, and reports counts in a fixed order -- errors, warnings, recommendations, passed, blocked, skipped -- omitting any that is zero, separated by commas. The label is what tells the line from the check lines above it, which lead with a token in the same column. It is the block's last line, following any `Fixes` recap.
 
-**Every block heads itself with a breadcrumb.** A run block is headed `━━`, and its segments read source, then kit, then checklist, parted by a spaced slash. A segment appears only where it distinguishes something: the source where the kit came from anywhere but the local kits directory or the working directory, the kit where the run holds more than one or a source segment is already there, the checklist where the kit runs more than one. A lone local kit running one checklist heads nothing at all. The summary table heads itself at `━━` too, as a peer of the blocks it tallies, and each of its rows repeats the breadcrumb of the block it summarizes, the same segments elided; `Fixes` and each command's own heading stay at `──`, which heads a section and nothing else.
+**Every block heads itself with a breadcrumb.** A run block is headed `━━`, and its segments read source, then kit, then checklist, separated by a spaced slash. A segment appears only where it distinguishes something: the source where the kit came from anywhere but the local kits directory or the working directory, the kit where the run holds more than one or a source segment is already there, the checklist where the kit runs more than one. A lone local kit running one checklist heads nothing at all. The summary table heads itself at `━━` too, as a peer of the blocks it tallies, and each of its rows repeats the breadcrumb of the block it summarizes, the same segments elided; `Fixes` and each command's own heading stay at `──`, which heads a section and nothing else.
 
 Blank lines part blocks rather than decorate headings: none opens a command's output, follows a heading, or falls inside a block, and exactly one parts one block from the next, a kit boundary included. More than one checklist anywhere in the run adds a summary table:
 
@@ -593,7 +593,7 @@ A kit from an installed package, a repository, or a URL names where it came from
 ━━ 📁 ../shared-kits / 📓 default
 ```
 
-A run spanning several kits tallies them together, each row naming its source and kit so it reads without reference to the blocks above. Row names carry no role glyphs, since the padding that aligns the columns counts characters rather than terminal cells:
+A run spanning several kits tallies them together, each row naming its source and kit so it reads without reference to the blocks above. Row names have no role glyphs, since the padding that aligns the columns counts characters rather than terminal cells:
 
 ```
 ━━ Summary
@@ -608,7 +608,7 @@ A run spanning several kits tallies them together, each row naming its source an
 
 ### Output styles
 
-`--style` selects rendering; `RDY_STYLE` carries a standing preference. The flag outranks the environment variable, which outranks detection.
+`--style` selects rendering; `RDY_STYLE` holds a standing preference. The flag outranks the environment variable, which outranks detection.
 
 | Value   | Renders                                                                       |
 | ------- | ----------------------------------------------------------------------------- |
@@ -637,7 +637,7 @@ Once a style is named explicitly, output is identical to a terminal or a pipe. `
 
 ### Suppressing a finding
 
-A check naming located sites reports each as `path:line`. A source suppresses one by carrying a pragma:
+A check naming located sites reports each as `path:line`. A source suppresses one with a pragma:
 
 ```ts
 // rdy-ignore-next-line -- the bootstrap shim, no deps allowed
@@ -667,7 +667,7 @@ A failed check prints its id bracketed ahead of its fraction, and that printed f
 
 A kit an installed package publishes namespaces its checks under that package's name with the scope stripped, so `@williamthorsen/toolbelt.errors` yields `toolbelt.errors/<id>`. The fully-qualified `@williamthorsen/toolbelt.errors/<id>` is accepted too; the bare id is not, because the namespace is what keeps two kits' same-named checks apart. A kit reached any other way -- from the local kits directory, a `--from` directory, or a URL -- has no namespace, and its bare id stands. An id naming no check in the run suppresses nothing, as does a pragma on a check that declares no id at all.
 
-The id list ends at the first token that is not an id: a `--` reason, the delimiter closing a block comment, a second pragma token, or the line's end. Everything before that is read as ids, so a reason written without `--` names checks rather than explaining the decision: `// rdy-ignore because the API is frozen` suppresses for a check called `because`, and therefore for none. Write a reason behind `--`. Under `--json`, each check entry carries its `id` in both detail projections.
+The id list ends at the first token that is not an id: a `--` reason, the delimiter closing a block comment, a second pragma token, or the line's end. Everything before that is read as ids, so a reason written without `--` names checks rather than explaining the decision: `// rdy-ignore because the API is frozen` suppresses for a check called `because`, and therefore for none. Write a reason behind `--`. Under `--json`, each check entry includes its `id` in both detail projections.
 
 A suppressed finding leaves the audit rather than being downgraded: out of the detail, and out of both halves of the check's fraction, so a project that has settled every remaining site reaches completion rather than resting one short. An unqualified pragma takes the site out of every check's fraction at once, which is what keeps the checks of one run comparable; a qualified one takes it out of the checks it names and leaves it standing in the rest.
 
@@ -798,7 +798,7 @@ Configured packages are resolved through `node_modules` rather than through the 
 📓 smoke (readyup v0.22.0)
 ```
 
-A local `--from` source with no manifest falls back to listing the compiled kits on disk; those rows carry a name and path only. A remote source still requires a manifest.
+A local `--from` source with no manifest falls back to listing the compiled kits on disk; those rows have a name and path only. A remote source still requires a manifest.
 
 #### Listing a whole repository
 
@@ -844,15 +844,15 @@ The sweep considers every directory holding a `package.json`, the working direct
       📓 npm-auto-publish
 ```
 
-Every project's dependencies and configured packages are read from its own `package.json` and its own `.config/readyup.config.ts`, so a package one workspace names and another does not reads `not listed in the readyup config` only where it is unnamed. A workspace's own dependency is reachable from nowhere else, so its command carries the `cd` that gets there: `rdy run` takes no directory, and `--from` names a kit source rather than a working directory.
+Every project's dependencies and configured packages are read from its own `package.json` and its own `.config/readyup.config.ts`, so a package one workspace names and another does not reads `not listed in the readyup config` only where it is unnamed. A workspace's own dependency is reachable from nowhere else, so its command includes the `cd` that gets there: `rdy run` takes no directory, and `--from` names a kit source rather than a working directory.
 
 This sweep is wider than the one `--recursive` makes alone. It considers every directory holding a `package.json`, whether or not that directory has a readyup footprint, because a workspace authoring no kits of its own still declares dependencies that publish them -- and that workspace is the one the question is about. A project with no kit-publishing dependency is not rendered at all, its directory line included, and a sweep left with nothing prints `No dependency of any project below this directory publishes kits.`
 
-Unlike every other listing, this view carries no heading rules. The two rule weights it would otherwise need are a stroke apart, and the roles they would mark are already told apart by their glyphs; under `--style plain`, where the role glyphs are empty, the indentation carries all three levels on its own. That is also why each command is labelled `To run:`: it shares a column with the kits beneath it, and the label is what keeps it from reading as one more kit.
+Unlike every other listing, this view has no heading rules. The two rule weights it would otherwise need are a stroke apart, and the roles they would mark are already told apart by their glyphs; under `--style plain`, where the role glyphs are empty, the indentation marks all three levels on its own. That is also why each command is labelled `To run:`: it shares a column with the kits beneath it, and the label is what keeps it from reading as one more kit.
 
 Rows are keyed by `name`, `kind`, `project`, **and** `origin.package` together. Under the default configuration a compiled source appears twice -- once as `internal` and once as `compiled`. A package's kit is `compiled` like any other bundle, distinguished by the package it records rather than by a kind of its own, so `name` and `kind` alone collide between your kit and a package's kit of the same name; under `--recursive` they collide again between two projects that each hold a `default`, and under `--recursive --packages` between two workspaces depending on the same package. A consumer indexing on less than the full key silently drops a row.
 
-Every kit a package published carries `origin.configured`, reporting whether the config names that package and so whether `rdy run --packages` would reach it. It is emitted under `--packages`, under `--recursive --packages`, and under a plain `rdy list` alike, so a consumer never has to know which invocation wrote the payload; it is absent only from a payload written before the field existed. Candidates from the **Available** section are not kits and appear separately in `availablePackages`, which accompanies the owner listing alone: under `--packages` those packages' kits are rows of their own, so there is nothing left to name separately.
+Every kit a package published has `origin.configured`, reporting whether the config names that package and so whether `rdy run --packages` would reach it. It is emitted under `--packages`, under `--recursive --packages`, and under a plain `rdy list` alike, so a consumer never has to know which invocation wrote the payload; it is absent only from a payload written before the field existed. Candidates from the **Available** section are not kits and appear separately in `availablePackages`, which accompanies the owner listing alone: under `--packages` those packages' kits are rows of their own, so there is nothing left to name separately.
 
 ### Scaffolding
 
@@ -867,11 +867,11 @@ rdy init                       Scaffold a starter config and kit
 
 ## JSON output
 
-`run`, `compile`, `list`, and `verify` accept `--json`; `init` does not. With `--json`, stdout carries exactly one JSON document and every human-readable line goes to stderr. `--help` and `--version` have no JSON form.
+`run`, `compile`, `list`, and `verify` accept `--json`; `init` does not. With `--json`, stdout holds exactly one JSON document and every human-readable line goes to stderr. `--help` and `--version` have no JSON form.
 
 ### Published schemas
 
-Each payload is specified by a JSON Schema shipped with the package and carries an integer `schemaVersion` matching the `vN` in its filename.
+Each payload is specified by a JSON Schema shipped with the package and includes an integer `schemaVersion` matching the `vN` in its filename.
 
 | Payload        | Import path                              |
 | -------------- | ---------------------------------------- |
@@ -889,7 +889,7 @@ The five payloads version independently.
 
 - **Adding an optional field does not bump `schemaVersion`.** A validator pinned to `v1` keeps accepting payloads from a later ReadyUp.
 - **Removing, renaming, or re-typing a field does bump it**, publishing a new `vN` beside the old. Widening a closed set counts as re-typing.
-- **A field is `required` only when every payload carries it.** Omission is reserved for absent or empty data.
+- **A field is `required` only when every payload has it.** Omission is reserved for absent or empty data.
 - **`warnings[].code` is an open set**, exempt from the widening rule. Consumers must tolerate an unknown code, displaying its `message` and `remedy`. `error.code` stays closed.
 
 ### Error envelope
@@ -906,9 +906,9 @@ An invocation that fails before producing anything else emits:
 { "name": "release", "error": { "code": "kit-load", "message": "Cannot find .readyup/kits/release.js" } }
 ```
 
-An error entry carries no counts and no verdict, and the top-level totals cover only the kits that ran.
+An error entry has no counts and no verdict, and the top-level totals cover only the kits that ran.
 
-An error body may also carry `hint`, one action that would clear the failure:
+An error body may also include `hint`, one action that would clear the failure:
 
 ```json
 {
@@ -950,14 +950,14 @@ An error body may also carry `hint`, one action that would clear the failure:
 }
 ```
 
-- **`passed`** is the run verdict, agreeing with exit code 0 in every case. Kit and checklist entries carry their own.
+- **`passed`** is the run verdict, agreeing with exit code 0 in every case. Kit and checklist entries have their own.
 - **`counts`** holds the six tallies at report, kit, and checklist level, nested so count names and verdict names share no namespace.
 - **`worstSeverity`** is derived verdict data, omitted when nothing failed.
 - **`failOn`** and **`reportOn`** appear at the top level only when the corresponding flag was passed, and on every kit that ran as the value that governed it. See [thresholds](#thresholds) for how each resolves.
-- **`compiledWith`** names the readyup that built a kit's bundle. It appears on every kit that ran whose bundle carries a compile-time stamp, including where that stamp matches the report's own `readyupVersion`, and is absent for a bundle compiled before the stamp existed or for a kit run from source under `--jit`. `rdy verify`'s [`rebuildCompiledWith`](#verifying-by-recompiling) reports the same value under a narrower rule, appearing only where it disagrees with the running readyup: that field explains a mismatch, this one records what ran.
-- **`warnings`** carries any advisory as `{ code, message, remedy? }`, absent when none was raised.
+- **`compiledWith`** names the readyup that built a kit's bundle. It appears on every kit that ran whose bundle has a compile-time stamp, including where that stamp matches the report's own `readyupVersion`, and is absent for a bundle compiled before the stamp existed or for a kit run from source under `--jit`. `rdy verify`'s [`rebuildCompiledWith`](#verifying-by-recompiling) reports the same value under a narrower rule, appearing only where it disagrees with the running readyup: that field explains a mismatch, this one records what ran.
+- **`warnings`** lists any advisory as `{ code, message, remedy? }`, absent when none was raised.
 
-Payloads are slim by construction: a field carrying nothing is omitted rather than emitted as `null`, empty `checks` arrays are dropped, and `fix` appears only on failed checks.
+Payloads are slim by construction: an empty field is omitted rather than emitted as `null`, empty `checks` arrays are dropped, and `fix` appears only on failed checks.
 
 ### Detail level
 
@@ -975,7 +975,7 @@ The path from source to a consumer:
 4. Consumers run `rdy run --from github:org/repo`, which fetches the bundle the manifest describes.
 5. Run `rdy verify` in CI to catch a bundle edited by hand or a source left uncompiled, or `rdy verify --rebuild` to catch a bundle stale in anything the hashes do not record.
 
-A published package can carry its kits instead, so consumers reach them through the dependency they already have rather than through a repository URL. See [package-hosted kits](#package-hosted-kits).
+A published package can ship its kits instead, so consumers reach them through the dependency they already have rather than through a repository URL. See [package-hosted kits](#package-hosted-kits).
 
 ### Compiling
 
@@ -1035,9 +1035,9 @@ Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `fa
 
 The closure stops at `node_modules`. A dependency's contents are pinned by the lockfile and read exactly by [`rdy verify --rebuild`](#verifying-by-recompiling), while recording them would size a committed, per-compile-rewritten manifest to the dependency tree rather than to the kit: one `import zod` inlines 79 files.
 
-What the closure leaves out is recorded as versions instead: `esbuildVersion` names the bundler and `bundledDependencies` each inlined package, one entry per package rather than one per file. A package a bundle inlines at two versions at once records both, sorted and comma-separated. `bundledDependencies` is absent for a kit that bundles nothing, so `esbuildVersion` is the marker that an entry carries the record at all.
+What the closure leaves out is recorded as versions instead: `esbuildVersion` names the bundler and `bundledDependencies` each inlined package, one entry per package rather than one per file. A package a bundle inlines at two versions at once records both, sorted and comma-separated. `bundledDependencies` is absent for a kit that bundles nothing, so `esbuildVersion` is the marker that an entry has the record at all.
 
-An entry compiled before readyup recorded the closure carries no `inputs`; one compiled before the version record carries no `esbuildVersion`.
+An entry compiled before readyup recorded the closure has no `inputs`; one compiled before the version record has no `esbuildVersion`.
 
 ### Package-hosted kits
 
@@ -1076,7 +1076,7 @@ rdy run --packages       # the kit named `default`, from every listed package
 rdy run --packages drift # the kit named `drift`, from every listed package publishing it
 ```
 
-The kit name is the selector, exactly as it is for every other source, and each result carries the package and version it came from. A checklist filter is rejected in both spellings -- `--checklists` and inline `kit:checklist` -- because several listed packages may publish the named kit, leaving the checklists no single one to select within.
+The kit name is the selector, exactly as it is for every other source, and each result names the package and version it came from. A checklist filter is rejected in both spellings -- `--checklists` and inline `kit:checklist` -- because several listed packages may publish the named kit, leaving the checklists no single one to select within.
 
 A listed package that does not publish the requested kit is skipped. `rdy run --packages` asks whether this project satisfies what its listed packages require of it, and a package publishing no `default` requires nothing of it: that package contributes no kit, and a run that selects nothing reports as much and passes. The named form differs in one respect, because naming a kit asks for something specific: a name no listed package publishes is a usage error rather than an empty run.
 
@@ -1101,7 +1101,7 @@ ReadyUp publishes two kits of its own, about readyup projects themselves. Any pr
 ```bash
 rdy run --from npm:readyup            # default: authoring hygiene, advisory
 rdy run --from npm:readyup publishing # publication readiness, blocking
-rdy list --from npm:readyup           # both, with the checklists each one carries
+rdy list --from npm:readyup           # both, with the checklists each one has
 ```
 
 `default` reports at `warn` and below, so it is safe to run mid-edit:
@@ -1158,7 +1158,7 @@ rdy verify --rebuild           Also recompile each kit and compare it to the com
 1 of 2 kits failed verification.
 ```
 
-Each kit carries three independent verdicts. The compiled output is `ok`, `drift`, `missing`, or `unverified`; the source is `ok`, `stale`, `missing`, or `unverified`; the [recorded inputs](#what-a-manifest-entry-records) are `ok`, `stale`, or `unverified`. `drift` means someone edited the bundle by hand; a stale source means the TypeScript moved on and nobody recompiled; stale inputs mean the same of a module the bundle inlined or a JSON projection it substituted. A kit can be all three at once.
+Each kit has three independent verdicts. The compiled output is `ok`, `drift`, `missing`, or `unverified`; the source is `ok`, `stale`, `missing`, or `unverified`; the [recorded inputs](#what-a-manifest-entry-records) are `ok`, `stale`, or `unverified`. `drift` means someone edited the bundle by hand; a stale source means the TypeScript moved on and nobody recompiled; stale inputs mean the same of a module the bundle inlined or a JSON projection it substituted. A kit can be all three at once.
 
 The inputs verdict names every input that failed rather than the first, each on its own line, separating a changed module from a changed inline projection. A projected file that is still present while the fields the kit picked are gone is reported as `unprojectable`, which says something about the kit rather than about the file:
 
@@ -1170,7 +1170,7 @@ The inputs verdict names every input that failed rather than the first, each on 
 
 Anything other than `ok` or `unverified` on any axis fails the run. `unverified` does not, since an entry with no recorded hash -- or one compiled before readyup recorded the input closure -- says nothing about whether the kit changed.
 
-Under `--json`, each kit reports `status`, `sourceStatus`, and `inputsStatus`. A `drift` verdict carries `expected` and `actual`; a stale source carries `sourceExpected` and `sourceActual`; stale inputs carry `inputFailures`, one entry per input naming its `kind`, `path`, and `reason`, plus whichever of `expected`, `actual`, and `detail` that reason has.
+Under `--json`, each kit reports `status`, `sourceStatus`, and `inputsStatus`. A `drift` verdict reports `expected` and `actual`; a stale source reports `sourceExpected` and `sourceActual`; stale inputs report `inputFailures`, one entry per input naming its `kind`, `path`, and `reason`, plus whichever of `expected`, `actual`, and `detail` that reason has.
 
 In CI:
 
@@ -1206,7 +1206,7 @@ The comparison is against the bundle on disk, never the recorded hash, so the ve
 
 The verdict is `ok`, `mismatch`, `failed` (the source no longer compiles), or `missing` (nothing to recompile, or nothing to compare against). Only `ok` passes. There is no `unverified` here: an exactness check that waived the kits it could not reach would establish less than it appears to.
 
-Under `--json`, each kit adds `rebuildStatus`. A `mismatch` carries `rebuildExpected` and `rebuildActual`, plus `rebuildCompiledWith` when the bundle was built by a different readyup, `rebuildEsbuild` (the recorded esbuild against the rebuild's) whenever the entry records one, and `rebuildDependencyChanges` when at least one bundled package's version moved; a `failed` carries `rebuildError`. Without the flag, none of these fields appears.
+Under `--json`, each kit adds `rebuildStatus`. A `mismatch` reports `rebuildExpected` and `rebuildActual`, plus `rebuildCompiledWith` when the bundle was built by a different readyup, `rebuildEsbuild` (the recorded esbuild against the rebuild's) whenever the entry records one, and `rebuildDependencyChanges` when at least one bundled package's version moved; a `failed` reports `rebuildError`. Without the flag, none of these fields appears.
 
 Three things to know before wiring it into CI: It requires esbuild, which a repository that compiles kits already has. The readyup version forms part of a bundle's hash, so a readyup upgrade makes every kit mismatch until recompiled; an esbuild or dependency upgrade mismatches wherever it changes a bundle, and the mismatch clause names it. And it must not run after a step that recompiles kits, because recompilation would defeat the comparison.
 
@@ -1270,7 +1270,7 @@ Every path a check utility takes resolves against `cwd` unless it is absolute, i
 | `hasDevDependency(name)`                              | Dev dependency is declared                |
 | `hasMinDevDependencyVersion(name, version, options?)` | Dev dependency meets a minimum            |
 
-`hasMinDevDependencyVersion` compares the floor against the version it reads out of the specifier in `package.json`, so the specifier's protocol can settle the answer before any comparison happens. Any `workspace:`-prefixed specifier satisfies any floor, `workspace:^1.2.3` included: it links to the package the repo builds, and a repo that publishes a package is not a consumer of it. A `catalog:` specifier settles nothing on its own and is resolved through `pnpm-workspace.yaml` in the working directory, and the version found there is what the floor is compared against. `catalog:` names the `default` catalog, which pnpm also spells `catalog:default`, and which the file writes as the top-level `catalog:` block or as a `default` block under `catalogs:`; any other `catalog:<name>` selects its own block under `catalogs:`. A specifier the file does not resolve meets no floor, as does one whose catalog entry opens a YAML construct this reader does not follow, such as an alias or a flow mapping. A version reached that way is read the same as a declared one, so a catalog entry of `workspace:*` satisfies any floor in its turn. The version is read from the start of the specifier, past any range operator, so one naming fewer than three segments (`7`, `^6`) is measured rather than skipped; a specifier carrying its version elsewhere, as the `npm:` alias protocol does, is read for a three-segment version anywhere in it. Pass `options.exempt` to exempt further specifiers; it receives the specifier as written, so a catalogued dependency reaches it as `catalog:` rather than as the version behind it, and it adds to the built-in exemption rather than replacing it.
+`hasMinDevDependencyVersion` compares the floor against the version it reads out of the specifier in `package.json`, so the specifier's protocol can settle the answer before any comparison happens. Any `workspace:`-prefixed specifier satisfies any floor, `workspace:^1.2.3` included: it links to the package the repo builds, and a repo that publishes a package is not a consumer of it. A `catalog:` specifier settles nothing on its own and is resolved through `pnpm-workspace.yaml` in the working directory, and the version found there is what the floor is compared against. `catalog:` names the `default` catalog, which pnpm also spells `catalog:default`, and which the file writes as the top-level `catalog:` block or as a `default` block under `catalogs:`; any other `catalog:<name>` selects its own block under `catalogs:`. A specifier the file does not resolve meets no floor, as does one whose catalog entry opens a YAML construct this reader does not follow, such as an alias or a flow mapping. A version reached that way is read the same as a declared one, so a catalog entry of `workspace:*` satisfies any floor in its turn. The version is read from the start of the specifier, past any range operator, so one naming fewer than three segments (`7`, `^6`) is measured rather than skipped; a specifier with its version elsewhere, as the `npm:` alias protocol does, is read for a three-segment version anywhere in it. Pass `options.exempt` to exempt further specifiers; it receives the specifier as written, so a catalogued dependency reaches it as `catalog:` rather than as the version behind it, and it adds to the built-in exemption rather than replacing it.
 
 ### Versions and runtime alignment
 
@@ -1284,7 +1284,7 @@ Every path a check utility takes resolves against `cwd` unless it is absolute, i
 | `readTsconfigLanguageLevel(path)`    | Effective `lib` and `target`, resolved through `extends`                                 |
 | `readTsconfigChain(path)`            | Each config the `extends` chain reaches, and what it declares in its own right           |
 
-Each reader answers only what it can see, so a check composing them decides for itself what each unknown means. `readEnginesNodeFloor` recognizes only forms from which a single floor follows (`>=24`, `^22.1`, `24.1.0`); a union or wildcard comes back `unparseable` rather than an invented floor. `readTsconfigLanguageLevel` resolves `extends` as TypeScript does, following relative paths and published base configs alike; it also returns `chain` (the configs it read) and `unresolvedExtends` (references it could not follow), so a check can tell an incomplete answer from an undeclared setting. `readTsconfigChain` reports that same walk one layer down: every config it reached, the `extends` specifier that reached each one, and what each declares in its own right, with values left exactly as written. Reach for it to ask which config declared a setting, or to read a field the language-level reader does not cover, such as `files` or `include`. The specifier is a chain entry's stable identity: a package's path shifts with install layout, resolving under `node_modules/.pnpm/` in one project and under a linked workspace directory in another. Where two `extends` branches reach one config, the entry names the branch that reached it first.
+Each reader reports only what it can see, so a check composing them decides for itself what each unknown means. `readEnginesNodeFloor` recognizes only forms from which a single floor follows (`>=24`, `^22.1`, `24.1.0`); a union or wildcard comes back `unparseable` rather than an invented floor. `readTsconfigLanguageLevel` resolves `extends` as TypeScript does, following relative paths and published base configs alike; it also returns `chain` (the configs it read) and `unresolvedExtends` (references it could not follow), so a check can tell an incomplete answer from an undeclared setting. `readTsconfigChain` reports that same walk one layer down: every config it reached, the `extends` specifier that reached each one, and what each declares in its own right, with values left exactly as written. Reach for it to ask which config declared a setting, or to read a field the language-level reader does not cover, such as `files` or `include`. The specifier is a chain entry's stable identity: a package's path shifts with install layout, resolving under `node_modules/.pnpm/` in one project and under a linked workspace directory in another. Where two `extends` branches reach one config, the entry names the branch that reached it first.
 
 ```ts
 import {
@@ -1329,7 +1329,7 @@ const findings = discoverWorkspaces().flatMap(({ dir, packageJson }) => {
 
 ### Workspaces
 
-`discoverWorkspaces()` returns a uniform `Workspace[]` collapsing pnpm, npm, and yarn monorepo conventions -- and single-workspace repos -- into one iteration shape. Each entry carries `dir` (relative to `cwd`; `'.'` for the repo root), `absolutePath`, `name`, `isPackage` (`package.json.private !== true`), `isRoot`, and the parsed `packageJson`.
+`discoverWorkspaces()` returns a uniform `Workspace[]` collapsing pnpm, npm, and yarn monorepo conventions -- and single-workspace repos -- into one iteration shape. Each entry has `dir` (relative to `cwd`; `'.'` for the repo root), `absolutePath`, `name`, `isPackage` (`package.json.private !== true`), `isRoot`, and the parsed `packageJson`.
 
 The repo root is reported in every shape, exactly once, so every call shape is a filter over one list rather than a list a caller adds the root to and dedupes.
 
@@ -1352,7 +1352,7 @@ Discovery is memoized per `cwd` for the life of the process: Repeated calls in o
 const missing = discoverKitPackages().filter((name) => !configuredPackages.includes(name));
 ```
 
-It answers best effort: a project manifest it cannot read or parse yields `[]`. An empty result therefore does not distinguish a project with no kit-publishing dependencies from one whose manifest could not be read, which a check treating the result as authoritative would report as a pass either way.
+It is best effort: a project manifest it cannot read or parse yields `[]`. An empty result therefore does not distinguish a project with no kit-publishing dependencies from one whose manifest could not be read, which a check treating the result as authoritative would report as a pass either way.
 
 ### Project sources
 
@@ -1369,7 +1369,7 @@ These six are what an adoption kit needs -- one reporting where a project hand-r
 
 `listTrackedFiles` lists with `git ls-files -z`. The `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in quotes, and that file drops out of the sweep unreported. Below the repo root git emits paths relative to `cwd` and limited to that subtree, the same scope a relative `readFile` path works in. The sweep therefore follows the project `rdy` was invoked in, never the repository a kit was loaded from.
 
-`readTrackedSources` applies its filter before any read, so a caller never pays for a file it excluded, and holds what it read for the life of the process. A file two kits both select costs one read between them, and each pays only for the remainder the other did not ask for. That cache lives here rather than in a kit because a compiled kit leaves its `readyup` imports unbundled, making `check-utils` one module instance across every kit of a run; a cache inside a bundled helper would be one per bundle. Listings are held the same way and are shared by checks that start together, which the runner does. The sweep never reads `node_modules/` or `.readyup/kits/*.js` whatever the filter answers for them -- the latter is readyup's own generated artifact, and sweeping it would report a kit's bundled source back to its author. That kit exclusion names the default `compile.outDir`; a project compiling its kits elsewhere excludes that directory itself. A caller wanting further exclusions applies them in its own filter.
+`readTrackedSources` applies its filter before any read, so a caller never pays for a file it excluded, and holds what it read for the life of the process. A file two kits both select costs one read between them, and each pays only for the remainder the other did not ask for. That cache lives here rather than in a kit because a compiled kit leaves its `readyup` imports unbundled, making `check-utils` one module instance across every kit of a run; a cache inside a bundled helper would be one per bundle. Listings are held the same way and are shared by checks that start together, which the runner does. The sweep never reads `node_modules/` or `.readyup/kits/*.js` whatever the filter returns for them -- the latter is readyup's own generated artifact, and sweeping it would report a kit's bundled source back to its author. That kit exclusion names the default `compile.outDir`; a project compiling its kits elsewhere excludes that directory itself. A caller wanting further exclusions applies them in its own filter.
 
 It also reports the paths it returns to the run, which is the evidence a [pragma that suppressed nothing](#advisory-warnings) is judged against, so a check reading the project this way declares no `scanned` of its own and a sweep it reads in `skip` counts as much as one it reads in `check`. `listTrackedFiles` reports nothing, so a check taking that listing and reading the files itself declares `scanned`.
 
@@ -1381,7 +1381,7 @@ It also reports the paths it returns to the run, which is the evidence a [pragma
 
 `buildFindingReport` takes every finding the project holds plus a predicate selecting the ones the calling check reports, and returns them as a `FindingOutcome` for the runner to suppress, render, and count. The runner names each reported finding as `symbol (path:line)`, or `path:line` where it declares no symbol, and derives the fraction from every finding passed rather than only the reported ones, so the checks of one run share a denominator the reader can compare across them.
 
-Pass `ownImplementation` -- the package name, the export names, and the swept sources -- and every finding sited in that package's own implementation drops, from the detail and from both halves of the fraction. A declaration qualifies by being exported under one of the named exports from a file inside a workspace whose `package.json` names the package, so the repo publishing an idiom is not told it hand-rolled it. The same doctrine governs `hasMinDevDependencyVersion`: a repo that publishes a package is not a consumer of it. The rule is declaration-scoped, because a workspace is the whole repository in a single-package project, where a workspace-wide rule would turn the check off, and the argument carries one step further: the reasoning reaches the wrapper alone, so a neighbouring declaration in the same file is ordinary code and is still reported. A declaration owns the lines from its own head to the line before the next head, or to the file's last line where it is the last, because a generic constraint's braces and a return-type annotation's both defeat a scan for the closing brace and a span cut short reports the implementation the rule exists to exempt. A re-exporting barrel declares no implementation and holds no exempted lines; a file in the package that declares the name without exporting it is a hand-roll and is still reported. A file that declares the export under another name and renames it on export from a second file is not recognized, which surfaces in the publishing repo itself rather than in a consumer's.
+Pass `ownImplementation` -- the package name, the export names, and the swept sources -- and every finding sited in that package's own implementation drops, from the detail and from both halves of the fraction. A declaration qualifies by being exported under one of the named exports from a file inside a workspace whose `package.json` names the package, so the repo publishing an idiom is not told it hand-rolled it. The same doctrine governs `hasMinDevDependencyVersion`: a repo that publishes a package is not a consumer of it. The rule is declaration-scoped, because a workspace is the whole repository in a single-package project, where a workspace-wide rule would turn the check off, and the argument goes one step further: the reasoning reaches the wrapper alone, so a neighbouring declaration in the same file is ordinary code and is still reported. A declaration owns the lines from its own head to the line before the next head, or to the file's last line where it is the last, because a generic constraint's braces and a return-type annotation's both defeat a scan for the closing brace and a span cut short reports the implementation the rule exists to exempt. A re-exporting barrel declares no implementation and holds no exempted lines; a file in the package that declares the name without exporting it is a hand-roll and is still reported. A file that declares the export under another name and renames it on export from a second file is not recognized, which surfaces in the publishing repo itself rather than in a consumer's.
 
 The [`rdy-ignore` pragma](#suppressing-a-finding) is honored by the runner rather than here, which is the layer holding both the check and the provenance a pragma naming that check is matched against. A kit passes nothing for it and recognizes nothing: the pragma is readyup's, so every kit reporting through this path speaks one dialect of it rather than each publishing its own. Give the check an `id` and a consumer can suppress its findings by name.
 

--- a/packages/readyup/agents/README.md
+++ b/packages/readyup/agents/README.md
@@ -4,12 +4,12 @@ This directory is a CodeAssembly content root, declared by the `codeassembly.con
 
 ## Why the rulebook delivers as a skill
 
-`guidance/rulebooks/readyup-kits.md` carries `delivery: skill`, so CodeAssembly renders it as a `consult-readyup-kits` skill in each consuming repo rather than injecting its body at launch.
+`guidance/rulebooks/readyup-kits.md` declares `delivery: skill`, so CodeAssembly renders it as a `consult-readyup-kits` skill in each consuming repo rather than injecting its body at launch.
 
 Ambient delivery fails here on three counts:
 
 - **Relevance rate.** nmr's ambient cheatsheet is paid on every task and repays it, because `nmr` is invoked in nearly every session. Kit authoring is episodic: a consuming repo writes its kit once, extends it a few times a year, and runs `rdy` in CI forever.
-- **Compression.** An ambient body has to stay a cheatsheet. The worked-cases table is what makes the skip rule land, and a cheatsheet cannot carry it.
+- **Compression.** An ambient body has to stay a cheatsheet. The worked-cases table is what makes the skip rule land, and a cheatsheet cannot hold it.
 - **Duplication.** Harnesses list installed skills by name and description, so a skill's description already occupies the ambient slot. Delivering ambient as well would pay twice for one signal.
 
 Both modes require the consumer to run `codeassembly sync`, so the choice costs nothing in adoption.

--- a/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
+++ b/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
@@ -25,7 +25,7 @@ The second question is a fast check, not the rule. A skip is correct whenever th
 | `code-quality workflow does not use nmr prepush`  | pass                                    | the skip masks a pass                                  |
 | `.github/labels.yaml exists`                      | pass                                    | the skip is correct; release-kit does not own the file |
 
-The last row is the one the fast check alone gets wrong. `.github/labels.yaml` is a filename several label-sync tools write, and release-kit generates it only from a `repoLabels` block, so a repo carrying that file without the block would have passed `fileExists` and still deserves the skip.
+The last row is the one the fast check alone gets wrong. `.github/labels.yaml` is a filename several label-sync tools write, and release-kit generates it only from a `repoLabels` block, so a repo with that file but no such block would have passed `fileExists` and still deserves the skip.
 
 The third row is the failure mode to watch for: `skip` and `check` ran the identical predicate, so the check could never pass.
 

--- a/packages/readyup/bin/rdy.js
+++ b/packages/readyup/bin/rdy.js
@@ -3,7 +3,7 @@ try {
   await import('../dist/esm/bin/rdy.js');
 } catch (error) {
   if (error.code === 'ERR_MODULE_NOT_FOUND') {
-    process.stderr.write('rdy: build output not found — run `pnpm run build` first\n');
+    process.stderr.write('rdy: build output not found -- run `nmr build` first\n');
   } else {
     process.stderr.write(`rdy: failed to load: ${error.message}\n`);
   }

--- a/packages/readyup/src/__tests__/packaging.tool.test.ts
+++ b/packages/readyup/src/__tests__/packaging.tool.test.ts
@@ -18,11 +18,11 @@ describe('published tarball', () => {
     packedPaths = listPackedPaths();
   }, 120_000);
 
-  it('carries the CodeAssembly content root declared by codeassembly.content', () => {
+  it('includes the CodeAssembly content root declared by codeassembly.content', () => {
     expect(packedPaths).toContain('agents/guidance/rulebooks/readyup-kits.md');
   });
 
-  it('carries the README that `rdy help <topic>` reads its sections from', () => {
+  it('includes the README that `rdy help <topic>` reads its sections from', () => {
     expect(packedPaths).toContain('README.md');
   });
 });

--- a/packages/readyup/src/__tests__/sideEffectFreeSrc.app.unit.test.ts
+++ b/packages/readyup/src/__tests__/sideEffectFreeSrc.app.unit.test.ts
@@ -50,7 +50,7 @@ describe('readyup source tree is side-effect-free', () => {
 
   it.each(checked)('%s contains only declarative top-level statements', (_rel, absolutePath) => {
     const offenders = findTopLevelSideEffects(absolutePath);
-    const formatted = offenders.map((o) => `  line ${o.line}: ${o.kind} — ${o.snippet}`).join('\n');
+    const formatted = offenders.map((o) => `  line ${o.line}: ${o.kind} -- ${o.snippet}`).join('\n');
     expect(offenders, `Found non-declarative top-level statements:\n${formatted}`).toStrictEqual([]);
   });
 

--- a/packages/readyup/src/bin/__tests__/route.compiledWithReporting.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.compiledWithReporting.unit.test.ts
@@ -50,7 +50,7 @@ describe('compile-time readyup version in the run report', () => {
     expect(parsed).toHaveProperty('kits.0.compiledWith', VERSION);
   });
 
-  it('omits the key for a bundle carrying no stamp', async () => {
+  it('omits the key for a bundle with no stamp', async () => {
     using io = captureStdio();
 
     await routeCommand(['unstamped', '--json']);

--- a/packages/readyup/src/bin/__tests__/route.styleSelection.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.styleSelection.unit.test.ts
@@ -105,7 +105,7 @@ describe('a style named ahead of the command', () => {
     expect(stdout).toMatch(/^\d+\.\d+\.\d+/u);
   });
 
-  it('still rejects a trailing --style that carries no value', async () => {
+  it('still rejects a trailing --style with no value', async () => {
     const { exitCode } = await route(['--style']);
 
     expect(exitCode).toBe(2);

--- a/packages/readyup/src/bin/__tests__/route.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.unit.test.ts
@@ -410,7 +410,7 @@ describe(routeCommand, () => {
     });
   });
 
-  it('writes no hint line for a failure that carries none', async () => {
+  it('writes no hint line for a failure that has none', async () => {
     mockParseRunArgs.mockImplementation(() => {
       throw usageError('nothing found');
     });
@@ -651,7 +651,7 @@ describe(routeCommand, () => {
       expect(stderr).toBe('');
     });
 
-    it('carries a hint as its own envelope field, leaving the message unchanged', async () => {
+    it('reports a hint as its own envelope field, leaving the message unchanged', async () => {
       mockParseRunArgs.mockImplementation(() => {
         throw usageError('nothing found', { hint: 'Set GITHUB_TOKEN.' });
       });
@@ -812,7 +812,7 @@ describe(routeCommand, () => {
       expect(mockParseRunArgs).toHaveBeenCalledWith(args);
     });
 
-    it('runs a bare word carrying a checklist filter as a kit', async () => {
+    it('runs a bare word with a checklist filter as a kit', async () => {
       mockParseRunArgs.mockReturnValue(parsedRunArgs({ kitSpecifiers: [{ kitName: 'lis', checklists: ['t'] }] }));
       mockRunCommand.mockResolvedValue(0);
 

--- a/packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts
@@ -49,7 +49,7 @@ describe(discoverKitPackages, () => {
     expect(discoverKitPackages(temp.dir)).not.toContain('undeclared-kit');
   });
 
-  it('answers with nothing when the project manifest cannot be read', () => {
+  it('returns nothing when the project manifest cannot be read', () => {
     using manifestless = createTempTree({}, { prefix: 'discover-no-manifest-' });
 
     expect(discoverKitPackages(manifestless.dir)).toStrictEqual([]);

--- a/packages/readyup/src/check-utils/__tests__/engines.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/engines.unit.test.ts
@@ -72,7 +72,7 @@ describe(satisfiesNodeFloor, () => {
     expect(satisfiesNodeFloor('23.9.9', '24')).toBe(false);
   });
 
-  it('accepts a leading `v`, as `process.version` carries', () => {
+  it('accepts a leading `v`, as `process.version` has', () => {
     expect(satisfiesNodeFloor('v24.18.0', '24')).toBe(true);
     expect(satisfiesNodeFloor('v20.6.0', 'v24')).toBe(false);
   });

--- a/packages/readyup/src/check-utils/__tests__/package-json.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/package-json.unit.test.ts
@@ -146,7 +146,7 @@ describe(hasMinDevDependencyVersion, () => {
     expect(hasMinDevDependencyVersion('vue', '3.0.0')).toBe(false);
   });
 
-  it('measures a catalog version carrying a range operator', ({ temp }) => {
+  it('measures a catalog version with a range operator', ({ temp }) => {
     writePackageJson(temp, { devDependencies: { react: 'catalog:' } });
     writeWorkspaceYaml(temp, ['catalog:', '  react: ^19.0.0', ''].join('\n'));
 

--- a/packages/readyup/src/check-utils/__tests__/pnpmWorkspaceYaml.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/pnpmWorkspaceYaml.unit.test.ts
@@ -29,7 +29,7 @@ describe(findPnpmCatalogVersion, () => {
     expect(findPnpmCatalogVersion(yaml, 'react')).toBe('^19.0.0');
   });
 
-  it('keeps a value carrying its own colon', () => {
+  it('keeps a value with its own colon', () => {
     const yaml = ['catalog:', '  readyup: workspace:*', ''].join('\n');
 
     expect(findPnpmCatalogVersion(yaml, 'readyup')).toBe('workspace:*');

--- a/packages/readyup/src/check-utils/__tests__/tsconfig.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/tsconfig.unit.test.ts
@@ -56,7 +56,7 @@ describe(readTsconfigChain, () => {
     expect(readTsconfigLanguageLevel('tsconfig.json')?.target).toBe('es2025');
   });
 
-  it('carries top-level fields that are not compilerOptions', ({ temp }) => {
+  it('reports top-level fields that are not compilerOptions', ({ temp }) => {
     temp.writeJson('tsconfig.json', { files: ['vite.config.ts'], include: ['src'] });
 
     expect(readTsconfigChain('tsconfig.json')?.entries[0]?.config).toStrictEqual({

--- a/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
@@ -71,7 +71,7 @@ describe(`${discoverWorkspaces.name} memoization`, () => {
     expect(readDirectories.length).toBeGreaterThan(walkedForFirstRoot);
   });
 
-  it('answers a later call in full after a caller empties the array it returned', ({ temp }) => {
+  it('returns a full array to a later call after a caller empties the one it returned', ({ temp }) => {
     writeMonorepo(temp);
 
     discoverWorkspaces().length = 0;

--- a/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
@@ -334,7 +334,7 @@ describe(discoverWorkspaces, () => {
 
       const [workspace] = discoverWorkspaces();
 
-      // `Object.isFrozen` answers true for `undefined`, so each subject is pinned before it is tested.
+      // `Object.isFrozen` returns true for `undefined`, so each subject is pinned before it is tested.
       expect(workspace).toBeDefined();
       expect(Object.isFrozen(workspace)).toBe(true);
       expect(Object.isFrozen(workspace?.packageJson)).toBe(true);

--- a/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
@@ -79,7 +79,7 @@ describe(buildFindingReport, () => {
     expect(outcome).toStrictEqual({ adoptedCount: 0, findings: [] });
   });
 
-  it('suppresses nothing, leaving a site carrying a pragma to the runner', ({ temp }) => {
+  it('suppresses nothing, leaving a site with a pragma to the runner', ({ temp }) => {
     temp.write('src/errors.ts', ['', ...Array.from({ length: 10 }, () => ''), 'x; // rdy-ignore', ''].join('\n'));
 
     const outcome = buildFindingReport({ adoptedCount: 0, findings: [CLONE], shouldReport: () => true });

--- a/packages/readyup/src/check-utils/project/__tests__/listOwnImplementationSpans.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listOwnImplementationSpans.unit.test.ts
@@ -157,7 +157,7 @@ describe(listOwnImplementationSpans, () => {
       expect(listOwnImplementationSpans(path, own)).toStrictEqual([]);
     });
 
-    it('exempts nothing when no workspace carries the declared name', ({ temp }) => {
+    it('exempts nothing when no workspace has the declared name', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/errors/src/describeError.ts';
       const sources = [{ path, text: 'export function describeError(error: unknown) {}' }];

--- a/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.tool.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.tool.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, test } from 'vitest';
 
 import { listTrackedFiles } from '../listTrackedFiles.ts';
 
-// Separated from the module's unit suite, which answers git from a stub: only real git escapes and quotes a path,
+// Separated from the module's unit suite, which stubs git: only real git escapes and quotes a path,
 // so only real git can show that `-z` defeats it.
 const it = test.extend(
   'temp',

--- a/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.unit.test.ts
@@ -95,7 +95,7 @@ function listInvocationCount(): number {
   return execFileAsync.mock.calls.filter(([, args]) => args.includes('ls-files')).length;
 }
 
-/** Answers the repo probe and the listing that follows it, defaulting the probe to a working tree. */
+/** Stubs the repo probe and the listing that follows it, defaulting the probe to a working tree. */
 function respondWith(options: { isRepo?: boolean; trackedOutput?: string }): void {
   const { isRepo = true, trackedOutput = '' } = options;
   execFileAsync.mockImplementation((_file, args) => {

--- a/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
@@ -243,7 +243,7 @@ function countReads(relativePath: string): number {
   return readPaths.filter((read) => read.endsWith(`/${relativePath}`)).length;
 }
 
-/** Answers the repo probe with a working tree, and the listing with the given paths. */
+/** Stubs the repo probe with a working tree, and the listing with the given paths. */
 function trackPaths(...paths: string[]): void {
   execFileAsync.mockImplementation((_file, args) => {
     if (args.includes('rev-parse')) return Promise.resolve({ stdout: '.git\n', stderr: '' });

--- a/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
@@ -90,7 +90,7 @@ describe(readTrackedSources, () => {
     expect(countProbes('src/rejected.ts')).toBe(0);
   });
 
-  it('never reads an excluded path, whatever the filter answers for it', async ({ temp }) => {
+  it('never reads an excluded path, whatever the filter returns for it', async ({ temp }) => {
     temp.write('src/kept.ts', 'kept');
     temp.write('node_modules/dependency/index.js', 'dependency');
     temp.write('.readyup/kits/default.js', 'bundle');

--- a/packages/readyup/src/check-utils/project/listOwnImplementationSpans.ts
+++ b/packages/readyup/src/check-utils/project/listOwnImplementationSpans.ts
@@ -66,7 +66,7 @@ function containsPath(dir: string, path: string): boolean {
 /**
  * Names the directories of the workspaces publishing the package.
  *
- * Discovery answers best effort here: a repo it cannot read reports as one holding no such workspace, so a check that
+ * Discovery is best effort here: a repo it cannot read reports as one holding no such workspace, so a check that
  * worked before the rule existed keeps working rather than erroring out of it. The match is on the declared name
  * alone, because what the rule needs is a repo holding the implementation, not one publishing it to a registry.
  */

--- a/packages/readyup/src/check-utils/project/readTrackedSources.ts
+++ b/packages/readyup/src/check-utils/project/readTrackedSources.ts
@@ -24,7 +24,7 @@ const textsByCwd = new Map<string, Map<string, string | undefined>>();
 /**
  * Reads one path's text, from the cache where a sweep already read it, and `undefined` where the path holds none.
  *
- * The exclusions governing what a sweep reads do not apply here. This answers about a path its caller already holds,
+ * The exclusions governing what a sweep reads do not apply here. This reports on a path its caller already holds,
  * such as the one a finding names, rather than deciding what a sweep goes looking at.
  */
 export function readSourceText(path: string): string | undefined {

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -26,7 +26,7 @@ export interface TsconfigChainEntry {
   /**
    * The `extends` specifier that reached this config; undefined for the entry config. Unlike `path`, it survives a
    * change of install layout: pnpm resolves a package under `.pnpm` and a workspace link under the directory it
-   * points at, so one base config answers to two different paths. Where two branches reach one config, it names the
+   * points at, so one base config resolves to two different paths. Where two branches reach one config, it names the
    * branch that reached it first.
    */
   specifier: string | undefined;

--- a/packages/readyup/src/compile/JsonProjectionError.ts
+++ b/packages/readyup/src/compile/JsonProjectionError.ts
@@ -22,7 +22,7 @@ export interface JsonProjectionErrorOptions {
  *
  * `reason` travels separately from `message` so a caller can report the failure in its own wording:
  * `pickJson` names the path as the kit wrote it, while a verdict over a recorded input names the kind
- * of staleness. Carrying the diagnosis as data is what keeps both from matching on message text.
+ * of staleness. Holding the diagnosis as data is what keeps both from matching on message text.
  */
 export class JsonProjectionError extends Error {
   /** The JSON file, absolute. */

--- a/packages/readyup/src/compile/__tests__/buildBundle.closure.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.closure.tool.test.ts
@@ -53,7 +53,7 @@ describe('buildBundle input closure', () => {
     expect(inputs).toContainEqual({ hash: expect.any(String), kind: 'module', path: path.join(treeRoot, 'helper.ts') });
   });
 
-  it('records a projected JSON file as an inline input carrying its path specifier', () => {
+  it('records a projected JSON file as an inline input with its path specifier', () => {
     expect(inputs).toContainEqual({
       hash: expect.any(String),
       kind: 'inline',

--- a/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/compileCommand.unit.test.ts
@@ -1371,7 +1371,7 @@ describe(compileCommand, () => {
     manifestExists: boolean;
   }
 
-  /** Answers `existsSync` per path, so the source directory and the manifest are arranged independently. */
+  /** Stubs `existsSync` per path, so the source directory and the manifest are arranged independently. */
   function arrangeExistence(existence: ArrangeExistenceArgs): void {
     const { srcDirExists, manifestExists } = existence;
     mockExistsSync.mockImplementation((target: unknown) =>

--- a/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/projectJsonFile.unit.test.ts
@@ -68,7 +68,7 @@ describe(projectJsonFile, () => {
   });
 
   // The detail names the root as JSON sees it, so an array and a null are distinguishable from an object.
-  it('reports a non-object root as not-an-object, carrying the type it found', async () => {
+  it('reports a non-object root as not-an-object, naming the type it found', async () => {
     const error = await captureProjectionError('[1,2,3]');
 
     expect(error.reason).toBe('not-an-object');

--- a/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
@@ -36,7 +36,7 @@ describe(resolveCompileRoot, () => {
     rmSync(treeRoot, { recursive: true, force: true });
   });
 
-  it('answers with the nearest ancestor holding a package.json', () => {
+  it('returns the nearest ancestor holding a package.json', () => {
     const root = resolveCompileRoot(path.join(treeRoot, 'outer', 'inner', 'kits', 'kit.ts'));
 
     expect(root).toBe(path.join(treeRoot, 'outer', 'inner'));
@@ -48,19 +48,19 @@ describe(resolveCompileRoot, () => {
     expect(root).toBe(path.join(treeRoot, 'outer'));
   });
 
-  it("answers with the source's own directory when no ancestor holds a package.json", () => {
+  it("returns the source's own directory when no ancestor holds a package.json", () => {
     const kitsDir = path.join(treeRoot, 'unpackaged', 'kits');
 
     expect(resolveCompileRoot(path.join(kitsDir, 'kit.ts'))).toBe(kitsDir);
   });
 
-  it('answers with a real path for a source reached through a symlinked ancestor', () => {
+  it('returns a real path for a source reached through a symlinked ancestor', () => {
     const root = resolveCompileRoot(path.join(treeRoot, 'link', 'inner', 'kits', 'kit.ts'));
 
     expect(root).toBe(path.join(treeRoot, 'outer', 'inner'));
   });
 
-  it('answers for a source that does not exist, leaving the failure to the bundler', () => {
+  it('returns a path for a source that does not exist, leaving the failure to the bundler', () => {
     const kitsDir = path.join(treeRoot, 'unpackaged', 'absent');
 
     expect(resolveCompileRoot(path.join(kitsDir, 'kit.ts'))).toBe(kitsDir);

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -63,7 +63,7 @@ const UNRESOLVED_SPECIFIER_HINT =
  * disk even when its source has not moved.
  */
 const GENERATED_HEADER = [
-  '/** @noformat — @generated. Do not edit. Compiled by rdy. */',
+  '/** @noformat -- @generated. Do not edit. Compiled by rdy. */',
   '/* eslint-disable */',
   `export const __readyupVersion = ${JSON.stringify(VERSION)};`,
   '',

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -47,7 +47,7 @@ export const ESBUILD_INSTALL_HINT = 'Install it with: pnpm add --save-dev esbuil
 /**
  * Why an import a kit resolved under the host repo's configuration no longer resolves.
  *
- * esbuild answers an unresolved import by suggesting the path be marked external, which for a kit
+ * esbuild responds to an unresolved import by suggesting the path be marked external, which for a kit
  * yields a bundle that fails at run time instead of at compile time. This names the cause its
  * suggestion cannot: `KIT_TSCONFIG` leaves kits with no `paths` aliases to resolve through.
  */

--- a/packages/readyup/src/errors/__tests__/RdyError.unit.test.ts
+++ b/packages/readyup/src/errors/__tests__/RdyError.unit.test.ts
@@ -17,13 +17,13 @@ describe(toRdyError, () => {
     expect(coerced.message).toBe('boom');
   });
 
-  it('forwards a hint carried by an unrecognized failure', () => {
+  it('forwards a hint on an unrecognized failure', () => {
     const coerced = toRdyError(Object.assign(new Error('boom'), { hint: 'Install it.' }));
 
     expect(coerced.hint).toBe('Install it.');
   });
 
-  it('leaves the hint absent when the failure carries none', () => {
+  it('leaves the hint absent when the failure has none', () => {
     expect(toRdyError(new Error('boom')).hint).toBeUndefined();
   });
 

--- a/packages/readyup/src/errors/__tests__/extractHint.unit.test.ts
+++ b/packages/readyup/src/errors/__tests__/extractHint.unit.test.ts
@@ -6,7 +6,7 @@ import { extractHint } from '../error-handling.ts';
 import { configError } from '../RdyError.ts';
 
 describe(extractHint, () => {
-  it('returns the hint an RdyError carries', () => {
+  it('returns the hint an RdyError has', () => {
     expect(extractHint(configError('boom', { hint: 'Set GITHUB_TOKEN.' }))).toBe('Set GITHUB_TOKEN.');
   });
 
@@ -14,14 +14,14 @@ describe(extractHint, () => {
     expect(extractHint(Object.assign(new Error('boom'), { hint: 'Install it.' }))).toBe('Install it.');
   });
 
-  it('returns the hint carried by an error thrown in another realm', () => {
+  it('returns the hint on an error thrown in another realm', () => {
     // A foreign realm has its own `Error`, so `instanceof` reports false for this value.
     const foreign: unknown = runInNewContext('Object.assign(new Error("boom"), { hint: "Install it." })');
 
     expect(extractHint(foreign)).toBe('Install it.');
   });
 
-  it('returns undefined for an error carrying no hint', () => {
+  it('returns undefined for an error with no hint', () => {
     expect(extractHint(new Error('boom'))).toBeUndefined();
   });
 
@@ -31,7 +31,7 @@ describe(extractHint, () => {
 
   it.each([
     ['a string', 'raw string'],
-    ['a plain object carrying a hint', { hint: 'not an Error' }],
+    ['a plain object with a hint', { hint: 'not an Error' }],
     ['null', null],
     ['undefined', undefined],
   ])('returns undefined for %s', (_label, value) => {

--- a/packages/readyup/src/help/__tests__/helpCommand.unit.test.ts
+++ b/packages/readyup/src/help/__tests__/helpCommand.unit.test.ts
@@ -39,7 +39,7 @@ describe('rdy help', () => {
     },
   );
 
-  it('carries the subsections of a topic that has them', async () => {
+  it('includes the subsections of a topic that has them', async () => {
     const { stdout } = await route(['help', 'concepts']);
 
     expect(stdout).toContain('### Severities');

--- a/packages/readyup/src/help/__tests__/readmeSection.unit.test.ts
+++ b/packages/readyup/src/help/__tests__/readmeSection.unit.test.ts
@@ -52,17 +52,17 @@ describe(extractSection, () => {
     expect(extractSection(MARKDOWN, 'Second')).not.toContain('```');
   });
 
-  it('returns undefined for a heading the document does not carry', () => {
+  it('returns undefined for a heading the document does not have', () => {
     expect(extractSection(MARKDOWN, 'Fourth')).toBeUndefined();
   });
 
-  it('matches a level-2 heading rather than a deeper one carrying the same text', () => {
+  it('matches a level-2 heading rather than a deeper one with the same text', () => {
     const markdown = ['### Concepts', '', 'Subsection body.', '', '## Concepts', '', 'Section body.', ''].join('\n');
 
     expect(extractSection(markdown, 'Concepts')).toBe(['## Concepts', '', 'Section body.', ''].join('\n'));
   });
 
-  it('returns undefined when only a deeper heading carries the text', () => {
+  it('returns undefined when only a deeper heading has the text', () => {
     expect(extractSection(['## Other', '', '### Concepts', '', 'Body.', ''].join('\n'), 'Concepts')).toBeUndefined();
   });
 });

--- a/packages/readyup/src/help/helpText.ts
+++ b/packages/readyup/src/help/helpText.ts
@@ -195,7 +195,7 @@ Examples:
   rdy run --fail-on warn                 Fail the run on warnings as well as errors
   rdy run --quiet                        Report only what is not passing
   rdy run --diagnose                     Report skips whose check would have passed
-  rdy run --json --detail summary        Emit a JSON report carrying only failed checks
+  rdy run --json --detail summary        Emit a JSON report with only failed checks
 
 ${DOCS_POINTER}
 `;

--- a/packages/readyup/src/init/__tests__/initCommand.scaffold.unit.test.ts
+++ b/packages/readyup/src/init/__tests__/initCommand.scaffold.unit.test.ts
@@ -43,7 +43,7 @@ describe('scaffolded kit', () => {
     expect(results).toMatchObject([{ name: 'NODE_ENV is set', status: 'passed', detail: 'NODE_ENV is production' }]);
   });
 
-  it('fails with NODE_ENV unset, reporting that the environment carries no value', async () => {
+  it('fails with NODE_ENV unset, reporting that the environment has no value', async () => {
     using _silent = silenceConsole(['error', 'info']);
 
     vi.stubEnv('NODE_ENV', undefined);

--- a/packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts
@@ -65,7 +65,7 @@ describe(collectKitPackageGroups, () => {
     expect(group?.kits.map((kit) => kit.kitName)).toStrictEqual(['drift', 'preflight']);
   });
 
-  it('carries the description a publisher records for its kit', ({ temp }) => {
+  it('reports the description a publisher records for its kit', ({ temp }) => {
     const group = collect([], temp.dir).find((one) => one.packageName === '@acme/kits');
 
     expect(group?.kits.map((kit) => kit.description)).toStrictEqual(['Dependency drift', undefined]);

--- a/packages/readyup/src/installed-packages/__tests__/resolvePackageRoot.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/resolvePackageRoot.unit.test.ts
@@ -33,7 +33,7 @@ describe(resolvePackageRoot, () => {
       expect(root).toBe(path.join(REPO_ROOT, 'packages', 'readyup'));
     });
 
-    it('answers undefined for a package that is not installed', () => {
+    it('returns undefined for a package that is not installed', () => {
       expect(resolvePackageRoot('readyup-package-that-does-not-exist', REPO_ROOT)).toBeUndefined();
     });
   });
@@ -67,7 +67,7 @@ describe(resolvePackageRoot, () => {
       );
     });
 
-    it('ignores a node_modules entry that carries no manifest', () => {
+    it('ignores a node_modules entry with no manifest', () => {
       expect(resolvePackageRoot('readyup-fixture-manifestless', nestedDir)).toBeUndefined();
     });
   });

--- a/packages/readyup/src/kitImports/UnresolvableKitImportsError.ts
+++ b/packages/readyup/src/kitImports/UnresolvableKitImportsError.ts
@@ -15,7 +15,7 @@ export interface UnresolvableImports {
 /**
  * A compiled kit binding readyup symbols the running readyup cannot supply.
  *
- * Carries findings rather than a composed message: the remedy depends on where the kit came from, which only the
+ * Holds findings rather than a composed message: the remedy depends on where the kit came from, which only the
  * boundary that resolved the kit knows.
  */
 export class UnresolvableKitImportsError extends Error {

--- a/packages/readyup/src/kitImports/__tests__/scanReadyupImports.unit.test.ts
+++ b/packages/readyup/src/kitImports/__tests__/scanReadyupImports.unit.test.ts
@@ -79,7 +79,7 @@ describe(scanReadyupImports, () => {
     expect(found[0]?.names).toStrictEqual(['fileExists']);
   });
 
-  it('keeps every name in a clause where only one carries a comment', async () => {
+  it('keeps every name in a clause where only one has a comment', async () => {
     const found = await scanReadyupImports('import { a, /* c */ b } from "readyup";');
 
     expect(found[0]?.names).toStrictEqual(['a', 'b']);

--- a/packages/readyup/src/kits/__tests__/assertIsRdyKit.unit.test.ts
+++ b/packages/readyup/src/kits/__tests__/assertIsRdyKit.unit.test.ts
@@ -390,7 +390,7 @@ describe(assertIsRdyKit, () => {
       ).not.toThrow();
     });
 
-    it('accepts a check carrying every optional field', () => {
+    it('accepts a check with every optional field', () => {
       expect(() =>
         assertIsRdyKit({
           checklists: [

--- a/packages/readyup/src/kits/__tests__/loadRdyKit.unit.test.ts
+++ b/packages/readyup/src/kits/__tests__/loadRdyKit.unit.test.ts
@@ -218,7 +218,7 @@ describe(loadRdyKit, () => {
     expect(kit.checklists[0]?.name).toBe('test');
   });
 
-  it('carries through fixLocation when present', async () => {
+  it('passes fixLocation through when present', async () => {
     const validChecklists = [{ name: 'test', checks: [{ name: 'a', check: () => true }] }];
     mockExistsSync.mockReturnValue(true);
     mockJitiImport.mockResolvedValue({ checklists: validChecklists, fixLocation: 'inline' });

--- a/packages/readyup/src/kits/loadRdyKit.ts
+++ b/packages/readyup/src/kits/loadRdyKit.ts
@@ -83,7 +83,7 @@ function diagnoseMissingKit(resolvedPath: string): string {
   const available = listAvailableKits(dir, extension);
 
   // Scaffolding is the remedy only for a project that has no kits at all. A directory holding kits
-  // under other names is answered with those names, whichever kit was asked for.
+  // under other names gets those names back, whichever kit was asked for.
   if (available.length === 0 && name === 'default' && dir === path.resolve(process.cwd(), KITS_DIR)) {
     return `Kit "default" not found at ${toDisplayPath(resolvedPath)}. Run 'rdy init' to create one.`;
   }

--- a/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
@@ -44,7 +44,7 @@ describe('formatCheckLine', () => {
     expect(line).toBe(`${FAILED_ERROR} suite [toolbelt.errors/no-instanceof-error] [7 of 10]`);
   });
 
-  it('carries exactly one separator when both detail and progress are present', () => {
+  it('renders exactly one separator when both detail and progress are present', () => {
     const line = engine.formatCheckLine({
       token: 'failedError',
       name: 'suite',
@@ -146,7 +146,7 @@ describe('formatReasonBlock', () => {
     expect(reason).toBe('   lockfile out of date');
   });
 
-  it('indents every line of a reason that carries its own line breaks', () => {
+  it('indents every line of a reason with its own line breaks', () => {
     const [reason] = engine.formatReasonBlock(['rebuild failed (first line\nsecond line)']);
 
     expect(reason).toBe('   rebuild failed (first line\n   second line)');
@@ -169,7 +169,7 @@ describe('formatHeading', () => {
   });
 
   // Separation belongs to whoever emits the sequence, so two adjacent headings cannot each contribute one.
-  it('carries no blank line of its own', () => {
+  it('renders no blank line of its own', () => {
     expect(engine.formatHeading('deploy', 'kit')).not.toContain('\n');
   });
 
@@ -180,7 +180,7 @@ describe('formatHeading', () => {
     expect(rendered).not.toContain('---');
   });
 
-  it('carries detail behind the separator', () => {
+  it('renders detail behind the separator', () => {
     expect(engine.formatHeading('deploy', 'kit', 'not configured')).toBe(
       '\u{2501}\u{2501} deploy \u{00B7} not configured',
     );
@@ -249,7 +249,7 @@ describe('formatBreadcrumbLabel', () => {
     { role: 'checklist', text: 'repo' },
   ];
 
-  it('parts the segments as a heading does, carrying none of their glyphs', () => {
+  it('separates the segments as a heading does, with none of their glyphs', () => {
     expect(engine.formatBreadcrumbLabel(segments)).toBe('@acme/release-kit@2.1.0 / npm-auto-publish / repo');
   });
 
@@ -301,7 +301,7 @@ describe('formatCounts', () => {
     expect(engine.formatCounts(makeCounts({ blocked: 3, optional: 4 }))).toBe('3 blocked, 4 skipped');
   });
 
-  it('carries no per-field tokens', () => {
+  it('renders no per-field tokens', () => {
     const counts = makeCounts({ passed: 1, errors: 1, blocked: 1, optional: 1, worstSeverity: 'error' });
 
     for (const { glyph } of Object.values(richFormatter.tokens)) {
@@ -365,7 +365,7 @@ describe('formatSummaryTable', () => {
   });
 
   // The run's writer separates one block from the next, so a table with its own blanks would double the gap.
-  it('carries no blank line of its own', () => {
+  it('renders no blank line of its own', () => {
     expect(engine.formatSummaryTable(input)).not.toContain('');
   });
 
@@ -420,7 +420,7 @@ describe('formatSummaryTable', () => {
     expect(lines[3]?.startsWith(PASSED)).toBe(true);
   });
 
-  it('names a row by its breadcrumb, carrying no role glyphs', () => {
+  it('names a row by its breadcrumb, with no role glyphs', () => {
     const lines = engine.formatSummaryTable({
       rows: [
         makeRow({
@@ -438,7 +438,7 @@ describe('formatSummaryTable', () => {
     expect(lines[2]).toBe(`${PASSED} @acme/release-kit@2.1.0 / default / repo  100ms  1 passed`);
   });
 
-  it('pads to the widest breadcrumb when rows carry different segment counts', () => {
+  it('pads to the widest breadcrumb when rows have different segment counts', () => {
     const lines = engine.formatSummaryTable({
       rows: [
         makeRow({

--- a/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
@@ -199,7 +199,7 @@ describe('formatHeading', () => {
 });
 
 describe('formatBreadcrumb', () => {
-  it('parts each segment from the next with a spaced separator', () => {
+  it('separates each segment from the next with a spaced separator', () => {
     const rendered = engine.formatBreadcrumb(
       [
         { role: 'sourcePackage', text: '@acme/release-kit@2.1.0' },

--- a/packages/readyup/src/layout/__tests__/plainFormatter.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/plainFormatter.unit.test.ts
@@ -50,7 +50,7 @@ describe('rendered output', () => {
     expect(engine.formatCheckLine({ token: 'failedError', name: 'migrations' })).toBe('FAIL  migrations');
   });
 
-  it('reserves the gutter for a token carrying no glyph, so names stay in one column', () => {
+  it('reserves the gutter for a token with no glyph, so names stay in one column', () => {
     const noun = engine.formatCheckLine({ token: 'kit', name: 'deploy' });
     const status = engine.formatCheckLine({ token: 'passed', name: 'deploy' });
 

--- a/packages/readyup/src/layout/__tests__/plainFormatter.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/plainFormatter.unit.test.ts
@@ -58,7 +58,7 @@ describe('rendered output', () => {
     expect(noun).toBe('      deploy');
   });
 
-  it('parts a detail from the name with an ASCII separator', () => {
+  it('separates a detail from the name with an ASCII separator', () => {
     expect(engine.formatCheckLine({ token: 'failedWarn', name: 'lint', detail: 'not installed' })).toBe(
       'WARN  lint - not installed',
     );

--- a/packages/readyup/src/layout/__tests__/richFormatter.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/richFormatter.unit.test.ts
@@ -44,7 +44,7 @@ describe('richFormatter', () => {
       expect(width).toBe(2);
     });
 
-    it('carries no variation selector', () => {
+    it('renders no variation selector', () => {
       expect(glyph).not.toContain(VARIATION_SELECTOR_16);
     });
 

--- a/packages/readyup/src/list/__tests__/formatList.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/formatList.unit.test.ts
@@ -85,7 +85,7 @@ describe(formatOwnerView, () => {
   });
 
   // A blank separates one section from the next, and the first section opens the output with no blank at all.
-  it('parts one section from the next with a blank line, opening with none', () => {
+  it('separates one section from the next with a blank line, opening with none', () => {
     const lines = formatOwnerView({
       internalKits: ['deploy'],
       compiledKits: ['monitor'],
@@ -460,7 +460,7 @@ describe(formatPackagesView, () => {
     expect(result).not.toContain('preflight \u{00B7}');
   });
 
-  it('parts one package block from the next with a blank line', () => {
+  it('separates one package block from the next with a blank line', () => {
     const result = formatPackagesView({
       groups: [
         buildGroup({ packageName: '@acme/kits', kits: ['drift'] }),
@@ -548,7 +548,7 @@ describe(formatRecursiveView, () => {
     expect(result).toContain('demo');
   });
 
-  it('parts one project block from the next with a blank line, opening with none', () => {
+  it('separates one project block from the next with a blank line, opening with none', () => {
     const lines = formatRecursiveView({
       projects: [buildProject({ dir: '.', kits: ['demo'] }), buildProject({ dir: 'packages/ui', kits: ['deploy'] })],
     }).split('\n');
@@ -674,7 +674,7 @@ describe(formatRecursivePackagesView, () => {
     expect(result).toContain(`${COMPILED} drift \u{00B7} Dependency drift`);
   });
 
-  it('parts one package from the next with a blank line, and keeps the directory against its first', () => {
+  it('separates one package from the next with a blank line, and keeps the directory against its first', () => {
     const result = formatRecursivePackagesView({
       projects: [
         buildProjectPackages({

--- a/packages/readyup/src/list/__tests__/formatList.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/formatList.unit.test.ts
@@ -481,7 +481,7 @@ describe(formatRecursiveView, () => {
     setStyle('rich');
   });
 
-  it('heads each project with its directory, carrying a trailing slash', () => {
+  it('heads each project with its directory, with a trailing slash', () => {
     const result = formatRecursiveView({
       projects: [buildProject({ dir: '.', kits: ['demo'] }), buildProject({ dir: 'packages/ui', kits: ['deploy'] })],
     });

--- a/packages/readyup/src/list/__tests__/listCommand.from.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.from.unit.test.ts
@@ -266,7 +266,7 @@ describe(listCommand, () => {
       expect(error.hint).toBe(BITBUCKET_HINT);
     });
 
-    it('leaves the message untouched, carrying the hint beside it', async () => {
+    it('leaves the message untouched, with the hint beside it', async () => {
       mockFetch.mockResolvedValue(mockResponse('Nope', { status: 401, statusText: 'Unauthorized' }));
 
       const error = await captureError(RdyError, () => listCommand(['--from', 'github:acme/private']));

--- a/packages/readyup/src/list/__tests__/listCommand.packages.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.packages.unit.test.ts
@@ -138,7 +138,7 @@ describe('list --packages', () => {
       });
     });
 
-    it('carries the description a publisher records, and omits the field where there is none', async () => {
+    it('reports the description a publisher records, and omits the field where there is none', async () => {
       const payload = await runForPayload();
 
       expect(findKit(payload, 'default')).toMatchObject({ description: 'Dependency drift' });

--- a/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
@@ -120,7 +120,7 @@ describe('list --recursive', () => {
       expect(stdout).toContain('rdy run --from packages/readyup [<name>]');
     });
 
-    it('carries the descriptions the manifest records, and renders a bare name without one', async () => {
+    it('reports the descriptions the manifest records, and renders a bare name without one', async () => {
       const { stdout } = await list(['--recursive']);
 
       expect(stdout).toContain('\u{1F4D3} default \u{00B7} Authoring hygiene for a project that defines readyup kits');

--- a/packages/readyup/src/list/__tests__/listCommand.recursivePackages.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.recursivePackages.unit.test.ts
@@ -104,7 +104,7 @@ describe('list --recursive --packages', () => {
       expect(stdout).not.toContain('packages/bare');
     });
 
-    // Configured membership is a fact about one project's config, so the same package answers differently.
+    // Configured membership is a fact about one project's config, so the same package reports differently.
     it('marks a package against the config of the project reporting it', async () => {
       configureProjects({ '.': ['@acme/kits'], 'packages/app': ['plain-kit'] });
 

--- a/packages/readyup/src/list/__tests__/listCommand.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.unit.test.ts
@@ -102,7 +102,7 @@ describe(listCommand, () => {
       expect(stdout.slice(stdout.indexOf('Available'))).not.toContain('@acme/kits');
     });
 
-    it('carries package provenance into the JSON payload, apart from the kits it lists', async () => {
+    it('passes package provenance into the JSON payload, apart from the kits it lists', async () => {
       mockDiscoverKitPackages.mockReturnValue(['plain-kit']);
       configureOnePackage();
 
@@ -215,7 +215,7 @@ describe(listCommand, () => {
       expect(stdout).toContain('default');
     });
 
-    it('renders a hint the config failure carries, on a line of its own', async () => {
+    it('renders a hint the config failure has, on a line of its own', async () => {
       mockLoadConfig.mockRejectedValue(
         Object.assign(new Error("Cannot resolve 'some-lib' while evaluating config.ts."), {
           hint: 'Install it with: pnpm add --save-dev some-lib',
@@ -230,7 +230,7 @@ describe(listCommand, () => {
       ]);
     });
 
-    it('writes no hint line for a config failure that carries none', async () => {
+    it('writes no hint line for a config failure that has none', async () => {
       mockLoadConfig.mockRejectedValue(new Error('bad config'));
 
       const { stderrChunks } = await list([]);
@@ -413,7 +413,7 @@ describe(listCommand, () => {
       });
     });
 
-    it('sends the human view to stderr so stdout carries one document', async () => {
+    it('sends the human view to stderr so stdout holds one document', async () => {
       mockEnumerateKits.mockReturnValue(['draft']);
       mockReadManifest.mockReturnValue({ version: 1, kits: [] });
 
@@ -435,7 +435,7 @@ describe(listCommand, () => {
       expect(stderr).toContain('No kits found.');
     });
 
-    it('carries the manifest fields in manifest mode', async () => {
+    it('reports the manifest fields in manifest mode', async () => {
       mockReadManifest.mockReturnValue({
         version: 1,
         kits: [{ name: 'deploy', description: 'Deploy checks', readyupVersion: '0.21.2' }],

--- a/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.wiring.unit.test.ts
@@ -92,7 +92,7 @@ describe('listCommand wiring', () => {
   });
 
   describe('--from with a manifest present', () => {
-    it('prefers the manifest and carries the fields only it knows', async () => {
+    it('prefers the manifest and reports the fields only it knows', async () => {
       writeKitsDir('kits', ['deploy']);
       writeFileSync(
         path.join(tempDir, 'kits', 'manifest.json'),

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -29,7 +29,7 @@ export type CompiledStyle = LocalConventionStyle | CustomOutDirStyle;
  *
  * Whether an `outDir` is the convention is a fact about the project, so it is settled against
  * `projectDir`; the path a reader is shown has to resolve from where they stand, so it is named against
- * `renderFrom`. They coincide for a listing of the working directory, and part for a sweep rendering
+ * `renderFrom`. They coincide for a listing of the working directory, and diverge for a sweep rendering
  * another project's kits.
  */
 export function resolveCompiledStyle(projectDir: string, outDir: string, renderFrom: string): CompiledStyle {

--- a/packages/readyup/src/manifest/__tests__/manifestSchema.unit.test.ts
+++ b/packages/readyup/src/manifest/__tests__/manifestSchema.unit.test.ts
@@ -105,7 +105,7 @@ describe('ManifestSchema', () => {
     expect(firstKit.targetHash).toBe('e5f6a7b8');
   });
 
-  it('accepts an entry carrying a targetHash but no sourceHash', () => {
+  it('accepts an entry with a targetHash but no sourceHash', () => {
     const input = {
       version: 1,
       kits: [{ name: 'deploy', path: 'kits/deploy.js', source: 'kits/deploy.ts', targetHash: 'e5f6a7b8' }],
@@ -171,7 +171,7 @@ describe('ManifestSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('round-trips an entry carrying recorded inputs', () => {
+  it('round-trips an entry with recorded inputs', () => {
     const inputs = [
       { hash: 'a1b2c3d4', kind: 'inline', path: '../package.json', paths: ['version', ['engines', 'node']] },
       { hash: 'e5f6a7b8', kind: 'module', path: 'kits/checks/shared.ts' },

--- a/packages/readyup/src/output/__tests__/terminal.unit.test.ts
+++ b/packages/readyup/src/output/__tests__/terminal.unit.test.ts
@@ -17,7 +17,7 @@ function makeResult(overrides: Partial<WriteResult> = {}): WriteResult {
 }
 
 describe(printStep, () => {
-  it('renders a step label as a section heading, parted from what precedes it', () => {
+  it('renders a step label as a section heading, separated from what precedes it', () => {
     using silent = silenceConsole(['info']);
 
     printStep('Scaffolding config');

--- a/packages/readyup/src/portable/__tests__/jitiImport.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/jitiImport.unit.test.ts
@@ -37,7 +37,7 @@ describe(jitiImport, () => {
     );
   });
 
-  it('carries the install command as a hint rather than in the message', async () => {
+  it('reports the install command as a hint rather than in the message', async () => {
     mockExistsSync.mockImplementation((target: string) => target.endsWith('pnpm-lock.yaml'));
     mockImport.mockRejectedValue(
       Object.assign(new Error("Cannot find package 'readyup'"), { code: 'ERR_MODULE_NOT_FOUND' }),

--- a/packages/readyup/src/portable/__tests__/listDeclarationSpans.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/listDeclarationSpans.unit.test.ts
@@ -45,7 +45,7 @@ describe(listDeclarationSpans, () => {
     ]);
   });
 
-  it('covers a body through a head carrying a brace-bearing generic constraint', () => {
+  it('covers a body through a head with a generic constraint that contains braces', () => {
     const spans = listSpans([
       'export function describeError<T extends { message: string }>(error: T): string {',
       '  return error.message;',
@@ -55,7 +55,7 @@ describe(listDeclarationSpans, () => {
     expect(spans).toStrictEqual([{ endLine: 3, name: 'describeError', startLine: 1 }]);
   });
 
-  it('covers a body through a head carrying a brace-bearing return-type annotation', () => {
+  it('covers a body through a head with a return-type annotation that contains braces', () => {
     const spans = listSpans([
       'export function describeError(error: unknown): { message: string } {',
       '  return { message: String(error) };',

--- a/packages/readyup/src/portable/__tests__/toError.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/toError.unit.test.ts
@@ -23,7 +23,7 @@ describe(toError, () => {
     ['a number', 42, '42'],
     ['null', null, 'null'],
     ['undefined', undefined, 'undefined'],
-  ])('wraps %s in an Error carrying its text', (_label, value, expected) => {
+  ])('wraps %s in an Error with its text', (_label, value, expected) => {
     expect(toError(value).message).toBe(expected);
   });
 

--- a/packages/readyup/src/portable/isSkippableFilesystemError.ts
+++ b/packages/readyup/src/portable/isSkippableFilesystemError.ts
@@ -3,7 +3,7 @@ import { isError } from '@williamthorsen/toolbelt.errors';
 /** Filesystem errors that cost a read one directory rather than the whole answer. */
 const SKIPPABLE_ERROR_CODES = new Set(['EACCES', 'ENOENT', 'EPERM']);
 
-/** Reports whether a filesystem failure is one a read may answer as an empty directory. */
+/** Reports whether a filesystem failure is one a read may treat as an empty directory. */
 export function isSkippableFilesystemError(error: unknown): boolean {
   return isNodeError(error) && error.code !== undefined && SKIPPABLE_ERROR_CODES.has(error.code);
 }

--- a/packages/readyup/src/projects/project-discovery.ts
+++ b/packages/readyup/src/projects/project-discovery.ts
@@ -141,7 +141,7 @@ async function readProjectConfig(absolutePath: string, dir: string): Promise<Res
   }
 }
 
-/** Answers `false` for a directory the sweep cannot read, rethrowing a failure it cannot skip past. */
+/** Returns `false` for a directory the sweep cannot read, rethrowing a failure it cannot skip past. */
 function skipUnreadableDir(dir: string, error: unknown): false {
   if (!isSkippableFilesystemError(error)) throw error;
   process.stderr.write(`Warning: Cannot read ${dir}. Reading the project without it.\n`);

--- a/packages/readyup/src/remote/RemoteFetchError.ts
+++ b/packages/readyup/src/remote/RemoteFetchError.ts
@@ -1,7 +1,7 @@
 /**
- * A remote fetch that answered with a failing HTTP status.
+ * A remote fetch that returned a failing HTTP status.
  *
- * Carries the status so a boundary can decide what the failure means without re-parsing the message.
+ * Holds the status so a boundary can decide what the failure means without re-parsing the message.
  * A transport failure and a malformed body are not this error: neither has a status to reason about.
  */
 export class RemoteFetchError extends Error {

--- a/packages/readyup/src/remote/__tests__/loadRemoteKit.unit.test.ts
+++ b/packages/readyup/src/remote/__tests__/loadRemoteKit.unit.test.ts
@@ -34,7 +34,7 @@ describe(loadRemoteKit, () => {
     );
   });
 
-  it.each([401, 403, 404])('throws RemoteFetchError carrying the %i status', async (status) => {
+  it.each([401, 403, 404])('throws RemoteFetchError with the %i status', async (status) => {
     mockFetch.mockResolvedValue(mockResponse('Nope', { status, statusText: 'Nope' }));
 
     const error = await captureError(RemoteFetchError, () => loadRemoteKit({ url: 'https://example.com/config.js' }));

--- a/packages/readyup/src/remote/__tests__/loadRemoteKit.validation.unit.test.ts
+++ b/packages/readyup/src/remote/__tests__/loadRemoteKit.validation.unit.test.ts
@@ -50,7 +50,7 @@ describe('loadRemoteKit validation', () => {
     );
   });
 
-  it('carries through fixLocation when exported', async () => {
+  it('passes fixLocation through when exported', async () => {
     const jsBody = `
       export const fixLocation = 'inline';
       export const checklists = [

--- a/packages/readyup/src/remote/__tests__/loadRemoteManifest.unit.test.ts
+++ b/packages/readyup/src/remote/__tests__/loadRemoteManifest.unit.test.ts
@@ -64,7 +64,7 @@ describe(loadRemoteManifest, () => {
     );
   });
 
-  it.each([401, 403, 500])('throws RemoteFetchError carrying the %i status', async (status) => {
+  it.each([401, 403, 500])('throws RemoteFetchError with the %i status', async (status) => {
     mockFetch.mockResolvedValue(mockResponse('boom', { status, statusText: 'Nope' }));
 
     const error = await captureError(RemoteFetchError, () =>

--- a/packages/readyup/src/remote/__tests__/toRemoteRdyError.unit.test.ts
+++ b/packages/readyup/src/remote/__tests__/toRemoteRdyError.unit.test.ts
@@ -34,7 +34,7 @@ describe(toRemoteRdyError, () => {
       expect(error.message).toBe('Failed to fetch manifest: 500 Boom');
     });
 
-    it('supplies the URL for a transport failure, which carries none', () => {
+    it('supplies the URL for a transport failure, which has none', () => {
       const error = toRemoteRdyError(new Error('ECONNREFUSED'), context());
 
       expect(error.message).toBe(`Failed to reach ${GITHUB_URL}: ECONNREFUSED`);

--- a/packages/readyup/src/remote/remote-provider.ts
+++ b/packages/readyup/src/remote/remote-provider.ts
@@ -14,7 +14,7 @@ const PROVIDER_HOSTS: Record<RemoteProvider, string> = {
  * Builds the `Authorization` header for a provider, or `undefined` when none can be built.
  *
  * Absorbs the scheme difference between the two providers, so no caller spells out `token` against
- * `Bearer`. Answers `undefined` both for an unknown provider and for a known one with no ambient
+ * `Bearer`. Returns `undefined` both for an unknown provider and for a known one with no ambient
  * token, which is the state a caller reports as "no credential was forwarded".
  */
 export function resolveRemoteAuthHeaders(provider: RemoteProvider | undefined): Record<string, string> | undefined {

--- a/packages/readyup/src/remote/toRemoteRdyError.ts
+++ b/packages/readyup/src/remote/toRemoteRdyError.ts
@@ -11,7 +11,7 @@ const CREDENTIAL_STATUSES = new Set([401, 403, 404]);
 /**
  * Remediation a provider's credential failure calls for.
  *
- * Phrased conditionally because 404 is genuinely ambiguous: GitHub answers it for a private
+ * Phrased conditionally because 404 is genuinely ambiguous: GitHub returns it for a private
  * repository fetched anonymously as well as for one that does not exist, so the hint must not assert
  * which case the reader is in.
  */

--- a/packages/readyup/src/reporting/__tests__/formatCombinedSummary.unit.test.ts
+++ b/packages/readyup/src/reporting/__tests__/formatCombinedSummary.unit.test.ts
@@ -37,7 +37,7 @@ function renderLines(rows: SummaryRow[]): string[] {
 
 describe(formatCombinedSummary, () => {
   // The run's writer separates one block from the next, so a table with its own blank would double the gap.
-  it('carries no separation of its own', () => {
+  it('renders no separation of its own', () => {
     expect(renderLines([makeRow()])[0]).not.toBe('');
   });
 
@@ -128,7 +128,7 @@ describe(formatCombinedSummary, () => {
       expect(totalLine).not.toContain('passed');
     });
 
-    it('carries no per-field tokens', () => {
+    it('renders no per-field tokens', () => {
       const output = formatCombinedSummary([makeRow({ passed: 1, errors: 1, worstSeverity: 'error' })]);
       const totalLine = output.split('\n').at(-1) ?? '';
 

--- a/packages/readyup/src/reporting/__tests__/formatJsonError.unit.test.ts
+++ b/packages/readyup/src/reporting/__tests__/formatJsonError.unit.test.ts
@@ -4,7 +4,7 @@ import { configError, internalError, kitLoadError, usageError } from '../../erro
 import { formatJsonError } from '../formatJsonError.ts';
 
 describe(formatJsonError, () => {
-  it('wraps the code and message in a versioned envelope carrying nothing else', () => {
+  it('wraps the code and message in a versioned envelope with nothing else', () => {
     const output = formatJsonError(usageError('something went wrong'));
     const parsed: unknown = JSON.parse(output);
 
@@ -29,7 +29,7 @@ describe(formatJsonError, () => {
     expect(output).not.toContain('\n');
   });
 
-  it('carries a hint beside the message rather than inside it', () => {
+  it('reports a hint beside the message rather than inside it', () => {
     const error = configError('No manifest found at https://example.com/manifest.json.', {
       hint: 'If the repository is private, set GITHUB_TOKEN.',
     });
@@ -44,7 +44,7 @@ describe(formatJsonError, () => {
     });
   });
 
-  it('omits the field entirely when the error carries no hint', () => {
+  it('omits the field entirely when the error has no hint', () => {
     expect(formatJsonError(usageError('x'))).not.toContain('hint');
   });
 });

--- a/packages/readyup/src/reporting/__tests__/formatJsonReport.unit.test.ts
+++ b/packages/readyup/src/reporting/__tests__/formatJsonReport.unit.test.ts
@@ -179,7 +179,7 @@ describe(formatJsonReport, () => {
       expect(parsed).toHaveProperty('detail', 'full');
     });
 
-    it('carries collected warnings alongside the results', () => {
+    it('reports collected warnings alongside the results', () => {
       const warnings = [{ code: 'source-stale' as const, message: 'kit is stale', remedy: 'Run `rdy compile`.' }];
 
       const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', makeReport()), { warnings }));
@@ -211,7 +211,7 @@ describe(formatJsonReport, () => {
       expect(parsed).toHaveProperty('kits.0.compiledWith', VERSION);
     });
 
-    it('omits the compiling readyup for a kit that carries no stamp', () => {
+    it('omits the compiling readyup for a kit with no stamp', () => {
       const parsed: unknown = JSON.parse(formatReport(singleKit('deploy', makeReport())));
 
       expect(parsed).not.toHaveProperty('kits.0.compiledWith');
@@ -233,7 +233,7 @@ describe(formatJsonReport, () => {
       ];
     }
 
-    it('carries the threshold that governed each kit rather than one value for the run', () => {
+    it('reports the threshold that governed each kit rather than one value for the run', () => {
       const parsed: unknown = JSON.parse(formatReport(mixedThresholdKits()));
 
       expect(parsed).toMatchObject({
@@ -453,7 +453,7 @@ describe(formatJsonReport, () => {
   });
 
   describe('check entries', () => {
-    it('carries severity, ok, and skipReason where each applies', () => {
+    it('reports severity, ok, and skipReason where each applies', () => {
       const report = makeReport({
         results: [
           makePassedResult({ name: 'a', severity: 'warn', durationMs: 1 }),
@@ -564,7 +564,7 @@ describe(formatJsonReport, () => {
       return { name, entries: [{ name: 'check', report }] };
     }
 
-    it('passes a failed kit through carrying only its name and error', () => {
+    it('passes a failed kit through with only its name and error', () => {
       const parsed: unknown = JSON.parse(formatReport([FAILURE]));
 
       expect(parsed).toMatchObject({ counts: NO_COUNTS, durationMs: 0, kits: [FAILURE] });
@@ -842,7 +842,7 @@ describe(formatJsonReport, () => {
   });
 
   describe('check ids', () => {
-    it('carries the id of a check that declares one', () => {
+    it('reports the id of a check that declares one', () => {
       const withId = makeReport({
         results: [makePassedResult({ name: 'a', id: 'toolbelt.errors/no-instanceof-error' })],
       });
@@ -860,7 +860,7 @@ describe(formatJsonReport, () => {
       expect(output).not.toContain('"id"');
     });
 
-    it('carries the id into the summary projection, where a failure is all that survives', () => {
+    it('passes the id into the summary projection, where a failure is all that survives', () => {
       const failing = makeReport({
         results: [makeFailedResult({ name: 'a', id: 'toolbelt.errors/no-instanceof-error' })],
         passed: false,

--- a/packages/readyup/src/reporting/__tests__/reportRdy.unit.test.ts
+++ b/packages/readyup/src/reporting/__tests__/reportRdy.unit.test.ts
@@ -271,7 +271,7 @@ describe(reportRdy, () => {
   });
 
   describe('failure reasons', () => {
-    it('leaves the failed line carrying only its claim', () => {
+    it('leaves the failed line stating only its claim', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'target', detail: 'lockfile is stale' })], passed: false }),
       ).body;
@@ -392,7 +392,7 @@ describe(reportRdy, () => {
       expect(output.split('\n').at(-1)).toBe(`${PASSED} Total: 1 passed (100ms)`);
     });
 
-    it('carries no bare rule between the tree and the count line', () => {
+    it('renders no bare rule between the tree and the count line', () => {
       const output = reportRdy(makeReport({ results: [makePassedResult({ name: 'target' })] })).body;
 
       expect(output).not.toContain('\u{2500}\u{2500}\n');
@@ -408,7 +408,7 @@ describe(reportRdy, () => {
       expect(indexNaming(output, 'Fixes')).toBeLessThan(lines.length - 1);
     });
 
-    it('carries no blank line inside the block', () => {
+    it('renders no blank line inside the block', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'broken', fix: 'Run pnpm install' })], passed: false }),
       ).body;
@@ -473,7 +473,7 @@ describe(reportRdy, () => {
       expect(output.split('\n')[checkLine + 2]).not.toContain('Update config');
     });
 
-    it('omits the recap when no failed check carries a fix', () => {
+    it('omits the recap when no failed check has a fix', () => {
       const output = reportRdy(
         makeReport({ results: [makeFailedResult({ name: 'broken', error: new Error('bad') })], passed: false }),
       ).body;

--- a/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
@@ -40,7 +40,7 @@ describe(readManifestTracking, () => {
     mockReadManifest.mockReset();
   });
 
-  it('answers with the manifest and the directory holding it', () => {
+  it('returns the manifest and the directory holding it', () => {
     const manifest = { version: 1, kits: [] };
     mockReadManifest.mockReturnValue(manifest);
 
@@ -55,7 +55,7 @@ describe(readManifestTracking, () => {
     expect(mockReadManifest).not.toHaveBeenCalled();
   });
 
-  it('answers with nothing when no manifest exists', () => {
+  it('returns nothing when no manifest exists', () => {
     mockReadManifest.mockImplementation(() => {
       throw new Error('Manifest file not found: /abs/.readyup/manifest.json');
     });
@@ -63,7 +63,7 @@ describe(readManifestTracking, () => {
     expect(readManifestTracking(false)).toBeUndefined();
   });
 
-  it('answers with nothing when the manifest cannot be parsed', () => {
+  it('returns nothing when the manifest cannot be parsed', () => {
     mockReadManifest.mockImplementation(() => {
       throw new Error('Manifest file contains invalid JSON: /abs/.readyup/manifest.json');
     });
@@ -137,7 +137,7 @@ describe(warnOnKitStaleness, () => {
       ]);
     });
 
-    it('raises all three advisories when every axis has parted from the manifest', () => {
+    it('raises all three advisories when every axis differs from the manifest', () => {
       arrangeTargetDrift();
       arrangeSourceStale();
       arrangeInputStale();
@@ -149,7 +149,7 @@ describe(warnOnKitStaleness, () => {
       ]);
     });
 
-    it('raises both advisories when both artifacts have parted from the manifest', () => {
+    it('raises both advisories when both artifacts differ from the manifest', () => {
       arrangeTargetDrift();
       arrangeSourceStale();
 

--- a/packages/readyup/src/run/__tests__/listPragmaSites.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/listPragmaSites.unit.test.ts
@@ -36,7 +36,7 @@ describe(listPragmaSites, () => {
       expect(sites).toStrictEqual([{ coveredLine: 1, line: 1, token: 'rdy-ignore' }]);
     });
 
-    it('carries the line of each token in a source holding several', () => {
+    it('reports the line of each token in a source holding several', () => {
       const sites = listPragmaSites(['// rdy-ignore', 'x;', '/* rdy-ignore-next-line */', 'y;', ''].join('\n'));
 
       expect(sites).toStrictEqual([

--- a/packages/readyup/src/run/__tests__/loadKit.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/loadKit.unit.test.ts
@@ -46,7 +46,7 @@ describe(loadKit, () => {
   });
 
   describe('local source', () => {
-    it('answers with what the local loader produced', async () => {
+    it('returns what the local loader produced', async () => {
       const loaded = { kit: makeKit(), compileTimeVersion: VERSION };
       mockLoadRdyKit.mockResolvedValue(loaded);
 
@@ -71,7 +71,7 @@ describe(loadKit, () => {
       expect(error.message).toBe("Cannot find package 'chalk'");
     });
 
-    it('passes through an error carrying no module code under --jit', async () => {
+    it('passes through an error with no module code under --jit', async () => {
       mockLoadRdyKit.mockRejectedValue(new Error('boom'));
 
       const error = await captureError(RdyError, () => loadKit(localEntry(), true));
@@ -79,7 +79,7 @@ describe(loadKit, () => {
       expect(error.message).toBe('boom');
     });
 
-    it('passes through an error carrying an unrelated code under --jit', async () => {
+    it('passes through an error with an unrelated code under --jit', async () => {
       mockLoadRdyKit.mockRejectedValue(Object.assign(new Error('boom'), { code: 'EACCES' }));
 
       const error = await captureError(RdyError, () => loadKit(localEntry(), true));
@@ -103,7 +103,7 @@ describe(loadKit, () => {
       expect(error.message).toBe("Cannot find package 'readyup'");
     });
 
-    it('forwards an install hint the underlying failure carries', async () => {
+    it('forwards an install hint the underlying failure has', async () => {
       mockLoadRdyKit.mockRejectedValue(
         Object.assign(new Error("Cannot resolve 'some-lib' while evaluating deploy.ts."), {
           hint: 'Install it with: pnpm add --save-dev some-lib',
@@ -177,7 +177,7 @@ describe(loadKit, () => {
       expect(error.message).toContain(BITBUCKET_URL);
     });
 
-    it('names the URL a network failure does not carry', async () => {
+    it('names the URL a network failure does not have', async () => {
       mockLoadRemoteKit.mockRejectedValue(new TypeError('fetch failed'));
 
       const error = await captureError(RdyError, () => loadKit(remoteEntry(BITBUCKET_URL), false));

--- a/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
@@ -33,7 +33,7 @@ describe('--packages run path wiring', () => {
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  it('expands a configured package into entries carrying its name and version', () => {
+  it('expands a configured package into entries with its name and version', () => {
     installPackage('@acme/kits', ['default'], { version: '2.1.0' });
 
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
@@ -106,7 +106,7 @@ describe('--packages run path wiring', () => {
     expect(stdout).toBe('No kits to run.\n');
   });
 
-  it('carries the package and version into the JSON report', async () => {
+  it('passes the package and version into the JSON report', async () => {
     installPackage('@acme/kits', ['default'], { version: '2.1.0' });
     const entries = resolveKitSources({ ...baseArgs, packages: true, configuredPackages: ['@acme/kits'] });
 
@@ -170,7 +170,7 @@ describe('--packages run path wiring', () => {
   });
 
   // A row is an index into the blocks above it, so it repeats its heading rather than naming its own scheme.
-  it('names each row by the breadcrumb heading its block carries', async () => {
+  it('names each row by the breadcrumb heading its block has', async () => {
     installPackage('@acme/kits', ['default'], { version: '2.1.0' });
     installPackage('plain-kit', ['default'], { version: '1.0.0' });
     const entries = resolveKitSources({

--- a/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
@@ -179,7 +179,7 @@ function sweepingCheck(options: { path: string; skipReason?: string }): RdyCheck
   };
 }
 
-/** Answers the repo probe with a working tree, and the listing with the given paths. */
+/** Stubs the repo probe with a working tree, and the listing with the given paths. */
 function trackPaths(...paths: string[]): void {
   execFileAsync.mockImplementation((_file, args) => {
     if (args.includes('rev-parse')) return Promise.resolve({ stdout: '.git\n', stderr: '' });

--- a/packages/readyup/src/run/__tests__/resolveCheckIds.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveCheckIds.unit.test.ts
@@ -40,7 +40,7 @@ describe(resolveCheckIds, () => {
       expect(ids).toStrictEqual({ accepted: ['no-instanceof-error'], printed: 'no-instanceof-error' });
     });
 
-    it('leaves the bare id standing where the kit carries no provenance', () => {
+    it('leaves the bare id standing where the kit has no provenance', () => {
       const ids = resolveCheckIds('no-instanceof-error', undefined);
 
       expect(ids).toStrictEqual({ accepted: ['no-instanceof-error'], printed: 'no-instanceof-error' });

--- a/packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts
@@ -44,14 +44,14 @@ describe(resolveFindingOutcome, () => {
     expect(outcome.progress).toStrictEqual({ count: 3, passedCount: 1, type: 'fraction' });
   });
 
-  it('carries no progress where the outcome names no adopted count', () => {
+  it('reports no progress where the outcome names no adopted count', () => {
     const outcome = resolveFindingOutcome({ findings: [CLONE] }, []);
 
     expect(outcome.progress).toBeUndefined();
   });
 
   describe('given a source suppressing a finding', () => {
-    it('drops a finding on a line carrying `rdy-ignore`', ({ temp }) => {
+    it('drops a finding on a line with `rdy-ignore`', ({ temp }) => {
       writeSourceLine(temp, 'src/errors.ts', 12, 'error instanceof Error; // rdy-ignore');
 
       const outcome = resolveFindingOutcome({ adoptedCount: 0, findings: [CLONE, INLINE] }, []);

--- a/packages/readyup/src/run/__tests__/resolveFromSource.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveFromSource.unit.test.ts
@@ -30,7 +30,7 @@ describe(resolveFromSource, () => {
     ]);
   });
 
-  it('carries the GitHub ref into both the URL and the label', () => {
+  it('passes the GitHub ref into both the URL and the label', () => {
     const source: FromSource = { type: 'github', org: 'org', repo: 'repo', ref: 'v1' };
 
     expect(resolveFromSource(source, [{ kitName: 'nmr', checklists: [] }], '.js')).toStrictEqual([
@@ -83,7 +83,7 @@ describe(resolveFromSource, () => {
     ]);
   });
 
-  it('carries the Bitbucket ref into both the URL and the label', () => {
+  it('passes the Bitbucket ref into both the URL and the label', () => {
     const source: FromSource = { type: 'bitbucket', workspace: 'myteam', repo: 'repo', ref: 'v2' };
 
     expect(resolveFromSource(source, DEFAULT_SPECS, '.js')).toStrictEqual([
@@ -121,7 +121,7 @@ describe(resolveFromSource, () => {
 
   // The provenance is what names the copy a check ran against, which is the whole point of resolving from an
   // installed package. It reads from the same manifest the resolver reads, so a version bump leaves this alone.
-  it('carries the package and its installed version as the kit provenance', () => {
+  it('reports the package and its installed version as the kit provenance', () => {
     const source: FromSource = { type: 'npm', name: 'readyup', versionSpec: undefined };
     const [entry] = resolveFromSource(source, DEFAULT_SPECS, '.js');
 

--- a/packages/readyup/src/run/__tests__/runCommand.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runCommand.unit.test.ts
@@ -98,7 +98,7 @@ describe(runCommand, () => {
     expect(mockRunHumanMode).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ quiet: true }), false);
   });
 
-  it('carries the thresholds the invocation named through to the human mode', async () => {
+  it('passes the thresholds the invocation named through to the human mode', async () => {
     await runCommand({ kitEntries: singleKitEntry(), json: false, failOn: 'warn', reportOn: 'error' });
 
     expect(mockRunHumanMode).toHaveBeenCalledWith(
@@ -108,7 +108,7 @@ describe(runCommand, () => {
     );
   });
 
-  it('carries the thresholds the invocation named through to the JSON mode', async () => {
+  it('passes the thresholds the invocation named through to the JSON mode', async () => {
     await runCommand({ kitEntries: singleKitEntry(), json: true, failOn: 'warn', reportOn: 'error' });
 
     expect(mockRunJsonMode).toHaveBeenCalledWith(
@@ -124,7 +124,7 @@ describe(runCommand, () => {
     expect(mockRunHumanMode).toHaveBeenCalledWith(expect.anything(), expect.anything(), false);
   });
 
-  it('carries a just-in-time run through to the mode', async () => {
+  it('passes a just-in-time run through to the mode', async () => {
     await runCommand({ kitEntries: singleKitEntry(), json: true }, true);
 
     expect(mockRunJsonMode).toHaveBeenCalledWith(expect.anything(), expect.anything(), true);

--- a/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
@@ -197,7 +197,7 @@ describe(runHumanMode, () => {
   });
 
   // One blank separates blocks of the same kit, and the summary that tallies them is separated the same way.
-  it('parts one block from the next with a single blank line', async () => {
+  it('separates one block from the next with a single blank line', async () => {
     const kit = makeKit();
     mockLoadRdyKit.mockResolvedValue({ kit, compileTimeVersion: undefined });
     mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
@@ -290,7 +290,7 @@ describe(runHumanMode, () => {
 
   // The heading below a gap names the kit it opens, so a kit boundary takes the same one blank line every
   // other boundary takes. The run's first block opens with none.
-  it('parts one kit from the next with the same single blank line, opening with none', async () => {
+  it('separates one kit from the next with the same single blank line, opening with none', async () => {
     const kit = makeKit({
       checklists: [{ name: 'deploy', checks: [{ name: 'a', check: () => true }] }],
     });

--- a/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
@@ -277,7 +277,7 @@ describe(runJsonMode, () => {
       ];
     }
 
-    it('carries every advisory the run raised into the JSON report', async () => {
+    it('passes every advisory the run raised into the JSON report', async () => {
       const tracking = { manifest: { version: 1, kits: [] }, manifestDir: '.readyup' };
       mockReadManifestTracking.mockReturnValue(tracking);
       mockWarnOnKitStaleness.mockReturnValueOnce([TARGET_DRIFT]).mockReturnValueOnce([SOURCE_STALE]);
@@ -296,7 +296,7 @@ describe(runJsonMode, () => {
       expect(exitCode).toBe(0);
     });
 
-    it('carries a diagnosed masked pass into the report and onto stderr', async () => {
+    it('puts a diagnosed masked pass into the report and onto stderr', async () => {
       mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({
         results: [],
@@ -361,7 +361,7 @@ describe(runJsonMode, () => {
       expect(mockWarnOnUnusedPragmas).toHaveBeenCalledExactlyOnceWith(ledgers[0]);
     });
 
-    it('carries the entries into the report’s warnings', async () => {
+    it('passes the entries into the report’s warnings', async () => {
       mockWarnOnUnusedPragmas.mockReturnValue([PRAGMA_UNUSED]);
       mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
@@ -380,7 +380,7 @@ describe(runJsonMode, () => {
     const GITHUB_URL = 'https://raw.githubusercontent.com/acme/private/main/.readyup/kits/deploy.js';
     const GITHUB_HINT = 'If the repository is private, set GITHUB_TOKEN or run `gh auth login`.';
 
-    it('carries the hint into the JSON report’s kit error entry', async () => {
+    it('passes the hint into the JSON report’s kit error entry', async () => {
       mockResolveGitHubToken.mockReturnValue(undefined);
       mockLoadRemoteKit.mockRejectedValue(new RemoteFetchError('boom', 404));
       mockFormatJsonReport.mockReturnValue('{}');

--- a/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
@@ -612,7 +612,7 @@ describe(runRdy, () => {
   });
 
   describe('structured check outcomes', () => {
-    it('carries detail from a passing CheckOutcome', async () => {
+    it('takes detail from a passing CheckOutcome', async () => {
       const checklist: RdyChecklist = {
         name: 'outcome',
         checks: [{ name: 'with-detail', check: () => ({ ok: true, detail: 'all files present' }) }],
@@ -625,7 +625,7 @@ describe(runRdy, () => {
       expect(report.results[0]?.detail).toBe('all files present');
     });
 
-    it('carries progress from a failing CheckOutcome', async () => {
+    it('takes progress from a failing CheckOutcome', async () => {
       const checklist: RdyChecklist = {
         name: 'outcome',
         checks: [
@@ -643,7 +643,7 @@ describe(runRdy, () => {
       expect(report.results[0]?.progress).toStrictEqual({ type: 'fraction', passedCount: 7, count: 10 });
     });
 
-    it('carries both detail and progress', async () => {
+    it('takes both detail and progress', async () => {
       const checklist: RdyChecklist = {
         name: 'outcome',
         checks: [
@@ -745,7 +745,7 @@ describe(runRdy, () => {
       expect(report.results[0]?.quiet).toBe(false);
     });
 
-    it('carries a declared quiet onto a passed result', async () => {
+    it('sets a declared quiet on a passed result', async () => {
       const checklist: RdyChecklist = {
         name: 'quiet',
         checks: [{ name: 'passes', check: () => true, quiet: true }],
@@ -756,7 +756,7 @@ describe(runRdy, () => {
       expect(report.results[0]?.quiet).toBe(true);
     });
 
-    it('carries a declared quiet onto a failed result', async () => {
+    it('sets a declared quiet on a failed result', async () => {
       const checklist: RdyChecklist = {
         name: 'quiet',
         checks: [{ name: 'fails', check: () => false, quiet: true }],
@@ -767,7 +767,7 @@ describe(runRdy, () => {
       expect(report.results[0]?.quiet).toBe(true);
     });
 
-    it('carries a declared quiet onto an n/a-skipped result', async () => {
+    it('sets a declared quiet on an n/a-skipped result', async () => {
       const checklist: RdyChecklist = {
         name: 'quiet',
         checks: [{ name: 'not-applicable', check: () => true, quiet: true, skip: () => 'no target' }],
@@ -778,7 +778,7 @@ describe(runRdy, () => {
       expect(report.results[0]?.quiet).toBe(true);
     });
 
-    it('carries a declared quiet onto a precondition-skipped result', async () => {
+    it('sets a declared quiet on a precondition-skipped result', async () => {
       const checklist: RdyChecklist = {
         name: 'quiet',
         preconditions: [{ name: 'gate', check: () => false }],
@@ -792,7 +792,7 @@ describe(runRdy, () => {
       expect(blocked.quiet).toBe(true);
     });
 
-    it('carries a declared quiet onto a check broken rather than failing', async () => {
+    it('sets a declared quiet on a check broken rather than failing', async () => {
       const checklist: RdyChecklist = {
         name: 'quiet',
         checks: [
@@ -1022,7 +1022,7 @@ describe(runRdy, () => {
       expect(report.diagnoses).toStrictEqual([{ name: 'would-pass', verdict: 'masked-pass' }]);
     });
 
-    it('reports a check that throws as inconclusive, carrying its message', async () => {
+    it('reports a check that throws as inconclusive, with its message', async () => {
       const checklist: RdyChecklist = {
         name: 'unreachable',
         checks: [
@@ -1862,7 +1862,7 @@ describe(runRdy, () => {
       expect(report.results[0]?.id).toBe('no-instanceof-error');
     });
 
-    it('carries no id for a check declaring none', async () => {
+    it('reports no id for a check declaring none', async () => {
       const checklist: RdyChecklist = { name: 'adoption', checks: [{ name: 'claim', check: () => true }] };
 
       const report = await runRdy(checklist);

--- a/packages/readyup/src/run/__tests__/skip-diagnosis.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/skip-diagnosis.unit.test.ts
@@ -34,7 +34,7 @@ describe(warnOnMaskedSkips, () => {
     ]);
   });
 
-  it('ends the sentence with one period where the reason already carries one', () => {
+  it('ends the sentence with one period where the reason already has one', () => {
     const { warnings } = warn([{ name: 'a', verdict: 'inconclusive', reason: 'check() returned null.' }]);
 
     expect(warnings[0]?.message).toBe(

--- a/packages/readyup/src/run/__tests__/suppressesFinding.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/suppressesFinding.unit.test.ts
@@ -40,7 +40,7 @@ describe(suppressesFinding, () => {
   });
 
   describe('given a pragma naming no check', () => {
-    it('suppresses whatever ids the check carries', () => {
+    it('suppresses whatever ids the check has', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore');
 
       expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
@@ -66,7 +66,7 @@ describe(suppressesFinding, () => {
       expect(suppressesFinding(lines, 1, NAMED)).toBe(false);
     });
 
-    it('suppresses nothing for a check carrying no id at all', () => {
+    it('suppresses nothing for a check with no id at all', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore toolbelt.errors/no-instanceof-error');
 
       expect(suppressesFinding(lines, 1, [])).toBe(false);
@@ -154,14 +154,14 @@ describe(suppressesFinding, () => {
     expect(suppressesFinding(lines, 1, [])).toBe(true);
   });
 
-  it('answers for each scope where one line carries both tokens', () => {
+  it('reports for each scope where one line has both tokens', () => {
     const lines = linesOf('// rdy-ignore rdy-ignore-next-line\nerror;');
 
     expect(suppressesFinding(lines, 1, [])).toBe(true);
     expect(suppressesFinding(lines, 2, [])).toBe(true);
   });
 
-  it('suppresses nothing where no line carries a pragma', () => {
+  it('suppresses nothing where no line has a pragma', () => {
     const lines = linesOf('const a = 1;\nerror instanceof Error;');
 
     expect(suppressesFinding(lines, 2, [])).toBe(false);

--- a/packages/readyup/src/run/__tests__/validateRunFlags.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/validateRunFlags.unit.test.ts
@@ -4,7 +4,7 @@ import type { KitSpecifier } from '../parseKitSpecifiers.ts';
 import { type RunFlagConstraints, validateRunFlags } from '../validateRunFlags.ts';
 
 describe(validateRunFlags, () => {
-  it('accepts an invocation carrying no flags', () => {
+  it('accepts an invocation with no flags', () => {
     expect(() => validateRunFlags(buildConstraints(), [])).not.toThrow();
   });
 

--- a/packages/readyup/src/run/kit-staleness.ts
+++ b/packages/readyup/src/run/kit-staleness.ts
@@ -98,7 +98,7 @@ export function warnOnKitStaleness(
 /**
  * Finds the manifest entry describing a kit, matching on resolved compiled path.
  *
- * Matching by name instead would misfire wherever a kit's name and its file part company: `--file`
+ * Matching by name instead would misfire wherever a kit's name and its file differ: `--file`
  * names a kit by an arbitrary path, and a custom `outDir` puts a differently-named entry's output
  * where this one's would go.
  */

--- a/packages/readyup/src/run/resolveFromSource.ts
+++ b/packages/readyup/src/run/resolveFromSource.ts
@@ -98,7 +98,7 @@ function buildGitHubKitUrl(org: string, repo: string, ref: string, kit: string, 
  * Locates the root of a package named by `npm:`, rejecting the forms that are reserved but not yet served.
  *
  * A version spec is parsed rather than ignored so the syntax stays reserved for running a published
- * version; until that lands, naming one is answered with the flag that reaches a published kit today.
+ * version; until that lands, naming one points at the flag that reaches a published kit today.
  *
  * The not-installed message names the direct-dependency requirement because pnpm's layout links only
  * direct dependencies into a project's `node_modules`. A transitive dependency is genuinely unreachable

--- a/packages/readyup/src/run/runHumanMode.ts
+++ b/packages/readyup/src/run/runHumanMode.ts
@@ -30,7 +30,7 @@ interface HumanRunSettings {
 /**
  * Runs all kit entries in human-readable mode.
  *
- * Carries the same per-kit boundary as JSON mode, reporting the failure on stderr so it stays
+ * Uses the same per-kit boundary as JSON mode, reporting the failure on stderr so it stays
  * distinguishable from a failed check, which prints into the stdout report and means a different
  * exit code.
  */

--- a/packages/readyup/src/run/suppressesFinding.ts
+++ b/packages/readyup/src/run/suppressesFinding.ts
@@ -21,7 +21,7 @@ const PRAGMA_TOKENS = new Set(['rdy-ignore', 'rdy-ignore-next-line']);
  * cannot erase a pragma first.
  */
 export function suppressesFinding(lines: readonly string[], line: number, checkIds: readonly string[]): boolean {
-  return carriesPragma(lines[line - 1], 'line', checkIds) || carriesPragma(lines[line - 2], 'next-line', checkIds);
+  return hasPragma(lines[line - 1], 'line', checkIds) || hasPragma(lines[line - 2], 'next-line', checkIds);
 }
 
 // region | Helpers
@@ -30,7 +30,7 @@ export function suppressesFinding(lines: readonly string[], line: number, checkI
  * Reports whether a line has a pragma covering the named scope and suppressing for `checkIds`. A line past
  * either end of the source has none.
  */
-function carriesPragma(line: string | undefined, scope: 'line' | 'next-line', checkIds: readonly string[]): boolean {
+function hasPragma(line: string | undefined, scope: 'line' | 'next-line', checkIds: readonly string[]): boolean {
   if (line === undefined) return false;
 
   for (const match of line.matchAll(createIgnorePragmaMatcher())) {

--- a/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
@@ -46,7 +46,7 @@ describe('generated JSON Schemas', () => {
   describe('report document', () => {
     const report = documentFor('report.v1.json');
 
-    it('requires exactly the fields every report carries', () => {
+    it('requires exactly the fields every report has', () => {
       expect(valueAt(report, 'required')).toStrictEqual([
         'schemaVersion',
         'readyupVersion',
@@ -143,11 +143,11 @@ describe('generated JSON Schemas', () => {
       expect(validatorFor('report.v1.json')({ ...withoutCounts, ...counts })).toBe(false);
     });
 
-    it('rejects a report carrying the old numeric warnings field', () => {
+    it('rejects a report with the old numeric warnings field', () => {
       expect(validatorFor('report.v1.json')({ ...minimalReportPayload, warnings: 2 })).toBe(false);
     });
 
-    it('accepts a report carrying a field it has never heard of', () => {
+    it('accepts a report with a field it has never heard of', () => {
       expect(validatorFor('report.v1.json')({ ...minimalReportPayload, addedLater: 'ok' })).toBe(true);
     });
   });

--- a/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
@@ -99,7 +99,7 @@ describe('JSON payload schemas', () => {
       expect(() => ReportSchema.parse({ ...minimalReportPayload, kits })).not.toThrow();
     });
 
-    it('accepts an error body carrying no hint', () => {
+    it('accepts an error body with no hint', () => {
       expect(() => ErrorEnvelopeSchema.parse(errorEnvelopePayload)).not.toThrow();
     });
 
@@ -137,7 +137,7 @@ describe('JSON payload schemas', () => {
   });
 
   describe('thresholds', () => {
-    it('carries the kit-declared threshold that governed a kit, not the one the run requested', () => {
+    it('reports the kit-declared threshold that governed a kit, not the one the run requested', () => {
       const parsed = ReportSchema.parse(reportPayload);
       const kit = parsed.kits[0];
       assert.ok(kit !== undefined && !('error' in kit), 'expected a kit that ran');
@@ -182,7 +182,7 @@ describe('JSON payload schemas', () => {
       expect(() => VerifyOutputSchema.parse({ schemaVersion: 1, passed: true, kits })).not.toThrow();
     });
 
-    it('accepts a rebuild mismatch carrying both hashes', () => {
+    it('accepts a rebuild mismatch with both hashes', () => {
       const kits = [
         {
           name: 'deploy',
@@ -230,7 +230,7 @@ describe('JSON payload schemas', () => {
       expect(() => ReportSchema.parse({ ...minimalReportPayload, kits })).not.toThrow();
     });
 
-    it('rejects a kit that carries neither results nor an error', () => {
+    it('rejects a kit with neither results nor an error', () => {
       expect(() => ReportSchema.parse({ ...minimalReportPayload, kits: [{ name: 'orphan' }] })).toThrow(ZodError);
     });
   });

--- a/packages/readyup/src/schemas/buildSchemas.ts
+++ b/packages/readyup/src/schemas/buildSchemas.ts
@@ -9,7 +9,7 @@ import { ListOutputSchema, SCHEMA_VERSION as LIST_VERSION } from './listOutputSc
 import { ReportSchema, SCHEMA_VERSION as REPORT_VERSION } from './reportSchema.ts';
 import { SCHEMA_VERSION as VERIFY_VERSION, VerifyOutputSchema } from './verifyOutputSchema.ts';
 
-/** Where a published schema answers from once the package is on npm. */
+/** Where a published schema is served from once the package is on npm. */
 export const SCHEMA_BASE_URL = 'https://unpkg.com/readyup/schemas';
 
 /** One payload's published schema: what to call the file and what to put in it. */

--- a/packages/readyup/src/schemas/listOutputSchema.ts
+++ b/packages/readyup/src/schemas/listOutputSchema.ts
@@ -20,7 +20,7 @@ export const KitKindSchema = z.enum(['compiled', 'internal']).meta({ id: 'KitKin
  *
  * `configured` reports whether the readyup config names the package, which is what decides whether
  * `rdy run --packages` would reach the kit. Under a repo-wide sweep the config is the one belonging to
- * the row's own `project`, so the same package answers differently across workspaces. It is absent only
+ * the row's own `project`, so the same package reports differently across workspaces. It is absent only
  * from a payload written before the field existed, never as a way of saying `false`.
  */
 export const ListKitOriginSchema = z

--- a/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
@@ -49,7 +49,7 @@ describe(checkInputDrift, () => {
   });
 
   describe('a module input', () => {
-    it('reports a changed module with both hashes and the file that carries them', () => {
+    it('reports a changed module with both hashes and the file that has them', () => {
       writeInput('kits/shared.ts', 'export const shared = 2;\n');
 
       expect(checkInputDrift(kitWith([RECORDED_MODULE]), tempDir)).toStrictEqual({

--- a/packages/readyup/src/verify/__tests__/checkRebuild.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkRebuild.unit.test.ts
@@ -36,7 +36,7 @@ describe(checkRebuild, () => {
     expect(status.kind).toBe('ok');
   });
 
-  it('returns mismatch carrying the recompiled and on-disk hashes when the bytes differ', async () => {
+  it('returns mismatch with the recompiled and on-disk hashes when the bytes differ', async () => {
     const onDisk = Buffer.from('stale output');
     const rebuilt = Buffer.from('fresh output');
     writeKitFiles(tempDir, onDisk);
@@ -88,7 +88,7 @@ describe(checkRebuild, () => {
     expect(status).toMatchObject({ kind: 'mismatch', esbuild: { recorded: '0.28.1', rebuilt: '0.29.0' } });
   });
 
-  it('carries the esbuild comparison even when the recorded version matches the rebuild', async () => {
+  it('reports the esbuild comparison even when the recorded version matches the rebuild', async () => {
     writeKitFiles(tempDir, Buffer.from('stale output'));
     mockBuildBundle.mockResolvedValue(rebuildResult({ esbuildVersion: '0.29.0' }));
 
@@ -138,7 +138,7 @@ describe(checkRebuild, () => {
     expect(status).not.toHaveProperty('dependencyChanges');
   });
 
-  it('returns failed carrying the compile error when the source no longer compiles', async () => {
+  it('returns failed with the compile error when the source no longer compiles', async () => {
     writeKitFiles(tempDir, Buffer.from('compiled output'));
     mockBuildBundle.mockRejectedValue(new Error('Unexpected token'));
 

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -475,7 +475,7 @@ describe(verifyCommand, () => {
       expect(stdout).toContain('recorded esbuild and dependency versions match the rebuild');
     });
 
-    it('carries the esbuild comparison and dependency changes in the JSON payload', async () => {
+    it('reports the esbuild comparison and dependency changes in the JSON payload', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({
         kind: 'mismatch',
@@ -508,7 +508,7 @@ describe(verifyCommand, () => {
       expect(stdout).not.toContain('rebuildDependencyChanges');
     });
 
-    it('fails a kit whose source no longer compiles, carrying the compile error', async () => {
+    it('fails a kit whose source no longer compiles, with the compile error', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'failed', message: 'Unexpected token' });
 
@@ -545,7 +545,7 @@ describe(verifyCommand, () => {
       expect(stdout).toContain('rebuild ok');
     });
 
-    it('carries the rebuild verdict and its hashes in the JSON payload', async () => {
+    it('reports the rebuild verdict and its hashes in the JSON payload', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'mismatch', expected: '1111aaaa', actual: '2222bbbb' });
 
@@ -587,7 +587,7 @@ describe(verifyCommand, () => {
       expect(stdout).toContain(`${UNVERIFIED} alpha`);
     });
 
-    it('carries the compiling version in the JSON payload when it differs from the runner', async () => {
+    it('reports the compiling version in the JSON payload when it differs from the runner', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({
         kind: 'mismatch',
@@ -611,7 +611,7 @@ describe(verifyCommand, () => {
       expect(stdout).not.toContain('rebuildCompiledWith');
     });
 
-    it('carries the compile error in the JSON payload for a kit that failed to build', async () => {
+    it('reports the compile error in the JSON payload for a kit that failed to build', async () => {
       arrangeSingleKit();
       mockCheckRebuild.mockResolvedValue({ kind: 'failed', message: 'Unexpected token' });
 
@@ -694,7 +694,7 @@ describe(verifyCommand, () => {
       expect(stdout).toContain('\u{2500}\u{2500} Verifying kits against ');
     });
 
-    it('leaves a wholly verified kit carrying nothing beyond its token', async () => {
+    it('leaves a wholly verified kit with nothing beyond its token', async () => {
       mockReadManifest.mockReturnValue({
         version: 1,
         kits: [{ name: 'alpha', path: 'alpha.js', targetHash: 'aaaa1111', source: 'alpha.ts', sourceHash: '5555aaaa' }],

--- a/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.wiring.unit.test.ts
@@ -132,7 +132,7 @@ describe('verifyCommand wiring', () => {
       expect(stdout).toContain(`${FAILED} demo\n   source file missing`);
     });
 
-    it('carries both source hashes in the JSON entry for a stale kit', async () => {
+    it('reports both source hashes in the JSON entry for a stale kit', async () => {
       const sourcePath = writeCompiledPair();
       const edited = Buffer.from('export default defineRdyKit({ checklists: [], failOn: "warn" });\n');
       writeFileSync(sourcePath, edited);
@@ -235,7 +235,7 @@ describe('verifyCommand wiring', () => {
       expect(stdout).toContain(`${OK} demo`);
     });
 
-    it('carries the axis and every failure into the JSON entry, at the schema version it always emitted', async () => {
+    it('passes the axis and every failure into the JSON entry, at the schema version it always emitted', async () => {
       writeRecordedClosure();
       writeFileSync(path.join(tempDir, 'shared.ts'), 'export const shared = 2;\n');
       writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'demo' }));

--- a/packages/readyup/src/verify/checkRebuild.ts
+++ b/packages/readyup/src/verify/checkRebuild.ts
@@ -92,7 +92,7 @@ export async function checkRebuild(kit: RdyManifestKit, manifestDir: string): Pr
   }
 
   // The generated banner embeds the compiling readyup's version, so a version move alone makes an
-  // untouched source rebuild to a different bundle. Carry the recorded version to keep that cause
+  // untouched source rebuild to a different bundle. Report the recorded version to keep that cause
   // distinguishable from a hand edit.
   const compiledWith = kit.readyupVersion !== VERSION ? kit.readyupVersion : undefined;
 


### PR DESCRIPTION
## What

Applies the plain-speech standard to `packages/readyup`'s markdown, test titles, and non-test source prose. `carriesPragma` is renamed to `hasPragma` to match naming conventions. The `rdy` binary's missing-build message is corrected to name `nmr build` as the command to run.

## Why

The vocabulary the earlier sweep replaced survived in the surfaces it left out, and the split was visible line to line: `formatCombinedSummary.unit.test.ts` had the comment `The run's writer separates one block from the next` directly above `it('carries no separation of its own')`. A reader could find `separated by a spaced slash` and `what parts one segment from the next` in one README, describing the same behavior.

`bin/rdy.js` compounded that with a message that sent anyone hitting a missing build to `pnpm run build`, which the package does not declare.

## Details

### ♻️ Refactoring

- `carriesPragma` is module-private to `suppressesFinding.ts`; both call sites follow the rename, and nothing outside the file names it.

### 🧪 Tests

- 152 title lines across 71 files in the first pass, plus 8 more in the follow-up. No title collides with a sibling in its `describe` block, and every diff line in a test file is a title string or one comment the earlier sweep overlooked.

### 📚 Documentation

- `README.md` (45 lines), `agents/README.md` (2), and `agents/guidance/rulebooks/readyup-kits.md` (1). No heading text moved, so `readmeSection.ts`'s section extraction, the `rdy help` topics that index it, and every anchor link are unaffected.
- The paragraph duplicated between `README.md` and the `readyup-kits` rulebook stays byte-identical across both homes; nothing guards the duplication.
- 21 non-test source files. Where something literally answers a question, `answers` is the plain verb and stands: `` `detail` answers why this status ``, `` the exit code answers "can I retry this invocation?" ``, and `checkRebuild.ts`'s `Answers exactly the question the hash verdicts approximate`.
- A follow-up pass closed two gaps the first left. Sentence-initial occurrences (`Carries the status …`, `Answers the repo probe …`) sit above the classes and helpers they describe, which is where a doc description most often puts its verb, and a case-sensitive sweep steps over all of them. Verb uses of `part` and `parts` were a second gap, split from the `parted` and `parting` the first pass did rewrite. Noun uses (`as part of`, `` the `@ref` part ``) are untouched.
- `.readyup/kits/demo.js` is recompiled to match its new banner, and `.readyup/manifest.json` records the new `targetHash`. `nmr ci` verifies bundles by recompiling before it builds, so a missed recompile fails the run.

Closes #408
