### PR TITLE
#320 Compare a recorded hash at its own length in rdy verify

### DIFF
--- a/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/default.unit.test.ts
@@ -5,6 +5,7 @@ import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { computeHash } from '../../../src/check-utils/hashing.ts';
 import type { RdyResult } from '../../../src/kits/types.ts';
 import { pickResult, runChecklist } from '../test-utils/checklist-results.ts';
 import { loadOwnKit } from '../test-utils/loadOwnKit.ts';
@@ -12,6 +13,7 @@ import type { FixtureManifestInput } from '../test-utils/project-fixture.ts';
 import {
   FIXTURE_INLINED_MODULE_PATH,
   FIXTURE_KITS_DIR,
+  SELF_CONTAINED_BUNDLE,
   withInputs,
   writeInlineInput,
   writeKit,
@@ -137,6 +139,27 @@ describe('default kit', () => {
       expect(pickResult(results, 'Its bundle')).toMatchObject({
         status: 'failed',
         detail: expect.stringContaining('not the recorded 0badcafe'),
+      });
+    });
+
+    it.each([12, 64])('passes on a bundle recorded with a %i-character hash', async (length) => {
+      const entry = writeKit(projectRoot, 'default');
+      writeKitManifest(projectRoot, [{ ...entry, targetHash: computeHash(SELF_CONTAINED_BUNDLE).slice(0, length) }]);
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Its bundle')).toMatchObject({ status: 'passed' });
+    });
+
+    it.each(['0badcaf', '0badcafg'])('reports %o as a recorded value that is not a hash', async (targetHash) => {
+      const entry = writeKit(projectRoot, 'default');
+      writeKitManifest(projectRoot, [{ ...entry, targetHash }]);
+
+      const results = await runFreshness();
+
+      expect(pickResult(results, 'Its bundle')).toMatchObject({
+        status: 'failed',
+        detail: expect.stringContaining(`records ${targetHash}, which is not a hash`),
       });
     });
 

--- a/packages/readyup/.readyup/kits/checks/__tests__/readerAgreement.unit.test.ts
+++ b/packages/readyup/.readyup/kits/checks/__tests__/readerAgreement.unit.test.ts
@@ -6,8 +6,9 @@ import process from 'node:process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { computeHash } from '../../../../src/check-utils/hashing.ts';
-import { checkDrift } from '../../../../src/verify/checkDrift.ts';
 import type { RdyResult } from '../../../../src/kits/types.ts';
+import { readManifest } from '../../../../src/manifest/readManifest.ts';
+import { checkDrift } from '../../../../src/verify/checkDrift.ts';
 import { pickResult, runChecklist } from '../../test-utils/checklist-results.ts';
 import { loadOwnKit } from '../../test-utils/loadOwnKit.ts';
 import {
@@ -57,6 +58,22 @@ describe('recorded-hash readers', () => {
     writeFileSync(path.join(projectRoot, FIXTURE_KITS_DIR, 'default.js'), EDITED_BUNDLE);
 
     expect(await readsAsFresh(entry)).toStrictEqual({ kit: false, verify: false });
+  });
+
+  // Below the floor the two readers agree through the schema rather than through the comparison:
+  // `readManifest` rejects the record before `checkDrift` sees it, and `checkDrift` called directly on
+  // a truthful seven-character prefix would return `ok` where the kit reports a malformed record.
+  it('both reject a bundle recorded with a hash shorter than the format admits', async () => {
+    const targetHash = computeHash(SELF_CONTAINED_BUNDLE).slice(0, 7);
+    writeKitManifest(projectRoot, [{ ...writeKit(projectRoot, 'default'), targetHash }]);
+
+    expect(() => readManifest(FIXTURE_MANIFEST_PATH)).toThrow(/lowercase hex digest prefix/);
+
+    const results = await runChecklist(await loadOwnKit('default'), 'freshness');
+    expect(pickResult(results, 'Its bundle')).toMatchObject({
+      status: 'failed',
+      detail: expect.stringContaining(`records ${targetHash}, which is not a hash`),
+    });
   });
 });
 

--- a/packages/readyup/.readyup/kits/checks/__tests__/readerAgreement.unit.test.ts
+++ b/packages/readyup/.readyup/kits/checks/__tests__/readerAgreement.unit.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { computeHash } from '../../../../src/check-utils/hashing.ts';
+import { checkDrift } from '../../../../src/verify/checkDrift.ts';
+import type { RdyResult } from '../../../../src/kits/types.ts';
+import { pickResult, runChecklist } from '../../test-utils/checklist-results.ts';
+import { loadOwnKit } from '../../test-utils/loadOwnKit.ts';
+import {
+  FIXTURE_KITS_DIR,
+  FIXTURE_MANIFEST_PATH,
+  SELF_CONTAINED_BUNDLE,
+  writeKit,
+  writeKitManifest,
+} from '../../test-utils/project-fixture.ts';
+
+const EDITED_BUNDLE = `${SELF_CONTAINED_BUNDLE}// edited by hand\n`;
+
+/**
+ * Asserts that `rdy verify` and the `freshness` kit reach one verdict on a manifest neither wrote.
+ *
+ * The two read the same record through different code, and a recorded hash of a length other than the
+ * eight characters `rdy compile` writes is where they can disagree. Each case asserts they agree rather
+ * than asserting two literal verdicts, so a change to either reader's wording leaves the test meaningful.
+ */
+describe('recorded-hash readers', () => {
+  let projectRoot: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(path.join(tmpdir(), 'reader-agreement-'));
+    originalCwd = process.cwd();
+    process.chdir(projectRoot);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it.each([12, 64])('both pass an unchanged bundle recorded with a %i-character hash', async (length) => {
+    const targetHash = computeHash(SELF_CONTAINED_BUNDLE).slice(0, length);
+    const entry = { ...writeKit(projectRoot, 'default'), targetHash };
+    writeKitManifest(projectRoot, [entry]);
+
+    expect(await readsAsFresh(entry)).toStrictEqual({ kit: true, verify: true });
+  });
+
+  it.each([12, 64])('both fail an edited bundle recorded with a %i-character hash', async (length) => {
+    const targetHash = computeHash(SELF_CONTAINED_BUNDLE).slice(0, length);
+    const entry = { ...writeKit(projectRoot, 'default'), targetHash };
+    writeKitManifest(projectRoot, [entry]);
+    writeFileSync(path.join(projectRoot, FIXTURE_KITS_DIR, 'default.js'), EDITED_BUNDLE);
+
+    expect(await readsAsFresh(entry)).toStrictEqual({ kit: false, verify: false });
+  });
+});
+
+// region | Helpers
+
+/** How each reader judges the recorded bundle: `true` where it finds the kit fresh. */
+async function readsAsFresh(entry: { name: string; path: string; targetHash: string }): Promise<Verdicts> {
+  const verify = checkDrift(entry, path.dirname(FIXTURE_MANIFEST_PATH)).kind === 'ok';
+
+  const results: RdyResult[] = await runChecklist(await loadOwnKit('default'), 'freshness');
+  const kit = pickResult(results, 'Its bundle').status === 'passed';
+
+  return { kit, verify };
+}
+
+/** One verdict per reader of the same manifest entry. */
+interface Verdicts {
+  kit: boolean;
+  verify: boolean;
+}
+
+// endregion | Helpers

