### PR TITLE
#352 Name the value a description returns instead of calling it nothing

### DIFF
--- a/packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts
@@ -49,7 +49,7 @@ describe(discoverKitPackages, () => {
     expect(discoverKitPackages(temp.dir)).not.toContain('undeclared-kit');
   });
 
-  it('returns nothing when the project manifest cannot be read', () => {
+  it('returns an empty list when the project manifest cannot be read', () => {
     using manifestless = createTempTree({}, { prefix: 'discover-no-manifest-' });
 
     expect(discoverKitPackages(manifestless.dir)).toStrictEqual([]);

--- a/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
@@ -69,7 +69,7 @@ describe(resolveCompileRoot, () => {
 
 // region | Helpers
 
-/** Returns the nearest directory at or above `fromDir` holding a `package.json`, or nothing where none does. */
+/** Returns the nearest directory at or above `fromDir` holding a `package.json`, or undefined where none does. */
 function findAncestorManifest(fromDir: string): string | undefined {
   for (let directory = fromDir; ; directory = path.dirname(directory)) {
     if (existsSync(path.join(directory, 'package.json'))) return directory;

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -239,7 +239,7 @@ function hasUnresolvedSpecifier(error: unknown): boolean {
  * Returns the name and version of the package holding `directory`, walking up to the nearest
  * `package.json` that declares both.
  *
- * The walk never leaves `node_modules`: a store path with no identifiable package returns nothing
+ * The walk never leaves `node_modules`: a store path with no identifiable package returns undefined
  * rather than climbing on and attributing the file to the host project.
  */
 function identifyPackage(directory: string): { name: string; version: string } | undefined {
@@ -257,7 +257,7 @@ function isDependencyFile(filePath: string): boolean {
   return filePath.split(path.sep).includes(EXCLUDED_DIRECTORY);
 }
 
-/** Returns a package.json's name and version, or nothing when the file does not declare both readably. */
+/** Returns a package.json's name and version, or undefined when the file does not declare both readably. */
 function readPackageIdentity(manifestPath: string): { name: string; version: string } | undefined {
   let parsed: unknown;
   try {

--- a/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
@@ -129,7 +129,7 @@ describe('formatReasonBlock', () => {
     expect(engine.formatReasonBlock(['first', 'second'])).toHaveLength(2);
   });
 
-  it('returns nothing for no reasons', () => {
+  it('returns an empty list for no reasons', () => {
     expect(engine.formatReasonBlock([])).toStrictEqual([]);
   });
 
@@ -511,7 +511,7 @@ describe('token and glyph', () => {
     expect(engine.inlineGlyph('skippedOptional')).toBe(`${SKIPPED} `);
   });
 
-  it('returns nothing for a token the formatter gives no glyph, so no orphan space is left behind', () => {
+  it('returns an empty string for a token the formatter gives no glyph, so no orphan space is left behind', () => {
     const glyphless = createLayoutEngine({
       ...richFormatter,
       tokens: { ...richFormatter.tokens, kit: { glyph: '', width: 0 } },

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -225,7 +225,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
   /**
    * Returns a token's glyph and one trailing space, for placement mid-sentence rather than at a line's head.
    *
-   * A formatter that gives the token no glyph returns nothing, so the sentence closes up with no space.
+   * A formatter that gives the token no glyph returns an empty string, so the sentence closes up with no space.
    */
   function inlineGlyph(name: TokenName): string {
     const { glyph } = formatter.tokens[name];
@@ -282,7 +282,7 @@ function formatCounts(counts: SummaryCounts): string {
   return fields.length > 0 ? fields.join(COUNT_SEPARATOR) : EMPTY_COUNTS;
 }
 
-/** Returns the formatted duration, or nothing for a skipped token or a duration under the floor. */
+/** Returns the formatted duration, or undefined for a skipped token or a duration under the floor. */
 function resolveDuration(token: TokenName, durationMs: number | undefined): string | undefined {
   if (durationMs === undefined || SKIPPED_TOKENS.has(token)) return undefined;
   return durationMs >= DURATION_FLOOR_MS ? formatDuration(durationMs) : undefined;

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -307,7 +307,7 @@ function buildProjectHint(project: RecursiveProjectView): string {
 }
 
 /**
- * Returns what a dependency command needs to run from the sweep root, which is nothing at the root itself.
+ * Returns what a dependency command needs to run from the sweep root, which is an empty string at the root itself.
  *
  * A workspace's own dependency is reachable from nowhere else: `rdy run` takes no directory, and `--from`
  * names a kit source rather than a working directory.

--- a/packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts
@@ -110,7 +110,7 @@ describe(walkDirectories, () => {
     expect(found).toStrictEqual(['.', 'deep/one/two', 'packages/a']);
   });
 
-  it('returns nothing for a root that does not exist', ({ temp }) => {
+  it('returns an empty list for a root that does not exist', ({ temp }) => {
     const found = walkDirectories({ root: `${temp.dir}/absent`, match: '**/package.json' });
 
     expect(found).toStrictEqual([]);

--- a/packages/readyup/src/portable/blankNonCode.ts
+++ b/packages/readyup/src/portable/blankNonCode.ts
@@ -175,7 +175,7 @@ function findBlockCommentEnd(source: string, from: number): number {
   return end === -1 ? source.length : end + 2;
 }
 
-/** Returns the offset past the comment opening at an offset, or nothing where none opens there. */
+/** Returns the offset past the comment opening at an offset, or undefined where none opens there. */
 function findCommentEnd(source: string, from: number): number | undefined {
   if (source[from] !== '/') return undefined;
 
@@ -191,7 +191,7 @@ function findLineEnd(source: string, from: number): number {
   return end === -1 ? source.length : end;
 }
 
-/** Returns the offset past a regular expression's closing delimiter, or nothing where the line ends first. */
+/** Returns the offset past a regular expression's closing delimiter, or undefined where the line ends first. */
 function findRegexEnd(source: string, start: number): number | undefined {
   let index = start + 1;
   let isInClass = false;

--- a/packages/readyup/src/reporting/formatJsonReport.ts
+++ b/packages/readyup/src/reporting/formatJsonReport.ts
@@ -160,7 +160,7 @@ function splitCounts(counts: SummaryCounts): { counts: JsonCounts; worstSeverity
 }
 
 /**
- * Returns the `checks` property for a checklist entry, or nothing when the projection leaves it empty.
+ * Returns a checklist entry's `checks` property, omitted when the projection leaves it empty.
  *
  * The reporting threshold prunes first and the detail projection second, so `summary` shows the same
  * failures `full` would, without the checks that passed around them.

--- a/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
@@ -55,7 +55,7 @@ describe(readManifestTracking, () => {
     expect(mockReadManifest).not.toHaveBeenCalled();
   });
 
-  it('returns nothing when no manifest exists', () => {
+  it('returns undefined when no manifest exists', () => {
     mockReadManifest.mockImplementation(() => {
       throw new Error('Manifest file not found: /abs/.readyup/manifest.json');
     });
@@ -63,7 +63,7 @@ describe(readManifestTracking, () => {
     expect(readManifestTracking(false)).toBeUndefined();
   });
 
-  it('returns nothing when the manifest cannot be parsed', () => {
+  it('returns undefined when the manifest cannot be parsed', () => {
     mockReadManifest.mockImplementation(() => {
       throw new Error('Manifest file contains invalid JSON: /abs/.readyup/manifest.json');
     });

--- a/packages/readyup/src/run/__tests__/resolveCheckIds.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveCheckIds.unit.test.ts
@@ -47,7 +47,7 @@ describe(resolveCheckIds, () => {
     });
   });
 
-  it('resolves nothing for a check declaring no id', () => {
+  it('resolves to undefined for a check declaring no id', () => {
     expect(resolveCheckIds(undefined, packageProvenance('@williamthorsen/toolbelt.errors'))).toBeUndefined();
   });
 });

--- a/packages/readyup/src/run/__tests__/resolveConfiguredPackages.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveConfiguredPackages.unit.test.ts
@@ -59,7 +59,7 @@ describe(resolveConfiguredPackages, () => {
   });
 
   // A bare `--packages` fills the name in, so no package publishing it is the "requires nothing" case.
-  it('resolves to nothing when no configured package publishes the default kit', ({ temp }) => {
+  it('resolves to an empty list when no configured package publishes the default kit', ({ temp }) => {
     installPackage(temp, '@acme/kits', ['preflight']);
 
     expect(resolveConfiguredPackages(['@acme/kits'], ['default'], '.js')).toStrictEqual([]);

--- a/packages/readyup/src/run/kit-staleness.ts
+++ b/packages/readyup/src/run/kit-staleness.ts
@@ -120,7 +120,7 @@ function hasChangedInput(status: InputsStatus | undefined): boolean {
   return status?.kind === 'stale' && status.failures.some((failure) => failure.reason === 'changed');
 }
 
-/** Returns a staleness verdict, or nothing when reaching one needed a file that cannot be read. */
+/** Returns a staleness verdict, or undefined when reaching one needed a file that cannot be read. */
 function readVerdict<TStatus>(check: () => TStatus): TStatus | undefined {
   try {
     return check();

--- a/packages/readyup/src/run/resolveCheckIds.ts
+++ b/packages/readyup/src/run/resolveCheckIds.ts
@@ -7,7 +7,7 @@ export interface CheckIds {
 }
 
 /**
- * Returns the strings naming a check, or nothing where the check declares no id.
+ * Returns the strings naming a check, or undefined where the check declares no id.
  *
  * A kit a package publishes namespaces its checks under that package's name with the scope stripped, and
  * accepts the fully-qualified name too. The bare id is not accepted there: the namespace is what keeps two

--- a/packages/readyup/src/run/runHumanMode.ts
+++ b/packages/readyup/src/run/runHumanMode.ts
@@ -136,7 +136,7 @@ function createBlockWriter(): BlockWriter {
 }
 
 /**
- * Returns the segment naming where a kit came from, or nothing where there is nothing to name.
+ * Returns the segment naming where a kit came from, or undefined where there is nothing to name.
  *
  * A kit the local kits directory holds has no source, and neither does one whose directory resolves to
  * the working directory: naming the directory the reader is standing in tells them nothing. A package

--- a/packages/readyup/src/run/skip-diagnosis.ts
+++ b/packages/readyup/src/run/skip-diagnosis.ts
@@ -60,7 +60,7 @@ function describeCheck(entry: ResolvedKitEntry, checklistName: string, name: str
 }
 
 /**
- * Diagnoses one skipped check, answering with nothing where its `check` would have failed.
+ * Diagnoses one skipped check, returning undefined where its `check` would have failed.
  *
  * A `check` that throws, one whose findings cannot be read, or one returning a value expressing no
  * verdict leaves the question undecided: reporting any of them as a masked pass would assert something

--- a/packages/readyup/src/verify/checkInputDrift.ts
+++ b/packages/readyup/src/verify/checkInputDrift.ts
@@ -45,7 +45,7 @@ export function checkInputDrift(kit: RdyManifestKit, manifestDir: string): Input
 
 // region | Helpers
 
-/** Returns what is wrong with one recorded input, or nothing when it still matches. */
+/** Returns what is wrong with one recorded input, or undefined when it still matches. */
 function checkInput(input: RdyManifestInput, manifestDir: string): InputFailure | undefined {
   const resolvedPath = path.resolve(manifestDir, input.path);
   if (!existsSync(resolvedPath)) {

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -242,7 +242,7 @@ function hasSourceFailed(status: SourceStatus): boolean {
   return status.kind === 'missing' || status.kind === 'stale';
 }
 
-/** Returns a clause describing the compiled-output verdict, or nothing when the verdict is `ok`. */
+/** Returns a clause describing the compiled-output verdict, or undefined when the verdict is `ok`. */
 function describeDriftStatus(kit: RdyManifestKit, status: DriftStatus): string | undefined {
   switch (status.kind) {
     case 'ok':
@@ -256,7 +256,7 @@ function describeDriftStatus(kit: RdyManifestKit, status: DriftStatus): string |
   }
 }
 
-/** Returns a clause describing the source verdict, or nothing when it is `ok` or `unverified`. */
+/** Returns a clause describing the source verdict, or undefined when it is `ok` or `unverified`. */
 function describeSourceStatus(kit: RdyManifestKit, status: SourceStatus): string | undefined {
   switch (status.kind) {
     case 'stale':
@@ -287,7 +287,7 @@ function describeInputFailure(failure: InputFailure): string {
 }
 
 /**
- * Returns a clause describing the rebuild verdict, or nothing when there is nothing to add.
+ * Returns a clause describing the rebuild verdict, or undefined when there is nothing to add.
  *
  * A passing rebuild is silent only where the hash verdicts already reached `ok` and it would
  * restate them. Anywhere else it speaks, because it then holds the line's strongest answer: over


### PR DESCRIPTION
## What

Replaces the vague use of "nothing" in `readyup`'s doc descriptions and test titles with the value the code actually returns: `undefined`, an empty string, an empty list, or a property omitted from the returned object.

## Why

The word named four different values at once, so a reader who met it had to open the signature to learn which one a description meant, and a reader who did not carried the wrong assumption into the next change. The package had already settled a clearer form, and the `nothing` sites were a minority variant that read as established style to the next author looking for a pattern to follow.

## Details

### 📚 Documentation

- 25 sites under `packages/readyup/src`, 7 of them test titles or a test helper's description. 17 name `undefined` and match the `or undefined where <condition>` form the package already used; 3 name an empty string, 4 an empty list, and 1 a property omitted from the returned object.
- Two sentences carry `nothing` twice with different meanings and keep the second use: `runHumanMode.ts` reads "or undefined where there is nothing to name", and `verifyCommand.ts` "or undefined when there is nothing to add".
- `skip-diagnosis.ts` corrects its verb in passing, from "answering with nothing" to "returning undefined". Every other use of `answers` is left to #353.
- The sites where `nothing` names an absence stand as written: a file yielding no entries, a write that does not happen, a resolution nothing satisfies.

Closes #352
