### PR TITLE
#369 Replace the consistent-test-it file list with per-suite directives

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -41,6 +41,11 @@ const config = defineConfig([
     ignores: ['**/*.sh', '**/.claude/**', '**/.readyup/**', '**/coverage/**', '**/dist/**', '**/local/**'],
   },
   {
+    // `strict-lint` promotes rule severities and not this report, so the default `warn` would leave a directive
+    // whose rule has stopped reporting in place indefinitely.
+    linterOptions: { reportUnusedDisableDirectives: 'error' },
+  },
+  {
     files: patterns.codeFiles,
     rules: {
       'n/no-missing-import': 'off',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -76,61 +76,14 @@ const config = defineConfig([
   defineConfig({
     files: patterns.testFiles,
     extends: [await createConfig.vitest()],
-  }),
-  {
-    // The suites taking their trees as fixtures bind `test.extend(...)` to `it`, and some of them register
-    // `it.aroundAll(...)` or `it.aroundEach(...)`, which @vitest/eslint-plugin 1.6.27 misreads twice:
-    // `consistent-test-it` compares the resolved import name (`test`) rather than the local binding, so every
-    // describe-nested `it(...)` is a false positive; and `require-hook`'s call-chain table lacks both hooks,
-    // so the registration reads as bare top-level code. Both are plugin defects; delete this block when the
-    // upstream fixes land:
-    // https://github.com/vitest-dev/eslint-plugin-vitest/issues/955 (require-hook) and
-    // https://github.com/vitest-dev/eslint-plugin-vitest/issues/956 (consistent-test-it).
-    //
-    // The list grows per migrated suite rather than the preamble collapsing into a shared helper: an imported
-    // `it` traces back to no vitest export, at which point the plugin stops applying every vitest rule to the
-    // file.
-    files: [
-      'packages/readyup/src/bin/__tests__/route.compiledWithReporting.unit.test.ts',
-      'packages/readyup/src/bin/__tests__/route.detailProjection.unit.test.ts',
-      'packages/readyup/src/bin/__tests__/route.exitCodes.tool.test.ts',
-      'packages/readyup/src/bin/__tests__/route.partialResults.unit.test.ts',
-      'packages/readyup/src/bin/__tests__/route.styleSelection.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/filesystem.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/hashing.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/json.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/package-json.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/tool-versions.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/tsconfig.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts',
-      'packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts',
-      'packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts',
-      'packages/readyup/src/check-utils/project/__tests__/listOwnImplementationSpans.unit.test.ts',
-      'packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.tool.test.ts',
-      'packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts',
-      'packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts',
-      'packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts',
-      'packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts',
-      'packages/readyup/src/list/__tests__/listCommand.packages.unit.test.ts',
-      'packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts',
-      'packages/readyup/src/list/__tests__/listCommand.recursivePackages.unit.test.ts',
-      'packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts',
-      'packages/readyup/src/projects/__tests__/project-discovery.unit.test.ts',
-      'packages/readyup/src/run/__tests__/pragma-report.unit.test.ts',
-      'packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts',
-      'packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts',
-      'packages/readyup/src/run/__tests__/resolveConfiguredPackages.unit.test.ts',
-      'packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts',
-      'packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts',
-    ],
     rules: {
-      'vitest/consistent-test-it': 'off',
+      // A suite taking its tree as a fixture registers `it.aroundAll(...)` or `it.aroundEach(...)`, which
+      // @vitest/eslint-plugin 1.6.27 reads as bare top-level code: `require-hook`'s call-chain table lacks both
+      // hooks. Drop the option when the upstream fix lands:
+      // https://github.com/vitest-dev/eslint-plugin-vitest/issues/955
       'vitest/require-hook': ['warn', { allowedFunctionCalls: ['it.aroundAll', 'it.aroundEach'] }],
     },
-  },
+  }),
   {
     // Config files legitimately mutate and compose configuration objects at module top level.
     files: [...patterns.codeExtensions.map((extensions) => `**/*.config.${extensions}`), '**/config/**'],

--- a/packages/readyup/src/bin/__tests__/route.compiledWithReporting.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.compiledWithReporting.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { VERSION } from '../../version.ts';
 import { routeCommand } from '../route.ts';
@@ -9,7 +9,8 @@ import { routeCommand } from '../route.ts';
 /** A kit whose single check passes, shared by every fixture here so only the stamp varies. */
 const KIT_BODY = `export default { checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   { scope: 'file' },
   makeFixture(() =>

--- a/packages/readyup/src/bin/__tests__/route.detailProjection.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.detailProjection.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { routeCommand } from '../route.ts';
 
@@ -12,7 +12,8 @@ const MIXED_KIT =
   `  { name: 'nope', check: () => false, fix: 'do the thing' },\n` +
   `] }] };\n`;
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   { scope: 'file' },
   makeFixture(() => createTempTree({ '.readyup/kits/default.js': MIXED_KIT }, { prefix: 'readyup-detail-' })),

--- a/packages/readyup/src/bin/__tests__/route.exitCodes.tool.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.exitCodes.tool.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { routeCommand } from '../route.ts';
 
@@ -22,7 +22,8 @@ const MULTI_KIT =
   `  { name: 'lint', checks: [{ name: 'lint-ok', check: () => true }] },\n` +
   `] };\n`;
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   { scope: 'file' },
   makeFixture(() => {

--- a/packages/readyup/src/bin/__tests__/route.partialResults.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.partialResults.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { routeCommand } from '../route.ts';
 
@@ -11,7 +11,8 @@ const PASSING_KIT = `export default { checklists: [{ name: 'main', checks: [{ na
 /** A kit whose single error-severity check fails. */
 const FAILING_KIT = `export default { checklists: [{ name: 'main', checks: [{ name: 'nope', check: () => false }] }] };\n`;
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   { scope: 'file' },
   makeFixture(() =>

--- a/packages/readyup/src/bin/__tests__/route.styleSelection.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.styleSelection.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it as baseIt, vi } from 'vitest';
 
 import { plainFormatter } from '../../layout/plainFormatter.ts';
 import { STYLE_ENV_VAR } from '../../layout/resolveStyle.ts';
@@ -33,7 +33,8 @@ const RENDERING_COMMANDS = [
   { name: 'init', args: ['init', '--dry-run'], expected: /^PASS {2}\.config\/readyup\.config\.ts/mu },
 ] as const;
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   { scope: 'file' },
   makeFixture(() => {

--- a/packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/discoverKitPackages.unit.test.ts
@@ -1,10 +1,11 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { discoverKitPackages } from '../discoverKitPackages.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   { scope: 'file' },
   makeFixture(() =>

--- a/packages/readyup/src/check-utils/__tests__/filesystem.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/filesystem.unit.test.ts
@@ -3,11 +3,12 @@ import { join } from 'node:path';
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { fileContains, fileDoesNotContain, fileExists, filesExist, readFile } from '../filesystem.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-fs-' })),
 );

--- a/packages/readyup/src/check-utils/__tests__/hashing.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/hashing.unit.test.ts
@@ -3,11 +3,12 @@ import { createHash } from 'node:crypto';
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { computeHash, fileMatchesHash } from '../hashing.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-hash-' })),
 );