--- a/packages/readyup/.readyup/kits/checks/__tests__/readerAgreement.unit.test.ts
+++ b/packages/readyup/.readyup/kits/checks/__tests__/readerAgreement.unit.test.ts
@@ -48,7 +48,7 @@ describe('recorded-hash readers', () => {
     const entry = { ...writeKit(projectRoot, 'default'), targetHash };
     writeKitManifest(projectRoot, [entry]);
 
-    expect(await readsAsFresh(entry)).toStrictEqual({ kit: true, verify: true });
+    await expect(readsAsFresh(entry)).resolves.toStrictEqual({ kit: true, verify: true });
   });
 
   it.each([12, 64])('both fail an edited bundle recorded with a %i-character hash', async (length) => {
@@ -57,7 +57,7 @@ describe('recorded-hash readers', () => {
     writeKitManifest(projectRoot, [entry]);
     writeFileSync(path.join(projectRoot, FIXTURE_KITS_DIR, 'default.js'), EDITED_BUNDLE);
 
-    expect(await readsAsFresh(entry)).toStrictEqual({ kit: false, verify: false });
+    await expect(readsAsFresh(entry)).resolves.toStrictEqual({ kit: false, verify: false });
   });
 
   // Below the floor the two readers agree through the schema rather than through the comparison:

--- a/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
@@ -1,6 +1,13 @@
 import { DEFAULT_MANIFEST_PATH } from 'readyup';
 import type { CheckOutcome, FractionProgress, RdyCheck } from 'readyup';
-import { computeHash, describeJsonProjectionFailure, fileExists, projectJsonFile, readFile } from 'readyup/check-utils';
+import {
+  describeJsonProjectionFailure,
+  fileExists,
+  hashToRecordedLength,
+  isRecordedHash,
+  projectJsonFile,
+  readFile,
+} from 'readyup/check-utils';
 
 import type { ManifestEntry, ManifestInput } from './kit-layout.ts';
 import { readManifestEntries, resolveRecordedPath, skipWithoutBundles } from './kit-layout.ts';
@@ -67,18 +74,15 @@ function buildUnrecordedBundlesCheck(): RdyCheck {
   };
 }
 
-/**
- * Compares a file the manifest names against the hash recorded for it.
- *
- * The recorded value's own length decides how much of the digest to compare, so the kit reads whatever
- * prefix `rdy compile` wrote rather than a length of its own that a later readyup could outgrow.
- */
+/** Compares a file the manifest names against the hash recorded for it. */
 function compareToRecordedHash(recordedPath: string | undefined, expected: string | undefined): CheckOutcome {
   if (recordedPath === undefined || expected === undefined) {
     return { ok: false, detail: 'The manifest records nothing to compare against' };
   }
 
   const filePath = resolveRecordedPath(recordedPath);
+  if (!isRecordedHash(expected)) return { ok: false, detail: `${filePath} records ${expected}, which is not a hash` };
+
   const content = readFile(filePath);
   if (content === undefined) return { ok: false, detail: `${filePath} is missing` };
 
@@ -113,7 +117,7 @@ function compareToRecordedInputs(inputs: ManifestInput[]): CheckOutcome {
  * bundle, not over the contents of the file holding it.
  */
 function describeHashDrift(filePath: string, hashed: string, expected: string, verb: string): string | undefined {
-  const actual = computeHash(hashed).slice(0, expected.length);
+  const actual = hashToRecordedLength(hashed, expected);
   if (actual === expected) return undefined;
   return `${filePath} ${verb} ${actual}, not the recorded ${expected}`;
 }
@@ -150,6 +154,8 @@ function describeInputDrift(input: ManifestInput): string | undefined {
   }
 
   const filePath = resolveRecordedPath(recordedPath);
+  if (!isRecordedHash(hash)) return `${filePath} records ${hash}, which is not a hash`;
+
   if (kind === 'module') {
     const content = readFile(filePath);
     if (content === undefined) return `${filePath} is missing`;

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1092,6 +1092,8 @@ Under `--json`, each kit reports `name`, `status` (`compiled`, `skipped`, or `fa
 | `sourceHash`          | Hash of that source, read back out of its own `inputs` record                               |
 | `targetHash`          | Hash of the compiled bundle                                                                 |
 
+Every hash the manifest records is a prefix of a SHA-256 hex digest, between 8 and 64 characters. Readers compare the digest at the recorded value's own length rather than at a length of their own, so a manifest written by a readyup recording a longer prefix verifies clean instead of reading as wholly stale. The floor is what keeps a record too short to distinguish anything from passing every check it reaches.
+
 `inputs` is the compile's input closure: every module the bundle inlined past the entry, and every JSON file [`pickJson`](#inlining-json-at-compile-time) projected. A module records the hash of its contents. An inlined JSON file records the hash of the projection that was substituted, with the path specifier that produced it, so an edit to a field the kit did not pick is not staleness.
 
 The closure stops at `node_modules`. A dependency's contents are pinned by the lockfile and read exactly by [`rdy verify --rebuild`](#verifying-by-recompiling), while recording them would size a committed, per-compile-rewritten manifest to the dependency tree rather than to the kit: one `import zod` inlines 79 files.

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1383,10 +1383,12 @@ const findings = discoverWorkspaces().flatMap(({ dir, packageJson }) => {
 
 ### Hashing
 
-| Function                          | Returns                          |
-| --------------------------------- | -------------------------------- |
-| `computeHash(content)`            | Hash of a string                 |
-| `fileMatchesHash(path, expected)` | File's hash matches the expected |
+| Function                                  | Returns                                        |
+| ----------------------------------------- | ---------------------------------------------- |
+| `computeHash(content)`                    | Hash of a string or byte sequence              |
+| `fileMatchesHash(path, expected)`         | File's hash matches the expected               |
+| `hashToRecordedLength(content, recorded)` | Hash truncated to a recorded hash's own length |
+| `isRecordedHash(value)`                   | Value is a well-formed recorded hash           |
 
 ### Workspaces
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -742,6 +742,14 @@ Three compare the kits it is about to run against `.readyup/manifest.json` and s
 
 They are silent when the manifest is absent, when no entry describes the kit, when an entry records no hashes or no input closure, or when a file they would compare is gone or cannot be read. Only the local manifest is consulted, so a kit reached through `--from` is out of scope -- run `rdy verify` in that root instead. They also do not apply to `--url` or `--jit`.
 
+A manifest that is present and cannot be read is the one case that speaks for itself, because all three then go unchecked for every kit in the run.
+
+| Code                  | Raised when                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `manifest-unreadable` | `.readyup/manifest.json` exists but does not parse against the schema |
+
+An absent manifest stays silent: it is the normal state of a project that never compiled, and says nothing about any kit.
+
 Two more come from [`--diagnose`](#run-options), and are raised only where that flag asked for them.
 
 | Code                     | Raised when                                                        |

--- a/packages/readyup/src/check-utils/__tests__/hashing.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/hashing.unit.test.ts
@@ -5,7 +5,7 @@ import { pointCwdAt } from '@williamthorsen/toolbelt.testing/candidate';
 import { makeFixture } from '@williamthorsen/toolbelt.vitest/candidate';
 import { describe, expect, it as baseIt } from 'vitest';
 
-import { computeHash, fileMatchesHash } from '../hashing.ts';
+import { computeHash, fileMatchesHash, hashToRecordedLength, isRecordedHash } from '../hashing.ts';
 
 // eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
 const it = baseIt.extend(
@@ -53,5 +53,50 @@ describe(fileMatchesHash, () => {
 
   it('returns false when the file does not exist', () => {
     expect(fileMatchesHash('missing.js', 'any-hash')).toBe(false);
+  });
+});
+
+describe(hashToRecordedLength, () => {
+  it('returns the digest truncated to the length the record uses', () => {
+    const digest = createHash('sha256').update('bundle').digest('hex');
+
+    expect(hashToRecordedLength('bundle', 'a'.repeat(12))).toBe(digest.slice(0, 12));
+  });
+
+  it('returns the whole digest when the recorded value is a full digest', () => {
+    const digest = createHash('sha256').update('bundle').digest('hex');
+
+    expect(hashToRecordedLength('bundle', digest)).toBe(digest);
+  });
+
+  it('returns the eight characters the compile records when the recorded value is that long', () => {
+    const digest = createHash('sha256').update('bundle').digest('hex');
+
+    expect(hashToRecordedLength('bundle', digest.slice(0, 8))).toBe(digest.slice(0, 8));
+  });
+
+  it('hashes bytes and the string they encode to the same value', () => {
+    const recorded = 'a'.repeat(12);
+
+    expect(hashToRecordedLength(Buffer.from('bundle', 'utf8'), recorded)).toBe(
+      hashToRecordedLength('bundle', recorded),
+    );
+  });
+});
+
+describe(isRecordedHash, () => {
+  it.each([8, 12, 40, 64])('accepts a %i-character lowercase hex value', (length) => {
+    expect(isRecordedHash('a1b2c3d4'.repeat(8).slice(0, length))).toBe(true);
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['a1b2c3d', 'one character below the floor'],
+    ['a'.repeat(65), 'one character above a full digest'],
+    ['A1B2C3D4', 'uppercase'],
+    ['a1b2c3g4', 'a non-hex character'],
+    ['a1b2 c3d4', 'whitespace'],
+  ])('rejects %o, which is %s', (value) => {
+    expect(isRecordedHash(value)).toBe(false);
   });
 });

--- a/packages/readyup/src/check-utils/hashing.ts
+++ b/packages/readyup/src/check-utils/hashing.ts
@@ -2,8 +2,16 @@ import { createHash } from 'node:crypto';
 
 import { readFile } from './filesystem.ts';
 
-/** Computes the SHA-256 hex digest of a string. */
-export function computeHash(content: string): string {
+/**
+ * The form of a hash the manifest records: a prefix of a SHA-256 hex digest.
+ *
+ * The floor is the length `rdy compile` writes. A shorter record compares too few characters to
+ * distinguish anything, and one of zero length would match every file on every axis at once.
+ */
+const RECORDED_HASH_PATTERN = /^[0-9a-f]{8,64}$/;
+
+/** Computes the SHA-256 hex digest of a string or byte sequence. */
+export function computeHash(content: string | Uint8Array): string {
   return createHash('sha256').update(content).digest('hex');
 }
 
@@ -12,4 +20,21 @@ export function fileMatchesHash(filePath: string, expectedHash: string): boolean
   const content = readFile(filePath);
   if (content === undefined) return false;
   return computeHash(content) === expectedHash;
+}
+
+/**
+ * Returns a content's SHA-256 digest truncated to a recorded hash's own length.
+ *
+ * The recorded value decides how much of the digest to compare, so every reader of a manifest honors
+ * whatever prefix the compile that wrote it used rather than a length of its own that a later readyup
+ * could outgrow. It takes the recorded value rather than a length, so no caller can reinstate a fixed
+ * comparison by reaching for a constant.
+ */
+export function hashToRecordedLength(content: string | Uint8Array, recorded: string): string {
+  return computeHash(content).slice(0, recorded.length);
+}
+
+/** Reports whether a value is a well-formed recorded hash. */
+export function isRecordedHash(value: string): boolean {
+  return RECORDED_HASH_PATTERN.test(value);
 }

--- a/packages/readyup/src/check-utils/index.ts
+++ b/packages/readyup/src/check-utils/index.ts
@@ -15,7 +15,7 @@ export { compareRefToRemote } from './git/compare-ref-to-remote.ts';
 export { makeLocalRefSyncCheck, makeRemoteRefSyncCheck } from './git/factories.ts';
 export { isAtRepoRoot, isGitRepo } from './git/repo-predicates.ts';
 export { expandHome, runGit } from './git/run-git.ts';
-export { computeHash, fileMatchesHash } from './hashing.ts';
+export { computeHash, fileMatchesHash, hashToRecordedLength, isRecordedHash } from './hashing.ts';
 export { hasJsonField, hasJsonFields, readJsonFile, readJsonValue } from './json.ts';
 export { getJsonValue, hasJsonValue } from './json-value.ts';
 export { missingFrom } from './missingFrom.ts';

--- a/packages/readyup/src/manifest/__tests__/manifestSchema.unit.test.ts
+++ b/packages/readyup/src/manifest/__tests__/manifestSchema.unit.test.ts
@@ -239,4 +239,68 @@ describe('ManifestSchema', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it.each(['sourceHash', 'targetHash'])('accepts a full 64-character digest as %s', (field) => {
+    const input = { version: 1, kits: [{ name: 'deploy', [field]: FULL_DIGEST }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each(['sourceHash', 'targetHash'])('accepts a twelve-character prefix as %s', (field) => {
+    const input = { version: 1, kits: [{ name: 'deploy', [field]: FULL_DIGEST.slice(0, 12) }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each(MALFORMED_HASHES)('rejects %o as a sourceHash, which is %s', (hash) => {
+    const input = { version: 1, kits: [{ name: 'deploy', sourceHash: hash }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each(MALFORMED_HASHES)('rejects %o as a targetHash, which is %s', (hash) => {
+    const input = { version: 1, kits: [{ name: 'deploy', targetHash: hash }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each(MALFORMED_HASHES)("rejects %o as an input's hash, which is %s", (hash) => {
+    const inputs = [{ hash, kind: 'module', path: 'kits/shared.ts' }];
+    const input = { version: 1, kits: [{ name: 'deploy', inputs }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('names the recorded-hash form in the failure message', () => {
+    const input = { version: 1, kits: [{ name: 'deploy', targetHash: 'abc' }] };
+
+    const result = ManifestSchema.safeParse(input);
+
+    assert(!result.success);
+    expect(result.error.message).toContain('lowercase hex digest prefix of 8 to 64 characters');
+  });
 });
+
+// region | Helpers
+
+const FULL_DIGEST = 'a1b2c3d4e5f6a7b8'.repeat(4);
+
+const MALFORMED_HASHES: [string, string][] = [
+  ['', 'empty'],
+  ['a1b2c3d', 'one character below the floor'],
+  ['a'.repeat(65), 'one character above a full digest'],
+  ['A1B2C3D4', 'uppercase'],
+  ['a1b2c3g4', 'a non-hex character'],
+];
+
+// endregion | Helpers

--- a/packages/readyup/src/manifest/__tests__/manifestSchema.unit.test.ts
+++ b/packages/readyup/src/manifest/__tests__/manifestSchema.unit.test.ts
@@ -286,7 +286,7 @@ describe('ManifestSchema', () => {
 
     const result = ManifestSchema.safeParse(input);
 
-    assert(!result.success);
+    assert.ok(!result.success);
     expect(result.error.message).toContain('lowercase hex digest prefix of 8 to 64 characters');
   });
 });

--- a/packages/readyup/src/manifest/manifestSchema.ts
+++ b/packages/readyup/src/manifest/manifestSchema.ts
@@ -1,7 +1,21 @@
 import { z } from 'zod';
 
+import { isRecordedHash } from '../check-utils/hashing.ts';
+
 /** Schema for a `pickJson` path specifier list, mirroring the function's second argument. */
 const JsonPathSpecSchema = z.array(z.union([z.string(), z.array(z.string())]));
+
+/**
+ * Schema for a hash the manifest records, which is a prefix of a SHA-256 hex digest.
+ *
+ * Every reader compares the digest at the recorded value's own length, so how much of it a record
+ * covers is the compile's to choose: a readyup recording a longer prefix does not read as stale to one
+ * that records eight characters. The floor is what keeps a record too short to distinguish anything
+ * from reaching a comparison, where it would pass every axis on every kit.
+ */
+const RecordedHashSchema = z
+  .string()
+  .refine(isRecordedHash, { message: 'must be a lowercase hex digest prefix of 8 to 64 characters' });
 
 /**
  * Schema for one file the compile read to produce a kit's bundle.
@@ -14,8 +28,8 @@ const JsonPathSpecSchema = z.array(z.union([z.string(), z.array(z.string())]));
  * Paths are relative to the manifest directory, as `path` and `source` are.
  */
 const ManifestInputSchema = z.discriminatedUnion('kind', [
-  z.object({ hash: z.string(), kind: z.literal('inline'), path: z.string(), paths: JsonPathSpecSchema }),
-  z.object({ hash: z.string(), kind: z.literal('module'), path: z.string(), paths: z.undefined().optional() }),
+  z.object({ hash: RecordedHashSchema, kind: z.literal('inline'), path: z.string(), paths: JsonPathSpecSchema }),
+  z.object({ hash: RecordedHashSchema, kind: z.literal('module'), path: z.string(), paths: z.undefined().optional() }),
 ]);
 
 /**
@@ -28,7 +42,8 @@ const ManifestInputSchema = z.discriminatedUnion('kind', [
  *
  * `sourceHash` and `targetHash` are the two ends of the compile: the hash of the `.ts` the kit was
  * built from and the hash of the `.js` it produced. Comparing each against the file on disk is what
- * separates a source edited without recompiling from a compiled bundle edited by hand.
+ * separates a source edited without recompiling from a compiled bundle edited by hand. Both are
+ * recorded hashes, compared at their own length rather than at a length the reader fixes.
  *
  * `inputs` records everything else the compile read, which is every module the bundle inlined past the
  * entry and every JSON file `pickJson` projected. It is optional on the same terms `checklists` is: an
@@ -53,8 +68,8 @@ const ManifestKitSchema = z.object({
   path: z.string().optional(),
   readyupVersion: z.string().optional(),
   source: z.string().optional(),
-  sourceHash: z.string().optional(),
-  targetHash: z.string().optional(),
+  sourceHash: RecordedHashSchema.optional(),
+  targetHash: RecordedHashSchema.optional(),
 });
 
 /** Schema for the readyup manifest file. */

--- a/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
@@ -5,13 +5,15 @@ import { captureStdio } from '@williamthorsen/toolbelt.testing/candidate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { RdyManifestKit } from '../../manifest/manifestSchema.ts';
+import { ManifestNotFoundError } from '../../manifest/readManifest.ts';
 
 const mockReadManifest = vi.hoisted(() => vi.fn());
 const mockCheckDrift = vi.hoisted(() => vi.fn());
 const mockCheckInputDrift = vi.hoisted(() => vi.fn());
 const mockCheckSourceDrift = vi.hoisted(() => vi.fn());
 
-vi.mock(import('../../manifest/readManifest.ts'), () => ({
+vi.mock(import('../../manifest/readManifest.ts'), async (importOriginal) => ({
+  ...(await importOriginal()),
   readManifest: mockReadManifest,
 }));
 
@@ -45,31 +47,62 @@ describe(readManifestTracking, () => {
     mockReadManifest.mockReturnValue(manifest);
 
     expect(readManifestTracking(false)).toStrictEqual({
-      manifest,
-      manifestDir: path.resolve(process.cwd(), '.readyup'),
+      tracking: { manifest, manifestDir: path.resolve(process.cwd(), '.readyup') },
+      warnings: [],
     });
   });
 
   it('skips the read under --jit, which runs from source the manifest does not describe', () => {
-    expect(readManifestTracking(true)).toBeUndefined();
+    expect(readManifestTracking(true)).toStrictEqual({ tracking: undefined, warnings: [] });
     expect(mockReadManifest).not.toHaveBeenCalled();
   });
 
-  it('returns undefined when no manifest exists', () => {
+  it('stays silent when no manifest exists, which is the normal state of a project that never compiled', () => {
     mockReadManifest.mockImplementation(() => {
-      throw new Error('Manifest file not found: /abs/.readyup/manifest.json');
+      throw new ManifestNotFoundError('/abs/.readyup/manifest.json');
     });
 
-    expect(readManifestTracking(false)).toBeUndefined();
+    expect(readManifestTracking(false)).toStrictEqual({ tracking: undefined, warnings: [] });
   });
 
-  it('returns undefined when the manifest cannot be parsed', () => {
+  it('raises manifest-unreadable when the manifest is present and cannot be parsed', () => {
     mockReadManifest.mockImplementation(() => {
       throw new Error('Manifest file contains invalid JSON: /abs/.readyup/manifest.json');
     });
 
-    expect(readManifestTracking(false)).toBeUndefined();
+    const { result, stderr } = read();
+
+    expect(result.tracking).toBeUndefined();
+    expect(result.warnings).toStrictEqual([
+      {
+        code: 'manifest-unreadable',
+        message: expect.stringContaining('could not be read, so no kit was checked against it'),
+        remedy: 'Run `rdy compile` to rewrite it.',
+      },
+    ]);
+    expect(stderr).toContain('could not be read');
   });
+
+  it('names the parse failure in the advisory, so the run says why it stopped checking', () => {
+    mockReadManifest.mockImplementation(() => {
+      throw new Error('Invalid manifest schema in /abs/.readyup/manifest.json: targetHash must be a hash');
+    });
+
+    expect(read().result.warnings[0]?.message).toContain('targetHash must be a hash');
+  });
+
+  // region | Helpers
+
+  /** Reads the manifest, returning the result alongside what the call wrote to stderr. */
+  function read() {
+    using io = captureStdio();
+
+    const result = readManifestTracking(false);
+
+    return { result, stderr: io.stderr };
+  }
+
+  // endregion | Helpers
 });
 
 describe(warnOnKitStaleness, () => {

--- a/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
@@ -75,7 +75,7 @@ describe(runHumanMode, () => {
   beforeEach(() => {
     mockReportRdy.mockReturnValue({ body: 'report output', hasVisibleResults: true });
     mockFormatCombinedSummary.mockReturnValue('combined summary');
-    mockReadManifestTracking.mockReturnValue(undefined);
+    mockReadManifestTracking.mockReturnValue({ tracking: undefined, warnings: [] });
     mockWarnOnKitStaleness.mockReturnValue([]);
     mockWarnOnUnusedPragmas.mockReturnValue([]);
   });
@@ -551,7 +551,7 @@ describe(runHumanMode, () => {
 
     it('advises on each kit against the source that kit resolved to', async () => {
       const tracking = { manifest: { version: 1, kits: [] }, manifestDir: '.readyup' };
-      mockReadManifestTracking.mockReturnValue(tracking);
+      mockReadManifestTracking.mockReturnValue({ tracking, warnings: [] });
       mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
 

--- a/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
@@ -70,7 +70,7 @@ import { makeKit, singleKitEntry } from '../test-utils/kit-fixtures.ts';
 describe(runJsonMode, () => {
   beforeEach(() => {
     mockFormatJsonReport.mockReturnValue('{"worstSeverity":null}');
-    mockReadManifestTracking.mockReturnValue(undefined);
+    mockReadManifestTracking.mockReturnValue({ tracking: undefined, warnings: [] });
     mockWarnOnKitStaleness.mockReturnValue([]);
     mockWarnOnUnusedPragmas.mockReturnValue([]);
   });
@@ -279,7 +279,7 @@ describe(runJsonMode, () => {
 
     it('passes every advisory the run raised into the JSON report', async () => {
       const tracking = { manifest: { version: 1, kits: [] }, manifestDir: '.readyup' };
-      mockReadManifestTracking.mockReturnValue(tracking);
+      mockReadManifestTracking.mockReturnValue({ tracking, warnings: [] });
       mockWarnOnKitStaleness.mockReturnValueOnce([TARGET_DRIFT]).mockReturnValueOnce([SOURCE_STALE]);
       mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
       mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
@@ -292,6 +292,26 @@ describe(runJsonMode, () => {
       expect(mockFormatJsonReport).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ warnings: [TARGET_DRIFT, SOURCE_STALE] }),
+      );
+      expect(exitCode).toBe(0);
+    });
+
+    it('passes an advisory raised by the manifest read itself into the report', async () => {
+      const manifestUnreadable = {
+        code: 'manifest-unreadable',
+        message: '.readyup/manifest.json could not be read, so no kit was checked against it: bad JSON',
+        remedy: 'Run `rdy compile` to rewrite it.',
+      };
+      mockReadManifestTracking.mockReturnValue({ tracking: undefined, warnings: [manifestUnreadable] });
+      mockLoadRdyKit.mockResolvedValue({ kit: makeKit(), compileTimeVersion: undefined });
+      mockRunRdy.mockResolvedValue({ results: [], passed: true, durationMs: 0 });
+      mockFormatJsonReport.mockReturnValue('{"kits":[]}');
+
+      const { exitCode } = await runJson(singleKitEntry(['deploy']));
+
+      expect(mockFormatJsonReport).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ warnings: [manifestUnreadable] }),
       );
       expect(exitCode).toBe(0);
     });

--- a/packages/readyup/src/run/kit-staleness.ts
+++ b/packages/readyup/src/run/kit-staleness.ts
@@ -1,15 +1,24 @@
 import path from 'node:path';
 import process from 'node:process';
 
+import { describeError } from '@williamthorsen/toolbelt.errors';
+
 import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifest } from '../manifest/manifestSchema.ts';
-import { readManifest } from '../manifest/readManifest.ts';
+import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
+import { toDisplayPath } from '../portable/toDisplayPath.ts';
 import type { RaisedWarning } from '../schemas/common.ts';
 import { checkDrift } from '../verify/checkDrift.ts';
 import type { InputsStatus } from '../verify/checkInputDrift.ts';
 import { checkInputDrift } from '../verify/checkInputDrift.ts';
 import { checkSourceDrift } from '../verify/checkSourceDrift.ts';
 import type { KitSource } from './ResolvedKitEntry.ts';
+
+/** What reading the manifest yielded: the tracking where one was read, and any advisory the read raised. */
+export interface ManifestRead {
+  tracking: ManifestTracking | undefined;
+  warnings: RaisedWarning[];
+}
 
 /** The manifest an invocation checks its kits against, read once and shared by every kit in the run. */
 export interface ManifestTracking {
@@ -20,19 +29,24 @@ export interface ManifestTracking {
 /**
  * Reads the default manifest for the run's advisories, best effort.
  *
- * Every failure here yields no manifest at all: a missing one is the normal state of a
- * project that never compiled, and an unreadable or unrecognized one says nothing about any kit. A
- * verification tool that refused to run because its own bookkeeping was unreadable would be worse
- * than one that runs and stays quiet. `--jit` runs from source, which the manifest does not
- * describe, so they skip the read entirely.
+ * No failure here stops the run: a verification tool that refused to run because its own bookkeeping
+ * was unreadable would be worse than one that runs and says so. What separates the two outcomes is
+ * whether the manifest is there. An absent one is the normal state of a project that never compiled
+ * and says nothing about any kit, so it is silent. A present one that cannot be read raises
+ * `manifest-unreadable`, because every staleness axis then goes unchecked for every kit in the run,
+ * and a run that checked nothing is indistinguishable from one that found nothing. `--jit` runs from
+ * source, which the manifest does not describe, so they skip the read entirely.
  */
-export function readManifestTracking(isJit: boolean): ManifestTracking | undefined {
-  if (isJit) return undefined;
+export function readManifestTracking(isJit: boolean): ManifestRead {
+  if (isJit) return { tracking: undefined, warnings: [] };
+
   const manifestPath = path.resolve(process.cwd(), DEFAULT_MANIFEST_PATH);
   try {
-    return { manifest: readManifest(manifestPath), manifestDir: path.dirname(manifestPath) };
-  } catch {
-    return undefined;
+    const tracking = { manifest: readManifest(manifestPath), manifestDir: path.dirname(manifestPath) };
+    return { tracking, warnings: [] };
+  } catch (error: unknown) {
+    if (error instanceof ManifestNotFoundError) return { tracking: undefined, warnings: [] };
+    return { tracking: undefined, warnings: [raiseUnreadableManifest(manifestPath, error)] };
   }
 }
 
@@ -118,6 +132,17 @@ function findManifestEntry(kitPath: string, tracking: ManifestTracking): RdyMani
  */
 function hasChangedInput(status: InputsStatus | undefined): boolean {
   return status?.kind === 'stale' && status.failures.some((failure) => failure.reason === 'changed');
+}
+
+/** Raises the advisory for a manifest that is present and unreadable, and writes its stderr line. */
+function raiseUnreadableManifest(manifestPath: string, error: unknown): RaisedWarning {
+  const warning: RaisedWarning = {
+    code: 'manifest-unreadable',
+    message: `${toDisplayPath(manifestPath)} could not be read, so no kit was checked against it: ${describeError(error)}`,
+    remedy: 'Run `rdy compile` to rewrite it.',
+  };
+  process.stderr.write(`Warning: ${warning.message} ${warning.remedy}\n`);
+  return warning;
 }
 
 /** Returns a staleness verdict, or `undefined` when reaching one needed a file that cannot be read. */

--- a/packages/readyup/src/run/runHumanMode.ts
+++ b/packages/readyup/src/run/runHumanMode.ts
@@ -48,7 +48,7 @@ export async function runHumanMode(
   }
 
   const isMultiKit = kitEntries.length > 1;
-  const tracking = readManifestTracking(isJit);
+  const { tracking } = readManifestTracking(isJit);
   const pragmaLedger = createPragmaLedger();
   const writeBlock = createBlockWriter();
   const rows: SummaryRow[] = [];

--- a/packages/readyup/src/run/runJsonMode.ts
+++ b/packages/readyup/src/run/runJsonMode.ts
@@ -41,7 +41,8 @@ export async function runJsonMode(
   const { detail, diagnose, failOn, reportOn } = settings;
   const kitInputs: KitInput[] = [];
   const warnings: JsonWarning[] = [];
-  const tracking = readManifestTracking(isJit);
+  const { tracking, warnings: manifestWarnings } = readManifestTracking(isJit);
+  warnings.push(...manifestWarnings);
   const pragmaLedger = createPragmaLedger();
   let allPassed = true;
   let anyKitFailed = false;

--- a/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/buildSchemas.unit.test.ts
@@ -70,6 +70,7 @@ describe('generated JSON Schemas', () => {
           enum: [
             'diagnosis-inconclusive',
             'input-stale',
+            'manifest-unreadable',
             'pragma-unused',
             'skip-masks-pass',
             'source-stale',

--- a/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
+++ b/packages/readyup/src/schemas/__tests__/schemas.unit.test.ts
@@ -252,6 +252,7 @@ describe('JSON payload schemas', () => {
       expectTypeOf<RaisedWarning['code']>().toEqualTypeOf<
         | 'diagnosis-inconclusive'
         | 'input-stale'
+        | 'manifest-unreadable'
         | 'pragma-unused'
         | 'skip-masks-pass'
         | 'source-stale'
@@ -261,6 +262,7 @@ describe('JSON payload schemas', () => {
       expectTypeOf<JsonWarning['code']>().not.toEqualTypeOf<
         | 'diagnosis-inconclusive'
         | 'input-stale'
+        | 'manifest-unreadable'
         | 'pragma-unused'
         | 'skip-masks-pass'
         | 'source-stale'

--- a/packages/readyup/src/schemas/common.ts
+++ b/packages/readyup/src/schemas/common.ts
@@ -53,6 +53,7 @@ export const CountsSchema = z
 export const WarningCodeSchema = z.enum([
   'diagnosis-inconclusive',
   'input-stale',
+  'manifest-unreadable',
   'pragma-unused',
   'skip-masks-pass',
   'source-stale',

--- a/packages/readyup/src/verify/__tests__/checkDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkDrift.unit.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { checkDrift } from '../checkDrift.ts';
+import { computeHash } from '../../check-utils/hashing.ts';
 import { hashBytes } from '../targetHash.ts';
 
 describe(checkDrift, () => {
@@ -26,6 +27,25 @@ describe(checkDrift, () => {
     const status = checkDrift({ name: 'demo', path: 'demo.js', targetHash: expectedHash }, tempDir);
 
     expect(status.kind).toBe('ok');
+  });
+
+  it.each([12, 64])('returns ok when the manifest records a %i-character targetHash', (length) => {
+    const content = Buffer.from('compiled output');
+    writeFileSync(path.join(tempDir, 'demo.js'), content);
+    const recorded = computeHash(content).slice(0, length);
+
+    const status = checkDrift({ name: 'demo', path: 'demo.js', targetHash: recorded }, tempDir);
+
+    expect(status).toStrictEqual({ kind: 'ok', targetHash: recorded });
+  });
+
+  it('reports the actual hash at the recorded length when a longer record has drifted', () => {
+    writeFileSync(path.join(tempDir, 'demo.js'), 'on-disk content');
+    const recorded = computeHash('other content').slice(0, 64);
+
+    const status = checkDrift({ name: 'demo', path: 'demo.js', targetHash: recorded }, tempDir);
+
+    expect(status).toMatchObject({ kind: 'drift', expected: recorded, actual: computeHash('on-disk content') });
   });
 
   it('returns drift when hashes differ', () => {

--- a/packages/readyup/src/verify/__tests__/checkDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkDrift.unit.test.ts
@@ -4,8 +4,8 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { checkDrift } from '../checkDrift.ts';
 import { computeHash } from '../../check-utils/hashing.ts';
+import { checkDrift } from '../checkDrift.ts';
 import { hashBytes } from '../targetHash.ts';
 
 describe(checkDrift, () => {

--- a/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkInputDrift.unit.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { computeHash } from '../../check-utils/hashing.ts';
 import type { RdyManifestInput, RdyManifestKit } from '../../manifest/manifestSchema.ts';
 import { checkInputDrift } from '../checkInputDrift.ts';
 import { hashBytes, hashProjection } from '../targetHash.ts';
@@ -66,6 +67,31 @@ describe(checkInputDrift, () => {
       });
     });
 
+    it.each([12, 64])('returns ok when the record holds a %i-character hash', (length) => {
+      writeInput('kits/shared.ts', MODULE_SOURCE);
+      const recorded: RdyManifestInput = { ...RECORDED_MODULE, hash: computeHash(MODULE_SOURCE).slice(0, length) };
+
+      expect(checkInputDrift(kitWith([recorded]), tempDir)).toStrictEqual({ kind: 'ok' });
+    });
+
+    it('reports the actual hash at the recorded length when a longer record has changed', () => {
+      writeInput('kits/shared.ts', 'export const shared = 2;\n');
+      const recorded: RdyManifestInput = { ...RECORDED_MODULE, hash: computeHash(MODULE_SOURCE) };
+
+      expect(checkInputDrift(kitWith([recorded]), tempDir)).toStrictEqual({
+        kind: 'stale',
+        failures: [
+          {
+            kind: 'module',
+            path: 'kits/shared.ts',
+            reason: 'changed',
+            expected: recorded.hash,
+            actual: computeHash('export const shared = 2;\n'),
+          },
+        ],
+      });
+    });
+
     it('reports a module the compile read that is no longer on disk', () => {
       expect(checkInputDrift(kitWith([RECORDED_MODULE]), tempDir)).toStrictEqual({
         kind: 'stale',
@@ -90,6 +116,14 @@ describe(checkInputDrift, () => {
           },
         ],
       });
+    });
+
+    it.each([12, 64])('returns ok when the record holds a %i-character projection hash', (length) => {
+      writeInput('package.json', JSON.stringify(PACKAGE_JSON));
+      const projection = JSON.stringify({ version: PACKAGE_JSON.version });
+      const recorded: RdyManifestInput = { ...RECORDED_PICK, hash: computeHash(projection).slice(0, length) };
+
+      expect(checkInputDrift(kitWith([recorded]), tempDir)).toStrictEqual({ kind: 'ok' });
     });
 
     it('leaves an edit to a field the kit did not pick as ok', () => {

--- a/packages/readyup/src/verify/__tests__/checkSourceDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkSourceDrift.unit.test.ts
@@ -4,8 +4,8 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { checkSourceDrift } from '../checkSourceDrift.ts';
 import { computeHash } from '../../check-utils/hashing.ts';
+import { checkSourceDrift } from '../checkSourceDrift.ts';
 import { hashBytes } from '../targetHash.ts';
 
 describe(checkSourceDrift, () => {

--- a/packages/readyup/src/verify/__tests__/checkSourceDrift.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/checkSourceDrift.unit.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { checkSourceDrift } from '../checkSourceDrift.ts';
+import { computeHash } from '../../check-utils/hashing.ts';
 import { hashBytes } from '../targetHash.ts';
 
 describe(checkSourceDrift, () => {
@@ -25,6 +26,29 @@ describe(checkSourceDrift, () => {
     const status = checkSourceDrift({ name: 'demo', source: 'demo.ts', sourceHash: hashBytes(content) }, tempDir);
 
     expect(status.kind).toBe('ok');
+  });
+
+  it.each([12, 64])('returns ok when the manifest records a %i-character sourceHash', (length) => {
+    const content = Buffer.from('export default { checklists: [] };');
+    writeFileSync(path.join(tempDir, 'demo.ts'), content);
+    const recorded = computeHash(content).slice(0, length);
+
+    const status = checkSourceDrift({ name: 'demo', source: 'demo.ts', sourceHash: recorded }, tempDir);
+
+    expect(status).toStrictEqual({ kind: 'ok', sourceHash: recorded });
+  });
+
+  it('reports the actual hash at the recorded length when a longer record has gone stale', () => {
+    writeFileSync(path.join(tempDir, 'demo.ts'), 'export default { checklists: [1] };');
+    const recorded = computeHash('export default { checklists: [] };').slice(0, 64);
+
+    const status = checkSourceDrift({ name: 'demo', source: 'demo.ts', sourceHash: recorded }, tempDir);
+
+    expect(status).toMatchObject({
+      kind: 'stale',
+      expected: recorded,
+      actual: computeHash('export default { checklists: [1] };'),
+    });
   });
 
   it('returns stale with both hashes when the source has changed since compile', () => {

--- a/packages/readyup/src/verify/checkDrift.ts
+++ b/packages/readyup/src/verify/checkDrift.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
-import { hashFile } from './targetHash.ts';
+import { hashFileToRecordedLength } from './targetHash.ts';
 
 /** Outcome of a per-kit drift check. */
 export type DriftStatus =
@@ -29,7 +29,7 @@ export function checkDrift(kit: RdyManifestKit, manifestDir: string): DriftStatu
     return { kind: 'missing', resolvedPath };
   }
 
-  const actual = hashFile(resolvedPath);
+  const actual = hashFileToRecordedLength(resolvedPath, kit.targetHash);
   if (actual !== kit.targetHash) {
     return { kind: 'drift', expected: kit.targetHash, actual, resolvedPath };
   }

--- a/packages/readyup/src/verify/checkInputDrift.ts
+++ b/packages/readyup/src/verify/checkInputDrift.ts
@@ -1,10 +1,11 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
+import { hashToRecordedLength } from '../check-utils/hashing.ts';
 import { describeJsonProjectionFailure } from '../compile/JsonProjectionError.ts';
 import { projectJsonFile } from '../compile/projectJsonFile.ts';
 import type { RdyManifestInput, RdyManifestKit } from '../manifest/manifestSchema.ts';
-import { hashFile, hashProjection } from './targetHash.ts';
+import { hashFileToRecordedLength } from './targetHash.ts';
 
 /**
  * One recorded input that no longer matches what the compile read, and why.
@@ -53,14 +54,14 @@ function checkInput(input: RdyManifestInput, manifestDir: string): InputFailure 
   }
 
   if (input.kind === 'module') {
-    const actual = hashFile(resolvedPath);
+    const actual = hashFileToRecordedLength(resolvedPath, input.hash);
     if (actual === input.hash) return undefined;
     return { kind: 'module', path: input.path, reason: 'changed', expected: input.hash, actual };
   }
 
   let actual: string;
   try {
-    actual = hashProjection(projectJsonFile(resolvedPath, input.paths));
+    actual = hashToRecordedLength(projectJsonFile(resolvedPath, input.paths), input.hash);
   } catch (error: unknown) {
     return { kind: 'inline', path: input.path, reason: 'unprojectable', detail: describeJsonProjectionFailure(error) };
   }

--- a/packages/readyup/src/verify/checkSourceDrift.ts
+++ b/packages/readyup/src/verify/checkSourceDrift.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
-import { hashFile } from './targetHash.ts';
+import { hashFileToRecordedLength } from './targetHash.ts';
 
 /** Outcome of a per-kit source-staleness check. */
 export type SourceStatus =
@@ -31,7 +31,7 @@ export function checkSourceDrift(kit: RdyManifestKit, manifestDir: string): Sour
     return { kind: 'missing', resolvedPath };
   }
 
-  const actual = hashFile(resolvedPath);
+  const actual = hashFileToRecordedLength(resolvedPath, kit.sourceHash);
   if (actual !== kit.sourceHash) {
     return { kind: 'stale', expected: kit.sourceHash, actual, resolvedPath };
   }

--- a/packages/readyup/src/verify/targetHash.ts
+++ b/packages/readyup/src/verify/targetHash.ts
@@ -1,24 +1,37 @@
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 
-/** Length of the hex prefix stored in the manifest's `targetHash` field. */
+import { hashToRecordedLength } from '../check-utils/hashing.ts';
+
+/** Length of the hex prefix `rdy compile` records for a hash. */
 const HASH_PREFIX_LENGTH = 8;
 
-/** Returns the first 8 hex characters of a buffer's SHA-256 digest. */
+/**
+ * Returns the hash of a buffer in the form the manifest records it.
+ *
+ * This and its two siblings write a record; they are not how one is read back. A reader compares
+ * through `hashToRecordedLength`, which honors whatever prefix the compile that wrote the record
+ * used, so hashing here and comparing the result would reinstate a fixed-length comparison.
+ */
 export function hashBytes(bytes: Buffer): string {
   return createHash('sha256').update(bytes).digest('hex').slice(0, HASH_PREFIX_LENGTH);
 }
 
-/** Returns the first 8 hex characters of a file's SHA-256 digest. */
+/** Returns the hash of a file in the form the manifest records it. */
 export function hashFile(filePath: string): string {
   return hashBytes(readFileSync(filePath));
+}
+
+/** Returns a file's SHA-256 digest truncated to a recorded hash's own length. */
+export function hashFileToRecordedLength(filePath: string, recorded: string): string {
+  return hashToRecordedLength(readFileSync(filePath), recorded);
 }
 
 /**
  * Returns the hash of a serialized JSON projection, which is what a recorded inline input stores.
  *
- * The compile and every reader of a recorded input hash the projection through here, so neither can
- * encode it differently and report a file neither changed as stale.
+ * The compile hashes the projection through here, so its serialization and the hash over it are one
+ * format rather than two implementations that can drift.
  */
 export function hashProjection(projection: string): string {
   return hashBytes(Buffer.from(projection, 'utf8'));


### PR DESCRIPTION
## What

Fixes an issue where `rdy verify` treated a kit as stale if its manifest contained hashes longer than the eight characters written by `rdy compile`. Every axis now compares the digest at the recorded value's own length. The manifest schema constrains a recorded hash to a lowercase hex digest prefix of 8 to 64 characters.

Separately, `rdy run` raises a new `manifest-unreadable` advisory when `.readyup/manifest.json` is present but unparseable.

Two new functions, `hashToRecordedLength` and `isRecordedHash`, have been added to `readyup/check-utils`. `computeHash` now accepts a byte sequence as well as a string.

## Why

A manifest written by a readyup that records a different prefix length, or carrying a full digest from a hand edit, could not be verified at all: `rdy verify` compared its own fixed eight characters against the recorded value exactly, so every axis failed at once against files nobody had touched. The `freshness` kit read the same manifest and reached the opposite verdict, leaving two readers of one record that could not agree.

## Details

### 🎉 Features

- `readyup/check-utils` exports `hashToRecordedLength(content, recorded)`, which truncates a digest to a recorded hash's own length, and `isRecordedHash(value)`, which reports whether a value is well-formed. Both are listed in the README's check-utils Hashing table. `hashToRecordedLength` takes the recorded value rather than a length, so a caller cannot reinstate a fixed comparison by passing a constant.
- `computeHash` widens from `string` to `string | Uint8Array`, which is what lets one digest function serve a caller holding file bytes and a caller holding a projection string.
- `manifest-unreadable` joins `WarningCodeSchema`, so it appears in the generated JSON Schema enum and in the `warnings` array under `--json` alongside the stderr line. The advisory names the file and the parse failure and leaves the exit code alone.

### 🐛 Bug fixes

- `checkDrift`, `checkSourceDrift`, and both branches of `checkInputDrift`'s `checkInput` compare through the shared rule instead of a pre-truncated eight-character digest. Each failure payload's `actual` is rendered at the recorded length, so `expected` and `actual` stay comparable side by side in the human line and the JSON report.
- `ManifestInputSchema.hash`, `ManifestKitSchema.sourceHash`, and `ManifestKitSchema.targetHash` share one `RecordedHashSchema` in place of three bare `z.string()`s. The floor closes a silent pass: an unconstrained recorded value of zero length would have matched every axis of every kit under prefix comparison. The form is constrained rather than the length pinned, so a manifest a future readyup writes still parses.
- `readManifestTracking` distinguishes an absent manifest from a present one it cannot read, bringing the run's manifest read into line with `rdy compile` and `rdy list`. It returns the advisory alongside the tracking, and `runJsonMode` folds it into the report's warnings.

### ♻️ Refactoring

- `buildFreshnessChecks` calls the shared `hashToRecordedLength` in place of its own `computeHash(...).slice(0, expected.length)`, and gains `isRecordedHash` arms in `compareToRecordedHash` and `describeInputDrift` so a record below the floor fails rather than passing on a three-character comparison.
- `hashBytes`, `hashFile`, and `hashProjection` keep their names and their truncation as the writer helpers, with doc comments that now name the split between writing a record and reading one. `verify/targetHash.ts` gains `hashFileToRecordedLength` for the reader side.

### 🧪 Tests

- `readerAgreement.unit.test.ts` runs `rdy verify` and the `freshness` kit over one fixture manifest at 12 and 64 characters, unchanged and edited, asserting the two verdicts are equal rather than two literals. A third case covers a record below the floor, where the two agree through the schema rejecting it rather than through the comparison.
- Per-axis cases in `checkDrift`, `checkSourceDrift`, and `checkInputDrift` cover a clean verdict at 12 and 64 characters and the `actual` rendering when a longer record has drifted.
- `manifestSchema.unit.test.ts` covers acceptance and rejection on each of the three fields and pins the refine message text. `kit-staleness.unit.test.ts` covers the absent-versus-unreadable split and asserts the advisory names the parse failure.


Closes #320

