### PR TITLE
#418 Name the value compositor descriptions and titles call nothing

### DIFF
--- a/packages/compositor/src/apply/applyPlan.ts
+++ b/packages/compositor/src/apply/applyPlan.ts
@@ -132,7 +132,7 @@ function describeDrift(file: FileEntry, held: Hash | undefined): string {
   return `The destination holds ${holds} where the plan recorded ${recorded}, so it moved after the plan was composed.`;
 }
 
-/** Hashes what a destination holds, or reports that it holds nothing. */
+/** Hashes what a destination holds, returning undefined where it holds none. */
 async function hashIfPresent(destination: string): Promise<Hash | undefined> {
   try {
     return hashBytes(await readFile(destination));

--- a/packages/compositor/src/apply/applyPlan.ts
+++ b/packages/compositor/src/apply/applyPlan.ts
@@ -132,7 +132,7 @@ function describeDrift(file: FileEntry, held: Hash | undefined): string {
   return `The destination holds ${holds} where the plan recorded ${recorded}, so it moved after the plan was composed.`;
 }
 
-/** Hashes what a destination holds, returning undefined where it holds none. */
+/** Hashes what a destination holds, returning `undefined` where it holds none. */
 async function hashIfPresent(destination: string): Promise<Hash | undefined> {
   try {
     return hashBytes(await readFile(destination));

--- a/packages/compositor/src/closure/__tests__/buildEdgeGraph.unit.test.ts
+++ b/packages/compositor/src/closure/__tests__/buildEdgeGraph.unit.test.ts
@@ -182,7 +182,7 @@ async function buildCatalog(): Promise<Catalog> {
   ]);
 }
 
-/** Contributes `contribution` for one artifact and nothing for every other. */
+/** Contributes `contribution` for one artifact and an empty contribution for every other. */
 function contributeFor(artifactId: string, contribution: EdgeContribution): (read: ArtifactRead) => EdgeContribution {
   return (read: ArtifactRead): EdgeContribution =>
     read.artifactId === artifactId ? contribution : { edges: [], partials: [] };

--- a/packages/compositor/src/closure/__tests__/expandWildcard.unit.test.ts
+++ b/packages/compositor/src/closure/__tests__/expandWildcard.unit.test.ts
@@ -40,7 +40,7 @@ describe(expandWildcard, () => {
     expect(expandWildcard(entryFor('skill:review'), index, emittingKindIds)).toStrictEqual(['subagent:auditor']);
   });
 
-  it('names nothing when the declaring source contains nothing else that emits', () => {
+  it('names no artifact when the declaring source contains nothing else that emits', () => {
     const alone = buildCatalogFromSpec({
       traversalOnlyKinds: ['collection'],
       sources: ['team'],

--- a/packages/compositor/src/closure/__tests__/readFrontmatterEdges.unit.test.ts
+++ b/packages/compositor/src/closure/__tests__/readFrontmatterEdges.unit.test.ts
@@ -64,7 +64,7 @@ describe(readFrontmatterEdges, () => {
     ]);
   });
 
-  it('reads no edges from an artifact with no frontmatter, and faults nothing', () => {
+  it('reads no edges and no faults from an artifact with no frontmatter', () => {
     expect(readFrontmatterEdges(inputFor('# Lint\n'))).toStrictEqual({ edges: [], diagnostics: [] });
   });
 

--- a/packages/compositor/src/closure/readFrontmatterEdges.ts
+++ b/packages/compositor/src/closure/readFrontmatterEdges.ts
@@ -136,7 +136,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-/** Parses one frontmatter block, returning undefined when it is not valid YAML. */
+/** Parses one frontmatter block, returning `undefined` when it is not valid YAML. */
 function parseBlock(block: string): unknown {
   try {
     const parsed: unknown = parseYaml(block);
@@ -148,7 +148,7 @@ function parseBlock(block: string): unknown {
 }
 
 /**
- * Reads `key` from `record`, or undefined when the record does not have it itself.
+ * Reads `key` from `record`, or `undefined` when the record does not have it itself.
  *
  * Both records read here are keyed by strings someone else wrote, and a plain object returns `constructor`, `toString`,
  * and every other inherited member with something that is not a declaration.

--- a/packages/compositor/src/closure/readFrontmatterEdges.ts
+++ b/packages/compositor/src/closure/readFrontmatterEdges.ts
@@ -136,7 +136,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-/** Parses one frontmatter block, or reports nothing when it is not valid YAML. */
+/** Parses one frontmatter block, returning undefined when it is not valid YAML. */
 function parseBlock(block: string): unknown {
   try {
     const parsed: unknown = parseYaml(block);
@@ -148,7 +148,7 @@ function parseBlock(block: string): unknown {
 }
 
 /**
- * Reads `key` from `record`, or reports nothing when the record does not have it itself.
+ * Reads `key` from `record`, or undefined when the record does not have it itself.
  *
  * Both records read here are keyed by strings someone else wrote, and a plain object returns `constructor`, `toString`,
  * and every other inherited member with something that is not a declaration.

--- a/packages/compositor/src/config/loadConfig.ts
+++ b/packages/compositor/src/config/loadConfig.ts
@@ -73,7 +73,7 @@ function parseTierBody(raw: string, filePath: string): TierBody {
 }
 
 /**
- * Reads one tier from its file, resolving to nothing when that file is absent.
+ * Reads one tier from its file, resolving to undefined when that file is absent.
  *
  * `baseDir` is the file's own directory, so a relative path a tier declares resolves against where it was written, not
  * against the process's working directory.

--- a/packages/compositor/src/config/loadConfig.ts
+++ b/packages/compositor/src/config/loadConfig.ts
@@ -73,7 +73,7 @@ function parseTierBody(raw: string, filePath: string): TierBody {
 }
 
 /**
- * Reads one tier from its file, resolving to undefined when that file is absent.
+ * Reads one tier from its file, resolving to `undefined` when that file is absent.
  *
  * `baseDir` is the file's own directory, so a relative path a tier declares resolves against where it was written, not
  * against the process's working directory.

--- a/packages/compositor/src/config/locatePackage.ts
+++ b/packages/compositor/src/config/locatePackage.ts
@@ -54,7 +54,7 @@ function assertPackageName(name: string): void {
   }
 }
 
-/** Finds the installed directory of `name` with its parsed manifest, or nothing when no candidate has one. */
+/** Finds the installed directory of `name` with its parsed manifest, or undefined when no candidate has one. */
 async function findInstalledPackage(
   name: string,
   baseDir: string,

--- a/packages/compositor/src/config/locatePackage.ts
+++ b/packages/compositor/src/config/locatePackage.ts
@@ -54,7 +54,7 @@ function assertPackageName(name: string): void {
   }
 }
 
-/** Finds the installed directory of `name` with its parsed manifest, or undefined when no candidate has one. */
+/** Finds the installed directory of `name` with its parsed manifest, or `undefined` when no candidate has one. */
 async function findInstalledPackage(
   name: string,
   baseDir: string,

--- a/packages/compositor/src/consistency/__tests__/collectIds.unit.test.ts
+++ b/packages/compositor/src/consistency/__tests__/collectIds.unit.test.ts
@@ -13,7 +13,7 @@ describe(collectIds, () => {
     expect(collectIds([{ id: 'team' }, { id: 'team' }])).toStrictEqual(new Set(['team']));
   });
 
-  it('collects nothing from an empty table', () => {
+  it('collects an empty set from an empty table', () => {
     expect(collectIds([])).toStrictEqual(new Set());
   });
 });

--- a/packages/compositor/src/consistency/__tests__/countCaptureGroups.unit.test.ts
+++ b/packages/compositor/src/consistency/__tests__/countCaptureGroups.unit.test.ts
@@ -19,11 +19,11 @@ describe(countCaptureGroups, () => {
     expect(countCaptureGroups('^x+(y)$')).toBe(1);
   });
 
-  it('reports nothing for a pattern that does not compile', () => {
+  it('reports undefined for a pattern that does not compile', () => {
     expect(countCaptureGroups('([a-z')).toBeUndefined();
   });
 
-  it('reports nothing for a pattern ending in an escape, which the empty branch would otherwise absorb', () => {
+  it('reports undefined for a pattern ending in an escape, which the empty branch would otherwise absorb', () => {
     expect(countCaptureGroups('^#\\')).toBeUndefined();
   });
 });

--- a/packages/compositor/src/consistency/__tests__/createRequireKnown.unit.test.ts
+++ b/packages/compositor/src/consistency/__tests__/createRequireKnown.unit.test.ts
@@ -13,14 +13,14 @@ describe(createRequireKnown, () => {
     ]);
   });
 
-  it('if an id resolves, records nothing', () => {
+  it('if an id resolves, records no violation', () => {
     const violations: Array<Violation> = [];
     createRequireKnown(violations)(new Set(['team']), 'team', 'artifacts[0].sourceId', 'sources');
 
     expect(violations).toStrictEqual([]);
   });
 
-  it('if an id is absent, records nothing, so an optional reference needs no guard at its call site', () => {
+  it('if an id is absent, records no violation, so an optional reference needs no guard at its call site', () => {
     const violations: Array<Violation> = [];
     createRequireKnown(violations)(new Set(['team']), undefined, 'artifacts[0].sourceId', 'sources');
 

--- a/packages/compositor/src/consistency/__tests__/findDuplicateIds.unit.test.ts
+++ b/packages/compositor/src/consistency/__tests__/findDuplicateIds.unit.test.ts
@@ -9,7 +9,7 @@ describe(findDuplicateIds, () => {
     ]);
   });
 
-  it('if every id is unique, reports nothing', () => {
+  it('if every id is unique, reports no duplicate', () => {
     expect(findDuplicateIds([['sources', [{ id: 'team' }, { id: 'library' }]]])).toStrictEqual([]);
   });
 

--- a/packages/compositor/src/consistency/countCaptureGroups.ts
+++ b/packages/compositor/src/consistency/countCaptureGroups.ts
@@ -1,5 +1,5 @@
 /**
- * Counts the capture groups `source` declares, or reports nothing when it does not compile.
+ * Counts the capture groups `source` declares, or undefined when it does not compile.
  *
  * Alternating the pattern with an empty branch makes it match the empty string whatever it otherwise requires, so the
  * resulting array's length gives the count without a body to run it against. The source is compiled as written

--- a/packages/compositor/src/consistency/countCaptureGroups.ts
+++ b/packages/compositor/src/consistency/countCaptureGroups.ts
@@ -1,5 +1,5 @@
 /**
- * Counts the capture groups `source` declares, or undefined when it does not compile.
+ * Counts the capture groups `source` declares, or `undefined` when it does not compile.
  *
  * Alternating the pattern with an empty branch makes it match the empty string whatever it otherwise requires, so the
  * resulting array's length gives the count without a body to run it against. The source is compiled as written

--- a/packages/compositor/src/deployment/__tests__/resolveDeployedNames.unit.test.ts
+++ b/packages/compositor/src/deployment/__tests__/resolveDeployedNames.unit.test.ts
@@ -75,7 +75,7 @@ describe(resolveDeployedNames, () => {
     expect(resolve('claude', 'rulebook:shell')).toBe('x-$&y');
   });
 
-  it('resolves an artifact whose kind the target does not deploy to undefined', () => {
+  it('resolves to undefined for an artifact whose kind the target does not deploy', () => {
     const resolve = resolveDeployedNames([review, shell], [claude]);
 
     expect(resolve('claude', 'rulebook:shell')).toBeUndefined();

--- a/packages/compositor/src/deployment/__tests__/resolveDeployedNames.unit.test.ts
+++ b/packages/compositor/src/deployment/__tests__/resolveDeployedNames.unit.test.ts
@@ -75,13 +75,13 @@ describe(resolveDeployedNames, () => {
     expect(resolve('claude', 'rulebook:shell')).toBe('x-$&y');
   });
 
-  it('resolves an artifact whose kind the target does not deploy to nothing', () => {
+  it('resolves an artifact whose kind the target does not deploy to undefined', () => {
     const resolve = resolveDeployedNames([review, shell], [claude]);
 
     expect(resolve('claude', 'rulebook:shell')).toBeUndefined();
   });
 
-  it('resolves nothing for a target it was not given', () => {
+  it('resolves to undefined for a target it was not given', () => {
     const resolve = resolveDeployedNames([review], [claude]);
 
     expect(resolve('rovodev', 'skill:review')).toBeUndefined();

--- a/packages/compositor/src/deployment/name-templates.ts
+++ b/packages/compositor/src/deployment/name-templates.ts
@@ -6,7 +6,7 @@ import { escapeForRegExp } from '../portable/escapeForRegExp.ts';
 export const SLUG_PLACEHOLDER = '{slug}';
 
 /**
- * Recovers the slug a deployed name was rendered from, or nothing where the template could not have produced it.
+ * Recovers the slug a deployed name was rendered from, or undefined where the template could not have produced it.
  *
  * This is what lets a scan over a destination tell a file the engine deployed from one somebody else put there, the
  * name being the whole of what a previously deployed file records about which artifact it came from.

--- a/packages/compositor/src/deployment/name-templates.ts
+++ b/packages/compositor/src/deployment/name-templates.ts
@@ -6,7 +6,7 @@ import { escapeForRegExp } from '../portable/escapeForRegExp.ts';
 export const SLUG_PLACEHOLDER = '{slug}';
 
 /**
- * Recovers the slug a deployed name was rendered from, or undefined where the template could not have produced it.
+ * Recovers the slug a deployed name was rendered from, or `undefined` where the template could not have produced it.
  *
  * This is what lets a scan over a destination tell a file the engine deployed from one somebody else put there, the
  * name being the whole of what a previously deployed file records about which artifact it came from.

--- a/packages/compositor/src/deployment/resolveDeployedNames.ts
+++ b/packages/compositor/src/deployment/resolveDeployedNames.ts
@@ -24,9 +24,9 @@ export interface DeployableArtifact {
  * token rewrites to the name its artifact deploys under, so resolving names during the rewrite would make the two
  * depend on each other.
  *
- * An artifact whose kind a target declares no deployment for resolves to undefined, which is the deployability check a
- * token naming an artifact passes before rendering. That check is per kind: whether one artifact of a deployed kind
- * suppresses its own deployment is a fact the artifact declares, and nothing reads artifact declarations yet.
+ * An artifact whose kind a target declares no deployment for resolves to `undefined`, which is the deployability
+ * check a token naming an artifact passes before rendering. That check is per kind: whether one artifact of a deployed
+ * kind suppresses its own deployment is a fact the artifact declares, and nothing reads artifact declarations yet.
  *
  * A region-routed artifact resolves to the host path, so a token naming one renders the file a reader would open to
  * find it. Its own `deployedName` does not apply there: that field overrides the name a kind's template would produce,

--- a/packages/compositor/src/deployment/resolveDeployedNames.ts
+++ b/packages/compositor/src/deployment/resolveDeployedNames.ts
@@ -24,7 +24,7 @@ export interface DeployableArtifact {
  * token rewrites to the name its artifact deploys under, so resolving names during the rewrite would make the two
  * depend on each other.
  *
- * An artifact whose kind a target declares no deployment for resolves to nothing, which is the deployability check a
+ * An artifact whose kind a target declares no deployment for resolves to undefined, which is the deployability check a
  * token naming an artifact passes before rendering. That check is per kind: whether one artifact of a deployed kind
  * suppresses its own deployment is a fact the artifact declares, and nothing reads artifact declarations yet.
  *

--- a/packages/compositor/src/graph/__tests__/traversal.unit.test.ts
+++ b/packages/compositor/src/graph/__tests__/traversal.unit.test.ts
@@ -85,7 +85,7 @@ describe(buildDependentsIndex, () => {
     expect(findDependents('skill:lint')).toStrictEqual(['collection:core', 'skill:review']);
   });
 
-  it('returns nothing for an artifact no edge reaches', () => {
+  it('returns no dependent for an artifact no edge reaches', () => {
     const findDependents = buildDependentsIndex(buildPlan());
 
     expect(findDependents('collection:core')).toStrictEqual([]);

--- a/packages/compositor/src/inlays/__tests__/findUnmatchedBindings.unit.test.ts
+++ b/packages/compositor/src/inlays/__tests__/findUnmatchedBindings.unit.test.ts
@@ -22,7 +22,7 @@ describe(findUnmatchedBindings, () => {
     ]);
   });
 
-  it('reports nothing where an artifact declares the inlay', () => {
+  it('reports no binding where an artifact declares the inlay', () => {
     const found = find({
       bindings: [{ inlayName: 'preferences', artifactIds: ['rulebook:naming'] }],
       columns: [['claude', [['skill:review', declaring('preferences')]]]],

--- a/packages/compositor/src/inlays/fillInlays.ts
+++ b/packages/compositor/src/inlays/fillInlays.ts
@@ -95,7 +95,7 @@ interface BlockingFault {
   readonly detail: string;
 }
 
-/** Builds one filled inlay's whole block, or nothing where the inlay has no filler to put in it. */
+/** Builds one filled inlay's whole block, or undefined where the inlay has no filler to put in it. */
 function buildBlock(context: FillContext, inlayName: string, fillers: ReadonlyArray<Filler>): string | undefined {
   if (fillers.length === 0) {
     return undefined;

--- a/packages/compositor/src/inlays/fillInlays.ts
+++ b/packages/compositor/src/inlays/fillInlays.ts
@@ -95,7 +95,7 @@ interface BlockingFault {
   readonly detail: string;
 }
 
-/** Builds one filled inlay's whole block, or undefined where the inlay has no filler to put in it. */
+/** Builds one filled inlay's whole block, or `undefined` where the inlay has no filler to put in it. */
 function buildBlock(context: FillContext, inlayName: string, fillers: ReadonlyArray<Filler>): string | undefined {
   if (fillers.length === 0) {
     return undefined;

--- a/packages/compositor/src/links/rewriteLinks.ts
+++ b/packages/compositor/src/links/rewriteLinks.ts
@@ -72,7 +72,7 @@ function createDiagnostic(target: string, context: RewriteContext, partialId: Pa
 }
 
 /**
- * Reports whether `target` names its own destination and so resolves to nothing this pass can improve on.
+ * Reports whether `target` names its own destination, which `resolveTarget` leaves as written.
  *
  * The token test is anchored rather than searched, because a token elsewhere in a target says nothing about where the
  * target starts from; only one at the head replaces the path this pass would otherwise build.

--- a/packages/compositor/src/links/rewriteLinks.ts
+++ b/packages/compositor/src/links/rewriteLinks.ts
@@ -96,7 +96,7 @@ interface RewriteContext {
   readonly pattern: RegExp;
 }
 
-/** Resolves one link target to the absolute path it deploys at, or to undefined when it stays as written. */
+/** Resolves one link target to the absolute path it deploys at, or to `undefined` when it stays as written. */
 function resolveTarget(target: string, context: RewriteContext, partialId: PartialId | undefined): string | undefined {
   if (namesItsOwnDestination(target, context.openers)) {
     return undefined;

--- a/packages/compositor/src/links/rewriteLinks.ts
+++ b/packages/compositor/src/links/rewriteLinks.ts
@@ -96,7 +96,7 @@ interface RewriteContext {
   readonly pattern: RegExp;
 }
 
-/** Resolves one link target to the absolute path it deploys at, or to nothing when it stays as written. */
+/** Resolves one link target to the absolute path it deploys at, or to undefined when it stays as written. */
 function resolveTarget(target: string, context: RewriteContext, partialId: PartialId | undefined): string | undefined {
   if (namesItsOwnDestination(target, context.openers)) {
     return undefined;

--- a/packages/compositor/src/ownership/structured/locateCollection.ts
+++ b/packages/compositor/src/ownership/structured/locateCollection.ts
@@ -1,7 +1,7 @@
 import type { FileBlock } from '../../schemas/file-schemas.ts';
 import type { DocumentAccess, ItemHandle } from './document-access.ts';
 
-/** Where a declared collection stands: the items it holds, nothing at all, or a refusal to read what is there. */
+/** Where a declared collection stands: the items it holds, an absence, or a refusal to read what is there. */
 export type LocatedCollection =
   { readonly items: ReadonlyArray<ItemHandle> } | { readonly absent: true } | { readonly blocked: FileBlock };
 

--- a/packages/compositor/src/plan/__tests__/buildTraversalIndex.unit.test.ts
+++ b/packages/compositor/src/plan/__tests__/buildTraversalIndex.unit.test.ts
@@ -12,7 +12,7 @@ describe(buildTraversalIndex, () => {
     ]);
   });
 
-  it('returns nothing for an artifact no file reaches', () => {
+  it('returns an empty list for an artifact no file reaches', () => {
     const index = buildTraversalIndex(buildPlan());
 
     expect(index.findContributedFiles('collection:core')).toStrictEqual([]);

--- a/packages/compositor/src/plan/compose/__tests__/planOwnedItemsFiles.unit.test.ts
+++ b/packages/compositor/src/plan/compose/__tests__/planOwnedItemsFiles.unit.test.ts
@@ -110,11 +110,11 @@ describe(planOwnedItemsFiles, () => {
       expect(JSON.parse(bodyOf(files[0]))).toStrictEqual({ hooks: [{ command: 'vendor-tool sync' }] });
     });
 
-    it('plans nothing for a host holding none of the engine’s items', () => {
+    it('plans no file for a host holding none of the engine’s items', () => {
       expect(plan({ [HOST]: '{\n  "hooks": []\n}\n' }, [{ ...hooks, items: [] }]).files).toStrictEqual([]);
     });
 
-    it('plans nothing for a host the target does not hold', () => {
+    it('plans no file for a host the target does not hold', () => {
       expect(plan({}, [{ ...hooks, items: [] }]).files).toStrictEqual([]);
     });
   });

--- a/packages/compositor/src/plan/compose/file-entries.ts
+++ b/packages/compositor/src/plan/compose/file-entries.ts
@@ -55,7 +55,7 @@ export function describeAmbiguousClaim(claimed: ClaimedFile): string {
   return `${matched}, so which artifact deployed it is undecidable from shape.`;
 }
 
-/** Registers the body a destination holds now, or nothing where it holds none. */
+/** Registers the body a destination holds now, or undefined where it holds none. */
 export function readCurrentSide(blobs: BlobStore, claimed: ClaimedFile | undefined): FileSide | undefined {
   return claimed === undefined ? undefined : blobs.addEncoded(claimed.hash, claimed.body);
 }

--- a/packages/compositor/src/plan/compose/file-entries.ts
+++ b/packages/compositor/src/plan/compose/file-entries.ts
@@ -55,7 +55,7 @@ export function describeAmbiguousClaim(claimed: ClaimedFile): string {
   return `${matched}, so which artifact deployed it is undecidable from shape.`;
 }
 
-/** Registers the body a destination holds now, or undefined where it holds none. */
+/** Registers the body a destination holds now, or `undefined` where it holds none. */
 export function readCurrentSide(blobs: BlobStore, claimed: ClaimedFile | undefined): FileSide | undefined {
   return claimed === undefined ? undefined : blobs.addEncoded(claimed.hash, claimed.body);
 }

--- a/packages/compositor/src/plan/compose/planRegionFile.ts
+++ b/packages/compositor/src/plan/compose/planRegionFile.ts
@@ -189,7 +189,7 @@ function position(context: TargetPlanContext, deployment: RegionKindDeployment):
   return { targetId: context.targetId, path: deployment.host };
 }
 
-/** Registers the body a host holds now, or undefined where it holds none. */
+/** Registers the body a host holds now, or `undefined` where it holds none. */
 function readHostSide(context: TargetPlanContext, hostContent: string | undefined): FileSide | undefined {
   return hostContent === undefined ? undefined : context.blobs.addUtf8(hostContent);
 }

--- a/packages/compositor/src/plan/compose/planRegionFile.ts
+++ b/packages/compositor/src/plan/compose/planRegionFile.ts
@@ -189,7 +189,7 @@ function position(context: TargetPlanContext, deployment: RegionKindDeployment):
   return { targetId: context.targetId, path: deployment.host };
 }
 
-/** Registers the body a host holds now, or nothing where it holds none. */
+/** Registers the body a host holds now, or undefined where it holds none. */
 function readHostSide(context: TargetPlanContext, hostContent: string | undefined): FileSide | undefined {
   return hostContent === undefined ? undefined : context.blobs.addUtf8(hostContent);
 }

--- a/packages/compositor/src/portable/__tests__/hashValue.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/hashValue.unit.test.ts
@@ -26,7 +26,7 @@ describe(hashValue, () => {
     expect(hashValue({ alpha: 1 })).not.toBe(hashValue({ alpha: '1' }));
   });
 
-  it('digests a bare undefined, which JSON serializes to nothing at all', () => {
+  it('digests a bare undefined, which JSON serializes to undefined', () => {
     expect(hashValue(undefined)).toBe(hashUtf8(''));
   });
 });

--- a/packages/compositor/src/portable/__tests__/listFilesRecursively.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/listFilesRecursively.unit.test.ts
@@ -44,7 +44,7 @@ describe(listFilesRecursively, () => {
     await expect(sorted(tree.dir, (name) => name.startsWith('.'))).resolves.toStrictEqual(['notes.md']);
   });
 
-  it('reports an absent directory as containing nothing', async () => {
+  it('reports an absent directory as containing no file', async () => {
     using tree = createTempTree({});
 
     await expect(sorted(path.join(tree.dir, 'never-created'))).resolves.toStrictEqual([]);

--- a/packages/compositor/src/portable/__tests__/readDirNames.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/readDirNames.unit.test.ts
@@ -19,7 +19,7 @@ describe(readDirNames, () => {
     await expect(readDirNames(tree.dir)).resolves.toStrictEqual(['nested']);
   });
 
-  it('reports an absent directory as containing nothing', async () => {
+  it('reports an absent directory as containing no name', async () => {
     using tree = createTempTree({});
 
     await expect(readDirNames(path.join(tree.dir, 'never-created'))).resolves.toStrictEqual([]);

--- a/packages/compositor/src/portable/__tests__/readFileIfPresent.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/readFileIfPresent.unit.test.ts
@@ -13,13 +13,13 @@ describe(readFileIfPresent, () => {
     await expect(readFileIfPresent(path.join(tree.dir, 'notes.md'))).resolves.toBe('notes');
   });
 
-  it('reports nothing for an absent file', async () => {
+  it('reports undefined for an absent file', async () => {
     using tree = createTempTree({});
 
     await expect(readFileIfPresent(path.join(tree.dir, 'never-created.md'))).resolves.toBeUndefined();
   });
 
-  it('reports nothing for a path below a regular file, which fails as ENOTDIR rather than ENOENT', async () => {
+  it('reports undefined for a path below a regular file, which fails as ENOTDIR rather than ENOENT', async () => {
     using tree = createTempTree({ 'notes.md': 'notes' });
 
     await expect(readFileIfPresent(path.join(tree.dir, 'notes.md', 'below'))).resolves.toBeUndefined();

--- a/packages/compositor/src/portable/__tests__/statIfPresent.unit.test.ts
+++ b/packages/compositor/src/portable/__tests__/statIfPresent.unit.test.ts
@@ -19,13 +19,13 @@ describe(statIfPresent, () => {
     expect((await statIfPresent(path.join(tree.dir, 'nested')))?.isDirectory()).toBe(true);
   });
 
-  it('reports nothing for an absent path', async () => {
+  it('reports undefined for an absent path', async () => {
     using tree = createTempTree({});
 
     await expect(statIfPresent(path.join(tree.dir, 'never-created'))).resolves.toBeUndefined();
   });
 
-  it('reports nothing for a path below a regular file, which fails as ENOTDIR rather than ENOENT', async () => {
+  it('reports undefined for a path below a regular file, which fails as ENOTDIR rather than ENOENT', async () => {
     using tree = createTempTree({ 'notes.md': 'notes' });
 
     await expect(statIfPresent(path.join(tree.dir, 'notes.md', 'below'))).resolves.toBeUndefined();
@@ -38,7 +38,7 @@ describe(statIfPresent, () => {
     expect((await statIfPresent(path.join(tree.dir, 'linked')))?.isDirectory()).toBe(true);
   });
 
-  it('reports nothing for a symlink whose target is gone, rather than the link itself', async () => {
+  it('reports undefined for a symlink whose target is gone, rather than the link itself', async () => {
     using tree = createTempTree({});
     await symlink(path.join(tree.dir, 'never-created'), path.join(tree.dir, 'dangling'));
 

--- a/packages/compositor/src/portable/hashValue.ts
+++ b/packages/compositor/src/portable/hashValue.ts
@@ -10,7 +10,7 @@ import { hashUtf8 } from './hash-content.ts';
  * incident, so it is preserved.
  */
 export function hashValue(value: unknown): Hash {
-  // `JSON.stringify` returns nothing at all for a bare `undefined`, which its own type does not say.
+  // `JSON.stringify` returns undefined for a bare `undefined`, which its own type does not say.
   const json =
     value === undefined
       ? ''

--- a/packages/compositor/src/portable/hashValue.ts
+++ b/packages/compositor/src/portable/hashValue.ts
@@ -10,7 +10,7 @@ import { hashUtf8 } from './hash-content.ts';
  * incident, so it is preserved.
  */
 export function hashValue(value: unknown): Hash {
-  // `JSON.stringify` returns undefined for a bare `undefined`, which its own type does not say.
+  // `JSON.stringify` returns `undefined` for a bare `undefined`, which its own type does not say.
   const json =
     value === undefined
       ? ''

--- a/packages/compositor/src/portable/readFileIfPresent.ts
+++ b/packages/compositor/src/portable/readFileIfPresent.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { reportsMissingPath } from './reportsMissingPath.ts';
 
 /**
- * Reads `filePath`, resolving to undefined when it is absent.
+ * Reads `filePath`, resolving to `undefined` when it is absent.
  *
  * Any other failure rethrows, so a permission problem surfaces instead of reading as a bare absence and sending the
  * caller on as though nothing were there.

--- a/packages/compositor/src/portable/readFileIfPresent.ts
+++ b/packages/compositor/src/portable/readFileIfPresent.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { reportsMissingPath } from './reportsMissingPath.ts';
 
 /**
- * Reads `filePath`, resolving to nothing when it is absent.
+ * Reads `filePath`, resolving to undefined when it is absent.
  *
  * Any other failure rethrows, so a permission problem surfaces instead of reading as a bare absence and sending the
  * caller on as though nothing were there.

--- a/packages/compositor/src/portable/statIfPresent.ts
+++ b/packages/compositor/src/portable/statIfPresent.ts
@@ -4,7 +4,7 @@ import { stat } from 'node:fs/promises';
 import { reportsMissingPath } from './reportsMissingPath.ts';
 
 /**
- * Reads the stats of `filePath`, or undefined when it is absent.
+ * Reads the stats of `filePath`, or `undefined` when it is absent.
  *
  * Follows symlinks, which `readdir`'s own file types do not: a symlinked directory reports as a link rather than as
  * the directory it points at, and under a linked layout that would hide its contents entirely.

--- a/packages/compositor/src/portable/statIfPresent.ts
+++ b/packages/compositor/src/portable/statIfPresent.ts
@@ -4,7 +4,7 @@ import { stat } from 'node:fs/promises';
 import { reportsMissingPath } from './reportsMissingPath.ts';
 
 /**
- * Reads the stats of `filePath`, or nothing when it is absent.
+ * Reads the stats of `filePath`, or undefined when it is absent.
  *
  * Follows symlinks, which `readdir`'s own file types do not: a symlinked directory reports as a link rather than as
  * the directory it points at, and under a linked layout that would hide its contents entirely.

--- a/packages/compositor/src/render/__tests__/renderArtifact.unit.test.ts
+++ b/packages/compositor/src/render/__tests__/renderArtifact.unit.test.ts
@@ -235,7 +235,7 @@ describe(renderArtifact, () => {
     expect(result).toHaveProperty('failure.diagnostic.code', 'duplicate-name');
   });
 
-  it("renders nothing for a target taking none of the artifact's kind", async () => {
+  it("reports a target taking none of the artifact's kind as not-deployed", async () => {
     using tree = createTempTree({ 'skills/review/SKILL.md': '# Review\n' });
     const takesNoSkills: RenderTarget = { ...claude, deployments: [] };
 

--- a/packages/compositor/src/resolution/__tests__/enumerateSource.unit.test.ts
+++ b/packages/compositor/src/resolution/__tests__/enumerateSource.unit.test.ts
@@ -113,7 +113,7 @@ describe(enumerateSource, () => {
     await expect(collectSlugs(source, [skillKind])).resolves.toStrictEqual(['lint']);
   });
 
-  it('contains nothing for a kind whose root the source does not have', async () => {
+  it('contributes no artifact for a kind whose root the source does not have', async () => {
     const source = buildSource({ 'skills/lint/SKILL.md': 'lint' });
 
     await expect(collectSlugs(source, [rulebookKind, skillKind])).resolves.toStrictEqual(['lint']);

--- a/packages/compositor/src/resolution/__tests__/resolveCatalog.unit.test.ts
+++ b/packages/compositor/src/resolution/__tests__/resolveCatalog.unit.test.ts
@@ -151,7 +151,7 @@ describe(resolveCatalog, () => {
     }).not.toThrow();
   });
 
-  it('contains nothing when the sources are empty', async () => {
+  it('contains no entry when the sources are empty', async () => {
     const sources = buildSources({ local: {}, library: {} });
 
     await expect(resolveCatalog({ kinds, sources })).resolves.toMatchObject({ entries: [] });

--- a/packages/compositor/src/resolution/enumerateSource.ts
+++ b/packages/compositor/src/resolution/enumerateSource.ts
@@ -25,8 +25,8 @@ export interface SourceArtifact {
  * Enumerates every artifact `source` contains, across every kind in `kinds`.
  *
  * Resolution ranks shadowed candidates across sources, so it needs the whole of what each source contains. A kind whose
- * root is absent from this source contributes nothing, because a source is free to contain only some of the kinds in
- * play; an unreadable root is a failure, so a permission problem cannot pass for an empty one and let a
+ * root is absent from this source contributes no artifact, because a source is free to contain only some of the kinds
+ * in play; an unreadable root is a failure, so a permission problem cannot pass for an empty one and let a
  * lower-precedence source win by default.
  *
  * Results run by kind, in the order `kinds` gives, then by slug.
@@ -53,7 +53,7 @@ async function enumerateKind(sourceDir: string, kind: ResolveKind): Promise<Arra
 }
 
 /**
- * Reads one artifact at `name` under `rootDir`, or nothing when the entry is not one.
+ * Reads one artifact at `name` under `rootDir`, or undefined when the entry is not one.
  *
  * A `file` kind's entry must be a file with the declared extension. A `directory` kind's must be a directory whose
  * entry file exists and is itself a file, since a directory with the entry file's own name is not an artifact.

--- a/packages/compositor/src/resolution/enumerateSource.ts
+++ b/packages/compositor/src/resolution/enumerateSource.ts
@@ -53,7 +53,7 @@ async function enumerateKind(sourceDir: string, kind: ResolveKind): Promise<Arra
 }
 
 /**
- * Reads one artifact at `name` under `rootDir`, or undefined when the entry is not one.
+ * Reads one artifact at `name` under `rootDir`, or `undefined` when the entry is not one.
  *
  * A `file` kind's entry must be a file with the declared extension. A `directory` kind's must be a directory whose
  * entry file exists and is itself a file, since a directory with the entry file's own name is not an artifact.

--- a/packages/compositor/src/schemas/test-utils/findIssuePaths.ts
+++ b/packages/compositor/src/schemas/test-utils/findIssuePaths.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod';
 
 /**
- * Collects the path of each validation issue `value` raises against `schema`, or nothing when it validates.
+ * Collects the path of each validation issue `value` raises against `schema`, or undefined when it validates.
  *
  * Asserting on paths pins a rejection to the field that caused it, so a test cannot pass because some unrelated part of
  * the fixture happened to be malformed.

--- a/packages/compositor/src/schemas/test-utils/findIssuePaths.ts
+++ b/packages/compositor/src/schemas/test-utils/findIssuePaths.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod';
 
 /**
- * Collects the path of each validation issue `value` raises against `schema`, or undefined when it validates.
+ * Collects the path of each validation issue `value` raises against `schema`, or `undefined` when it validates.
  *
  * Asserting on paths pins a rejection to the field that caused it, so a test cannot pass because some unrelated part of
  * the fixture happened to be malformed.

--- a/packages/compositor/src/selection/__tests__/buildCatalogIndex.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/buildCatalogIndex.unit.test.ts
@@ -38,7 +38,7 @@ describe(buildCatalogIndex, () => {
     expect(buildCatalogIndex(catalog).bySource.get('skill')?.get('local')).toStrictEqual(['skill:review']);
   });
 
-  it('indexes nothing for a kind a source has no entries of', () => {
+  it('omits a source with no entries of a kind from the index', () => {
     expect(buildCatalogIndex(catalog).bySource.get('rulebook')?.get('acme')).toBeUndefined();
   });
 });

--- a/packages/compositor/src/selection/__tests__/expandSelector.unit.test.ts
+++ b/packages/compositor/src/selection/__tests__/expandSelector.unit.test.ts
@@ -37,21 +37,21 @@ describe(expandSelector, () => {
   it.each([
     ['an artifact no source contains', { artifact: 'absent' }, 'unknown-artifact'],
     ['a source that is not declared', { source: 'nowhere' }, 'unknown-source'],
-  ])('matches nothing and reports %s', (_label, selector, code) => {
+  ])('matches no artifact and reports %s', (_label, selector, code) => {
     const { matched, diagnostics } = expand(selector);
 
     expect(matched).toStrictEqual([]);
     expect(diagnostics.at(0)?.code).toBe(code);
   });
 
-  it('reports a source containing nothing of the kind, having matched nothing to report', () => {
+  it('reports a source containing nothing of the kind, having matched no artifact to report', () => {
     const { matched, diagnostics } = expand({ source: 'acme' }, 'rulebook');
 
     expect(matched).toStrictEqual([]);
     expect(diagnostics.at(0)?.code).toBe('empty-source');
   });
 
-  it('says nothing when the selector matches, so a diagnostic marks a mistake rather than a step', () => {
+  it('appends no diagnostic when the selector matches, so a diagnostic marks a mistake rather than a step', () => {
     expect(expand({ artifact: 'lint' }).diagnostics).toStrictEqual([]);
   });
 

--- a/packages/compositor/src/selection/expandSelector.ts
+++ b/packages/compositor/src/selection/expandSelector.ts
@@ -3,7 +3,7 @@ import type { Selector } from '../schemas/selection-schemas.ts';
 import type { CatalogIndex } from './buildCatalogIndex.ts';
 import type { ConfigEntryRef, SelectionDiagnostic } from './SelectionDiagnostic.ts';
 
-/** Expands `selector` to the artifacts it names, appending a diagnostic and matching nothing when it names none. */
+/** Expands `selector` to the artifacts it names, or to an empty list with a diagnostic when it names none. */
 export function expandSelector(
   selector: Selector,
   kindId: KindId,

--- a/packages/compositor/src/selection/selectArtifacts.ts
+++ b/packages/compositor/src/selection/selectArtifacts.ts
@@ -59,8 +59,8 @@ export interface Selection {
  * that both drops and binds one artifact ends bound. An inlay's `drop` unbinds from that inlay alone, leaving the
  * artifact wherever else it is bound and whatever else selected it.
  *
- * A selector matching nothing is a diagnostic rather than a failure, so validation reports every mistake in a config at
- * once.
+ * A selector matching no artifact is a diagnostic rather than a failure, so validation reports every mistake in a
+ * config at once.
  */
 export function selectArtifacts(config: CompositorConfig, catalog: Catalog): Selection {
   const fold: Fold = {

--- a/packages/compositor/src/snapshot/__tests__/captureSnapshot.unit.test.ts
+++ b/packages/compositor/src/snapshot/__tests__/captureSnapshot.unit.test.ts
@@ -87,13 +87,13 @@ describe(captureSnapshot, () => {
     });
   });
 
-  it('renders nothing for a kind the target declares no deployment for', async () => {
+  it('renders undefined for a kind the target declares no deployment for', async () => {
     const snapshot = await capture();
 
     expect(renderOf(snapshot, 'subagent:auditor')).toBeUndefined();
   });
 
-  it('renders nothing for a kind that emits no files', async () => {
+  it('renders undefined for a kind that emits no files', async () => {
     const snapshot = await capture();
 
     expect(renderOf(snapshot, 'collection:everything')).toBeUndefined();

--- a/packages/compositor/src/snapshot/__tests__/readArtifactAssets.unit.test.ts
+++ b/packages/compositor/src/snapshot/__tests__/readArtifactAssets.unit.test.ts
@@ -29,7 +29,7 @@ describe(readArtifactAssets, () => {
     expect(assets.map(({ relativePath }) => relativePath)).toStrictEqual(['checklist.md']);
   });
 
-  it('reads an artifact shipping nothing else as shipping nothing', async () => {
+  it('reads an artifact shipping nothing else as shipping no asset', async () => {
     using tree = createTempTree({ 'SKILL.md': '# Review\n' });
 
     await expect(readArtifactAssets(tree.dir, 'SKILL.md')).resolves.toStrictEqual([]);

--- a/packages/compositor/src/snapshot/__tests__/readTargetState.unit.test.ts
+++ b/packages/compositor/src/snapshot/__tests__/readTargetState.unit.test.ts
@@ -210,7 +210,7 @@ describe(readTargetState, () => {
     expect(after.digest).not.toBe(before.digest);
   });
 
-  it('reads a target holding nothing as holding nothing', async () => {
+  it('reads a target holding nothing as claiming no file and holding no host', async () => {
     const state = await readState({ 'unrelated.txt': 'x' }, [skills, rulebooks]);
 
     expect(state).toMatchObject({ targetId: 'claude', claimed: [], hosts: [], ownedHosts: [] });

--- a/packages/compositor/src/snapshot/readTargetState.ts
+++ b/packages/compositor/src/snapshot/readTargetState.ts
@@ -121,7 +121,7 @@ export interface ReadTargetStateOptions {
  * A directory is claimed only when it holds its layout's entry file. A directory with an artifact's name and nothing
  * else is somebody else's, and this scan's output is what decides removal.
  *
- * An absent root or host reads as nothing, while anything else rethrows: a permissions fault is not an authoring
+ * An absent root or host reads as an empty state, while anything else rethrows: a permissions fault is not an authoring
  * mistake, and reading one as an absence would offer a whole tree up as removed.
  */
 export async function readTargetState(target: RenderTarget, options: ReadTargetStateOptions): Promise<TargetState> {

--- a/packages/compositor/src/test-utils/captureComposition.ts
+++ b/packages/compositor/src/test-utils/captureComposition.ts
@@ -24,7 +24,7 @@ export interface CaptureCompositionOptions {
   readonly targetFiles?: Record<string, string | Uint8Array>;
   /** The `select` block the sole tier declares, defaulting to everything the source contains of each deployed kind. */
   readonly select?: unknown;
-  /** The `inlays` block the sole tier declares, defaulting to binding nothing. */
+  /** The `inlays` block the sole tier declares, defaulting to an empty block. */
   readonly inlays?: unknown;
   readonly buildTargets?: (targetRoot: string) => ReadonlyArray<RenderTarget>;
   readonly input?: Partial<CaptureSnapshotInput>;

--- a/packages/compositor/src/tokens/rewriteTokens.ts
+++ b/packages/compositor/src/tokens/rewriteTokens.ts
@@ -6,7 +6,7 @@ import type { Segment } from '../transclusion/expandTransclusions.ts';
 import { compileTokenPattern } from './compileTokenPattern.ts';
 import type { TokenDiagnostic, TokenFailure, TokenRef } from './TokenDiagnostic.ts';
 
-/** Resolves the name an artifact deploys under for one target, or undefined when it does not deploy there. */
+/** Resolves the name an artifact deploys under for one target, or `undefined` when it does not deploy there. */
 export type DeployedNameLookup = (targetId: TargetId, artifactId: ArtifactId) => string | undefined;
 
 /** Everything rendering one artifact's body for one target needs. */

--- a/packages/compositor/src/tokens/rewriteTokens.ts
+++ b/packages/compositor/src/tokens/rewriteTokens.ts
@@ -6,7 +6,7 @@ import type { Segment } from '../transclusion/expandTransclusions.ts';
 import { compileTokenPattern } from './compileTokenPattern.ts';
 import type { TokenDiagnostic, TokenFailure, TokenRef } from './TokenDiagnostic.ts';
 
-/** Resolves the name an artifact deploys under for one target, or nothing when it does not deploy there. */
+/** Resolves the name an artifact deploys under for one target, or undefined when it does not deploy there. */
 export type DeployedNameLookup = (targetId: TargetId, artifactId: ArtifactId) => string | undefined;
 
 /** Everything rendering one artifact's body for one target needs. */

--- a/packages/compositor/src/validate/__tests__/validateComposition.unit.test.ts
+++ b/packages/compositor/src/validate/__tests__/validateComposition.unit.test.ts
@@ -31,7 +31,7 @@ const MEMBER_RULE = {
 } as const;
 
 describe(validateComposition, () => {
-  it('reports nothing for a composition with nothing wrong in it', async () => {
+  it('reports no diagnostic for a composition with nothing wrong in it', async () => {
     const { config, snapshot } = await captureComposition();
 
     expect(validateComposition(config, snapshot).diagnostics).toStrictEqual([]);


### PR DESCRIPTION
## What

Replaces the vague use of "nothing" in Compositor's doc descriptions and test titles with the value the code actually returns: undefined, an empty string, an empty list, and so on.

## Why

A reader who met "nothing" in a description had to open the signature to learn whether the code returned `undefined`, an empty list, or no output at all.

## Details

### 📚 Documentation

- Sixty-one sites under `packages/compositor/src` name the value they return, thirty-five of them test titles. Thirty name `undefined`; the rest name what the empty collection would have held (no artifact, no dependent, no diagnostic, no file, no name, no asset, no entry, no binding, no duplicate, no violation), an empty list, set, block, or state, or a different value entirely: `renderArtifact`'s `not-deployed` status, and an index a source with no entries of a kind is simply absent from.
- Where a sentence read better restructured than patched, it was restructured. `LocatedCollection`'s middle variant reads as an absence rather than "nothing at all", which beside "the items it holds" read as an empty item list; `resolveDeployedNames`'s title for an undeployed kind fronts its return value, having read as "does not deploy to `undefined`" on first pass.
- Where a title carried the word twice with different senses, only the value-side use changed. A composition with nothing wrong in it, a source containing nothing of the kind, a target holding nothing, and an artifact shipping nothing else all stand as written.
- `undefined` is backticked at eighteen description and comment sites that named it bare, matching the seven prose uses that predate them. Test titles keep the bare word: no title in the package carries a backtick, and the terminal that renders them renders no Markdown.

### 🧪 Tests

- No test behavior changed. The edits reach `it()` titles alone, never an assertion or a fixture.

Closes #418
