### PR TITLE
#427 Enforce a kit's minReadyupVersion and warn on version skew

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -182,15 +182,18 @@ See [internal kits](#internal-kits) for what the `internal` keys select, and [pa
 
 ### Kit
 
-| Field             | Type                         | Default     | Meaning                                    |
-| ----------------- | ---------------------------- | ----------- | ------------------------------------------ |
-| `checklists`      | `Array<Checklist \| Staged>` | required    | The checklists this kit runs               |
-| `description`     | `string`                     | --          | Summary, reported by `rdy list --manifest` |
-| `suites`          | `Record<string, string[]>`   | --          | Named subsets of checklists                |
-| `defaultSeverity` | `Severity`                   | `error`     | Severity for checks that declare none      |
-| `failOn`          | `Severity`                   | `error`     | Failure threshold                          |
-| `reportOn`        | `Severity`                   | `recommend` | Reporting threshold                        |
-| `fixLocation`     | `'inline' \| 'end'`          | `end`       | Where fixes render                         |
+| Field               | Type                         | Default     | Meaning                                    |
+| ------------------- | ---------------------------- | ----------- | ------------------------------------------ |
+| `checklists`        | `Array<Checklist \| Staged>` | required    | The checklists this kit runs               |
+| `description`       | `string`                     | --          | Summary, reported by `rdy list --manifest` |
+| `minReadyupVersion` | `string`                     | --          | Readyup version the checks require         |
+| `suites`            | `Record<string, string[]>`   | --          | Named subsets of checklists                |
+| `defaultSeverity`   | `Severity`                   | `error`     | Severity for checks that declare none      |
+| `failOn`            | `Severity`                   | `error`     | Failure threshold                          |
+| `reportOn`          | `Severity`                   | `recommend` | Reporting threshold                        |
+| `fixLocation`       | `'inline' \| 'end'`          | `end`       | Where fixes render                         |
+
+A kit declaring `minReadyupVersion` fails to load on a runner below it. A kit declaring none falls back to an advisory floor, the version its bundle records at compile time, which a lower runner reports as a [`version-skew`](#advisory-warnings) warning rather than a failure.
 
 ### Checklists
 
@@ -748,6 +751,14 @@ Two more come from [`--diagnose`](#run-options), and are raised only where that 
 
 These read the checks rather than the manifest, so none of the silencing conditions above reaches them: they apply wherever the kit came from, `--url`, `--from`, `--packages`, and `--jit` alike. A check blocked by a failed precondition declared nothing and is not diagnosed.
 
+One compares the readyup that compiled a bundle against the one running it.
+
+| Code           | Raised when                                                      |
+| -------------- | ---------------------------------------------------------------- |
+| `version-skew` | A bundle was compiled by a newer readyup than the one running it |
+
+Only that direction is reported: the recorded version freezes at publish time while runners move on, so a bundle behind the runner is the ordinary state of a published kit. The advisory stands in for a floor the author never declared, so a kit declaring [`minReadyupVersion`](#kit) never raises it -- a runner below that floor has already failed the load. A bundle recording no version is silent, `--jit` runs from TypeScript source included.
+
 One more reads the sources the run's checks examined and reports the pragmas among them that suppressed nothing.
 
 | Code            | Raised when                                                                        |
@@ -1004,7 +1015,7 @@ An error body may also include `hint`, one action that would clear the failure:
 - **`counts`** holds the six tallies at report, kit, and checklist level, nested so count names and verdict names share no namespace.
 - **`worstSeverity`** is derived verdict data, omitted when nothing failed.
 - **`failOn`** and **`reportOn`** appear at the top level only when the corresponding flag was passed, and on every kit that ran as the value that governed it. See [thresholds](#thresholds) for how each resolves.
-- **`compiledWith`** names the readyup that built a kit's bundle. It appears on every kit that ran whose bundle has a compile-time stamp, including where that stamp matches the report's own `readyupVersion`, and is absent for a bundle compiled before the stamp existed or for a kit run from source under `--jit`. `rdy verify`'s [`rebuildCompiledWith`](#verifying-by-recompiling) reports the same value under a narrower rule, appearing only where it disagrees with the running readyup: that field explains a mismatch, this one records what ran.
+- **`compiledWith`** names the readyup that built a kit's bundle. It appears on every kit whose bundle records one, including where that version matches the report's own `readyupVersion`, and is absent for a bundle compiled before readyup recorded it and for a kit run from source under `--jit`. `rdy verify`'s [`rebuildCompiledWith`](#verifying-by-recompiling) reports the same value under a narrower rule, appearing only where it disagrees with the running readyup: that field explains a mismatch, this one records what ran.
 - **`warnings`** lists any advisory as `{ code, message, remedy? }`, absent when none was raised.
 
 Payloads are slim by construction: an empty field is omitted rather than emitted as `null`, empty `checks` arrays are dropped, and `fix` appears only on failed checks.

--- a/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
+++ b/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
@@ -39,6 +39,10 @@ A parent that _fails_ instead renders every descendant as its own 🚫, which is
 
 To make a whole checklist inapplicable, nest its checks under one parent check whose `skip` returns a reason. A checklist's `preconditions` do not serve here, because a precondition that skips does not gate.
 
+## Declaring a readyup floor
+
+Set `minReadyupVersion` to the version that introduced the behavior a check depends on, never to whichever readyup compiled the kit: a floor at the compiling version ages into a false failure on an older runner that would have served the kit fine.
+
 ## Reading a run
 
 ⚪ means the check does not apply. 🚫 means the check never ran.

--- a/packages/readyup/src/bin/__tests__/route.versionFloor.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.versionFloor.unit.test.ts
@@ -1,0 +1,117 @@
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, it as baseIt } from 'vitest';
+
+import { VERSION } from '../../version.ts';
+import { routeCommand } from '../route.ts';
+
+/** A floor no released readyup meets, so the kit declaring it always fails. */
+const UNREACHABLE_FLOOR = '99.0.0';
+
+/** A floor every readyup meets, so the kit declaring it always runs. */
+const MET_FLOOR = '0.0.1';
+
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
+  'temp',
+  { scope: 'file' },
+  makeFixture(() =>
+    createTempTree(
+      {
+        '.readyup/kits/met.js': buildKit(MET_FLOOR),
+        '.readyup/kits/passing.js': buildKit(),
+        '.readyup/kits/source.ts': buildKit(UNREACHABLE_FLOOR),
+        '.readyup/kits/unreachable.js': buildKit(UNREACHABLE_FLOOR),
+      },
+      { prefix: 'readyup-version-floor-' },
+    ),
+  ),
+);
+
+it.aroundAll(async (runSuite, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir, { chdir: true });
+
+  await runSuite();
+});
+
+describe('a kit-declared readyup floor', () => {
+  it('fails a kit whose floor the runner does not meet, naming both versions', async () => {
+    using io = captureStdio();
+
+    const exitCode = await routeCommand(['unreachable', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(exitCode).toBe(2);
+    expect(parsed).toHaveProperty('kits.0.error.code', 'kit-load');
+    expect(parsed).toHaveProperty(
+      'kits.0.error.message',
+      `kit "unreachable" requires readyup ${UNREACHABLE_FLOOR} or later, but this runner is ${VERSION}.`,
+    );
+  });
+
+  // The load path rewraps anything thrown inside it through `describeError`, which drops the hint.
+  it('keeps the hint naming the upgrade', async () => {
+    using io = captureStdio();
+
+    await routeCommand(['unreachable', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(parsed).toHaveProperty('kits.0.error.hint', expect.stringContaining(UNREACHABLE_FLOOR));
+  });
+
+  it('runs a kit whose floor the runner meets', async () => {
+    using io = captureStdio();
+
+    const exitCode = await routeCommand(['met', '--json']);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(io.stdout)).toMatchObject({ kits: [{ name: 'met', passed: true }] });
+  });
+
+  it('leaves the other kits in the run to execute', async () => {
+    using io = captureStdio();
+
+    const exitCode = await routeCommand(['passing', 'unreachable', 'met', '--json']);
+
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(io.stdout)).toMatchObject({
+      kits: [
+        { name: 'passing', passed: true },
+        { name: 'unreachable', error: { code: 'kit-load' } },
+        { name: 'met', passed: true },
+      ],
+    });
+  });
+
+  // The floor is measured against the running readyup, which a source run knows just as a bundle does.
+  it('holds for a kit run from TypeScript source under --jit', async () => {
+    using io = captureStdio();
+
+    const exitCode = await routeCommand(['source', '--jit', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(exitCode).toBe(2);
+    expect(parsed).toHaveProperty('kits.0.error.code', 'kit-load');
+    expect(parsed).toHaveProperty('kits.0.error.message', expect.stringContaining(`readyup ${UNREACHABLE_FLOOR}`));
+  });
+
+  it('reports the failure on stderr in human mode', async () => {
+    using io = captureStdio();
+
+    const exitCode = await routeCommand(['unreachable']);
+
+    expect(exitCode).toBe(2);
+    expect(io.stderr).toContain(`requires readyup ${UNREACHABLE_FLOOR} or later`);
+  });
+});
+
+// region | Helpers
+
+/** Builds a kit source whose single check passes, optionally declaring a readyup floor. */
+function buildKit(minReadyupVersion?: string): string {
+  const floor = minReadyupVersion === undefined ? '' : `minReadyupVersion: '${minReadyupVersion}', `;
+  return `export default { ${floor}checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/bin/__tests__/route.versionSkew.unit.test.ts
+++ b/packages/readyup/src/bin/__tests__/route.versionSkew.unit.test.ts
@@ -1,0 +1,97 @@
+import { createTempTree } from '@williamthorsen/toolbelt.filesystem/candidate';
+import { captureStdio, pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
+import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
+import { describe, expect, it as baseIt } from 'vitest';
+
+import { VERSION } from '../../version.ts';
+import { routeCommand } from '../route.ts';
+
+/** A stamp no released readyup reaches, so the bundle carrying it is always ahead of the runner. */
+const AHEAD_STAMP = '99.0.0';
+
+// eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
+const it = baseIt.extend(
+  'temp',
+  { scope: 'file' },
+  makeFixture(() =>
+    createTempTree(
+      {
+        '.readyup/kits/ahead.js': buildKit({ stamp: AHEAD_STAMP }),
+        '.readyup/kits/behind.js': buildKit({ stamp: '0.19.2' }),
+        '.readyup/kits/floored.js': buildKit({ floor: '0.0.1', stamp: AHEAD_STAMP }),
+        '.readyup/kits/unstamped.js': buildKit({}),
+      },
+      { prefix: 'readyup-version-skew-' },
+    ),
+  ),
+);
+
+it.aroundAll(async (runSuite, { temp }) => {
+  using _cwd = pointCwdAt(temp.dir, { chdir: true });
+
+  await runSuite();
+});
+
+describe('skew between a bundle stamp and the runner', () => {
+  it('reports a bundle compiled ahead of the runner, naming both versions', async () => {
+    using io = captureStdio();
+
+    await routeCommand(['ahead', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(parsed).toHaveProperty('warnings.0.code', 'version-skew');
+    expect(parsed).toHaveProperty(
+      'warnings.0.message',
+      `kit "ahead" was compiled by readyup ${AHEAD_STAMP}, ahead of the ${VERSION} running it.`,
+    );
+    expect(parsed).toHaveProperty('warnings.0.remedy', expect.stringContaining(AHEAD_STAMP));
+  });
+
+  it('leaves the exit code alone', async () => {
+    using io = captureStdio();
+
+    const exitCode = await routeCommand(['ahead', '--json']);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(io.stdout)).toMatchObject({ kits: [{ name: 'ahead', passed: true }] });
+  });
+
+  it.each([['behind'], ['unstamped']])('reports nothing for the %s bundle', async (kitName) => {
+    using io = captureStdio();
+
+    await routeCommand([kitName, '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(parsed).not.toHaveProperty('warnings');
+  });
+
+  // The floor is the author's own statement of what the kit needs, so the stamp adds nothing.
+  it('reports nothing for a kit that declares a floor', async () => {
+    using io = captureStdio();
+
+    await routeCommand(['floored', '--json']);
+    const parsed: unknown = JSON.parse(io.stdout);
+
+    expect(parsed).not.toHaveProperty('warnings');
+  });
+
+  it('writes the advisory to stderr in human mode', async () => {
+    using io = captureStdio();
+
+    const exitCode = await routeCommand(['ahead']);
+
+    expect(exitCode).toBe(0);
+    expect(io.stderr).toContain(`was compiled by readyup ${AHEAD_STAMP}, ahead of the ${VERSION} running it.`);
+  });
+});
+
+// region | Helpers
+
+/** Builds a kit source whose single check passes, optionally stamped and optionally declaring a floor. */
+function buildKit({ floor, stamp }: { floor?: string; stamp?: string }): string {
+  const banner = stamp === undefined ? '' : `export const __readyupVersion = '${stamp}';\n`;
+  const declaredFloor = floor === undefined ? '' : `minReadyupVersion: '${floor}', `;
+  return `${banner}export default { ${declaredFloor}checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }] };\n`;
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/kits/__tests__/assertIsRdyKit.unit.test.ts
+++ b/packages/readyup/src/kits/__tests__/assertIsRdyKit.unit.test.ts
@@ -489,5 +489,35 @@ describe(assertIsRdyKit, () => {
         'reportOn:',
       );
     });
+
+    it.each([
+      ['a range prefix', '>=0.33.0'],
+      ['a caret prefix', '^0.33.0'],
+      ['a prerelease tail', '0.33.0-rc.1'],
+      ['a leading v', 'v0.33.0'],
+      ['a non-numeric segment', '0.x'],
+      ['a fourth segment the comparison would discard', '0.33.0.1'],
+      ['an empty string', ''],
+    ])('throws when minReadyupVersion carries %s', async (_label, value) => {
+      await expect(
+        messageFrom({ checklists: [{ name: 'test', checks: [] }], minReadyupVersion: value }),
+      ).resolves.toContain('minReadyupVersion: expected a dotted numeric version');
+    });
+
+    it('names the type when minReadyupVersion is not a string', async () => {
+      await expect(
+        messageFrom({ checklists: [{ name: 'test', checks: [] }], minReadyupVersion: 33 }),
+      ).resolves.toContain('minReadyupVersion: expected a dotted numeric version, got number');
+    });
+
+    it.each([['0.33.0'], ['1'], ['0.33'], ['10.2.1']])('accepts the dotted numeric floor %s', (value) => {
+      expect(() =>
+        assertIsRdyKit({ checklists: [{ name: 'test', checks: [] }], minReadyupVersion: value }),
+      ).not.toThrow();
+    });
+
+    it('accepts a kit that declares no floor', () => {
+      expect(() => assertIsRdyKit({ checklists: [{ name: 'test', checks: [] }] })).not.toThrow();
+    });
   });
 });

--- a/packages/readyup/src/kits/__tests__/resolveKitExports.unit.test.ts
+++ b/packages/readyup/src/kits/__tests__/resolveKitExports.unit.test.ts
@@ -24,6 +24,22 @@ describe(resolveKitExports, () => {
     expect(result).toStrictEqual({ checklists, fixLocation: 'inline' });
   });
 
+  it('forwards minReadyupVersion when defined', () => {
+    const checklists = [{ name: 'main', checks: [] }];
+
+    const result = resolveKitExports({ checklists, minReadyupVersion: '0.33.0' });
+
+    expect(result).toStrictEqual({ checklists, minReadyupVersion: '0.33.0' });
+  });
+
+  it('omits minReadyupVersion when undefined', () => {
+    const checklists = [{ name: 'main', checks: [] }];
+
+    const result = resolveKitExports({ checklists });
+
+    expect(result).not.toHaveProperty('minReadyupVersion');
+  });
+
   it('omits fixLocation when undefined', () => {
     const checklists = [{ name: 'a', checks: [] }];
     const result = resolveKitExports({ checklists });

--- a/packages/readyup/src/kits/assertIsRdyKit.ts
+++ b/packages/readyup/src/kits/assertIsRdyKit.ts
@@ -25,6 +25,22 @@ const FunctionSchema = z.custom<(...args: never[]) => unknown>((value) => typeof
   error: (issue) => `expected a function, got ${describeType(issue.input)}`,
 });
 
+/** Matches a dotted numeric version of up to three segments, the only shape the runner's floor comparison orders. */
+const DOTTED_NUMERIC_VERSION = /^\d+(?:\.\d+){0,2}$/;
+
+/**
+ * Schema for the readyup version a kit names as its floor.
+ *
+ * A floor is authored rather than read off an installed package, so it takes no range prefix and no
+ * prerelease tail; rejecting those is what keeps a typo from silently never matching. A fourth
+ * segment is rejected for the mirror reason: the comparison reads three, and would discard it.
+ */
+const MinReadyupVersionSchema = z
+  .string({ error: (issue) => `expected a dotted numeric version, got ${describeType(issue.input)}` })
+  .regex(DOTTED_NUMERIC_VERSION, {
+    error: (issue) => `expected a dotted numeric version, got ${previewValue(issue.input)}`,
+  });
+
 /** Schema for the name every check and checklist must have. */
 const NameSchema = z.string('expected a non-empty string').min(1, 'expected a non-empty string');
 
@@ -94,6 +110,7 @@ const RdyKitSchema = z.looseObject({
   description: z.string().optional(),
   failOn: SeveritySchema.optional(),
   fixLocation: FixLocationSchema.optional(),
+  minReadyupVersion: MinReadyupVersionSchema.optional(),
   reportOn: SeveritySchema.optional(),
   suites: z.record(z.string(), z.array(z.string())).optional(),
 });

--- a/packages/readyup/src/kits/resolveKitExports.ts
+++ b/packages/readyup/src/kits/resolveKitExports.ts
@@ -3,9 +3,9 @@ import { isRecord } from '../portable/isRecord.ts';
 /**
  * Returns every recognized kit field in an imported module namespace, as a plain record.
  *
- * `checklists` is required; `defaultSeverity`, `description`, `failOn`, `fixLocation`, `reportOn`,
- * and `suites` are optional. Both `export default defineRdyKit({...})` and the named-export form,
- * `export const checklists = ...`, are recognized.
+ * `checklists` is required; `defaultSeverity`, `description`, `failOn`, `fixLocation`,
+ * `minReadyupVersion`, `reportOn`, and `suites` are optional. Both `export default
+ * defineRdyKit({...})` and the named-export form, `export const checklists = ...`, are recognized.
  */
 export function resolveKitExports(moduleRecord: Record<string, unknown>): Record<string, unknown> {
   // Unwrap default export when present (e.g., `export default defineRdyKit({...})`)
@@ -23,6 +23,7 @@ export function resolveKitExports(moduleRecord: Record<string, unknown>): Record
     ...(source['description'] !== undefined && { description: source['description'] }),
     ...(source['failOn'] !== undefined && { failOn: source['failOn'] }),
     ...(source['fixLocation'] !== undefined && { fixLocation: source['fixLocation'] }),
+    ...(source['minReadyupVersion'] !== undefined && { minReadyupVersion: source['minReadyupVersion'] }),
     ...(source['reportOn'] !== undefined && { reportOn: source['reportOn'] }),
     ...(source['suites'] !== undefined && { suites: source['suites'] }),
   };

--- a/packages/readyup/src/kits/types.ts
+++ b/packages/readyup/src/kits/types.ts
@@ -381,6 +381,12 @@ export interface RdyKit {
   /** Human-readable summary of what the kit checks. */
   description?: string | undefined;
 
+  /**
+   * Minimum readyup version this kit's checks require.
+   * A runner below it fails the kit rather than running it.
+   */
+  minReadyupVersion?: string | undefined;
+
   /** Named subsets of checklists. */
   suites?: Record<string, string[]> | undefined;
 

--- a/packages/readyup/src/run/__tests__/version-skew.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/version-skew.unit.test.ts
@@ -1,0 +1,97 @@
+import { captureError } from '@williamthorsen/toolbelt.testing/candidate';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runnerVersion = vi.hoisted(() => ({ current: '0.34.0' }));
+
+vi.mock(import('../../version.ts'), () => ({
+  get VERSION() {
+    return runnerVersion.current;
+  },
+}));
+
+import type { RdyKit } from '../../kits/types.ts';
+import { assertSatisfiesVersionFloor, warnOnVersionSkew } from '../version-skew.ts';
+
+describe(assertSatisfiesVersionFloor, () => {
+  beforeEach(() => {
+    runnerVersion.current = '0.34.0';
+  });
+
+  it('passes a kit that declares no floor', () => {
+    expect(() => assertSatisfiesVersionFloor('kit', buildKit())).not.toThrow();
+  });
+
+  it.each([['0.33.0'], ['0.34.0'], ['0.1'], ['0']])('passes a floor of %s the runner meets', (floor) => {
+    expect(() => assertSatisfiesVersionFloor('kit', buildKit(floor))).not.toThrow();
+  });
+
+  it('fails a floor above the runner, naming both versions', async () => {
+    const error = await captureError(() => assertSatisfiesVersionFloor('sweep', buildKit('0.35.0')));
+
+    expect(error.message).toContain('kit "sweep" requires readyup 0.35.0 or later');
+    expect(error.message).toContain('this runner is 0.34.0');
+  });
+
+  it('carries a hint naming the upgrade', async () => {
+    const error = await captureError(() => assertSatisfiesVersionFloor('sweep', buildKit('0.35.0')));
+
+    expect(error).toHaveProperty('code', 'kit-load');
+    expect(error).toHaveProperty('hint', expect.stringContaining('0.35.0'));
+  });
+
+  // A prerelease segment is `NaN` to `compareVersions`, which satisfies neither `>=` nor `<`, so an
+  // unnormalized runner would pass every floor and fail none.
+  it('measures a prerelease runner by its numeric core', () => {
+    runnerVersion.current = '0.35.0-rc.1';
+
+    expect(() => assertSatisfiesVersionFloor('kit', buildKit('0.35.0'))).not.toThrow();
+    expect(() => assertSatisfiesVersionFloor('kit', buildKit('0.36.0'))).toThrow('requires readyup 0.36.0');
+  });
+});
+
+describe(warnOnVersionSkew, () => {
+  beforeEach(() => {
+    runnerVersion.current = '0.34.0';
+  });
+
+  it('reports a bundle compiled ahead of the runner', () => {
+    const [warning] = warnOnVersionSkew('sweep', buildKit(), '0.35.0');
+
+    expect(warning).toHaveProperty('code', 'version-skew');
+    expect(warning?.message).toContain('compiled by readyup 0.35.0');
+    expect(warning?.message).toContain('ahead of the 0.34.0 running it');
+    expect(warning?.remedy).toContain('0.35.0');
+  });
+
+  it.each([['0.32.0'], ['0.34.0']])('reports nothing for a bundle stamped %s', (stamp) => {
+    expect(warnOnVersionSkew('kit', buildKit(), stamp)).toStrictEqual([]);
+  });
+
+  it('reports nothing for a bundle carrying no stamp', () => {
+    expect(warnOnVersionSkew('kit', buildKit(), undefined)).toStrictEqual([]);
+  });
+
+  // The floor is the author's own statement of what the kit needs, and it has already been enforced.
+  it('reports nothing for a kit that declares a floor', () => {
+    expect(warnOnVersionSkew('kit', buildKit('0.30.0'), '0.35.0')).toStrictEqual([]);
+  });
+
+  it('measures a prerelease runner by its numeric core', () => {
+    runnerVersion.current = '0.35.0-rc.1';
+
+    expect(warnOnVersionSkew('kit', buildKit(), '0.35.0')).toStrictEqual([]);
+    expect(warnOnVersionSkew('kit', buildKit(), '0.36.0')).toHaveLength(1);
+  });
+});
+
+// region | Helpers
+
+/** Builds a minimal kit, optionally declaring a readyup floor. */
+function buildKit(minReadyupVersion?: string): RdyKit {
+  return {
+    checklists: [{ name: 'main', checks: [{ name: 'ok', check: () => true }] }],
+    ...(minReadyupVersion !== undefined && { minReadyupVersion }),
+  };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/run/loadKit.ts
+++ b/packages/readyup/src/run/loadKit.ts
@@ -9,6 +9,7 @@ import { loadRemoteKit, type LoadRemoteKitOptions } from '../remote/loadRemoteKi
 import { resolveRemoteAuthHeaders, resolveRemoteProvider } from '../remote/remote-provider.ts';
 import { toRemoteRdyError } from '../remote/toRemoteRdyError.ts';
 import type { ResolvedKitEntry } from './ResolvedKitEntry.ts';
+import { assertSatisfiesVersionFloor } from './version-skew.ts';
 
 /**
  * Loads a rdy kit from a path or URL source.
@@ -17,6 +18,27 @@ import type { ResolvedKitEntry } from './ResolvedKitEntry.ts';
  * reported with a remedy chosen from the kit's provenance, which the source by itself does not state.
  */
 export async function loadKit(entry: ResolvedKitEntry, isJit: boolean): Promise<LoadedRdyKit> {
+  const loaded = await loadFromSource(entry, isJit);
+
+  // Checked outside the load, whose catch blocks rewrap anything thrown inside them through
+  // `describeError` and would drop the hint naming the upgrade.
+  assertSatisfiesVersionFloor(entry.name, loaded.kit);
+
+  return loaded;
+}
+
+// region | Helpers
+
+/** Detects module-not-found errors that mention a specific package name. */
+function isModuleNotFoundError(error: unknown, packageName: string): boolean {
+  if (!isError(error)) return false;
+  if (!('code' in error)) return false;
+  if (error.code !== 'MODULE_NOT_FOUND' && error.code !== 'ERR_MODULE_NOT_FOUND') return false;
+  return error.message.includes(packageName);
+}
+
+/** Fetches or reads a kit from its source, reporting every failure as the kit-load error a reader sees. */
+async function loadFromSource(entry: ResolvedKitEntry, isJit: boolean): Promise<LoadedRdyKit> {
   const { source } = entry;
 
   if ('url' in source) {
@@ -50,16 +72,6 @@ export async function loadKit(entry: ResolvedKitEntry, isJit: boolean): Promise<
     }
     throw kitLoadError(describeError(error), { cause: error, hint: extractHint(error) });
   }
-}
-
-// region | Helpers
-
-/** Detects module-not-found errors that mention a specific package name. */
-function isModuleNotFoundError(error: unknown, packageName: string): boolean {
-  if (!isError(error)) return false;
-  if (!('code' in error)) return false;
-  if (error.code !== 'MODULE_NOT_FOUND' && error.code !== 'ERR_MODULE_NOT_FOUND') return false;
-  return error.message.includes(packageName);
 }
 
 /** Turns unresolvable readyup imports into the kit-load failure a reader sees, named for where the kit came from. */

--- a/packages/readyup/src/run/runHumanMode.ts
+++ b/packages/readyup/src/run/runHumanMode.ts
@@ -19,6 +19,7 @@ import { resolveThresholds } from './resolveThresholds.ts';
 import { runRdy } from './runRdy.ts';
 import { selectChecklists } from './selectChecklists.ts';
 import { warnOnMaskedSkips } from './skip-diagnosis.ts';
+import { warnOnVersionSkew } from './version-skew.ts';
 
 interface HumanRunSettings {
   diagnose: boolean;
@@ -59,9 +60,10 @@ export async function runHumanMode(
     const kitSegments = buildKitSegments(entry, isMultiKit);
 
     try {
-      const { kit } = await loadKit(entry, isJit);
+      const { kit, compileTimeVersion } = await loadKit(entry, isJit);
 
       warnOnKitStaleness(entry.name, entry.source, tracking);
+      warnOnVersionSkew(entry.name, kit, compileTimeVersion);
 
       const kitResult = await runKit(kit, entry.checklists, settings, {
         entry,

--- a/packages/readyup/src/run/runJsonMode.ts
+++ b/packages/readyup/src/run/runJsonMode.ts
@@ -16,6 +16,7 @@ import { resolveThresholds } from './resolveThresholds.ts';
 import { runRdy } from './runRdy.ts';
 import { selectChecklists } from './selectChecklists.ts';
 import { warnOnMaskedSkips } from './skip-diagnosis.ts';
+import { warnOnVersionSkew } from './version-skew.ts';
 
 interface JsonRunSettings {
   detail: JsonDetail;
@@ -49,7 +50,10 @@ export async function runJsonMode(
     try {
       const { kit, compileTimeVersion } = await loadKit(entry, isJit);
 
-      warnings.push(...warnOnKitStaleness(entry.name, entry.source, tracking));
+      warnings.push(
+        ...warnOnKitStaleness(entry.name, entry.source, tracking),
+        ...warnOnVersionSkew(entry.name, kit, compileTimeVersion),
+      );
 
       const thresholds = resolveThresholds(kit, failOn, reportOn);
       const checklists = selectChecklists(kit, entry.checklists);

--- a/packages/readyup/src/run/version-skew.ts
+++ b/packages/readyup/src/run/version-skew.ts
@@ -1,0 +1,64 @@
+import process from 'node:process';
+
+import { compareVersions } from '../check-utils/semver.ts';
+import { kitLoadError } from '../errors/RdyError.ts';
+import type { RdyKit } from '../kits/types.ts';
+import type { RaisedWarning } from '../schemas/common.ts';
+import { VERSION } from '../version.ts';
+
+/**
+ * Fails a kit whose declared floor the running readyup does not meet.
+ *
+ * Checks the running readyup, not the version the bundle records, so a floor holds for a `--jit` run from source,
+ * which records none.
+ */
+export function assertSatisfiesVersionFloor(kitName: string, kit: RdyKit): void {
+  const floor = kit.minReadyupVersion;
+  if (floor === undefined) return;
+  if (compareVersions(toComparableVersion(VERSION), floor) >= 0) return;
+
+  throw kitLoadError(`kit "${kitName}" requires readyup ${floor} or later, but this runner is ${VERSION}.`, {
+    hint: `Upgrade readyup to ${floor} or later, or run the kit with a readyup that satisfies it.`,
+  });
+}
+
+/**
+ * Warns that a bundle was compiled by a readyup newer than the one running it.
+ *
+ * Stands in for a floor the author never declared, so a kit declaring one raises nothing here. The stderr line is
+ * written in both output modes; the returned entries are what JSON mode adds to the report.
+ */
+export function warnOnVersionSkew(
+  kitName: string,
+  kit: RdyKit,
+  compileTimeVersion: string | undefined,
+): RaisedWarning[] {
+  if (kit.minReadyupVersion !== undefined || compileTimeVersion === undefined) return [];
+  if (compareVersions(toComparableVersion(compileTimeVersion), toComparableVersion(VERSION)) <= 0) return [];
+
+  const warning: RaisedWarning = {
+    code: 'version-skew',
+    message: `kit "${kitName}" was compiled by readyup ${compileTimeVersion}, ahead of the ${VERSION} running it.`,
+    remedy: `Upgrade readyup to ${compileTimeVersion} or later, or recompile the kit with this one.`,
+  };
+  process.stderr.write(`Warning: ${warning.message} ${warning.remedy}\n`);
+  return [warning];
+}
+
+// region | Helpers
+
+/** Matches the prerelease and build tails semver appends to a numeric version. */
+const VERSION_TAIL = /[-+].*$/;
+
+/**
+ * Strips the prerelease and build tails from a version, leaving the numeric core.
+ *
+ * `compareVersions` maps each dot-separated segment through `Number`, so a prerelease yields `NaN` and satisfies
+ * neither `>=` nor `<=`, leaving a runner on one neither blocked by a floor nor reported as skewed. Comparing the
+ * numeric core makes `0.35.0-rc.1` satisfy a `0.35.0` floor, erring toward letting a chosen prerelease run.
+ */
+function toComparableVersion(version: string): string {
+  return version.replace(VERSION_TAIL, '');
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
@@ -74,6 +74,7 @@ describe('generated JSON Schemas', () => {
             'skip-masks-pass',
             'source-stale',
             'target-drift',
+            'version-skew',
           ],
         },
         { type: 'string' },

--- a/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
@@ -250,10 +250,22 @@ describe('JSON payload schemas', () => {
 
     it('binds a producer to the vocabulary this version declares while the wire stays open', () => {
       expectTypeOf<RaisedWarning['code']>().toEqualTypeOf<
-        'diagnosis-inconclusive' | 'input-stale' | 'pragma-unused' | 'skip-masks-pass' | 'source-stale' | 'target-drift'
+        | 'diagnosis-inconclusive'
+        | 'input-stale'
+        | 'pragma-unused'
+        | 'skip-masks-pass'
+        | 'source-stale'
+        | 'target-drift'
+        | 'version-skew'
       >();
       expectTypeOf<JsonWarning['code']>().not.toEqualTypeOf<
-        'diagnosis-inconclusive' | 'input-stale' | 'pragma-unused' | 'skip-masks-pass' | 'source-stale' | 'target-drift'
+        | 'diagnosis-inconclusive'
+        | 'input-stale'
+        | 'pragma-unused'
+        | 'skip-masks-pass'
+        | 'source-stale'
+        | 'target-drift'
+        | 'version-skew'
       >();
     });
 

--- a/packages/readyup/src/schemas/common.ts
+++ b/packages/readyup/src/schemas/common.ts
@@ -57,6 +57,7 @@ export const WarningCodeSchema = z.enum([
   'skip-masks-pass',
   'source-stale',
   'target-drift',
+  'version-skew',
 ]);
 
 /**


### PR DESCRIPTION
## What

Adds `minReadyupVersion` to the ReadyUp kit contract, specifying the minimum version of `readyup` that a kit's checks require. A runner refuses to load a kit declaring a higher floor than the runner's own version.

If a kit does not specify a version floor, the version stamped in the bundle at compile time is taken as an advisory floor: A runner below it raises a `version-skew` warning rather than failing the kit.

## Why

A kit running on a readyup it was not built for produced no signal at all. Where the skew crossed a behavior change, checks silently did less than they claimed and still reported PASS: a kit sweeping `discoverWorkspaces()` covers every member package but leaves the repo root unchecked on a readyup below 0.33.0. Kit authors had no way to surface this themselves, because a kit cannot read the running readyup's version and the declared devDependency is the wrong measure for a consumer following the documented `rdy run --from npm:...` route.

## Details

### 🎉 Features

- `RdyKit` gains an optional `minReadyupVersion`, validated at load as a dotted numeric version of up to three segments. A range prefix, a prerelease tail, a leading `v`, a fourth segment, and a non-string are each reported as a kit error, so a typo cannot silently never match nor silently always match.
- A breached floor fails as a `kit-load` error naming both versions, with a hint naming the upgrade that clears it. The run exits 2 through the per-kit error boundary both run modes already have.
- The floor is measured against the running readyup rather than a bundle's compile stamp, so it applies to a `--jit` run from TypeScript source, which carries no stamp.
- `version-skew` joins the advisory warning codes. Only a bundle ahead of its runner raises it: a stamp freezes at publish time while runners move on, so a bundle behind the runner is the ordinary state of any published kit. A kit declaring a floor raises it never, the floor being the author's own statement of what the checks need.
- Comparison strips a prerelease tail before ordering, so a prerelease runner reaches a verdict on its numeric core instead of being exempt from both mechanisms.

### ♻️ Refactoring

- `loadKit` moves its body into a `loadFromSource` helper so the floor assertion runs on the result, outside the catch blocks that would rewrap the error and drop its hint.

### 🧪 Tests

- New route-level suites drive `routeCommand` end to end for both mechanisms, covering the sibling-kit guarantee, the `--jit` path, the exit codes, and the stderr and JSON reporting that a unit test cannot reach.
- A new unit suite mocks the runner version to exercise the comparison directly, including both prerelease directions.

### 📚 Documentation

- The README records the field in the kit-fields table and adds `version-skew` to the advisory-warnings section with the reasoning for the one-directional rule.
- The `readyup-kits` rulebook states when an author should declare a floor: when a check depends on readyup behavior that changed, not on whichever readyup happened to compile the kit.

Closes #427

