### PR TITLE
#423 Export a Workspace fixture builder and document how to test a kit

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -124,6 +124,7 @@ const config = defineConfig([
       'packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts',
       'packages/readyup/src/run/__tests__/resolveConfiguredPackages.unit.test.ts',
       'packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts',
+      'packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts',
     ],
     rules: {
       'vitest/consistent-test-it': 'off',

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -421,6 +421,54 @@ A typo'd `severity` is the mistake this matters most for: an unrecognized value 
 
 A `fix` written as a getter is the half of `fix` validation that is deferred. Load leaves it unread, and the check that fails resolves it -- so a getter may reference a constant declared below the kit literal, and a check that passes, skips, or is blocked never invokes it. A getter that throws or yields a non-string is reported as `Unresolvable fix: ...` in that failure's remediation slot, rather than as a load error taking the whole kit down.
 
+### Testing a kit
+
+A kit's checks are ordinary functions, and the shape of the test follows what a check reads.
+
+**A check that calls `discoverWorkspaces` itself** is tested against a real directory tree, with `cwd` pointed at it. Nothing is mocked, so the check sees the workspace list discovery actually produces, root included:
+
+```ts
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+
+it('passes when every package README carries the marker', () => {
+  using temp = createTempTree({
+    'package.json': '{"name":"root","private":true}',
+    'pnpm-workspace.yaml': 'packages:\n  - packages/*\n',
+    'packages/alpha/package.json': '{"name":"alpha"}',
+    'packages/alpha/README.md': '<!-- marker -->',
+  });
+  using _cwd = pointCwdAt(temp.dir);
+
+  expect(readmesHaveMarkers()).toBe(true);
+});
+```
+
+`createTempTree` and `pointCwdAt` are the helpers ReadyUp uses for its own suites; any equivalent will do, since what the pattern needs is a real tree and a `cwd` pointed at it.
+
+Mocking `readyup/check-utils` instead is what produces a workspace list discovery cannot return -- most often one with no root entry, which every `!isRoot` filter then passes through untouched, so the filter is never exercised.
+
+**A function that takes a `Workspace` parameter** needs a value rather than a tree. `readyup/testing` exports a builder for one:
+
+```ts
+import { makeWorkspace } from 'readyup/testing';
+
+expect(skipIfNotPublishable(makeWorkspace({ isPackage: false }))).toBe('package.json#private is true');
+```
+
+`makeWorkspace` fills every field the call leaves out, so a field added to `Workspace` in a later release does not break the fixture. Its defaults are:
+
+| Field          | Default                                                                   |
+| -------------- | ------------------------------------------------------------------------- |
+| `dir`          | `'packages/example'`                                                      |
+| `absolutePath` | `/repo` joined to `dir`, in forward slashes: `'/repo/packages/example'`   |
+| `packageJson`  | `{ name }`, the name being `dir`'s last segment, or `'repo'` for the root |
+| `name`         | `packageJson.name`                                                        |
+| `isPackage`    | `packageJson.private !== true`                                            |
+| `isRoot`       | `dir === '.'`                                                             |
+
+The last three are derived by the same code `discoverWorkspaces` uses, so `makeWorkspace({ dir: '.' })` reports `isRoot: true` without being told. An explicit override wins over the derivation, which is how a test states a shape discovery would not produce. The result is frozen, as a discovered workspace is, and the manifest passed in is copied before freezing, so a literal shared between fixtures stays writable.
+
 ### Inlining JSON at compile time
 
 A compiled kit is self-contained, so it cannot read a JSON file that sits next to its source. `pickJson` closes that gap by copying selected fields into the bundle while it is being built:
@@ -1339,6 +1387,8 @@ const packages = discoverWorkspaces({ filter: (w) => w.isPackage });
 ```
 
 `isRoot` is independent of `isPackage`: a monorepo may publish its root, and a member may be private. A root `package.json` that is missing or unparseable throws, whatever the repo's shape.
+
+A kit test that needs a `Workspace` value builds one with `makeWorkspace`; see [Testing a kit](#testing-a-kit).
 
 `pnpm-workspace.yaml` is read by a minimal block-sequence parser; configs using YAML anchors, flow sequences, or negation patterns raise a clear error.
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -453,7 +453,9 @@ Mocking `readyup/check-utils` instead is what produces a workspace list discover
 ```ts
 import { makeWorkspace } from 'readyup/testing';
 
-expect(skipIfNotPublishable(makeWorkspace({ isPackage: false }))).toBe('package.json#private is true');
+expect(skipIfNotPublishable(makeWorkspace({ packageJson: { name: 'example', private: true } }))).toBe(
+  'package.json#private is true',
+);
 ```
 
 `makeWorkspace` fills every field the call leaves out, so a field added to `Workspace` in a later release does not break the fixture. Its defaults are:

--- a/packages/readyup/package.json
+++ b/packages/readyup/package.json
@@ -37,7 +37,11 @@
       "import": "./dist/esm/readyupResolverHook.js",
       "types": "./dist/esm/readyupResolverHook.d.ts"
     },
-    "./schemas/*.json": "./schemas/*.json"
+    "./schemas/*.json": "./schemas/*.json",
+    "./testing": {
+      "import": "./dist/esm/testing/index.js",
+      "types": "./dist/esm/testing/index.d.ts"
+    }
   },
   "bin": {
     "rdy": "bin/rdy.js",

--- a/packages/readyup/src/check-utils/buildWorkspaceFromPackageJson.ts
+++ b/packages/readyup/src/check-utils/buildWorkspaceFromPackageJson.ts
@@ -1,7 +1,7 @@
 import { deepFreeze } from '../portable/deepFreeze.ts';
 import type { Workspace } from './workspaces.ts';
 
-/** Builds a `Workspace` from a relative dir, absolute path, and a parsed `package.json`. */
+/** Builds a `Workspace`, deep-freezing the manifest it is given. */
 export function buildWorkspaceFromPackageJson(
   relDir: string,
   absolutePath: string,
@@ -10,7 +10,7 @@ export function buildWorkspaceFromPackageJson(
   const nameValue = packageJson['name'];
   const name = typeof nameValue === 'string' ? nameValue : undefined;
   const isPackage = packageJson['private'] !== true;
-  // One call's mutation would otherwise reach every later call, which shares these objects.
+  // A `Workspace`'s manifest is frozen, so no holder's write reaches another.
   deepFreeze(packageJson);
   return Object.freeze({ dir: relDir, absolutePath, name, isPackage, isRoot: relDir === '.', packageJson });
 }

--- a/packages/readyup/src/check-utils/buildWorkspaceFromPackageJson.ts
+++ b/packages/readyup/src/check-utils/buildWorkspaceFromPackageJson.ts
@@ -1,0 +1,16 @@
+import { deepFreeze } from '../portable/deepFreeze.ts';
+import type { Workspace } from './workspaces.ts';
+
+/** Builds a `Workspace` from a relative dir, absolute path, and a parsed `package.json`. */
+export function buildWorkspaceFromPackageJson(
+  relDir: string,
+  absolutePath: string,
+  packageJson: Record<string, unknown>,
+): Workspace {
+  const nameValue = packageJson['name'];
+  const name = typeof nameValue === 'string' ? nameValue : undefined;
+  const isPackage = packageJson['private'] !== true;
+  // One call's mutation would otherwise reach every later call, which shares these objects.
+  deepFreeze(packageJson);
+  return Object.freeze({ dir: relDir, absolutePath, name, isPackage, isRoot: relDir === '.', packageJson });
+}

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -1,9 +1,9 @@
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
-import { deepFreeze } from '../portable/deepFreeze.ts';
 import { isRecord } from '../portable/isRecord.ts';
 import { walkDirectories } from '../portable/walkDirectories.ts';
+import { buildWorkspaceFromPackageJson } from './buildWorkspaceFromPackageJson.ts';
 import { readJsonFile } from './json.ts';
 import { readPnpmWorkspacePackages } from './pnpmWorkspaceYaml.ts';
 
@@ -193,20 +193,6 @@ function buildWorkspace(rootDir: string, relDir: string): Workspace | undefined 
   const packageJson = readJsonFile(join(absoluteDir, 'package.json'));
   if (packageJson === undefined) return undefined;
   return buildWorkspaceFromPackageJson(relDir, absoluteDir, packageJson);
-}
-
-/** Builds a `Workspace` from a relative dir, absolute path, and a parsed `package.json`. */
-function buildWorkspaceFromPackageJson(
-  relDir: string,
-  absolutePath: string,
-  packageJson: Record<string, unknown>,
-): Workspace {
-  const nameValue = packageJson['name'];
-  const name = typeof nameValue === 'string' ? nameValue : undefined;
-  const isPackage = packageJson['private'] !== true;
-  // One call's mutation would otherwise reach every later call, which shares these objects.
-  deepFreeze(packageJson);
-  return Object.freeze({ dir: relDir, absolutePath, name, isPackage, isRoot: relDir === '.', packageJson });
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/kitImports/__tests__/listRunnerExports.unit.test.ts
+++ b/packages/readyup/src/kitImports/__tests__/listRunnerExports.unit.test.ts
@@ -44,6 +44,10 @@ describe(listRunnerExports, () => {
     expect(listRunnerExports('readyup/check-utils')).toContain('discoverKitPackages');
   });
 
+  it('reports the testing subpath as exporting its fixture builder', () => {
+    expect(listRunnerExports('readyup/testing')).toContain('makeWorkspace');
+  });
+
   it('omits a type-only export, which no bundle can bind', () => {
     expect(listRunnerExports('readyup')).not.toContain('RdyKit');
   });

--- a/packages/readyup/src/kitImports/listRunnerExports.ts
+++ b/packages/readyup/src/kitImports/listRunnerExports.ts
@@ -1,6 +1,7 @@
 import * as checkUtilsNamespace from '../check-utils/index.ts';
 import * as rootNamespace from '../index.ts';
 import * as resolverHookNamespace from '../readyupResolverHook.ts';
+import * as testingNamespace from '../testing/index.ts';
 
 /**
  * What the running readyup exports, keyed by the specifier a kit reaches it through.
@@ -15,6 +16,7 @@ const RUNNER_EXPORTS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['readyup', new Set(Object.keys(rootNamespace))],
   ['readyup/check-utils', new Set(Object.keys(checkUtilsNamespace))],
   ['readyup/readyupResolverHook', new Set(Object.keys(resolverHookNamespace))],
+  ['readyup/testing', new Set(Object.keys(testingNamespace))],
 ]);
 
 /** Returns the names a `readyup` specifier exports, or undefined where the runner publishes no such subpath. */

--- a/packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts
+++ b/packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts
@@ -3,10 +3,15 @@ import { join } from 'node:path';
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, it, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import { discoverWorkspaces } from '../../check-utils/workspaces.ts';
 import { makeWorkspace } from '../makeWorkspace.ts';
+
+const it = test.extend(
+  'temp',
+  makeFixture(() => createTempTree({}, { prefix: 'rdy-fixture-' })),
+);
 
 describe(makeWorkspace, () => {
   it('fills every field when given no overrides', () => {
@@ -57,12 +62,7 @@ describe(makeWorkspace, () => {
 });
 
 describe('fidelity to discovery', () => {
-  const itInTree = test.extend(
-    'temp',
-    makeFixture(() => createTempTree({}, { prefix: 'rdy-fixture-' })),
-  );
-
-  itInTree.aroundEach(async (runTest, { temp }) => {
+  it.aroundEach(async (runTest, { temp }) => {
     using _cwd = pointCwdAt(temp.dir);
 
     await runTest();
@@ -70,7 +70,7 @@ describe('fidelity to discovery', () => {
 
   // Every assertion above reads only the fields it names, so a builder drifting from the producer would still satisfy
   // them. This one compares the whole value.
-  itInTree('reports what discovery reports for the same directory and manifest', ({ temp }) => {
+  it('reports what discovery reports for the same directory and manifest', ({ temp }) => {
     writeRootPackageJson(temp, { name: 'root', private: true });
     writePnpmWorkspaceYaml(temp, 'packages:\n  - packages/*\n');
     writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha', version: '1.0.0' });

--- a/packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts
+++ b/packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts
@@ -68,8 +68,8 @@ describe('fidelity to discovery', () => {
     await runTest();
   });
 
-  // The assertion the builder's honesty rests on: every test above reads only the fields it names, so a builder that
-  // drifted from the producer would still satisfy them.
+  // Every assertion above reads only the fields it names, so a builder drifting from the producer would still satisfy
+  // them. This one compares the whole value.
   itInTree('reports what discovery reports for the same directory and manifest', ({ temp }) => {
     writeRootPackageJson(temp, { name: 'root', private: true });
     writePnpmWorkspaceYaml(temp, 'packages:\n  - packages/*\n');

--- a/packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts
+++ b/packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts
@@ -1,0 +1,110 @@
+import { join } from 'node:path';
+
+import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, it, test } from 'vitest';
+
+import { discoverWorkspaces } from '../../check-utils/workspaces.ts';
+import { makeWorkspace } from '../makeWorkspace.ts';
+
+describe(makeWorkspace, () => {
+  it('fills every field when given no overrides', () => {
+    expect(makeWorkspace()).toStrictEqual({
+      dir: 'packages/example',
+      absolutePath: '/repo/packages/example',
+      name: 'example',
+      isPackage: true,
+      isRoot: false,
+      packageJson: { name: 'example' },
+    });
+  });
+
+  it('derives the root fields from a `.` directory', () => {
+    expect(makeWorkspace({ dir: '.' })).toMatchObject({
+      absolutePath: '/repo',
+      name: 'repo',
+      isRoot: true,
+    });
+  });
+
+  it('derives `name` and `isPackage` from the manifest', () => {
+    const workspace = makeWorkspace({ packageJson: { name: '@scope/alpha', private: true } });
+
+    expect(workspace.name).toBe('@scope/alpha');
+    expect(workspace.isPackage).toBe(false);
+  });
+
+  it('lets an override win over the derivation', () => {
+    expect(makeWorkspace({ dir: '.', isRoot: false }).isRoot).toBe(false);
+    expect(makeWorkspace({ packageJson: { private: true }, isPackage: true }).isPackage).toBe(true);
+  });
+
+  it('freezes the workspace and its manifest', () => {
+    const workspace = makeWorkspace();
+
+    expect(() => Object.assign(workspace, { dir: 'elsewhere' })).toThrow(TypeError);
+    expect(() => Object.assign(workspace.packageJson, { name: 'elsewhere' })).toThrow(TypeError);
+  });
+
+  it('copies the manifest it is given, leaving the object the caller passed writable', () => {
+    const shared: Record<string, unknown> = { name: 'alpha' };
+
+    makeWorkspace({ packageJson: shared });
+
+    expect(() => Object.assign(shared, { version: '1.0.0' })).not.toThrow();
+  });
+});
+
+describe('fidelity to discovery', () => {
+  const itInTree = test.extend(
+    'temp',
+    makeFixture(() => createTempTree({}, { prefix: 'rdy-fixture-' })),
+  );
+
+  itInTree.aroundEach(async (runTest, { temp }) => {
+    using _cwd = pointCwdAt(temp.dir);
+
+    await runTest();
+  });
+
+  // The assertion the builder's honesty rests on: every test above reads only the fields it names, so a builder that
+  // drifted from the producer would still satisfy them.
+  itInTree('reports what discovery reports for the same directory and manifest', ({ temp }) => {
+    writeRootPackageJson(temp, { name: 'root', private: true });
+    writePnpmWorkspaceYaml(temp, 'packages:\n  - packages/*\n');
+    writeWorkspacePackage(temp, 'packages/alpha', { name: 'alpha', version: '1.0.0' });
+
+    const discovered = discoverWorkspaces();
+
+    expect(discovered.map((workspace) => workspace.dir)).toStrictEqual(['.', 'packages/alpha']);
+    for (const workspace of discovered) {
+      const fixture = makeWorkspace({
+        dir: workspace.dir,
+        absolutePath: workspace.absolutePath,
+        packageJson: workspace.packageJson,
+      });
+
+      expect(fixture).toStrictEqual(workspace);
+    }
+  });
+});
+
+// region | Helpers
+
+/** Writes the pnpm workspace manifest naming the member glob. */
+function writePnpmWorkspaceYaml(temp: TempTree, content: string): void {
+  temp.write('pnpm-workspace.yaml', content);
+}
+
+/** Writes the root manifest. */
+function writeRootPackageJson(temp: TempTree, content: Record<string, unknown>): void {
+  temp.writeJson('package.json', content);
+}
+
+/** Writes a package manifest at a root-relative directory. */
+function writeWorkspacePackage(temp: TempTree, relDir: string, content: Record<string, unknown>): void {
+  temp.writeJson(join(relDir, 'package.json'), content);
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/testing/index.ts
+++ b/packages/readyup/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { makeWorkspace } from './makeWorkspace.ts';

--- a/packages/readyup/src/testing/makeWorkspace.ts
+++ b/packages/readyup/src/testing/makeWorkspace.ts
@@ -10,13 +10,13 @@ const FIXTURE_ROOT = '/repo';
 /**
  * Builds a `Workspace` fixture, filling every field the caller leaves out.
  *
- * Defaults are derived rather than held as literals: `dir` decides `absolutePath` and the manifest name, and the
- * manifest decides `name`, `isPackage`, and `isRoot` through the same derivation `discoverWorkspaces` uses. A field
- * added to `Workspace` therefore reaches a fixture with the value discovery would give it.
+ * Every default is derived: `dir` decides `absolutePath` and the manifest name, and the manifest decides `name`,
+ * `isPackage`, and `isRoot` through the derivation `discoverWorkspaces` uses. A field added to `Workspace` therefore
+ * reaches a fixture with the value discovery would give it.
  *
  * Overrides apply after the derivation, so a test that needs a shape discovery would not produce can still state it.
- * The result is frozen, as a discovered workspace is, and the manifest is copied before freezing so a literal shared
- * between fixtures is not frozen in the caller's hands.
+ * The result is frozen, as a discovered workspace is, and the manifest is copied before freezing, so a literal the
+ * caller shares between fixtures stays writable.
  */
 export function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
   const dir = overrides.dir ?? DEFAULT_DIR;

--- a/packages/readyup/src/testing/makeWorkspace.ts
+++ b/packages/readyup/src/testing/makeWorkspace.ts
@@ -1,0 +1,45 @@
+import { buildWorkspaceFromPackageJson } from '../check-utils/buildWorkspaceFromPackageJson.ts';
+import type { Workspace } from '../check-utils/workspaces.ts';
+
+/** Directory a fixture reports when the caller names none. */
+const DEFAULT_DIR = 'packages/example';
+
+/** Root the default `absolutePath` is composed against. */
+const FIXTURE_ROOT = '/repo';
+
+/**
+ * Builds a `Workspace` fixture, filling every field the caller leaves out.
+ *
+ * Defaults are derived rather than held as literals: `dir` decides `absolutePath` and the manifest name, and the
+ * manifest decides `name`, `isPackage`, and `isRoot` through the same derivation `discoverWorkspaces` uses. A field
+ * added to `Workspace` therefore reaches a fixture with the value discovery would give it.
+ *
+ * Overrides apply after the derivation, so a test that needs a shape discovery would not produce can still state it.
+ * The result is frozen, as a discovered workspace is, and the manifest is copied before freezing so a literal shared
+ * between fixtures is not frozen in the caller's hands.
+ */
+export function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
+  const dir = overrides.dir ?? DEFAULT_DIR;
+  const absolutePath = overrides.absolutePath ?? composeAbsolutePath(dir);
+  const packageJson = structuredClone(overrides.packageJson ?? { name: composeName(dir) });
+
+  const derived = buildWorkspaceFromPackageJson(dir, absolutePath, packageJson);
+
+  return Object.freeze({ ...derived, ...overrides, packageJson: derived.packageJson });
+}
+
+// region | Helpers
+
+/** Composes the absolute path of a fixture directory, in forward slashes so a fixture reads the same on any platform. */
+function composeAbsolutePath(dir: string): string {
+  if (dir === '.') return FIXTURE_ROOT;
+  return `${FIXTURE_ROOT}/${dir}`;
+}
+
+/** Composes the manifest name of a fixture directory: its last segment, or `repo` for the root. */
+function composeName(dir: string): string {
+  if (dir === '.') return 'repo';
+  return dir.slice(dir.lastIndexOf('/') + 1);
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/testing/makeWorkspace.ts
+++ b/packages/readyup/src/testing/makeWorkspace.ts
@@ -10,8 +10,8 @@ const FIXTURE_ROOT = '/repo';
 /**
  * Builds a `Workspace` fixture, filling every field the caller leaves out.
  *
- * Every default is derived: `dir` decides `absolutePath` and the manifest name, and the manifest decides `name`,
- * `isPackage`, and `isRoot` through the derivation `discoverWorkspaces` uses. A field added to `Workspace` therefore
+ * Every default is derived: `dir` decides `absolutePath`, the manifest name, and `isRoot`, and the manifest decides
+ * `name` and `isPackage`, through the derivation `discoverWorkspaces` uses. A field added to `Workspace` therefore
  * reaches a fixture with the value discovery would give it.
  *
  * Overrides apply after the derivation, so a test that needs a shape discovery would not produce can still state it.

--- a/packages/readyup/vitest.config.ts
+++ b/packages/readyup/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineVitestConfig({
     resolve: {
       alias: [
         { find: 'readyup/check-utils', replacement: path.resolve(import.meta.dirname, 'src/check-utils/index.ts') },
+        { find: 'readyup/testing', replacement: path.resolve(import.meta.dirname, 'src/testing/index.ts') },
         { find: 'readyup', replacement: path.resolve(import.meta.dirname, 'src/index.ts') },
       ],
     },

--- a/packages/readyup/vitest.config.ts
+++ b/packages/readyup/vitest.config.ts
@@ -13,8 +13,8 @@ import { defineVitestConfig } from '@williamthorsen/nmr/vitest';
 // Restoring a stubbed environment variable is the runner's job rather than a suite's. `unstubEnvs` clears every stub
 // before each test, so a suite that stubs one has no hook to undo it.
 //
-// The aliases let a test import this package's own kits, which reach readyup by package name the way a consumer's kit
-// does, without a prior build standing between the test and the source. Longest specifier first: an alias on `readyup`
+// The aliases let a test reach readyup by package name -- as this package's own kits do, the way a consumer's kit
+// does -- without a prior build standing between the test and the source. Longest specifier first: an alias on `readyup`
 // also matches `readyup/check-utils`, and the first match wins.
 //
 // The coverage entry extends the inherited `src`-only glob, which would otherwise leave the kit tree unmeasured. Kits


### PR DESCRIPTION
## What

Adds `readyup/testing`, a new entry point whose `makeWorkspace` builds a `Workspace` fixture from partial overrides and fills fields omitted by the caller.

A "Testing a kit" section has been added to the README, covering both shapes that a kit test can take: a real directory tree for a check that calls `discoverWorkspaces` itself and the builder for a function that takes a `Workspace`.

## Why

A kit author testing a function that takes a `Workspace` had no way to build one but by hand, so every field added to the type broke fixtures in every consuming repo. Release 0.33.0 made that concrete: the new required `isRoot` landed its whole compile-time cost on fixture authors, who needed no warning, and gave no signal to the filter authors it was for.

ReadyUp also documented how to write a check and never how to test one, so the reachable default was mocking `readyup/check-utils`. That yields workspace lists discovery cannot return, most often one with no root entry, which leaves every `!isRoot` filter passing everything through and never exercised.

## Details

### 🎉 Features

- `readyup/testing` is a new published subpath exporting `makeWorkspace`. It takes `Partial<Workspace>`, derives `absolutePath` and the default manifest from `dir`, and derives `name`, `isPackage`, and `isRoot` through the same code `discoverWorkspaces` uses. Explicit overrides apply last, so a test can still state a shape discovery would not produce. The result is frozen as a discovered workspace is, and the manifest is copied before freezing, so a literal shared between fixtures stays writable.
- The subpath is kept separate from `readyup/check-utils` so a fixture helper does not enter the runtime import graph every compiled kit carries. It joins `RUNNER_EXPORTS`, so `listRunnerSpecifiers()` continues to account for every JavaScript subpath the package publishes.

### ♻️ Refactoring

- `buildWorkspaceFromPackageJson` moves out of `workspaces.ts` into a module of its own, so the builder binds the derivation without the discovery walk and `node:fs` that `workspaces.ts` brings with it. Its description now names the deep-freeze it performs on the manifest it is handed.

### 🧪 Tests

- A suite covers the builder's defaults, root derivation, manifest derivation, override precedence, freezing, and non-mutation of the caller's manifest. One test writes a real tree, runs `discoverWorkspaces`, and compares the builder's output field-for-field against every workspace discovery returns, so a builder drifting from its producer fails rather than passing against hand-written literals.
- `packages/readyup/vitest.config.ts` resolves `readyup/testing` to source, so an in-repo test reaches the subpath by package name with no prior build standing between the test and the source.

### 📚 Documentation

- The README's "Testing a kit" section carries a copyable example for each shape, a table of the builder's defaults, and the reason mocking `readyup/check-utils` produces fixtures discovery cannot return. The `discoverWorkspaces` reference section links to it.


Closes #423
