### PR TITLE
#411 Rename ScriptsSummary.ran to ranCount

### DIFF
--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -84,7 +84,7 @@ A full `chezmoi apply`: overwrite differing files, perform removals, run scripts
 
 ## How script results are surfaced
 
-Under `--create` / `--force`, `run_` script stdout and stderr stream **live to overlay's stderr**, keeping overlay's stdout clean for the text report or `--json`. `OverlayResult.scripts` records `{ ran, ok }`. A script that exits non-zero aborts chezmoi's apply; overlay maps that to exit `2` and surfaces chezmoi's diagnostic. chezmoi provides no per-script structured output, so overlay does not invent any.
+Under `--create` / `--force`, `run_` script stdout and stderr stream **live to overlay's stderr**, keeping overlay's stdout clean for the text report or `--json`. `OverlayResult.scripts` records `{ ranCount, ok }`. A script that exits non-zero aborts chezmoi's apply; overlay maps that to exit `2` and surfaces chezmoi's diagnostic. chezmoi provides no per-script structured output, so overlay does not invent any.
 
 ## Idempotency contract
 

--- a/packages/overlay/src/__tests__/overlay.tool.test.ts
+++ b/packages/overlay/src/__tests__/overlay.tool.test.ts
@@ -63,7 +63,7 @@ describe.skipIf(!hasChezmoi)('overlay against real chezmoi', () => {
     await expect(readFile(path.join(target, '.difffile'), 'utf8')).resolves.toBe(CANONICAL_CONTENT);
     expect(existsSync(path.join(target, '.sentinel'))).toBe(true);
     expect(existsSync(path.join(target, '.planted'))).toBe(false);
-    expect(result.scripts.ran).toBeGreaterThan(0);
+    expect(result.scripts.ranCount).toBeGreaterThan(0);
     expect(result.exitCode).toBe(0);
   });
 
@@ -74,7 +74,7 @@ describe.skipIf(!hasChezmoi)('overlay against real chezmoi', () => {
     const result = await overlay({ source, target, mode: 'verify' });
 
     expect(result.exitCode).toBe(0);
-    expect(result.scripts.ran).toBeGreaterThan(0);
+    expect(result.scripts.ranCount).toBeGreaterThan(0);
   });
 
   it('maps a failing run_ script to exit 2 under create', async () => {

--- a/packages/overlay/src/__tests__/overlay.unit.test.ts
+++ b/packages/overlay/src/__tests__/overlay.unit.test.ts
@@ -13,7 +13,7 @@ import { overlay } from '../overlay.ts';
 const stubResult: OverlayResult = {
   mode: 'verify',
   entries: [],
-  scripts: { ran: 0, ok: true },
+  scripts: { ranCount: 0, ok: true },
   counts: { created: 0, deleted: 0, forced: 0, conflicts: 0, pending: 0 },
   exitCode: 0,
 };

--- a/packages/overlay/src/bin/__tests__/run.unit.test.ts
+++ b/packages/overlay/src/bin/__tests__/run.unit.test.ts
@@ -9,7 +9,7 @@ import { run } from '../run.ts';
 const stubResult: OverlayResult = {
   mode: 'create',
   entries: [{ path: '.newfile', outcome: 'created' }],
-  scripts: { ran: 0, ok: true },
+  scripts: { ranCount: 0, ok: true },
   counts: { created: 1, deleted: 0, forced: 0, conflicts: 0, pending: 0 },
   exitCode: 0,
 };

--- a/packages/overlay/src/modes/__tests__/verify.unit.test.ts
+++ b/packages/overlay/src/modes/__tests__/verify.unit.test.ts
@@ -41,7 +41,7 @@ describe(runVerify, () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.entries).toStrictEqual([]);
-    expect(result.scripts).toStrictEqual({ ran: 2, ok: true });
+    expect(result.scripts).toStrictEqual({ ranCount: 2, ok: true });
   });
 
   it('surfaces pending scripts while still failing on file drift', async () => {
@@ -50,7 +50,7 @@ describe(runVerify, () => {
     const result = await runVerify(context);
 
     expect(result.exitCode).toBe(1);
-    expect(result.scripts.ran).toBe(1);
+    expect(result.scripts.ranCount).toBe(1);
     expect(result.counts.pending).toBe(1);
   });
 });

--- a/packages/overlay/src/modes/create.ts
+++ b/packages/overlay/src/modes/create.ts
@@ -44,7 +44,7 @@ export async function runCreate(context: ChezmoiContext): Promise<OverlayResult>
   // A failed file-apply aborts before the scripts pass, mirroring `--force`'s single apply: don't run normalization
   // scripts against a target whose files never converged.
   if (applyCode !== 0) {
-    return { mode: 'create', entries, scripts: { ran: pendingScriptCount, ok: false }, counts, exitCode: 2 };
+    return { mode: 'create', entries, scripts: { ranCount: pendingScriptCount, ok: false }, counts, exitCode: 2 };
   }
 
   const scriptsCode = pendingScriptCount > 0 ? await runChezmoiStreamed(context, ['apply', '--include=scripts']) : 0;
@@ -53,7 +53,7 @@ export async function runCreate(context: ChezmoiContext): Promise<OverlayResult>
   return {
     mode: 'create',
     entries,
-    scripts: { ran: pendingScriptCount, ok },
+    scripts: { ranCount: pendingScriptCount, ok },
     counts,
     exitCode: computeExitCode(ok, conflicts),
   };