--- a/packages/readyup/src/check-utils/__tests__/json.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/json.unit.test.ts
@@ -3,11 +3,12 @@ import { join } from 'node:path';
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from '../json.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-json-' })),
 );

--- a/packages/readyup/src/check-utils/__tests__/package-json.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/package-json.unit.test.ts
@@ -1,11 +1,12 @@
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { hasDevDependency, hasMinDevDependencyVersion, hasPackageJsonField, readPackageJson } from '../package-json.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-pkg-' })),
 );

--- a/packages/readyup/src/check-utils/__tests__/tool-versions.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/tool-versions.unit.test.ts
@@ -1,11 +1,12 @@
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { readToolVersionsNode } from '../tool-versions.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-tool-versions-' })),
 );

--- a/packages/readyup/src/check-utils/__tests__/tsconfig.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/tsconfig.unit.test.ts
@@ -1,11 +1,12 @@
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { readTsconfigChain, readTsconfigLanguageLevel } from '../tsconfig.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-tsconfig-' })),
 );

--- a/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.caching.unit.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it as baseIt, vi } from 'vitest';
 
 import { discoverWorkspaces } from '../workspaces.ts';
 
@@ -25,7 +25,8 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-ws-cache-' })),
 );

--- a/packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.cwd.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it as baseIt, vi } from 'vitest';
 
 import { discoverWorkspaces, type Workspace } from '../workspaces.ts';
 
@@ -41,7 +41,8 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-ws-cwd-' })),
 );

--- a/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
@@ -3,11 +3,12 @@ import { join } from 'node:path';
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { discoverWorkspaces, discoverWorkspacesAt } from '../workspaces.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-ws-' })),
 );

--- a/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it as baseIt, vi } from 'vitest';
 
 import { discoverWorkspaces } from '../workspaces.ts';
 
@@ -26,7 +26,8 @@ vi.mock('node:fs', async (importOriginal) => {
   };
 });
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-ws-walk-' })),
 );

--- a/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/buildFindingReport.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { buildFindingReport, type Finding } from '../buildFindingReport.ts';
 import type { OwnImplementation } from '../listOwnImplementationSpans.ts';
@@ -45,7 +45,8 @@ const OWN_IMPLEMENTATION: OwnImplementation = {
   ],
 };
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-finding-report-' })),
 );

