### PR TITLE
#421 Replace nothing with the value readyup returns, and backtick literals

### DIFF
--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -228,7 +228,7 @@ function dropLeadingStyleFlag(argv: string[]): string[] {
   return argv.slice(index);
 }
 
-/** Returns true when the flags request help for the current subcommand. */
+/** Returns `true` when the flags request help for the current subcommand. */
 function wantsHelp(flags: string[]): boolean {
   return flags.some((f) => HELP_FLAGS.has(f));
 }

--- a/packages/readyup/src/check-utils/engines.ts
+++ b/packages/readyup/src/check-utils/engines.ts
@@ -32,7 +32,7 @@ export function readEnginesNodeFloor(manifest: Record<string, unknown>): Engines
 }
 
 /**
- * Reports whether a Node version is at or above a floor, and undefined when either argument is not a
+ * Reports whether a Node version is at or above a floor, and `undefined` when either argument is not a
  * dotted numeric version -- the shape `.tool-versions` tokens such as `lts` and `system` do not take.
  * A leading `v` is tolerated on either argument, so `process.version` can be passed as it comes.
  */

--- a/packages/readyup/src/check-utils/es-year.ts
+++ b/packages/readyup/src/check-utils/es-year.ts
@@ -11,7 +11,7 @@ const ES_YEAR_BY_NODE_MAJOR: Readonly<Record<number, EsYear>> = {
 
 /**
  * Maps a Node major version to the ECMAScript year it supports.
- * Returns undefined for majors outside the table, leaving the caller to decide what an unrecognized major means.
+ * Returns `undefined` for majors outside the table, leaving the caller to decide what an unrecognized major means.
  */
 export function esYearForNodeMajor(major: number): EsYear | undefined {
   return ES_YEAR_BY_NODE_MAJOR[major];

--- a/packages/readyup/src/check-utils/filesystem.ts
+++ b/packages/readyup/src/check-utils/filesystem.ts
@@ -15,7 +15,7 @@ export function fileExists(filePath: string): boolean {
 
 /**
  * Reads a file, resolving a relative path against the working directory.
- * Returns undefined if it doesn't exist.
+ * Returns `undefined` if it doesn't exist.
  */
 export function readFile(filePath: string): string | undefined {
   const fullPath = resolve(process.cwd(), filePath);

--- a/packages/readyup/src/check-utils/git/compare-local-refs.ts
+++ b/packages/readyup/src/check-utils/git/compare-local-refs.ts
@@ -19,7 +19,7 @@ export async function compareLocalRefs(path: string, refA: string, refB: string)
   return { status: 'mismatch', shaA, shaB, ...(aheadBehind && { aheadBehind }) };
 }
 
-/** Returns the name of the first ref that does not exist, or undefined where both exist. */
+/** Returns the name of the first ref that does not exist, or `undefined` where both exist. */
 async function findMissingRef(path: string, refA: string, refB: string): Promise<string | undefined> {
   const [existsA, existsB] = await Promise.all([refExists(path, refA), refExists(path, refB)]);
   if (!existsA) return refA;
@@ -38,7 +38,7 @@ async function refExists(path: string, ref: string): Promise<boolean> {
   }
 }
 
-/** Returns the ahead/behind counts between two refs, or undefined where they cannot be computed. */
+/** Returns the ahead/behind counts between two refs, or `undefined` where they cannot be computed. */
 async function resolveAheadBehind(
   path: string,
   refA: string,

--- a/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
+++ b/packages/readyup/src/check-utils/git/compare-ref-to-remote.ts
@@ -33,7 +33,9 @@ export async function compareRefToRemote(
   return { status: 'out-of-sync', localSha, remoteSha, ...(aheadBehind && { aheadBehind }) };
 }
 
-/** Returns a local ref's SHA, or undefined where the ref does not exist, rethrowing errors that mean anything else. */
+/**
+ * Returns a local ref's SHA, or `undefined` where the ref does not exist, rethrowing errors that mean anything else.
+ */
 async function resolveLocalRef(path: string, ref: string): Promise<string | undefined> {
   try {
     return await runGit(path, 'rev-parse', '--verify', ref);
@@ -43,7 +45,9 @@ async function resolveLocalRef(path: string, ref: string): Promise<string | unde
   }
 }
 
-/** Returns a remote ref's SHA via `ls-remote`, or undefined where the ref does not exist. Throws on a network error. */
+/**
+ * Returns a remote ref's SHA via `ls-remote`, or `undefined` where the ref does not exist. Throws on a network error.
+ */
 async function resolveRemoteRef(path: string, ref: string, remote: string): Promise<string | undefined> {
   const output = await runGit(path, 'ls-remote', remote, ref);
   if (!output) return undefined;
@@ -51,7 +55,7 @@ async function resolveRemoteRef(path: string, ref: string, remote: string): Prom
   return sha;
 }
 
-/** Returns the ahead/behind counts from the local tracking ref, or undefined where they cannot be computed. */
+/** Returns the ahead/behind counts from the local tracking ref, or `undefined` where they cannot be computed. */
 async function resolveAheadBehind(
   path: string,
   ref: string,

--- a/packages/readyup/src/check-utils/git/repo-predicates.ts
+++ b/packages/readyup/src/check-utils/git/repo-predicates.ts
@@ -14,7 +14,7 @@ export async function isGitRepo(path: string): Promise<boolean> {
   }
 }
 
-/** Reports whether `path` is the top of a git working tree, so a subdirectory yields false. */
+/** Reports whether `path` is the top of a git working tree, so a subdirectory yields `false`. */
 export async function isAtRepoRoot(path: string): Promise<boolean> {
   const resolved = expandHome(path);
   if (!existsSync(resolved)) return false;

--- a/packages/readyup/src/check-utils/json.ts
+++ b/packages/readyup/src/check-utils/json.ts
@@ -5,7 +5,7 @@ import { readFile } from './filesystem.ts';
 import { getJsonValue } from './json-value.ts';
 import { missingFrom } from './missingFrom.ts';
 
-/** Reads and parses a JSON file. Returns undefined if it doesn't exist or isn't an object. */
+/** Reads and parses a JSON file. Returns `undefined` if it doesn't exist or isn't an object. */
 export function readJsonFile(filePath: string): Record<string, unknown> | undefined {
   const content = readFile(filePath);
   if (content === undefined) return undefined;

--- a/packages/readyup/src/check-utils/package-json.ts
+++ b/packages/readyup/src/check-utils/package-json.ts
@@ -10,7 +10,7 @@ const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml';
 /** Leading range operators and the `v` prefix, stripped before a version is parsed from the start of a specifier. */
 const RANGE_PREFIX = /^[\s^~=<>v]+/;
 
-/** Returns the parsed root package.json, or undefined where it does not exist or is not an object. */
+/** Returns the parsed root package.json, or `undefined` where it does not exist or is not an object. */
 export function readPackageJson(): Record<string, unknown> | undefined {
   return readJsonFile('package.json');
 }
@@ -66,7 +66,7 @@ export function hasMinDevDependencyVersion(
 
 // region | Helpers
 
-/** Extracts the version a specifier declares, or undefined when it names none. */
+/** Extracts the version a specifier declares, or `undefined` when it names none. */
 function extractVersion(specifier: string): string | undefined {
   // Parse from the start, so a specifier naming fewer than three segments (`7`, `^6`) is measured rather than skipped;
   // `compareVersions` pads a short version against the floor.
@@ -76,7 +76,7 @@ function extractVersion(specifier: string): string | undefined {
   return /\d+\.\d+\.\d+/.exec(specifier)?.[0];
 }
 
-/** Resolves a `catalog:` specifier to the version its catalog assigns the package, or undefined when nothing does. */
+/** Resolves a `catalog:` specifier to the version its catalog assigns the package, or `undefined` when nothing does. */
 function resolveCatalogSpecifier(specifier: string, name: string): string | undefined {
   const yaml = readFile(PNPM_WORKSPACE_FILE);
   if (yaml === undefined) return undefined;

--- a/packages/readyup/src/check-utils/package-json.ts
+++ b/packages/readyup/src/check-utils/package-json.ts
@@ -32,7 +32,7 @@ export function hasDevDependency(name: string): boolean {
  * Checks whether a dev dependency meets a minimum version. Any `workspace:`-prefixed specifier satisfies any floor,
  * including one that names a version: the specifier links to the package the repo builds, and a version it names is a
  * publish range, not the version that resolves. A `catalog:` specifier is resolved through `pnpm-workspace.yaml` and
- * measured against the version it finds there; one that resolves to nothing meets no floor. `exempt` receives the
+ * measured against the version it finds there; one that resolves to no version meets no floor. `exempt` receives the
  * specifier as declared, so a catalogued dependency reaches it as `catalog:`; it adds further exemptions and cannot
  * remove the `workspace:` one.
  */

--- a/packages/readyup/src/check-utils/pnpmWorkspaceYaml.ts
+++ b/packages/readyup/src/check-utils/pnpmWorkspaceYaml.ts
@@ -143,7 +143,7 @@ function collectBlockEntries(lines: string[], keyLineIndex: number): { index: nu
 }
 
 /**
- * Splits a `key: value` mapping line into its parts, or returns undefined when the line is not one or
+ * Splits a `key: value` mapping line into its parts, or returns `undefined` when the line is not one or
  * has a value this reader cannot follow. The key may be quoted, as a scoped package name in a
  * catalog is; the value keeps any `:` it contains, so a `workspace:*` entry survives.
  */
@@ -159,7 +159,7 @@ function parseMappingEntry(text: string): { key: string; value: string } | undef
   return { key: stripQuotes(rawKey), value: stripQuotes(rawValue) };
 }
 
-/** Returns the trimmed value after a `key:` on the same line, or null where there is no inline value. */
+/** Returns the trimmed value after a `key:` on the same line, or `null` where there is no inline value. */
 function extractInlineValue(line: string): string | null {
   const colonIndex = line.indexOf(':');
   if (colonIndex === -1) return null;

--- a/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
@@ -79,7 +79,7 @@ describe(buildFindingReport, () => {
     expect(outcome).toStrictEqual({ adoptedCount: 0, findings: [] });
   });
 
-  it('suppresses nothing, leaving a site with a pragma to the runner', ({ temp }) => {
+  it('keeps a finding sited at a pragma, leaving suppression to the runner', ({ temp }) => {
     temp.write('src/errors.ts', ['', ...Array.from({ length: 10 }, () => ''), 'x; // rdy-ignore', ''].join('\n'));
 
     const outcome = buildFindingReport({ adoptedCount: 0, findings: [CLONE], shouldReport: () => true });

--- a/packages/readyup/src/check-utils/project/__tests__/listOwnImplementationSpans.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listOwnImplementationSpans.unit.test.ts
@@ -107,7 +107,7 @@ describe(listOwnImplementationSpans, () => {
       ]);
     });
 
-    it('exempts nothing in a barrel that re-exports the name from another file', ({ temp }) => {
+    it('exempts no span in a barrel that re-exports the name from another file', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/errors/src/index.ts';
       const own = buildOwnImplementation([{ path, text: "export { describeError } from './describeError.ts';\n" }]);
@@ -115,7 +115,7 @@ describe(listOwnImplementationSpans, () => {
       expect(listOwnImplementationSpans(path, own)).toStrictEqual([]);
     });
 
-    it('exempts nothing in a file that declares the name without exporting it', ({ temp }) => {
+    it('exempts no span in a file that declares the name without exporting it', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/errors/src/format.ts';
       const own = buildOwnImplementation([{ path, text: 'function describeError(error: unknown) {}\n' }]);
@@ -123,7 +123,7 @@ describe(listOwnImplementationSpans, () => {
       expect(listOwnImplementationSpans(path, own)).toStrictEqual([]);
     });
 
-    it('exempts nothing in a file exporting the name under a different one', ({ temp }) => {
+    it('exempts no span in a file exporting the name under a different one', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/errors/src/format.ts';
       const text = 'function describeError(error: unknown) {}\nexport { describeError as toMessage };\n';
@@ -132,7 +132,7 @@ describe(listOwnImplementationSpans, () => {
       expect(listOwnImplementationSpans(path, own)).toStrictEqual([]);
     });
 
-    it('exempts nothing in a file that only imports and calls the export', ({ temp }) => {
+    it('exempts no span in a file that only imports and calls the export', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/errors/src/report.ts';
       const text = "import { describeError } from '@scope/errors';\nconst message = describeError(error);\n";
@@ -141,7 +141,7 @@ describe(listOwnImplementationSpans, () => {
       expect(listOwnImplementationSpans(path, own)).toStrictEqual([]);
     });
 
-    it('exempts nothing for a declaration that appears only in a comment', ({ temp }) => {
+    it('exempts no span for a declaration that appears only in a comment', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/errors/src/report.ts';
       const own = buildOwnImplementation([{ path, text: '// export function describeError(error: unknown) {}\n' }]);
@@ -149,7 +149,7 @@ describe(listOwnImplementationSpans, () => {
       expect(listOwnImplementationSpans(path, own)).toStrictEqual([]);
     });
 
-    it('exempts nothing in a defining file outside the publishing workspace', ({ temp }) => {
+    it('exempts no span in a defining file outside the publishing workspace', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/app/src/describeError.ts';
       const own = buildOwnImplementation([{ path, text: 'export function describeError(error: unknown) {}' }]);
@@ -157,7 +157,7 @@ describe(listOwnImplementationSpans, () => {
       expect(listOwnImplementationSpans(path, own)).toStrictEqual([]);
     });
 
-    it('exempts nothing when no workspace has the declared name', ({ temp }) => {
+    it('exempts no span when no workspace has the declared name', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/errors/src/describeError.ts';
       const sources = [{ path, text: 'export function describeError(error: unknown) {}' }];
@@ -166,14 +166,14 @@ describe(listOwnImplementationSpans, () => {
       expect(listOwnImplementationSpans(path, own)).toStrictEqual([]);
     });
 
-    it('exempts nothing for a path the sweep never read', ({ temp }) => {
+    it('exempts no span for a path the sweep never read', ({ temp }) => {
       writeMonorepo(temp);
       const own = buildOwnImplementation([]);
 
       expect(listOwnImplementationSpans('packages/errors/src/describeError.ts', own)).toStrictEqual([]);
     });
 
-    it('exempts nothing when the check names no exports', ({ temp }) => {
+    it('exempts no span when the check names no exports', ({ temp }) => {
       writeMonorepo(temp);
       const path = 'packages/errors/src/describeError.ts';
       const sources = [{ path, text: 'export function describeError(error: unknown) {}' }];
@@ -211,7 +211,7 @@ describe(listOwnImplementationSpans, () => {
     });
   });
 
-  it('exempts nothing in a repo whose workspaces cannot be discovered', () => {
+  it('exempts no span in a repo whose workspaces cannot be discovered', () => {
     const path = 'src/describeError.ts';
     const own = buildOwnImplementation([{ path, text: 'export function describeError(error: unknown) {}' }]);
 

--- a/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
@@ -175,7 +175,7 @@ describe(readTrackedSources, () => {
     expect(scanned).toStrictEqual([['src/kept.ts'], ['src/kept.ts']]);
   });
 
-  it('reports nothing outside a git working tree', async ({ temp }) => {
+  it('reports nothing to the recorder outside a git working tree', async ({ temp }) => {
     temp.write('src/present.ts', 'present');
     execFileAsync.mockRejectedValue(Object.assign(new Error('fatal: not a git repository'), { code: 128 }));
     const { recorder, scanned } = createRecorder();

--- a/packages/readyup/src/check-utils/tool-versions.ts
+++ b/packages/readyup/src/check-utils/tool-versions.ts
@@ -5,7 +5,7 @@ const NODE_TOOL_NAMES = new Set(['node', 'nodejs']);
 
 /**
  * Reads the Node version declared in a `.tool-versions` file.
- * Returns undefined when the file is absent or declares no Node version.
+ * Returns `undefined` when the file is absent or declares no Node version.
  */
 export function readToolVersionsNode(filePath = '.tool-versions'): string | undefined {
   const content = readFile(filePath);

--- a/packages/readyup/src/check-utils/tsconfig.ts
+++ b/packages/readyup/src/check-utils/tsconfig.ts
@@ -24,7 +24,7 @@ export interface TsconfigChainEntry {
   /** Path of the config, cwd-relative. */
   path: string;
   /**
-   * The `extends` specifier that reached this config; undefined for the entry config. Unlike `path`, it survives a
+   * The `extends` specifier that reached this config; `undefined` for the entry config. Unlike `path`, it survives a
    * change of install layout: pnpm resolves a package under `.pnpm` and a workspace link under the directory it
    * points at, so one base config resolves to two different paths. Where two branches reach one config, it names the
    * branch that reached it first.
@@ -62,7 +62,7 @@ interface Resolution {
 
 /**
  * Reads a tsconfig's `extends` chain, resolving it as TypeScript does, and reports what each config it reaches
- * declares in its own right. Returns undefined if the entry file is missing or unparseable; unresolvable parents
+ * declares in its own right. Returns `undefined` if the entry file is missing or unparseable; unresolvable parents
  * are reported in `unresolvedExtends` rather than treated as failures.
  */
 export function readTsconfigChain(filePath: string): TsconfigChain | undefined {
@@ -84,7 +84,7 @@ export function readTsconfigChain(filePath: string): TsconfigChain | undefined {
 }
 
 /**
- * Reads a tsconfig's effective `lib` and `target` from its `extends` chain. Returns undefined if the entry file is
+ * Reads a tsconfig's effective `lib` and `target` from its `extends` chain. Returns `undefined` if the entry file is
  * missing or unparseable; unresolvable parents are reported in `unresolvedExtends` rather than treated as failures.
  */
 export function readTsconfigLanguageLevel(filePath: string): TsconfigLanguageLevel | undefined {
@@ -124,7 +124,7 @@ function readExtends(value: unknown): string[] {
   return [];
 }
 
-/** Reads and JSONC-parses a JSON file. Returns undefined when the file is unreadable or is not an object. */
+/** Reads and JSONC-parses a JSON file. Returns `undefined` when the file is unreadable or is not an object. */
 function readJsonFile(absolutePath: string): Record<string, unknown> | undefined {
   if (!isFile(absolutePath)) return undefined;
   let content: string;
@@ -138,7 +138,7 @@ function readJsonFile(absolutePath: string): Record<string, unknown> | undefined
   return parsed;
 }
 
-/** Normalizes a declared `lib` to lowercased strings. Returns undefined when the value is not an array. */
+/** Normalizes a declared `lib` to lowercased strings. Returns `undefined` when the value is not an array. */
 function readLib(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   return value.filter((entry): entry is string => typeof entry === 'string').map((entry) => entry.toLowerCase());
@@ -161,7 +161,7 @@ function readNearestOption<T>(
   return undefined;
 }
 
-/** Normalizes a declared `target` to lowercase. Returns undefined when the value is not a string. */
+/** Normalizes a declared `target` to lowercase. Returns `undefined` when the value is not a string. */
 function readTarget(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   return value.toLowerCase();

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -17,7 +17,7 @@ export interface Workspace {
   readonly name: string | undefined;
   /** `true` iff `package.json.private !== true`. (Equivalently: "this workspace is a package".) */
   readonly isPackage: boolean;
-  /** True for the repo root, which every repo shape reports. Independent of `isPackage`: a root may publish. */
+  /** `true` for the repo root, which every repo shape reports. Independent of `isPackage`: a root may publish. */
   readonly isRoot: boolean;
   /** Parsed `package.json` contents, validated to be a record. */
   readonly packageJson: Readonly<Record<string, unknown>>;

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -15,7 +15,7 @@ export interface Workspace {
   readonly absolutePath: string;
   /** `name` from the workspace's `package.json`; `undefined` if absent. */
   readonly name: string | undefined;
-  /** True iff `package.json.private !== true`. (Equivalently: "this workspace is a package".) */
+  /** `true` iff `package.json.private !== true`. (Equivalently: "this workspace is a package".) */
   readonly isPackage: boolean;
   /** True for the repo root, which every repo shape reports. Independent of `isPackage`: a root may publish. */
   readonly isRoot: boolean;
@@ -25,7 +25,7 @@ export interface Workspace {
 
 /** Options for `discoverWorkspaces`. */
 export interface DiscoverWorkspacesOptions {
-  /** Optional predicate. Workspaces returning false are omitted. */
+  /** Optional predicate. Workspaces returning `false` are omitted. */
   filter?: (workspace: Workspace) => boolean;
 }
 
@@ -187,7 +187,7 @@ function normalizePattern(pattern: string): string {
   return pattern;
 }
 
-/** Builds a `Workspace` for a relative directory; returns undefined if its `package.json` is missing or malformed. */
+/** Builds a `Workspace` for a relative directory; returns `undefined` if its `package.json` is missing or malformed. */
 function buildWorkspace(rootDir: string, relDir: string): Workspace | undefined {
   const absoluteDir = resolve(rootDir, relDir);
   const packageJson = readJsonFile(join(absoluteDir, 'package.json'));

--- a/packages/readyup/src/compile/__tests__/buildBundle.closure.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.closure.tool.test.ts
@@ -62,7 +62,7 @@ describe('buildBundle input closure', () => {
     });
   });
 
-  it('records nothing from node_modules', () => {
+  it('records no input from node_modules', () => {
     expect(inputs.filter((input) => input.path.includes('node_modules'))).toStrictEqual([]);
   });
 

--- a/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
+++ b/packages/readyup/src/compile/__tests__/buildBundle.dependencies.tool.test.ts
@@ -82,7 +82,7 @@ describe('buildBundle bundled dependencies', () => {
     expect(result.esbuildVersion).toBe(installedEsbuildVersion);
   });
 
-  it('records nothing for a kit that bundles no packages', async () => {
+  it('records an empty bundledDependencies for a kit that bundles no packages', async () => {
     writeFileSync(path.join(treeRoot, 'bare-kit.ts'), 'export const kit = {};\n');
 
     const bare = await buildBundle(path.join(treeRoot, 'bare-kit.ts'));

--- a/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
+++ b/packages/readyup/src/compile/__tests__/resolveCompileRoot.unit.test.ts
@@ -15,7 +15,7 @@ describe(resolveCompileRoot, () => {
   beforeAll(() => {
     treeRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'compile-root-')));
 
-    // Two cases below assert that a walk reaching the filesystem root finds nothing, which only holds
+    // Two cases below assert that a walk reaching the filesystem root finds no manifest, which only holds
     // where no directory above the fixture has a manifest of its own.
     const ancestorManifest = findAncestorManifest(treeRoot);
     assert.ok(

--- a/packages/readyup/src/compile/buildBundle.ts
+++ b/packages/readyup/src/compile/buildBundle.ts
@@ -239,7 +239,7 @@ function hasUnresolvedSpecifier(error: unknown): boolean {
  * Returns the name and version of the package holding `directory`, walking up to the nearest
  * `package.json` that declares both.
  *
- * The walk never leaves `node_modules`: a store path with no identifiable package returns undefined
+ * The walk never leaves `node_modules`: a store path with no identifiable package returns `undefined`
  * rather than climbing on and attributing the file to the host project.
  */
 function identifyPackage(directory: string): { name: string; version: string } | undefined {
@@ -257,7 +257,7 @@ function isDependencyFile(filePath: string): boolean {
   return filePath.split(path.sep).includes(EXCLUDED_DIRECTORY);
 }
 
-/** Returns a package.json's name and version, or undefined when the file does not declare both readably. */
+/** Returns a package.json's name and version, or `undefined` when the file does not declare both readably. */
 function readPackageIdentity(manifestPath: string): { name: string; version: string } | undefined {
   let parsed: unknown;
   try {

--- a/packages/readyup/src/compile/compileCommand.ts
+++ b/packages/readyup/src/compile/compileCommand.ts
@@ -483,7 +483,7 @@ interface DriftSkip {
 }
 
 /**
- * Returns a single kit's drift status alongside the manifest entry to preserve, or undefined where
+ * Returns a single kit's drift status alongside the manifest entry to preserve, or `undefined` where
  * the kit should proceed to compile.
  */
 function detectDrift(args: DetectDriftArgs): DriftSkip | undefined {

--- a/packages/readyup/src/kitImports/listRunnerExports.ts
+++ b/packages/readyup/src/kitImports/listRunnerExports.ts
@@ -19,7 +19,7 @@ const RUNNER_EXPORTS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['readyup/testing', new Set(Object.keys(testingNamespace))],
 ]);
 
-/** Returns the names a `readyup` specifier exports, or undefined where the runner publishes no such subpath. */
+/** Returns the names a `readyup` specifier exports, or `undefined` where the runner publishes no such subpath. */
 export function listRunnerExports(specifier: string): ReadonlySet<string> | undefined {
   return RUNNER_EXPORTS.get(specifier);
 }

--- a/packages/readyup/src/kits/loadRdyKit.ts
+++ b/packages/readyup/src/kits/loadRdyKit.ts
@@ -102,7 +102,7 @@ function listAvailableKits(dir: string, extension: string): string[] {
   }
 }
 
-/** Narrows `__readyupVersion` in an imported module namespace to a string, or undefined. */
+/** Narrows `__readyupVersion` in an imported module namespace to a string, or `undefined`. */
 function readCompileTimeVersion(moduleRecord: Record<string, unknown>): string | undefined {
   const value = moduleRecord['__readyupVersion'];
   return typeof value === 'string' ? value : undefined;

--- a/packages/readyup/src/kits/types.ts
+++ b/packages/readyup/src/kits/types.ts
@@ -192,7 +192,7 @@ export interface RdyCheck {
   /**
    * Whether the check renders only when it does not pass. It still runs and still counts toward
    * the summary; a failure or a skip reports in full.
-   * Default: false.
+   * Default: `false`.
    */
   quiet?: boolean | undefined;
 
@@ -305,7 +305,7 @@ export interface RdyReport {
   diagnoses?: SkipDiagnosis[] | undefined;
 
   /**
-   * True when no check at or above the failure threshold has `ok: false`.
+   * `true` when no check at or above the failure threshold has `ok: false`.
    * Skipped checks do not affect this.
    */
   passed: boolean;

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -282,7 +282,7 @@ function formatCounts(counts: SummaryCounts): string {
   return fields.length > 0 ? fields.join(COUNT_SEPARATOR) : EMPTY_COUNTS;
 }
 
-/** Returns the formatted duration, or undefined for a skipped token or a duration under the floor. */
+/** Returns the formatted duration, or `undefined` for a skipped token or a duration under the floor. */
 function resolveDuration(token: TokenName, durationMs: number | undefined): string | undefined {
   if (durationMs === undefined || SKIPPED_TOKENS.has(token)) return undefined;
   return durationMs >= DURATION_FLOOR_MS ? formatDuration(durationMs) : undefined;

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -560,7 +560,7 @@ function enumerateCompiledKits(kitsDir: string, manifestPath: string): JsonListK
   }));
 }
 
-/** Reads a manifest, returning undefined where there is none and reporting any other failure. */
+/** Reads a manifest, returning `undefined` where there is none and reporting any other failure. */
 function readLocalManifestIfPresent(manifestPath: string): RdyManifest | undefined {
   try {
     return readManifest(manifestPath);

--- a/packages/readyup/src/portable/__tests__/findNearestWord.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/findNearestWord.unit.test.ts
@@ -20,11 +20,11 @@ describe(findNearestWord, () => {
     { label: 'the empty string', input: '' },
     { label: 'a long flag', input: '--json' },
     { label: 'a short flag', input: '-h' },
-  ])('matches nothing for $label', ({ input }) => {
+  ])('returns undefined for $label', ({ input }) => {
     expect(findNearestWord(input, COMMANDS)).toBeUndefined();
   });
 
-  it('matches nothing when the candidate list is empty', () => {
+  it('returns undefined when the candidate list is empty', () => {
     expect(findNearestWord('list', [])).toBeUndefined();
   });
 

--- a/packages/readyup/src/portable/__tests__/listDeclarationSpans.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/listDeclarationSpans.unit.test.ts
@@ -281,7 +281,7 @@ describe(listDeclarationSpans, () => {
     ]);
   });
 
-  it('lists nothing for a source holding no declaration', () => {
+  it('lists no span for a source holding no declaration', () => {
     expect(listSpans([''])).toStrictEqual([]);
   });
 });

--- a/packages/readyup/src/portable/blankNonCode.ts
+++ b/packages/readyup/src/portable/blankNonCode.ts
@@ -175,7 +175,7 @@ function findBlockCommentEnd(source: string, from: number): number {
   return end === -1 ? source.length : end + 2;
 }
 
-/** Returns the offset past the comment opening at an offset, or undefined where none opens there. */
+/** Returns the offset past the comment opening at an offset, or `undefined` where none opens there. */
 function findCommentEnd(source: string, from: number): number | undefined {
   if (source[from] !== '/') return undefined;
 
@@ -191,7 +191,7 @@ function findLineEnd(source: string, from: number): number {
   return end === -1 ? source.length : end;
 }
 
-/** Returns the offset past a regular expression's closing delimiter, or undefined where the line ends first. */
+/** Returns the offset past a regular expression's closing delimiter, or `undefined` where the line ends first. */
 function findRegexEnd(source: string, start: number): number | undefined {
   let index = start + 1;
   let isInClass = false;

--- a/packages/readyup/src/projects/__tests__/project-discovery.unit.test.ts
+++ b/packages/readyup/src/projects/__tests__/project-discovery.unit.test.ts
@@ -137,7 +137,7 @@ describe(discoverKitProjects, () => {
     await expect(discoverDirs(temp.dir)).resolves.toContain('packages/authored');
   });
 
-  it('reports nothing for a tree holding no kit project', async ({ temp }) => {
+  it('reports no project for a tree holding none', async ({ temp }) => {
     const { projects } = await discover(temp.resolve('packages/plain'));
 
     expect(projects).toStrictEqual([]);

--- a/packages/readyup/src/remote/loadRemoteKit.ts
+++ b/packages/readyup/src/remote/loadRemoteKit.ts
@@ -18,7 +18,7 @@ export interface LoadRemoteKitOptions {
 
 /**
  * Fetches a remote `.js` kit bundle, evaluates it, and returns the validated RdyKit alongside its
- * embedded `__readyupVersion`, which is undefined for a kit compiled before that field existed or
+ * embedded `__readyupVersion`, which is `undefined` for a kit compiled before that field existed or
  * fetched from a third-party source that omits it.
  *
  * Any supplied headers are sent with the request. This has no auth-scheme knowledge of its own, so `Authorization` and

--- a/packages/readyup/src/run/__tests__/PragmaLedger.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/PragmaLedger.unit.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { createPragmaLedger } from '../PragmaLedger.ts';
 
 describe(createPragmaLedger, () => {
-  it('records nothing until a check declares something', () => {
+  it('records no path and no suppression until a check declares something', () => {
     const ledger = createPragmaLedger();
 
     expect(ledger.scannedPaths()).toStrictEqual([]);

--- a/packages/readyup/src/run/__tests__/listPragmaSites.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/listPragmaSites.unit.test.ts
@@ -47,19 +47,19 @@ describe(listPragmaSites, () => {
   });
 
   describe('given a token the comment rule withholds', () => {
-    it('lists nothing for a token in a string literal', () => {
+    it('lists no site for a token in a string literal', () => {
       expect(listPragmaSites("const token = 'rdy-ignore';\n")).toStrictEqual([]);
     });
 
-    it('lists nothing for a token in a regular expression', () => {
+    it('lists no site for a token in a regular expression', () => {
       expect(listPragmaSites('const pattern = /rdy-ignore/;\n')).toStrictEqual([]);
     });
 
-    it('lists nothing for a token following prose inside a comment', () => {
+    it('lists no site for a token following prose inside a comment', () => {
       expect(listPragmaSites('// The token to write is rdy-ignore\n')).toStrictEqual([]);
     });
 
-    it('lists nothing for a token following commented-out code', () => {
+    it('lists no site for a token following commented-out code', () => {
       expect(listPragmaSites('// const a = 1; rdy-ignore\n')).toStrictEqual([]);
     });
 
@@ -69,11 +69,11 @@ describe(listPragmaSites, () => {
       expect(sites).toStrictEqual([{ coveredLine: 1, line: 1, token: 'rdy-ignore' }]);
     });
 
-    it('lists nothing for a token in bare code', () => {
+    it('lists no site for a token in bare code', () => {
       expect(listPragmaSites('const flag = rdy-ignore;\n')).toStrictEqual([]);
     });
 
-    it('lists nothing for a word the token is only the head of', () => {
+    it('lists no site for a word the token is only the head of', () => {
       expect(listPragmaSites('// rdy-ignored\n')).toStrictEqual([]);
     });
   });

--- a/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
@@ -49,7 +49,7 @@ describe('a run recording what its checks examined and suppressed', () => {
     expect(ledger.hasSuppressed(SOURCE_PATH, 2)).toBe(false);
   });
 
-  it('records nothing for a diagnosed check', async ({ temp }) => {
+  it('records no path and no suppression for a diagnosed check', async ({ temp }) => {
     temp.write(SOURCE_PATH, SOURCE_TEXT);
     const ledger = createPragmaLedger();
 

--- a/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
@@ -59,7 +59,7 @@ describe('a pragma reaching the check ids the runner resolved', () => {
     expect(verdicts(report.results).map((verdict) => verdict.status)).toStrictEqual(['passed', 'passed']);
   });
 
-  it('leaves both checks failing where the kit has no publishing package to namespace under', async ({ temp }) => {
+  it('suppresses neither where the kit has no publishing package to namespace under', async ({ temp }) => {
     temp.write(SOURCE_PATH, 'error instanceof Error; // rdy-ignore toolbelt.errors/no-instanceof-error\n');
 
     const report = await runRdy(twoChecksOverOneLine());

--- a/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
@@ -59,7 +59,7 @@ describe('a pragma reaching the check ids the runner resolved', () => {
     expect(verdicts(report.results).map((verdict) => verdict.status)).toStrictEqual(['passed', 'passed']);
   });
 
-  it('suppresses nothing by name where the kit has no publishing package to namespace under', async ({ temp }) => {
+  it('leaves both checks failing where the kit has no publishing package to namespace under', async ({ temp }) => {
     temp.write(SOURCE_PATH, 'error instanceof Error; // rdy-ignore toolbelt.errors/no-instanceof-error\n');
 
     const report = await runRdy(twoChecksOverOneLine());

--- a/packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts
@@ -141,7 +141,7 @@ describe(resolveFindingOutcome, () => {
       expect(ledger.scannedPaths()).toHaveLength(1);
     });
 
-    it('records nothing examined where the outcome declares no sweep', () => {
+    it('records no examined path where the outcome declares no sweep', () => {
       const ledger = createPragmaLedger();
 
       resolveFindingOutcome({ adoptedCount: 0, findings: [CLONE] }, [], ledger);

--- a/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runRdy.unit.test.ts
@@ -977,7 +977,7 @@ describe(runRdy, () => {
       expect(report.diagnoses).toStrictEqual([{ name: 'masked-check', verdict: 'masked-pass' }]);
     });
 
-    it('reports nothing for a skipped check whose check would have failed', async () => {
+    it('reports no diagnosis for a skipped check whose check would have failed', async () => {
       const checklist: RdyChecklist = {
         name: 'rightly-skipped',
         checks: [{ name: 'would-fail', check: () => false, skip: () => 'not applicable' }],

--- a/packages/readyup/src/run/__tests__/suppressesFinding.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/suppressesFinding.unit.test.ts
@@ -12,7 +12,7 @@ describe(suppressesFinding, () => {
       expect(suppressesFinding(lines, 2, [])).toBe(true);
     });
 
-    it('suppresses nothing on the line below it', () => {
+    it('reports false on the line below it', () => {
       const lines = linesOf('// rdy-ignore\nerror instanceof Error;');
 
       expect(suppressesFinding(lines, 2, [])).toBe(false);
@@ -32,7 +32,7 @@ describe(suppressesFinding, () => {
       expect(suppressesFinding(lines, 2, [])).toBe(true);
     });
 
-    it('suppresses nothing on the line it sits on', () => {
+    it('reports false on the line it sits on', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore-next-line');
 
       expect(suppressesFinding(lines, 1, [])).toBe(false);
@@ -60,13 +60,13 @@ describe(suppressesFinding, () => {
       expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
     });
 
-    it('suppresses nothing for a check it does not name', () => {
+    it('reports false for a check it does not name', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore toolbelt.errors/other-check');
 
       expect(suppressesFinding(lines, 1, NAMED)).toBe(false);
     });
 
-    it('suppresses nothing for a check with no id at all', () => {
+    it('reports false for a check with no id at all', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore toolbelt.errors/no-instanceof-error');
 
       expect(suppressesFinding(lines, 1, [])).toBe(false);
@@ -93,7 +93,7 @@ describe(suppressesFinding, () => {
       expect(suppressesFinding(lines, 1, NAMED)).toBe(true);
     });
 
-    it('suppresses nothing where the named check belongs to another kit', () => {
+    it('reports false where the named check belongs to another kit', () => {
       const lines = linesOf('error instanceof Error; // rdy-ignore other.kit/no-instanceof-error');
 
       expect(suppressesFinding(lines, 1, NAMED)).toBe(false);
@@ -128,20 +128,20 @@ describe(suppressesFinding, () => {
   });
 
   describe('given a token the grammar does not name', () => {
-    it('suppresses nothing for a word the token only prefixes', () => {
+    it('reports false for a word the token only prefixes', () => {
       const lines = linesOf('const rdy-ignored = 1;');
 
       expect(suppressesFinding(lines, 1, [])).toBe(false);
     });
 
-    it('suppresses nothing for a misspelt next-line suffix', () => {
+    it('reports false for a misspelt next-line suffix', () => {
       const lines = linesOf('// rdy-ignore-nextline\nerror instanceof Error;');
 
       expect(suppressesFinding(lines, 1, [])).toBe(false);
       expect(suppressesFinding(lines, 2, [])).toBe(false);
     });
 
-    it('suppresses nothing for a token a longer word ends with', () => {
+    it('reports false for a token a longer word ends with', () => {
       const lines = linesOf('const notrdy-ignore = 1;');
 
       expect(suppressesFinding(lines, 1, [])).toBe(false);
@@ -161,7 +161,7 @@ describe(suppressesFinding, () => {
     expect(suppressesFinding(lines, 2, [])).toBe(true);
   });
 
-  it('suppresses nothing where no line has a pragma', () => {
+  it('reports false where no line has a pragma', () => {
     const lines = linesOf('const a = 1;\nerror instanceof Error;');
 
     expect(suppressesFinding(lines, 2, [])).toBe(false);

--- a/packages/readyup/src/run/check-return.ts
+++ b/packages/readyup/src/run/check-return.ts
@@ -12,7 +12,7 @@ export function describeUninterpretableReturn(raw: unknown): string {
 }
 
 /**
- * Returns true if a check's return value is a structured outcome.
+ * Returns `true` if a check's return value is a structured outcome.
  *
  * `ok` must be a boolean: a truthy value of any other type is an authoring mistake, not a pass, and
  * treating it as one is how a broken check reports success.
@@ -22,7 +22,7 @@ export function isCheckOutcome(raw: unknown): raw is CheckOutcome {
 }
 
 /**
- * Returns true if a check's return value is a set of located findings.
+ * Returns `true` if a check's return value is a set of located findings.
  *
  * Keyed on an array `findings`, as `isCheckOutcome` is on a boolean `ok`: each arm is recognized by the
  * field it is built around rather than by a tag its author would have to remember to write.

--- a/packages/readyup/src/run/kit-staleness.ts
+++ b/packages/readyup/src/run/kit-staleness.ts
@@ -120,7 +120,7 @@ function hasChangedInput(status: InputsStatus | undefined): boolean {
   return status?.kind === 'stale' && status.failures.some((failure) => failure.reason === 'changed');
 }
 
-/** Returns a staleness verdict, or undefined when reaching one needed a file that cannot be read. */
+/** Returns a staleness verdict, or `undefined` when reaching one needed a file that cannot be read. */
 function readVerdict<TStatus>(check: () => TStatus): TStatus | undefined {
   try {
     return check();

--- a/packages/readyup/src/run/pragma-report.ts
+++ b/packages/readyup/src/run/pragma-report.ts
@@ -17,7 +17,7 @@ interface UnusedPragma extends PragmaSite {
  *
  * The evidence is what the run's checks read: a pragma is reported only where some check examined the file
  * holding it, by sweeping it or by declaring it, and no check suppressed a finding on the line it covers. A file
- * no check examined yields nothing, because the run holds no evidence either way about the pragmas in it.
+ * no check examined yields no entry, because the run holds no evidence either way about the pragmas in it.
  *
  * Each examined file is read and scanned once however many checks examined it, and only a JS-family source is
  * scanned at all, recognition resting on syntax the blanking reads.

--- a/packages/readyup/src/run/resolveCheckIds.ts
+++ b/packages/readyup/src/run/resolveCheckIds.ts
@@ -7,7 +7,7 @@ export interface CheckIds {
 }
 
 /**
- * Returns the strings naming a check, or undefined where the check declares no id.
+ * Returns the strings naming a check, or `undefined` where the check declares no id.
  *
  * A kit a package publishes namespaces its checks under that package's name with the scope stripped, and
  * accepts the fully-qualified name too. The bare id is not accepted there: the namespace is what keeps two

--- a/packages/readyup/src/run/resolveKitSources.ts
+++ b/packages/readyup/src/run/resolveKitSources.ts
@@ -53,7 +53,7 @@ export function resolveKitSources({
     return [{ name, source: { url: urlValue }, checklists: checklists ?? [], provenance: { kind: 'remote', label } }];
   }
 
-  // Assume `jit` is always false when `fromValue` is present; `parseRunArgs` enforces this constraint.
+  // Assume `jit` is always `false` when `fromValue` is present; `parseRunArgs` enforces this constraint.
   const extension = jit ? '.ts' : '.js';
 
   // Fill the default before the `--packages` branch reads it, so a bare invocation is structurally

--- a/packages/readyup/src/run/runHumanMode.ts
+++ b/packages/readyup/src/run/runHumanMode.ts
@@ -136,7 +136,7 @@ function createBlockWriter(): BlockWriter {
 }
 
 /**
- * Returns the segment naming where a kit came from, or undefined where there is nothing to name.
+ * Returns the segment naming where a kit came from, or `undefined` where there is nothing to name.
  *
  * A kit the local kits directory holds has no source, and neither does one whose directory resolves to
  * the working directory: naming the directory the reader is standing in tells them nothing. A package

--- a/packages/readyup/src/run/skip-diagnosis.ts
+++ b/packages/readyup/src/run/skip-diagnosis.ts
@@ -60,7 +60,7 @@ function describeCheck(entry: ResolvedKitEntry, checklistName: string, name: str
 }
 
 /**
- * Diagnoses one skipped check, returning undefined where its `check` would have failed.
+ * Diagnoses one skipped check, returning `undefined` where its `check` would have failed.
  *
  * A `check` that throws, one whose findings cannot be read, or one returning a value expressing no
  * verdict leaves the question undecided: reporting any of them as a masked pass would assert something

--- a/packages/readyup/src/schemas/compileOutputSchema.ts
+++ b/packages/readyup/src/schemas/compileOutputSchema.ts
@@ -28,7 +28,7 @@ export const CompileKitEntrySchema = z
  * Top-level shape of `rdy compile --json`.
  *
  * A sweep runs to completion, so every requested kit appears here whatever happened to the ones
- * before it. `passed` is true when every kit compiled, agreeing with exit code 0.
+ * before it. `passed` is `true` when every kit compiled, agreeing with exit code 0.
  */
 export const CompileOutputSchema = z
   .object({

--- a/packages/readyup/src/schemas/reportSchema.ts
+++ b/packages/readyup/src/schemas/reportSchema.ts
@@ -131,7 +131,7 @@ export const KitEntrySchema = z.union([KitErrorEntrySchema, KitResultEntrySchema
 /**
  * Top-level shape of `rdy run --json`.
  *
- * `passed` is the run verdict: true when every requested kit produced results and every kit passed
+ * `passed` is the run verdict: `true` when every requested kit produced results and every kit passed
  * under its own effective `failOn`, which makes it agree with exit code 0 in every case. A report is
  * only ever emitted once the run reaches its kits, so `passed: false` means "ran, but incompletely
  * or with failures" and never "could not start": that failure produces the error envelope instead.

--- a/packages/readyup/src/schemas/verifyOutputSchema.ts
+++ b/packages/readyup/src/schemas/verifyOutputSchema.ts
@@ -133,7 +133,7 @@ export const VerifyKitEntrySchema = z
 /**
  * Top-level shape of `rdy verify --json`.
  *
- * `passed` is true when every one of every kit's verdicts is `ok` or `unverified`, agreeing with
+ * `passed` is `true` when every one of every kit's verdicts is `ok` or `unverified`, agreeing with
  * exit code 0. An unreadable manifest produces the error envelope instead of this payload.
  */
 export const VerifyOutputSchema = z

--- a/packages/readyup/src/severity/meetsThreshold.ts
+++ b/packages/readyup/src/severity/meetsThreshold.ts
@@ -16,7 +16,7 @@ const SEVERITY_RANK: Record<Severity, number> = {
  *
  * Throws on a value outside the severity enum. Supplying a validated severity is the caller's
  * responsibility, and the throw is what makes that a contract rather than an assumption: an unranked
- * value compares as `undefined <= n`, which is false, so it would silently exclude the check from
+ * value compares as `undefined <= n`, which is `false`, so it would silently exclude the check from
  * both the failure and the reporting thresholds instead of failing loudly.
  */
 export function meetsThreshold(severity: Severity, threshold: Severity): boolean {

--- a/packages/readyup/src/verify/checkInputDrift.ts
+++ b/packages/readyup/src/verify/checkInputDrift.ts
@@ -45,7 +45,7 @@ export function checkInputDrift(kit: RdyManifestKit, manifestDir: string): Input
 
 // region | Helpers
 
-/** Returns what is wrong with one recorded input, or undefined when it still matches. */
+/** Returns what is wrong with one recorded input, or `undefined` when it still matches. */
 function checkInput(input: RdyManifestInput, manifestDir: string): InputFailure | undefined {
   const resolvedPath = path.resolve(manifestDir, input.path);
   if (!existsSync(resolvedPath)) {

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -146,7 +146,7 @@ function finishVerify(kits: JsonVerifyKitEntry[], passed: boolean, json: boolean
 }
 
 /**
- * Returns true when none of a kit's verdicts reports a mismatch or a missing file.
+ * Returns `true` when none of a kit's verdicts reports a mismatch or a missing file.
  *
  * Reads the verdicts themselves rather than the entry serialized from them. Each is a total union,
  * so every case is accounted for; the wire shape leaves `sourceStatus` optional for consumers that
@@ -232,17 +232,17 @@ function resolveToken({ drift, inputs, rebuild, source }: KitVerdicts): TokenNam
   return 'passed';
 }
 
-/** Returns true when the compiled-output verdict reports a mismatch or a missing file. */
+/** Returns `true` when the compiled-output verdict reports a mismatch or a missing file. */
 function hasTargetFailed(status: DriftStatus): boolean {
   return status.kind === 'missing' || status.kind === 'drift';
 }
 
-/** Returns true when the source verdict reports a mismatch or a missing file. */
+/** Returns `true` when the source verdict reports a mismatch or a missing file. */
 function hasSourceFailed(status: SourceStatus): boolean {
   return status.kind === 'missing' || status.kind === 'stale';
 }
 
-/** Returns a clause describing the compiled-output verdict, or undefined when the verdict is `ok`. */
+/** Returns a clause describing the compiled-output verdict, or `undefined` when the verdict is `ok`. */
 function describeDriftStatus(kit: RdyManifestKit, status: DriftStatus): string | undefined {
   switch (status.kind) {
     case 'ok':
@@ -256,7 +256,7 @@ function describeDriftStatus(kit: RdyManifestKit, status: DriftStatus): string |
   }
 }
 
-/** Returns a clause describing the source verdict, or undefined when it is `ok` or `unverified`. */
+/** Returns a clause describing the source verdict, or `undefined` when it is `ok` or `unverified`. */
 function describeSourceStatus(kit: RdyManifestKit, status: SourceStatus): string | undefined {
   switch (status.kind) {
     case 'stale':
@@ -287,7 +287,7 @@ function describeInputFailure(failure: InputFailure): string {
 }
 
 /**
- * Returns a clause describing the rebuild verdict, or undefined when there is nothing to add.
+ * Returns a clause describing the rebuild verdict, or `undefined` when there is nothing to add.
  *
  * A passing rebuild is silent only where the hash verdicts already reached `ok` and it would
  * restate them. Anywhere else it speaks, because it then holds the line's strongest answer: over


### PR DESCRIPTION
## What

Replaces the vague use of "nothing" in `readyup`'s doc descriptions and test titles with the value the code actually returns, such as the literal scalar or an empty collection.

Also reformats descriptions to use backticks around literal values.

## Why

`nothing` names no value, so a title reading "suppresses nothing on the line below it" leaves a reader unable to say whether the function returned `false`, an empty list, or no output at all. A bare literal has the mirror problem: "reports false for a pattern that does not compile" parses as English rather than as the value returned.

#352 replaced `nothing` where the word stood in a return type's place but drew the line short of descriptions, and #418 applied the same rule to `compositor`. This brings `readyup` to it.

## Details

### 📚 Documentation

- Rewrites the four clusters the ticket names -- `suppressesFinding`, `listOwnImplementationSpans`, `listPragmaSites`, and `findNearestWord` -- and 13 scattered singles across `PragmaLedger`, `pragmaRecording`, `buildBundle`, `resolveFindingOutcome`, `runRdy`, `readTrackedSources`, `project-discovery`, `listDeclarationSpans`, `buildFindingReport`, `qualifiedSuppression`, `resolveCompileRoot`, and `check-utils/package-json.ts`.
- Restructures the two sites that assert no returned empty value around what is kept instead: `buildFindingReport` asserts its report kept the finding, and `qualifiedSuppression` asserts both checks still failed.
- Backticks the literal in every description under `packages/readyup/src` that names one, across 34 files. Two single-line block comments in `check-utils/git/compare-ref-to-remote.ts` become multi-line so the added characters stay inside the 120-column limit.
- Leaves bare the words doing English work: "asserts non-null", "a null-prototype object", "phrased to read true on a pass", "would be false", and "a null map".
- Keeps the 149 surviving uses of `nothing`, each of which is either produced-nothing (no console output, no write, no recorder call) or subject-side, among them `sweepRecorder`'s "reports to nothing" and `workspaces.caching`'s "caches nothing".

### 🧪 Tests

- Changes test titles only. No assertion, fixture, or helper is touched, and the suite's 3043 tests are unchanged in count and outcome.

Closes #421