--- a/packages/overlay/src/modes/force.ts
+++ b/packages/overlay/src/modes/force.ts
@@ -24,7 +24,7 @@ export async function runForce(context: ChezmoiContext): Promise<OverlayResult> 
   return {
     mode: 'force',
     entries,
-    scripts: { ran: pendingScriptCount, ok },
+    scripts: { ranCount: pendingScriptCount, ok },
     counts: {
       created: countOutcome(entries, 'created'),
       deleted: countOutcome(entries, 'deleted'),

--- a/packages/overlay/src/modes/types.ts
+++ b/packages/overlay/src/modes/types.ts
@@ -11,11 +11,11 @@ export interface OverlayEntry {
 }
 
 /**
- * Summary of `run_` script execution. `ran` is the number of pending/run scripts; `ok` is false only if execution
- * failed.
+ * Summary of `run_` script execution. `ranCount` is the number of pending/run scripts; `ok` is false only if
+ * execution failed.
  */
 export interface ScriptsSummary {
-  ran: number;
+  ranCount: number;
   ok: boolean;
 }
 

--- a/packages/overlay/src/modes/verify.ts
+++ b/packages/overlay/src/modes/verify.ts
@@ -6,8 +6,8 @@ import type { OverlayResult } from './types.ts';
 
 /**
  * Read-only mode: report drift from a parsed `chezmoi status` and exit non-zero when any exists. Drift is any
- * `A`/`M`/`D` row. `R` rows (pending `run_` scripts) are surfaced informationally in `scripts.ran` but never affect
- * the verdict, since overlay confirms *file convergence*, not *script execution*. This is why overlay parses
+ * `A`/`M`/`D` row. `R` rows (pending `run_` scripts) are surfaced informationally in `scripts.ranCount` but never
+ * affect the verdict, since overlay confirms *file convergence*, not *script execution*. This is why overlay parses
  * `status` instead of shelling out to `chezmoi verify`, which exits non-zero on pending scripts under throwaway
  * persistent-state.
  *
@@ -24,7 +24,7 @@ export async function runVerify(context: ChezmoiContext): Promise<OverlayResult>
   return {
     mode: 'verify',
     entries,
-    scripts: { ran: pendingScriptCount, ok: true },
+    scripts: { ranCount: pendingScriptCount, ok: true },
     counts: { created: 0, deleted: 0, forced: 0, conflicts: 0, pending: entries.length },
     exitCode: entries.length > 0 ? 1 : 0,
   };

--- a/packages/overlay/src/reporting/__tests__/formatReport.unit.test.ts
+++ b/packages/overlay/src/reporting/__tests__/formatReport.unit.test.ts
@@ -81,13 +81,13 @@ describe(formatReport, () => {
   });
 
   it('phrases pending scripts as "would run" under verify', () => {
-    const report = formatReport(buildResult({ mode: 'verify', scripts: { ran: 2, ok: true } }));
+    const report = formatReport(buildResult({ mode: 'verify', scripts: { ranCount: 2, ok: true } }));
 
     expect(report).toContain('2 scripts would run.');
   });
 
   it('phrases executed scripts as "ran" under create', () => {
-    const report = formatReport(buildResult({ mode: 'create', scripts: { ran: 1, ok: true } }));
+    const report = formatReport(buildResult({ mode: 'create', scripts: { ranCount: 1, ok: true } }));
 
     expect(report).toContain('1 script ran.');
   });
@@ -146,7 +146,7 @@ describe(formatReport, () => {
   });
 
   it('notes a script failure in the scripts summary', () => {
-    const report = formatReport(buildResult({ mode: 'force', scripts: { ran: 1, ok: false }, exitCode: 2 }));
+    const report = formatReport(buildResult({ mode: 'force', scripts: { ranCount: 1, ok: false }, exitCode: 2 }));
 
     expect(report).toContain('a script failed');
   });
@@ -172,7 +172,7 @@ function buildResult(overrides: Partial<OverlayResult>): OverlayResult {
   return {
     mode: 'verify',
     entries: [],
-    scripts: { ran: 0, ok: true },
+    scripts: { ranCount: 0, ok: true },
     counts: { created: 0, deleted: 0, forced: 0, conflicts: 0, pending: 0 },
     exitCode: 0,
     ...overrides,

--- a/packages/overlay/src/reporting/formatReport.ts
+++ b/packages/overlay/src/reporting/formatReport.ts
@@ -73,7 +73,7 @@ function summarizeCounts(result: OverlayResult): string {
 function summarizeScripts(result: OverlayResult): string {
   const verb = result.mode === 'verify' ? 'would run' : 'ran';
   const status = result.scripts.ok ? '' : ' (a script failed)';
-  return `${pluralizeWithCount(result.scripts.ran, 'script')} ${verb}${status}.`;
+  return `${pluralizeWithCount(result.scripts.ranCount, 'script')} ${verb}${status}.`;
 }
 
 // endregion | Helpers


### PR DESCRIPTION
## What

Renames the `ran` field of `OverlayResult.scripts` to `ranCount` for clarity.

Migration: Consumers reading `scripts.ran`, whether from `--json` output or from the `overlay()` return value, read `scripts.ranCount` instead.

## Why

`ScriptsSummary.ran` is a count named as a verb, the last of overlay's naming-convention violations. It is also the only one a consumer can observe, so correcting it changes the published output contract and had to land on its own rather than alongside the package's internal naming cleanup.

## Details

### 🎉 Features

- 🚨 **Breaking:** `OverlayResult.scripts.ran` is now `scripts.ranCount`, in the exported `ScriptsSummary` type and in `--json` output. `ok` is unchanged, and `ScriptsSummary` keeps its name.
- The rendered text report is unaffected: its "N script(s) ran" wording is built from a pluralization helper rather than from the field name.

Closes #411