--- a/packages/readyup/src/check-utils/project/__tests__/listOwnImplementationSpans.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listOwnImplementationSpans.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { listOwnImplementationSpans, type OwnImplementation } from '../listOwnImplementationSpans.ts';
 import type { ProjectSource } from '../readTrackedSources.ts';
@@ -9,7 +9,8 @@ import type { ProjectSource } from '../readTrackedSources.ts';
 const EXPORT_NAMES = ['describeError'];
 const PACKAGE_NAME = '@scope/errors';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-own-impl-' })),
 );

--- a/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.tool.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/listTrackedFiles.tool.test.ts
@@ -3,13 +3,14 @@ import { execFileSync } from 'node:child_process';
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { listTrackedFiles } from '../listTrackedFiles.ts';
 
 // Separated from the module's unit suite, which stubs git: only real git escapes and quotes a path,
 // so only real git can show that `-z` defeats it.
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-tracked-' })),
 );

--- a/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
+++ b/packages/readyup/src/check-utils/project/__tests__/readTrackedSources.unit.test.ts
@@ -3,7 +3,7 @@ import { promisify } from 'node:util';
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it as baseIt, vi } from 'vitest';
 
 const { existsProbes, readPaths } = vi.hoisted(() => {
   const existsProbes: string[] = [];
@@ -40,7 +40,8 @@ import { readSourceText, readTrackedSources } from '../readTrackedSources.ts';
 import { withSweepRecorder } from '../sweepRecorder.ts';
 import { createRecorder } from '../test-utils/sweep-recording.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-sources-' })),
 );

