### PR TITLE
#413 Apply the comment and plain-speech standard across the overlay package

### DIFF
--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -2,7 +2,7 @@
 
 Overlay a canonical set of scaffolding files onto a target directory you do not control, and idempotently converge it: create what is missing, delete what is declared for removal, run normalization scripts, and refuse to silently clobber content it does not own.
 
-Overlay is built on [chezmoi](https://www.chezmoi.io/), whose source-state model fits exactly — `dot_`-encoded filenames, `executable_`/`run_` attributes, and `--source`/`--destination` to drive any source tree into any target. Overlay adds three modes (`--verify`, `--create`, `--force`) computed from a parsed `chezmoi status`, plus one guarantee chezmoi lacks natively: `--create` never overwrites a differing managed file.
+Overlay is built on [chezmoi](https://www.chezmoi.io/), whose source-state model fits exactly: `dot_`-encoded filenames, `executable_`/`run_` attributes, and `--source`/`--destination` to drive any source tree into any target. Overlay adds three modes (`--verify`, `--create`, `--force`) computed from a parsed `chezmoi status`, plus one guarantee chezmoi lacks natively: `--create` never overwrites a differing managed file.
 
 <!-- section:release-notes --><!-- /section:release-notes -->
 
@@ -32,8 +32,8 @@ chezmoi `2.46.0` or later is required; overlay preflights the version and exits 
 overlay <source-dir> [target-dir] [--verify|--create|--force] [--json] [--help]
 ```
 
-- `<source-dir>` — a chezmoi source directory describing the files the target should have.
-- `[target-dir]` — the directory to converge (defaults to the current working directory).
+- `<source-dir>`: a chezmoi source directory describing the files the target should have.
+- `[target-dir]`: the directory to converge (defaults to the current working directory).
 - Modes are mutually exclusive; the default is `--verify`.
 - `--json` prints the structured result instead of the text report.
 
@@ -70,13 +70,13 @@ Read-only. Drift is any `A`/`M`/`D` row; overlay exits `1` if any exists, `0` ot
 
 ### Why overlay does not use `chezmoi verify` directly
 
-Overlay runs every chezmoi invocation with a **throwaway `--persistent-state`** (a temp file discarded after each run). Because chezmoi keeps no memory across runs, it always believes `run_once_` / `run_onchange_` scripts are still pending — so `chezmoi verify` exits non-zero on a fully file-converged target. Overlay therefore parses `chezmoi status` itself and ignores the `R` rows for the verdict, which is the only way to get a clean verify on a converged target.
+Overlay runs every chezmoi invocation with a **throwaway `--persistent-state`** (a temp file discarded after each run). Because chezmoi keeps no memory across runs, it always believes `run_once_` / `run_onchange_` scripts are still pending, so `chezmoi verify` exits non-zero on a fully file-converged target. Overlay therefore parses `chezmoi status` itself and ignores the `R` rows for the verdict, which is the only way to get a clean verify on a converged target.
 
 ### `--create`
 
 Creates missing entries (`A`), performs native removals (`D`), runs `run_` scripts (`R`), and reports differing files (`M`) as conflicts that are **never written**. The fix-it hint suggests re-running with `--force` to overwrite.
 
-Mechanically, overlay applies only the `A`/`D` entries by **absolute target path** (`chezmoi apply --include=files,dirs,remove -- <abs paths>`), skipping that apply entirely when no `A`/`D` entries exist — a bare apply would converge every file and clobber the `M` entries the mode exists to protect. Scripts then run in a separate `--include=scripts` pass.
+Mechanically, overlay applies only the `A`/`D` entries by **absolute target path** (`chezmoi apply --include=files,dirs,remove -- <abs paths>`), skipping that apply entirely when no `A`/`D` entries exist: A bare apply would converge every file and clobber the `M` entries the mode exists to protect. Scripts then run in a separate `--include=scripts` pass.
 
 ### `--force`
 
@@ -84,11 +84,11 @@ A full `chezmoi apply`: overwrite differing files, perform removals, run scripts
 
 ## How script results are surfaced
 
-Under `--create` / `--force`, `run_` script stdout and stderr stream **live to overlay's stderr** — keeping overlay's stdout clean for the text report or `--json`. `OverlayResult.scripts` records `{ ran, ok }`. A script that exits non-zero aborts chezmoi's apply; overlay maps that to exit `2` and surfaces chezmoi's diagnostic. chezmoi provides no per-script structured output, so overlay does not invent any.
+Under `--create` / `--force`, `run_` script stdout and stderr stream **live to overlay's stderr**, keeping overlay's stdout clean for the text report or `--json`. `OverlayResult.scripts` records `{ ran, ok }`. A script that exits non-zero aborts chezmoi's apply; overlay maps that to exit `2` and surfaces chezmoi's diagnostic. chezmoi provides no per-script structured output, so overlay does not invent any.
 
 ## Idempotency contract
 
-Because each invocation uses a throwaway persistent-state, chezmoi keeps no cross-run memory: `run_once_` / `run_onchange_` scripts effectively run on **every** `--create` / `--force`. Source `run_` scripts must therefore be **idempotent**. This is intentional — it keeps runs isolated, pollutes no host state, and behaves predictably across targets.
+Because each invocation uses a throwaway persistent-state, chezmoi keeps no cross-run memory: `run_once_` / `run_onchange_` scripts effectively run on **every** `--create` / `--force`. Source `run_` scripts must therefore be **idempotent**. This is intentional: It keeps runs isolated, pollutes no host state, and behaves predictably across targets.
 
 ## Source-state filename grammar
 
@@ -105,7 +105,7 @@ const result = await overlay({ source: './scaffold', target: './repo', mode: 'cr
 // result: { mode, entries, scripts, counts, exitCode }
 ```
 
-`overlay(options)` returns a structured `OverlayResult` — never printed text — so other TypeScript code can compose with it.
+`overlay(options)` returns a structured `OverlayResult` (never printed text), so other TypeScript code can compose with it.
 
 ### Rendering an entry outcome
 
@@ -127,4 +127,4 @@ for (const entry of result.entries) {
 | `forced`   | `would overwrite` | `overwritten`      |
 | `conflict` | `would conflict`  | `conflict`         |
 
-Labels name the entry's resulting state rather than an action overlay took, and every `verify` label carries a `would ` prefix, so a consumer can tell a read-only run from an applied one. `--verify` never produces a `forced` entry (a differing file reads as `conflict`), so that cell exists only for totality. Labels are unpadded; aligning a column is the caller's job.
+Labels name the entry's resulting state rather than an action overlay took, and every `verify` label has a `would ` prefix, so a consumer can tell a read-only run from an applied one. `--verify` never produces a `forced` entry (a differing file reads as `conflict`), so that cell exists only for totality. Labels are unpadded; aligning a column is the caller's job.

--- a/packages/overlay/bin/overlay.js
+++ b/packages/overlay/bin/overlay.js
@@ -3,7 +3,7 @@ try {
   await import('../dist/esm/bin/overlay.js');
 } catch (error) {
   if (error.code === 'ERR_MODULE_NOT_FOUND') {
-    process.stderr.write('overlay: build output not found — run `pnpm run build` first\n');
+    process.stderr.write('overlay: build output not found; run `nmr build` first\n');
   } else {
     process.stderr.write(`overlay: failed to load: ${error.message}\n`);
   }

--- a/packages/overlay/src/bin/parseArgs.ts
+++ b/packages/overlay/src/bin/parseArgs.ts
@@ -16,7 +16,7 @@ const OPTIONS = {
   help: { type: 'boolean', short: 'h' },
 } as const;
 
-/** Every option name a token can carry: `node:util.parseArgs` reports a short flag under its long name. */
+/** Every option name a token can resolve to: `node:util.parseArgs` reports a short flag under its long name. */
 const ACCEPTED_NAMES = new Set<string>(Object.keys(OPTIONS));
 
 /**

--- a/packages/overlay/src/bin/run.ts
+++ b/packages/overlay/src/bin/run.ts
@@ -7,7 +7,7 @@ import { formatJsonError } from '../reporting/formatJsonError.ts';
 import { formatReport } from '../reporting/formatReport.ts';
 import { parseArgs } from './parseArgs.ts';
 
-export const HELP = `overlay — overlay a chezmoi source tree onto a target directory
+export const HELP = `overlay: overlay a chezmoi source tree onto a target directory
 
 Usage:
   overlay <source-dir> [target-dir] [--verify|--create|--force] [--json] [--help]
@@ -42,7 +42,7 @@ Exit codes:
  *
  * Writes the help text or the run result (text report, or JSON under `--json`)
  * to stdout, and any error as a single-line JSON object to stderr. Never calls
- * `process.exit` — the bin entrypoint owns that, keeping this function testable.
+ * `process.exit`: The bin entrypoint owns that, keeping this function testable.
  */
 export async function run(argv: string[]): Promise<number> {
   try {

--- a/packages/overlay/src/chezmoi/__tests__/run-chezmoi.unit.test.ts
+++ b/packages/overlay/src/chezmoi/__tests__/run-chezmoi.unit.test.ts
@@ -132,7 +132,7 @@ function readStdio(options: unknown): unknown {
 /** Signature of the Node-style callback the promisified `execFile` drives. */
 type ExecFileCallback = (error: unknown, result?: { stdout: string; stderr: string }) => void;
 
-/** Drives the promisified `execFile` callback with a rejection carrying captured streams. */
+/** Drives the promisified `execFile` callback with a rejection that includes captured streams. */
 function rejectExecFile(error: Record<string, unknown>): void {
   execFileMock.mockImplementation((_cmd: string, _args: string[], callback: ExecFileCallback) => {
     callback(error);

--- a/packages/overlay/src/chezmoi/readStatus.ts
+++ b/packages/overlay/src/chezmoi/readStatus.ts
@@ -5,7 +5,7 @@ import { runChezmoiCaptured } from './run-chezmoi.ts';
  * Reads `chezmoi status`, treating a non-zero exit as a hard error.
  *
  * A non-zero `status` exit (missing source dir, rejected flag, config issue) yields empty stdout, which `parseStatus`
- * would read as "no drift" — silently masking the failure as a converged target. Throwing here propagates to the
+ * would read as "no drift", silently masking the failure as a converged target. Throwing here propagates to the
  * top-level handler, which maps it to exit `2`.
  */
 export async function readStatus(context: ChezmoiContext): Promise<string> {

--- a/packages/overlay/src/chezmoi/run-chezmoi.ts
+++ b/packages/overlay/src/chezmoi/run-chezmoi.ts
@@ -75,7 +75,7 @@ function buildArgs(context: ChezmoiContext, persistentStatePath: string, configP
 function interpretExecFileError(error: unknown): CapturedResult {
   if (isExecFileError(error)) {
     if (error.code === 'ENOENT') {
-      throw new Error('chezmoi not found on PATH — install it (e.g. `brew install chezmoi`)');
+      throw new Error('chezmoi not found on PATH; install it (e.g. `brew install chezmoi`)');
     }
     return {
       stdout: typeof error.stdout === 'string' ? error.stdout : '',
@@ -86,7 +86,7 @@ function interpretExecFileError(error: unknown): CapturedResult {
   throw error;
 }
 
-/** Shape of a Node `execFile` rejection carrying captured streams and an exit code. */
+/** Shape of a Node `execFile` rejection with captured streams and an exit code. */
 interface ExecFileError {
   code?: number | string;
   stdout?: unknown;

--- a/packages/overlay/src/chezmoi/version.ts
+++ b/packages/overlay/src/chezmoi/version.ts
@@ -19,7 +19,7 @@ const MINIMUM_VERSION: SemverParts = { major: 2, minor: 46, patch: 0 };
 export async function assertChezmoiVersion(context: ChezmoiContext): Promise<void> {
   const { stdout, code } = await runChezmoiCaptured(context, ['--version']);
   if (code !== 0) {
-    throw new Error('chezmoi is not available — install it (e.g. `brew install chezmoi`)');
+    throw new Error('chezmoi is not available; install it (e.g. `brew install chezmoi`)');
   }
   const installed = parseVersion(stdout);
   if (installed === undefined) {

--- a/packages/overlay/src/modes/__tests__/entry-outcomes.unit.test.ts
+++ b/packages/overlay/src/modes/__tests__/entry-outcomes.unit.test.ts
@@ -60,7 +60,7 @@ describe(partitionStatus, () => {
 });
 
 describe(countOutcome, () => {
-  it('counts only the entries carrying the given outcome', () => {
+  it('counts only the entries with the given outcome', () => {
     const entries: OverlayEntry[] = [
       { path: '.a', outcome: 'created' },
       { path: '.b', outcome: 'conflict' },
@@ -70,7 +70,7 @@ describe(countOutcome, () => {
     expect(countOutcome(entries, 'created')).toBe(2);
   });
 
-  it('returns 0 when no entry carries the given outcome', () => {
+  it('returns 0 when no entry has the given outcome', () => {
     expect(countOutcome([{ path: '.a', outcome: 'created' }], 'forced')).toBe(0);
   });
 });

--- a/packages/overlay/src/modes/create.ts
+++ b/packages/overlay/src/modes/create.ts
@@ -12,7 +12,7 @@ import type { OverlayResult } from './types.ts';
  * and report differing files (`M`) as conflicts that are never written.
  *
  * The `A`/`D` set is applied by *absolute* target path so chezmoi touches only those entries. When that set is empty
- * the targeted apply is skipped entirely — a bare `chezmoi apply` would converge *every* file and clobber the `M`
+ * the targeted apply is skipped entirely: A bare `chezmoi apply` would converge *every* file and clobber the `M`
  * entries the mode exists to protect. Scripts run in a separate `--include=scripts` pass. Exit `2` if the file-apply
  * or scripts pass failed, else `1` if any conflicts exist, else `0`.
  */

--- a/packages/overlay/src/modes/types.ts
+++ b/packages/overlay/src/modes/types.ts
@@ -32,7 +32,7 @@ export interface OverlayCounts {
   pending: number;
 }
 
-/** The structured result of an overlay run — never printed text. */
+/** The structured result of an overlay run, never printed text. */
 export interface OverlayResult {
   mode: OverlayMode;
   entries: OverlayEntry[];

--- a/packages/overlay/src/modes/verify.ts
+++ b/packages/overlay/src/modes/verify.ts
@@ -7,11 +7,11 @@ import type { OverlayResult } from './types.ts';
 /**
  * Read-only mode: report drift from a parsed `chezmoi status` and exit non-zero when any exists. Drift is any
  * `A`/`M`/`D` row. `R` rows (pending `run_` scripts) are surfaced informationally in `scripts.ran` but never affect
- * the verdict — overlay confirms *file convergence*, not *script execution*. This is why overlay parses `status`
- * instead of shelling out to `chezmoi verify`, which exits non-zero on pending scripts under throwaway
+ * the verdict, since overlay confirms *file convergence*, not *script execution*. This is why overlay parses
+ * `status` instead of shelling out to `chezmoi verify`, which exits non-zero on pending scripts under throwaway
  * persistent-state.
  *
- * Drift entries carry the outcome they *would* have under `--create`: an `A` row reads as `created`, `D` as
+ * A drift entry's outcome is the one it *would* have under `--create`: an `A` row reads as `created`, `D` as
  * `deleted`, and `M` as `conflict`.
  */
 export async function runVerify(context: ChezmoiContext): Promise<OverlayResult> {


### PR DESCRIPTION
## What

Applies the comment and plain-speech standard to `packages/overlay`, including its README, source comments, and user-facing error messages.

Also corrects an error message in overlay's launcher, naming `nmr build` as the command to run when the build is missing.

## Why

The standard had reached readyup's TypeScript comments but neither of overlay's passes, leaving one package's prose out of step with the rest of the monorepo. Overlay's launcher compounded that: A reader who hit a missing build was told to run a script that does not exist, so the message could not resolve the problem it reported.

## Details

### 🐛 Bug fixes

- `bin/overlay.js` told a reader hitting `ERR_MODULE_NOT_FOUND` to run `pnpm run build`. Neither `packages/overlay/package.json`, which declares only `prepare`, nor the repository root declares a `build` script; the repository builds through `nmr build`, and the message now names it. Its em-dash becomes a semicolon in the same edit. The published tarball ships `dist` via `files`, so this branch is reached in-repo, where `nmr` resolves.

### 📚 Documentation

- Eighteen em-dashes resolve to the mark each relation actually takes rather than to a uniform substitute. An identifier separated from its gloss takes a colon (the `HELP` banner, the README's option list); a diagnosis followed by an instruction takes a semicolon, consistently across all three error strings; a clause introducing its consequence takes a colon with a capitalized sentence following.
- The paired-dash parenthetical in `README.md` becomes parentheses plus a comma, keeping the aside intact rather than splitting it across two marks.
- Two sites are recast instead of repunctuated, where no mark read well. `verify.ts` turns a dash-joined consequence into a `since` clause, and rewrites "Drift entries carry the outcome they *would* have" as "A drift entry's outcome is the one it *would* have", removing the verb and the dash together.
- Seven `carry`-family verbs are replaced across the README, three source comments, two test titles, and one test helper's description. `holds`, `yields`, `surfaces`, and `owns` are left alone; they are the standard's own replacements, not violations of it.
- `CHANGELOG.md` is excluded. The release workflow generates it, so an edit would be overwritten on the next release.
- No test changed. The three rewritten error strings are matched by their prefixes, ahead of the punctuation that moved, so the existing assertions in `run-chezmoi.unit.test.ts`, `version.unit.test.ts`, and `run.unit.test.ts` pass unchanged.

Closes #413