--- a/packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts
@@ -1,11 +1,12 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { collectKitPackageGroups, type KitPackageGroup } from '../collectKitPackageGroups.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   { scope: 'file' },
   makeFixture(() =>

--- a/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts
@@ -1,10 +1,11 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { expandConfiguredPackages } from '../expandConfiguredPackages.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   { scope: 'file' },
   makeFixture(() =>

--- a/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts
@@ -1,10 +1,11 @@
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { expandConfiguredPackages } from '../expandConfiguredPackages.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   // A tree per test: workspace discovery holds its answer for the life of the process, keyed by directory.
   makeFixture(() => createTempTree({}, { prefix: 'expand-packages-workspaces-' })),

--- a/packages/readyup/src/list/__tests__/listCommand.packages.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.packages.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureError, captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it as baseIt, vi } from 'vitest';
 
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 
@@ -16,7 +16,8 @@ import { ListOutputSchema } from '../../schemas/listOutputSchema.ts';
 import { listCommand } from '../listCommand.ts';
 import { findPackageCommand } from '../test-utils/findPackageCommand.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() =>
     createTempTree(

--- a/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.recursive.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureError, captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, it as baseIt, vi } from 'vitest';
 
 const mockReaddirSync = vi.hoisted(() => vi.fn());
 
@@ -17,7 +17,7 @@ import { ListOutputSchema } from '../../schemas/listOutputSchema.ts';
 import { useFailingDirectoryRead } from '../../test-utils/useFailingDirectoryRead.ts';
 import { listCommand } from '../listCommand.ts';
 
-const it = test
+const it = baseIt
   .extend(
     'temp',
     makeFixture(() =>

--- a/packages/readyup/src/list/__tests__/listCommand.recursivePackages.unit.test.ts
+++ b/packages/readyup/src/list/__tests__/listCommand.recursivePackages.unit.test.ts
@@ -4,7 +4,7 @@ import process from 'node:process';
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it as baseIt, vi } from 'vitest';
 
 const mockLoadConfig = vi.hoisted(() => vi.fn());
 
@@ -18,7 +18,8 @@ import { DEFAULT_CONFIG } from '../../config/loadConfig.ts';
 import { ListOutputSchema } from '../../schemas/listOutputSchema.ts';
 import { listCommand } from '../listCommand.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() =>
     createTempTree(

--- a/packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts
+++ b/packages/readyup/src/portable/__tests__/walkDirectories.unit.test.ts
@@ -1,6 +1,6 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it as baseIt, vi } from 'vitest';
 
 const mockReaddirSync = vi.hoisted(() => vi.fn());
 
@@ -13,7 +13,7 @@ vi.mock(import('node:fs'), async (importOriginal) => {
 import { useFailingDirectoryRead } from '../../test-utils/useFailingDirectoryRead.ts';
 import { walkDirectories } from '../walkDirectories.ts';
 
-const it = test
+const it = baseIt
   .extend(
     'temp',
     makeFixture(() =>

--- a/packages/readyup/src/projects/__tests__/project-discovery.unit.test.ts
+++ b/packages/readyup/src/projects/__tests__/project-discovery.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it as baseIt, vi } from 'vitest';
 
 const mockReaddirSync = vi.hoisted(() => vi.fn());
 
@@ -14,7 +14,7 @@ vi.mock(import('node:fs'), async (importOriginal) => {
 import { useFailingDirectoryRead } from '../../test-utils/useFailingDirectoryRead.ts';
 import { discoverKitProjects, discoverProjects } from '../project-discovery.ts';
 
-const it = test
+const it = baseIt
   .extend(
     'temp',
     { scope: 'file' },

--- a/packages/readyup/src/run/__tests__/pragma-report.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/pragma-report.unit.test.ts
@@ -1,14 +1,15 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { warnOnUnusedPragmas } from '../pragma-report.ts';
 import { createPragmaLedger, type PragmaLedger } from '../PragmaLedger.ts';
 
 const REMEDY = 'Remove the pragma, or run the kit whose check it was written for.';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-pragma-report-' })),
 );

--- a/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/pragmaRecording.wiring.unit.test.ts
@@ -3,7 +3,7 @@ import { promisify } from 'node:util';
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it as baseIt, vi } from 'vitest';
 
 const execFileAsync = vi.hoisted(() =>
   vi.fn<(file: string, args: string[]) => Promise<{ stdout: string; stderr: string }>>(),
@@ -25,7 +25,8 @@ const OTHER_PATH = 'src/b.ts';
 /** A source whose first line has a pragma and whose second does not. */
 const SOURCE_TEXT = ['x; // rdy-ignore', 'y;', ''].join('\n');
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-pragma-recording-' })),
 );

--- a/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/qualifiedSuppression.wiring.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import type { KitProvenance } from '../../kits/KitProvenance.ts';
 import type { RdyChecklist, RdyResult } from '../../kits/types.ts';
@@ -11,7 +11,8 @@ const PACKAGE: KitProvenance = { kind: 'package', packageName: '@williamthorsen/
 
 const SOURCE_PATH = 'src/errors.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-qualified-suppression-' })),
 );

--- a/packages/readyup/src/run/__tests__/resolveConfiguredPackages.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveConfiguredPackages.unit.test.ts
@@ -3,13 +3,14 @@ import path from 'node:path';
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { captureError, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { RdyError } from '../../errors/RdyError.ts';
 import { resolveConfiguredPackages } from '../resolveConfiguredPackages.ts';
 import type { ResolvedKitEntry } from '../ResolvedKitEntry.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'resolve-configured-packages-' })),
 );

--- a/packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveFindingOutcome.unit.test.ts
@@ -1,7 +1,7 @@
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import type { OutcomeFinding } from '../../kits/types.ts';
 import { createPragmaLedger } from '../PragmaLedger.ts';
@@ -13,7 +13,8 @@ const COUNTED: OutcomeFinding = { line: 7, path: 'src/other.ts', reported: false
 
 const NAMED = ['toolbelt.errors/no-instanceof-error'];
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-finding-outcome-' })),
 );

--- a/packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts
+++ b/packages/readyup/src/testing/__tests__/makeWorkspace.unit.test.ts
@@ -3,12 +3,13 @@ import { join } from 'node:path';
 import { createTempTree, type TempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
 import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it as baseIt } from 'vitest';
 
 import { discoverWorkspaces } from '../../check-utils/workspaces.ts';
 import { makeWorkspace } from '../makeWorkspace.ts';
 
-const it = test.extend(
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
   'temp',
   makeFixture(() => createTempTree({}, { prefix: 'rdy-fixture-' })),
 );


### PR DESCRIPTION
## What

Restores `vitest/consistent-test-it` coverage across `readyup`'s test suites and aligns the tests with the rule. The rule is suppressed where the code is incorrectly flagged as faulty. Also sets `reportUnusedDisableDirectives` to `error`.

## Why

A `test(...)` written inside a `describe` went unreported in every suite the list named, and the list grew with each suite migrated onto fixture trees. Nothing prompted its removal once the upstream plugin defect is fixed.

## Details

### 🧪 Tests

- Every converted suite imports `it as baseIt` from `vitest` and roots its `.extend` chain at `baseIt`, so each `it(...)` call site resolves to `it` rather than to `test`.
- 31 suites carry `// eslint-disable-next-line vitest/consistent-test-it` on the declaration line, with a rationale naming the mechanism rather than linking the upstream issue. The three suites whose chain takes a second `.extend` are not reported and carry no directive.

### ⚙️ Tooling

- `eslint.config.ts` loses the block whose `files` array enumerated 34 suite paths and switched `vitest/consistent-test-it` off across them.
- The `vitest/require-hook` allowance for `it.aroundAll` and `it.aroundEach` moves into the general test-file config, where it holds for every suite rather than a named list. Its comment names the plugin defect behind it (vitest-dev/eslint-plugin-vitest#955).
- `linterOptions.reportUnusedDisableDirectives` is set to `error`. `strict-lint` promotes rule severities and not this report, so the ESLint default of `warn` left a dead directive in place indefinitely.


Closes #369
