### PR TITLE
#353 Replace the answers metaphor with plainer wording in comments and docs

### DIFF
--- a/.readyup/kits/internal/default.ts
+++ b/.readyup/kits/internal/default.ts
@@ -7,7 +7,7 @@ import { defineRdyKit } from 'readyup';
  * Checks run concurrently within a checklist.
  *
  * Three fields, three questions: `name` states what must be true, phrased so it reads
- * true on a pass; `detail` answers why this status; `fix` says what to do about it.
+ * true on a pass; `detail` explains why this status; `fix` says what to do about it.
  */
 export default defineRdyKit({
   checklists: [

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -18,7 +18,7 @@ import { defineConfig } from 'eslint/config';
  * from the shared config and would be lost the same way.
  *
  * The scope is TypeScript alone, though the base block this overrides also covers `patterns.javaScriptFiles`. The
- * `describeError` entry answers the `unknown` type TypeScript gives a catch binding, which JavaScript has no
+ * `describeError` entry covers the `unknown` type TypeScript gives a catch binding, which JavaScript has no
  * equivalent of, so a `.js` file receives the three statement bans without it.
  */
 const RESTRICTED_SYNTAX = [

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -244,7 +244,7 @@ A check naming located sites returns a `FindingOutcome` instead, and the runner 
 
 Three fields, three questions:
 
-> **`name` states what must be true. `detail` answers why this status. `fix` says what to do about it.**
+> **`name` states what must be true. `detail` explains why this status. `fix` says what to do about it.**
 
 A name is a claim that reads true on a pass and false on a fail. `🔴 Node >= 24` fails that test: the operator leaves the reader to infer which direction is the violation.
 
@@ -267,7 +267,7 @@ Neither is a `quiet` check, though it looks like one: its name reaches the reade
 
 ### The detail contract
 
-`detail` answers "why this status" -- not "what this check asserts", which the name already says. On a pass it reports the evidence; on a skip, why the check did not apply; on a failure, what went wrong. Write it as a complete sentence, capitalized and with no terminal period -- the register `name` and `fix` already use. A sentence whose subject is a code identifier keeps that identifier's own case, as in `package.json is missing or unreadable`.
+`detail` explains "why this status" -- not "what this check asserts", which the name already says. On a pass it reports the evidence; on a skip, why the check did not apply; on a failure, what went wrong. Write it as a complete sentence, capitalized and with no terminal period -- the register `name` and `fix` already use. A sentence whose subject is a code identifier keeps that identifier's own case, as in `package.json is missing or unreadable`.
 
 | Status  | Where `detail` renders                                  |
 | ------- | ------------------------------------------------------- |
@@ -497,7 +497,7 @@ Both arguments must be literals written in place. They are read out of the sourc
 Two consequences follow from the value being resolved at compile time:
 
 - `pickJson` throws if it is ever reached at runtime. A kit that hits it was not compiled.
-- Editing a picked field afterward leaves the bundle stale. Neither recorded hash changes -- the source did not move, and neither did the bundle -- but the compile records the projection it inlined, so [`rdy verify`](#verifying) names the file and [`rdy run`](#advisory-warnings) warns on it. [`rdy verify --rebuild`](#verifying-by-recompiling) is the exact answer, reading the file rather than a record of it.
+- Editing a picked field afterward leaves the bundle stale. Neither recorded hash changes -- the source did not move, and neither did the bundle -- but the compile records the projection it inlined, so [`rdy verify`](#verifying) names the file and [`rdy run`](#advisory-warnings) warns on it. [`rdy verify --rebuild`](#verifying-by-recompiling) is the exact check, reading the file rather than a record of it.
 
 ### TypeScript settings
 
@@ -842,7 +842,7 @@ Kits from configured packages get their own section, each named package-first so
 📦 @acme/release-kit
 ```
 
-`--packages` answers the dependency question on its own, and answers it for both groups at once. `rdy list --packages` reports every installed direct dependency that publishes kits, plus every package the config names, one block apiece with the kits it publishes and the descriptions their manifests record:
+`--packages` covers the dependency question on its own, and covers it for both groups at once. `rdy list --packages` reports every installed direct dependency that publishes kits, plus every package the config names, one block apiece with the kits it publishes and the descriptions their manifests record:
 
 ```
 ━━ 📦 @acme/eslint-config@2.1.0
@@ -1255,7 +1255,7 @@ In CI:
 
 The three verdicts cover what the compile read and recorded as hashes. A bundle is a function of more than that: the bundler's version, the compile options, and the contents of every dependency, none of which the hash verdicts cover, since [the closure stops at `node_modules`](#what-a-manifest-entry-records). A bundle stale in any of them still hashes as `ok`.
 
-`--rebuild` answers the question exactly. It recompiles each kit in memory and compares the result to the committed bundle byte for byte:
+`--rebuild` settles the question exactly. It recompiles each kit in memory and compares the result to the committed bundle byte for byte:
 
 ```
 ── Verifying kits against .readyup/manifest.json
@@ -1341,7 +1341,7 @@ Every path a check utility takes resolves against `cwd` unless it is absolute, i
 | `hasDevDependency(name)`                              | Dev dependency is declared                |
 | `hasMinDevDependencyVersion(name, version, options?)` | Dev dependency meets a minimum            |
 
-`hasMinDevDependencyVersion` compares the floor against the version it reads out of the specifier in `package.json`, so the specifier's protocol can settle the answer before any comparison happens. Any `workspace:`-prefixed specifier satisfies any floor, `workspace:^1.2.3` included: it links to the package the repo builds, and a repo that publishes a package is not a consumer of it. A `catalog:` specifier settles nothing on its own and is resolved through `pnpm-workspace.yaml` in the working directory, and the version found there is what the floor is compared against. `catalog:` names the `default` catalog, which pnpm also spells `catalog:default`, and which the file writes as the top-level `catalog:` block or as a `default` block under `catalogs:`; any other `catalog:<name>` selects its own block under `catalogs:`. A specifier the file does not resolve meets no floor, as does one whose catalog entry opens a YAML construct this reader does not follow, such as an alias or a flow mapping. A version reached that way is read the same as a declared one, so a catalog entry of `workspace:*` satisfies any floor in its turn. The version is read from the start of the specifier, past any range operator, so one naming fewer than three segments (`7`, `^6`) is measured rather than skipped; a specifier with its version elsewhere, as the `npm:` alias protocol does, is read for a three-segment version anywhere in it. Pass `options.exempt` to exempt further specifiers; it receives the specifier as written, so a catalogued dependency reaches it as `catalog:` rather than as the version behind it, and it adds to the built-in exemption rather than replacing it.
+`hasMinDevDependencyVersion` compares the floor against the version it reads out of the specifier in `package.json`, so the specifier's protocol can settle the question before any comparison happens. Any `workspace:`-prefixed specifier satisfies any floor, `workspace:^1.2.3` included: it links to the package the repo builds, and a repo that publishes a package is not a consumer of it. A `catalog:` specifier settles nothing on its own and is resolved through `pnpm-workspace.yaml` in the working directory, and the version found there is what the floor is compared against. `catalog:` names the `default` catalog, which pnpm also spells `catalog:default`, and which the file writes as the top-level `catalog:` block or as a `default` block under `catalogs:`; any other `catalog:<name>` selects its own block under `catalogs:`. A specifier the file does not resolve meets no floor, as does one whose catalog entry opens a YAML construct this reader does not follow, such as an alias or a flow mapping. A version reached that way is read the same as a declared one, so a catalog entry of `workspace:*` satisfies any floor in its turn. The version is read from the start of the specifier, past any range operator, so one naming fewer than three segments (`7`, `^6`) is measured rather than skipped; a specifier with its version elsewhere, as the `npm:` alias protocol does, is read for a three-segment version anywhere in it. Pass `options.exempt` to exempt further specifiers; it receives the specifier as written, so a catalogued dependency reaches it as `catalog:` rather than as the version behind it, and it adds to the built-in exemption rather than replacing it.
 
 ### Versions and runtime alignment
 
@@ -1355,7 +1355,7 @@ Every path a check utility takes resolves against `cwd` unless it is absolute, i
 | `readTsconfigLanguageLevel(path)`    | Effective `lib` and `target`, resolved through `extends`                                 |
 | `readTsconfigChain(path)`            | Each config the `extends` chain reaches, and what it declares in its own right           |
 
-Each reader reports only what it can see, so a check composing them decides for itself what each unknown means. `readEnginesNodeFloor` recognizes only forms from which a single floor follows (`>=24`, `^22.1`, `24.1.0`); a union or wildcard comes back `unparseable` rather than an invented floor. `readTsconfigLanguageLevel` resolves `extends` as TypeScript does, following relative paths and published base configs alike; it also returns `chain` (the configs it read) and `unresolvedExtends` (references it could not follow), so a check can tell an incomplete answer from an undeclared setting. `readTsconfigChain` reports that same walk one layer down: every config it reached, the `extends` specifier that reached each one, and what each declares in its own right, with values left exactly as written. Reach for it to ask which config declared a setting, or to read a field the language-level reader does not cover, such as `files` or `include`. The specifier is a chain entry's stable identity: a package's path shifts with install layout, resolving under `node_modules/.pnpm/` in one project and under a linked workspace directory in another. Where two `extends` branches reach one config, the entry names the branch that reached it first.
+Each reader reports only what it can see, so a check composing them decides for itself what each unknown means. `readEnginesNodeFloor` recognizes only forms from which a single floor follows (`>=24`, `^22.1`, `24.1.0`); a union or wildcard comes back `unparseable` rather than an invented floor. `readTsconfigLanguageLevel` resolves `extends` as TypeScript does, following relative paths and published base configs alike; it also returns `chain` (the configs it read) and `unresolvedExtends` (references it could not follow), so a check can tell an incomplete read from an undeclared setting. `readTsconfigChain` reports that same walk one layer down: every config it reached, the `extends` specifier that reached each one, and what each declares in its own right, with values left exactly as written. Reach for it to ask which config declared a setting, or to read a field the language-level reader does not cover, such as `files` or `include`. The specifier is a chain entry's stable identity: a package's path shifts with install layout, resolving under `node_modules/.pnpm/` in one project and under a linked workspace directory in another. Where two `extends` branches reach one config, the entry names the branch that reached it first.
 
 ```ts
 import {
@@ -1440,7 +1440,7 @@ It is best effort: a project manifest it cannot read or parse yields `[]`. An em
 | `countPackageUsage(sources, options)` | Calls into a package, counted only where the source imports it |
 | `buildFindingReport(options)`         | A `FindingOutcome` the runner suppresses, renders, and counts  |
 
-These six are what an adoption kit needs -- one reporting where a project hand-rolls what a package it already installed provides. Both readers return `undefined` outside a git working tree, which an empty list does not say: a project that cannot be swept is a different answer from one that was swept and holds nothing.
+These six are what an adoption kit needs -- one reporting where a project hand-rolls what a package it already installed provides. Both readers return `undefined` outside a git working tree, which an empty list does not say: a project that cannot be swept is a different result from one that was swept and holds nothing.
 
 `listTrackedFiles` lists with `git ls-files -z`. The `-z` is what makes the list complete: without it git escapes a path holding a non-ASCII byte and wraps it in quotes, and that file drops out of the sweep unreported. Below the repo root git emits paths relative to `cwd` and limited to that subtree, the same scope a relative `readFile` path works in. The sweep therefore follows the project `rdy` was invoked in, never the repository a kit was loaded from.
 

--- a/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
+++ b/packages/readyup/agents/guidance/rulebooks/readyup-kits.md
@@ -61,7 +61,7 @@ Give every check that names located sites an `id`. Without one, a consumer suppr
 
 Expect the site count to move in both directions. Blanking unmasks sites a comment was hiding, because a comment sitting mid-expression blanks to a run of spaces as wide as it was rather than breaking the anchor scan. Write an anchor that tolerates a whitespace run, not one that admits a single space.
 
-One pattern must not read blanked text: one matching a literal's own content, such as an import specifier, which blanking erases. `countPackageUsage` already answers that question against the text it needs; reach for it rather than hand-rolling the sweep.
+One pattern must not read blanked text: one matching a literal's own content, such as an import specifier, which blanking erases. `countPackageUsage` already scans the text it needs for that; reach for it rather than hand-rolling the sweep.
 
 ## Writing `fix`
 

--- a/packages/readyup/src/bin/hasJsonFlag.ts
+++ b/packages/readyup/src/bin/hasJsonFlag.ts
@@ -1,12 +1,12 @@
 /**
  * Detects JSON mode by scanning raw argv, before any flag parsing happens.
  *
- * Answering this without `parseArgs` is what lets a flag-parse failure still be reported through the JSON error
+ * Detecting it without `parseArgs` is what lets a flag-parse failure still be reported through the JSON error
  * envelope. The scan matches only `--json`, and stops at the `--` terminator, after which arguments are positional
  * rather than flags.
  *
  * The scan over-detects in one case a parser would resolve differently: `--file --json` gives `--file` the literal
- * value `--json`. That is deliberate. This answer is consulted only when rendering a failure, never on the success
+ * value `--json`. That is deliberate. This result is consulted only when rendering a failure, never on the success
  * path where parsed values govern, so over-detection sends an error to the wrong channel while under-detection
  * leaves it unreportable in JSON at all.
  */

--- a/packages/readyup/src/bin/route.ts
+++ b/packages/readyup/src/bin/route.ts
@@ -241,7 +241,7 @@ function wantsHelp(flags: string[]): boolean {
  * lives wherever that source resolves rather than on a path worth probing.
  *
  * Everything else is a bare word with no source, which `run` resolves against the conventional kit
- * directory alone. Probing exactly that directory is what makes the answer match what would run.
+ * directory alone. Probing exactly that directory is what makes the result match what would run.
  */
 function namesAKit(word: string, args: string[]): boolean {
   if (word.includes(':') || hasSourceFlag(args)) return true;

--- a/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.unit.test.ts
@@ -384,7 +384,7 @@ describe(discoverWorkspacesAt, () => {
     const workspaces = discoverWorkspacesAt(temp.resolve('nested'));
 
     expect(workspaces.map((w) => w.name)).toStrictEqual(['nested-root', 'alpha']);
-    // The ambient cwd holds no manifest, so an answer read through it could not be this one.
+    // The ambient cwd holds no manifest, so a result read through it could not be this one.
     expect(() => discoverWorkspaces()).toThrow(/no readable package.json/);
   });
 

--- a/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
+++ b/packages/readyup/src/check-utils/__tests__/workspaces.walk.unit.test.ts
@@ -56,7 +56,7 @@ describe(`${discoverWorkspaces.name} directory walk`, () => {
     expect(discoverWorkspaces().map((workspace) => workspace.name)).toStrictEqual(['root', 'alpha']);
   });
 
-  it('propagates a systemic read failure rather than answering with a partial walk', ({ temp }) => {
+  it('propagates a systemic read failure rather than returning a partial walk', ({ temp }) => {
     writeMonorepo(temp);
     failures.set(join(temp.dir, 'packages/locked'), 'EMFILE');
 

--- a/packages/readyup/src/check-utils/discoverKitPackages.ts
+++ b/packages/readyup/src/check-utils/discoverKitPackages.ts
@@ -14,7 +14,7 @@ const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies'];
  * Names the installed direct dependencies that publish kits, sorted.
  *
  * Reads the project's declared dependencies rather than sweeping `node_modules`, which bounds the work to
- * packages the reader already chose to depend on and keeps every answer actionable: a transitive package
+ * packages the reader already chose to depend on and keeps every result actionable: a transitive package
  * is not one they can sensibly add to a list of their own.
  *
  * Best effort throughout: a project manifest that cannot be read or parsed yields `[]`, which a caller

--- a/packages/readyup/src/check-utils/workspaces.ts
+++ b/packages/readyup/src/check-utils/workspaces.ts
@@ -55,7 +55,7 @@ export function discoverWorkspaces(options?: DiscoverWorkspacesOptions): Workspa
  *
  * The directory-taking half of `discoverWorkspaces`, for a caller resolving against a project other than the
  * one it is running in. It stays out of `check-utils`'s exports: a kit runs in the project it checks, so the
- * ambient answer is the one a kit author wants.
+ * ambient discovery is the one a kit author wants.
  */
 export function discoverWorkspacesAt(dir: string, options?: DiscoverWorkspacesOptions): Workspace[] {
   // Resolve before keying the memo, so a relative path and its absolute form share one discovery.
@@ -73,7 +73,7 @@ export function discoverWorkspacesAt(dir: string, options?: DiscoverWorkspacesOp
 
 // region | Helpers
 
-/** Applies the optional filter to a workspace list, answering with an array the caller owns either way. */
+/** Applies the optional filter to a workspace list, returning an array the caller owns either way. */
 function applyFilter(workspaces: Workspace[], filter: DiscoverWorkspacesOptions['filter']): Workspace[] {
   if (filter === undefined) return [...workspaces];
   return workspaces.filter(filter);

--- a/packages/readyup/src/help/topics.ts
+++ b/packages/readyup/src/help/topics.ts
@@ -1,4 +1,4 @@
-/** A conceptual topic `rdy help` offers, and the README section that answers it. */
+/** A conceptual topic `rdy help` offers, and the README section that covers it. */
 export interface HelpTopic {
   /** Level-2 README heading whose section the topic prints. */
   heading: string;

--- a/packages/readyup/src/init/templates.ts
+++ b/packages/readyup/src/init/templates.ts
@@ -20,7 +20,7 @@ export const rdyKitTemplate = `import { defineRdyKit } from 'readyup';
  * Checks run concurrently within a checklist.
  *
  * Three fields, three questions: \`name\` states what must be true, phrased so it reads
- * true on a pass; \`detail\` answers why this status; \`fix\` says what to do about it.
+ * true on a pass; \`detail\` explains why this status; \`fix\` says what to do about it.
  *
  * The rules that need judgment -- above all, when a check should skip rather than pass --
  * are in the consult-readyup-kits skill.

--- a/packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/collectKitPackageGroups.unit.test.ts
@@ -89,7 +89,7 @@ describe(collectKitPackageGroups, () => {
     ]);
   });
 
-  // Listing is read-only, so a dependency nobody can read costs its own group rather than the answer.
+  // Listing is read-only, so a dependency nobody can read costs its own group rather than the whole listing.
   it('warns and omits a configured package that cannot be resolved', ({ temp }) => {
     using io = captureStdio();
 

--- a/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.unit.test.ts
@@ -58,7 +58,7 @@ describe(expandConfiguredPackages, () => {
     ]);
   });
 
-  // The same precedence a local `--from` source follows, so a package and a directory answer alike.
+  // The same precedence a local `--from` source follows, so a package and a directory resolve alike.
   it('falls back to the kit directory when a package ships no manifest', ({ temp }) => {
     const [kit] = expandConfiguredPackages(['plain-kit'], '.js', temp.dir);
 

--- a/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts
+++ b/packages/readyup/src/installed-packages/__tests__/expandConfiguredPackages.workspaces.unit.test.ts
@@ -7,7 +7,7 @@ import { expandConfiguredPackages } from '../expandConfiguredPackages.ts';
 // eslint-disable-next-line vitest/consistent-test-it -- the rule reads this builder call as a top-level test.
 const it = baseIt.extend(
   'temp',
-  // A tree per test: workspace discovery holds its answer for the life of the process, keyed by directory.
+  // A tree per test: workspace discovery holds its result for the life of the process, keyed by directory.
   makeFixture(() => createTempTree({}, { prefix: 'expand-packages-workspaces-' })),
 );
 
@@ -50,7 +50,7 @@ describe(`${expandConfiguredPackages.name} workspace fallback`, () => {
     ]);
   });
 
-  // This suite runs in a repo whose own workspaces include `readyup`, so an answer read through the
+  // This suite runs in a repo whose own workspaces include `readyup`, so a result read through the
   // ambient cwd would resolve the name the directory under test does not hold.
   it('reads the workspaces of the directory it is handed, not those of the ambient cwd', ({ temp }) => {
     temp.writeJson('package.json', { name: 'root', private: true, workspaces: ['packages/*'] });

--- a/packages/readyup/src/installed-packages/collectKitPackageGroups.ts
+++ b/packages/readyup/src/installed-packages/collectKitPackageGroups.ts
@@ -26,11 +26,11 @@ interface KitPackageGroupOptions {
  * and falls back to the project's workspaces, so a configured package that is installed without being declared,
  * or published by a workspace, is one only the config half reports.
  *
- * Configured membership arrives as an argument rather than being read here, which leaves the answer a
+ * Configured membership arrives as an argument rather than being read here, which leaves the result a
  * function of a directory and a list: a caller sweeping a repository already holds each project's config.
  *
  * A package that cannot be expanded warns and is omitted, matching the warn-and-continue listing already
- * takes elsewhere. Listing is read-only, so a broken dependency costs its own group rather than the answer.
+ * takes elsewhere. Listing is read-only, so a broken dependency costs its own group rather than the whole listing.
  */
 export function collectKitPackageGroups({
   configuredPackages,

--- a/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
+++ b/packages/readyup/src/installed-packages/expandConfiguredPackages.ts
@@ -68,7 +68,7 @@ function expandOnePackage(packageName: string, extension: string, fromDir: strin
  * Names the kits a package publishes, preferring its manifest and falling back to its kit directory.
  *
  * The same precedence a local `--from` source already follows, so a package source and a directory source
- * answer alike. Only a missing manifest falls back: one that exists but cannot be parsed is a broken
+ * resolve alike. Only a missing manifest falls back: one that exists but cannot be parsed is a broken
  * publication, and quietly reading around it would report a kit list nobody declared. Descriptions live in
  * the manifest, so the fallback names kits without them.
  */

--- a/packages/readyup/src/installed-packages/isPackageInstalled.ts
+++ b/packages/readyup/src/installed-packages/isPackageInstalled.ts
@@ -3,7 +3,7 @@ import { resolvePackageRoot } from './resolvePackageRoot.ts';
 /**
  * Reports whether a package is installed in the current project.
  *
- * Resolution is anchored to the current directory rather than to this module, so the answer describes
+ * Resolution is anchored to the current directory rather than to this module, so the result describes
  * the project being worked on and not readyup's own installation. It also asks the filesystem rather
  * than the module resolver, which keeps ESM-only packages -- whose entry points no `require` condition
  * reaches -- from reading as absent.

--- a/packages/readyup/src/layout/engine.ts
+++ b/packages/readyup/src/layout/engine.ts
@@ -13,7 +13,7 @@ const engines: Record<Style, LayoutEngine> = {
  * The engine every command renders through, rich until an invocation selects otherwise.
  *
  * The default is a fixed style rather than a detected one. Detection belongs to the invocation, so
- * anything rendering without one -- a test formatting a report directly, say -- gets one answer rather
+ * anything rendering without one -- a test formatting a report directly, say -- gets one style rather
  * than one that changes with the terminal it happens to run under.
  */
 let active: LayoutEngine = engines.rich;

--- a/packages/readyup/src/layout/resolveStyle.ts
+++ b/packages/readyup/src/layout/resolveStyle.ts
@@ -77,7 +77,7 @@ export function describeInvalidStyle({ source, value }: InvalidStyle): string {
 /**
  * Reads the style an invocation asks for by scanning raw argv, before any flag parsing happens.
  *
- * Answering this without `parseArgs` is what lets a flag-parse failure be rendered in the style the caller
+ * Reading it without `parseArgs` is what lets a flag-parse failure be rendered in the style the caller
  * asked for. The scan accepts both `--style plain` and `--style=plain`, stops at the `--` terminator after
  * which arguments are positional, and keeps the last occurrence, matching what `parseArgs` would resolve.
  */

--- a/packages/readyup/src/list/formatList.ts
+++ b/packages/readyup/src/list/formatList.ts
@@ -278,7 +278,7 @@ function buildKitHint(kits: string[]): string {
  * Returns the command that runs a package's kits, which is also what marks the package as configured.
  *
  * `rdy run --packages` reaches only the packages the config names, and every other package is reachable
- * by the source naming it directly. So one hint answers both what to run and whether a `--packages` run
+ * by the source naming it directly. So one hint covers both what to run and whether a `--packages` run
  * would include it, and every kit listed stays reachable by the command above it.
  */
 function buildPackageHint(group: KitPackageGroup): string {

--- a/packages/readyup/src/list/listCommand.ts
+++ b/packages/readyup/src/list/listCommand.ts
@@ -169,7 +169,7 @@ async function runFromMode(fromArg: string, json: boolean): Promise<number> {
 /**
  * Locates the package a `list --from npm:` names, rejecting what `run` rejects for the same source.
  *
- * Listing and running answer about the same kits, so a spelling one accepts and the other refuses would
+ * Listing and running cover the same kits, so a spelling one accepts and the other refuses would
  * send the reader looking for a difference that does not exist.
  */
 function resolveListedPackageRoot(source: NpmSource): string {
@@ -282,7 +282,7 @@ async function runOwnerMode(json: boolean): Promise<number> {
 /**
  * Enumerates every kit-publishing dependency of the working directory, with the kits each publishes.
  *
- * The dependency axis alone: a project's own kits belong to the owner listing, and this view answers what
+ * The dependency axis alone: a project's own kits belong to the owner listing, and this view reports what
  * the project's dependencies offer rather than what it holds. Both the packages the config names and the
  * ones it omits are reported, since the question is what is available rather than what a run would select.
  */
@@ -463,7 +463,7 @@ function buildPackageEntry(kit: PackageKit, configured: boolean, project?: strin
  * Loads the project config, falling back to the defaults and reporting a config it cannot evaluate.
  *
  * Listing is read-only, so a config that cannot be evaluated costs the caller its settings rather than
- * the answer, taking the same warn-and-continue the corrupt-manifest paths take. `run` still fails hard on
+ * the whole listing, taking the same warn-and-continue the corrupt-manifest paths take. `run` still fails hard on
  * the same failure: it would otherwise execute against settings nobody chose.
  */
 async function loadListingConfig(): Promise<ResolvedRdyConfig> {
@@ -537,7 +537,7 @@ function buildInternalEntry(name: string, dir: string, extension: string): JsonL
  * checklist names, the readyup version a kit was built against -- lives in the manifest that is absent.
  *
  * A source with neither a manifest nor a kit directory is still an error. Reporting "no kits" for a
- * path that does not exist would turn a mistyped `--from` into a clean, empty answer.
+ * path that does not exist would turn a mistyped `--from` into a clean, empty listing.
  */
 function enumerateCompiledKits(kitsDir: string, manifestPath: string): JsonListKitEntry[] {
   if (!existsSync(kitsDir)) {

--- a/packages/readyup/src/portable/isSkippableFilesystemError.ts
+++ b/packages/readyup/src/portable/isSkippableFilesystemError.ts
@@ -1,6 +1,6 @@
 import { isError } from '@williamthorsen/toolbelt.errors';
 
-/** Filesystem errors that cost a read one directory rather than the whole answer. */
+/** Filesystem errors that cost a read one directory rather than the whole walk. */
 const SKIPPABLE_ERROR_CODES = new Set(['EACCES', 'ENOENT', 'EPERM']);
 
 /** Reports whether a filesystem failure is one a read may treat as an empty directory. */

--- a/packages/readyup/src/remote/__tests__/remote-provider.unit.test.ts
+++ b/packages/readyup/src/remote/__tests__/remote-provider.unit.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const mockResolveBitbucketToken = vi.hoisted(() => vi.fn());
 const mockResolveGitHubToken = vi.hoisted(() => vi.fn());
 
-// `resolveGitHubToken` shells out to `gh auth token`, so an unmocked run would answer differently
+// `resolveGitHubToken` shells out to `gh auth token`, so an unmocked run would behave differently
 // depending on whether the developer happens to be logged in.
 vi.mock(import('../resolveBitbucketToken.ts'), () => ({
   resolveBitbucketToken: mockResolveBitbucketToken,

--- a/packages/readyup/src/reporting/__tests__/reportRdy.unit.test.ts
+++ b/packages/readyup/src/reporting/__tests__/reportRdy.unit.test.ts
@@ -500,7 +500,7 @@ describe(reportRdy, () => {
     });
 
     // The recap names the check with the token the tree gave it, so a reader scanning fixes sees which
-    // answer errors and which answer recommendations.
+    // carry errors and which carry recommendations.
     it('leads a recapped check with its own severity token', () => {
       const output = reportRdy(
         makeReport({

--- a/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/packagesRun.wiring.unit.test.ts
@@ -73,7 +73,7 @@ describe('--packages run path wiring', () => {
     ]);
   });
 
-  // Selection reads names, so the manifest-less path needs no handling of its own -- but it has to answer alike.
+  // Selection reads names, so the manifest-less path needs no handling of its own -- but it has to resolve alike.
   it('selects by name when a package ships no manifest', () => {
     installPackage('plain-kit', ['default', 'preflight'], { hasManifest: false });
 

--- a/packages/readyup/src/run/__tests__/pragma-token.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/pragma-token.unit.test.ts
@@ -14,7 +14,7 @@ describe(createIgnorePragmaMatcher, () => {
 
   it('opens each scan at the start of the text however an earlier matcher was used', () => {
     // `matchAll` copies its regular expression's `lastIndex`, so a matcher one reader advanced would silently
-    // answer that a pragma before that offset is not there.
+    // report that a pragma before that offset is not there.
     const used = createIgnorePragmaMatcher();
     used.test('a rdy-ignore b');
 

--- a/packages/readyup/src/run/__tests__/resolveConfiguredPackages.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/resolveConfiguredPackages.unit.test.ts
@@ -49,7 +49,7 @@ describe(resolveConfiguredPackages, () => {
     ]);
   });
 
-  // Requiring nothing under a name is a package with nothing to answer for, not a failure of the run.
+  // Requiring nothing under a name is a package that asks nothing, not a failure of the run.
   it('skips a configured package that publishes no requested kit', ({ temp }) => {
     installPackage(temp, '@acme/kits', ['default', 'preflight']);
     installPackage(temp, '@beta/kits', ['default']);
@@ -66,7 +66,7 @@ describe(resolveConfiguredPackages, () => {
     expect(resolveConfiguredPackages(['@acme/kits'], ['default'], '.js')).toStrictEqual([]);
   });
 
-  // Answering with an empty pass would be the clean report of nothing checked.
+  // Returning an empty pass would be the clean report of nothing checked.
   it('rejects a named kit no configured package publishes', async ({ temp }) => {
     installPackage(temp, '@acme/kits', ['default', 'preflight']);
 

--- a/packages/readyup/src/run/listPragmaSites.ts
+++ b/packages/readyup/src/run/listPragmaSites.ts
@@ -30,7 +30,7 @@ export function isJsFamilyPath(path: string): boolean {
  * report naming a site has to be sure the comment is a pragma rather than prose quoting one, so a token following
  * anything else in its comment, or a second token on a line, is withheld rather than guessed at.
  *
- * `blankComments` is the comment oracle, no second tokenizer being needed to answer a question it already answers.
+ * `blankComments` is the comment oracle, no second tokenizer being needed to answer a question it already settles.
  * It preserves its input's length, so an offset found in the raw text reads the blanked text at the same place.
  *
  * Reads JavaScript-family syntax; a source in another language yields arbitrary output, as it does from the

--- a/packages/readyup/src/run/pragma-token.ts
+++ b/packages/readyup/src/run/pragma-token.ts
@@ -7,7 +7,7 @@
  *
  * A fresh matcher per scan, because a global regular expression has a `lastIndex` its readers all share: one
  * `test` or `exec` anywhere would leave it set, and every later `matchAll` would skip the text before that offset
- * and answer that a pragma suppressing a finding is not there.
+ * and report that a pragma suppressing a finding is not there.
  */
 export function createIgnorePragmaMatcher(): RegExp {
   return /(?<![\w-])rdy-ignore(-next-line)?(?![\w-])/g;

--- a/packages/readyup/src/run/resolveConfiguredPackages.ts
+++ b/packages/readyup/src/run/resolveConfiguredPackages.ts
@@ -37,7 +37,7 @@ export function resolveConfiguredPackages(
  *
  * A configured package not publishing a requested kit is skipped rather than reported: `--packages`
  * asks whether this project satisfies what its configured packages require of it, and a package
- * requiring nothing under that name has nothing to answer for.
+ * requiring nothing under that name asks nothing of it.
  *
  * Name-major so `--packages a b` runs every package's `a` before any package's `b`, matching the
  * order `rdy run a b` runs them in against a single source.

--- a/packages/readyup/src/schemas/listOutputSchema.ts
+++ b/packages/readyup/src/schemas/listOutputSchema.ts
@@ -46,7 +46,7 @@ export const ListKitEntrySchema = z
      * The project a kit was authored in, relative to the sweep root, present only for a repo-wide listing.
      *
      * Orthogonal to `origin` rather than an alternative to it: one names where a kit lives in this tree,
-     * the other which installed package published it, and a kit can answer both.
+     * the other which installed package published it, and a kit can carry both.
      */
     project: z.string().optional(),
     origin: ListKitOriginSchema.optional(),

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -558,7 +558,7 @@ describe(verifyCommand, () => {
       });
     });
 
-    it('speaks over an unverified target, where it supplies the answer the absent hash could not', async () => {
+    it('speaks over an unverified target, where it supplies the verdict the absent hash could not', async () => {
       mockReadManifest.mockReturnValue({
         version: 1,
         kits: [{ name: 'alpha', path: 'alpha.js', source: 'alpha.ts' }],
@@ -574,7 +574,7 @@ describe(verifyCommand, () => {
       expect(stdout).toContain('rebuild ok');
     });
 
-    it('keeps the skip token on an unverified target the rebuild did not answer for', async () => {
+    it('keeps the skip token on an unverified target the rebuild reached no verdict on', async () => {
       mockReadManifest.mockReturnValue({
         version: 1,
         kits: [{ name: 'alpha', path: 'alpha.js' }],

--- a/packages/readyup/src/verify/checkRebuild.ts
+++ b/packages/readyup/src/verify/checkRebuild.ts
@@ -54,7 +54,7 @@ export interface EsbuildComparison {
  * reports drift and a passing rebuild together, which is how the two verdicts distinguish a corrupt
  * bundle from corrupt bookkeeping.
  *
- * Every way the check can fail to reach an answer is reported rather than waved through: `missing`
+ * Every way the check can fail to reach a verdict is reported rather than waved through: `missing`
  * when an input is absent, `failed` when the source no longer compiles. `failed` is distinct from
  * `mismatch` because the remedy differs -- fix the kit, versus recompile it.
  */

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -122,7 +122,7 @@ export async function verifyCommand(args: string[]): Promise<number> {
  * Confirms esbuild is installed, raising a config error naming the install command when it is not.
  *
  * Refuses rather than degrading. `--rebuild` asks whether each bundle is reproducible, and a run
- * that answered "no esbuild, so nothing to report" would pass while establishing nothing -- the
+ * that concluded "no esbuild, so nothing to report" would pass while establishing nothing -- the
  * failure mode the flag exists to remove.
  */
 async function requireEsbuild(): Promise<void> {
@@ -155,7 +155,7 @@ function finishVerify(kits: JsonVerifyKitEntry[], passed: boolean, json: boolean
  * `unverified` passes on every recorded-hash axis: a manifest entry with no recorded hash predates
  * the feature or was written with `--skip-manifest`, which says nothing about whether the kit has
  * changed. The rebuild axis has no such case -- only `ok` passes there, and a kit the rebuild could
- * not reach an answer for fails rather than being waived.
+ * not reach a verdict on fails rather than being waived.
  */
 function isPassingVerdict({ drift, inputs, rebuild, source }: KitVerdicts): boolean {
   const targetPasses = drift.kind === 'ok' || drift.kind === 'unverified';
@@ -221,7 +221,7 @@ function formatStatusLine(kit: RdyManifestKit, verdicts: KitVerdicts): string {
  * Returns the token for the worst of a kit's verdicts.
  *
  * A mismatch or a missing file on any axis yields a failure. The skip token needs an unverified
- * target and no answer from the rebuild: a rebuild that reproduced the bundle has checked the kit
+ * target and no verdict from the rebuild: a rebuild that reproduced the bundle has checked the kit
  * more exactly than the absent hash would have, so the kit passed rather than went unchecked.
  */
 function resolveToken({ drift, inputs, rebuild, source }: KitVerdicts): TokenName {
@@ -290,9 +290,9 @@ function describeInputFailure(failure: InputFailure): string {
  * Returns a clause describing the rebuild verdict, or `undefined` when there is nothing to add.
  *
  * A passing rebuild is silent only where the hash verdicts already reached `ok` and it would
- * restate them. Anywhere else it speaks, because it then holds the line's strongest answer: over
+ * restate them. Anywhere else it speaks, because it then holds the line's strongest evidence: over
  * a failing verdict it says the bundle reproduces and the manifest's record of it is what went
- * wrong, and over an unverified one it supplies the answer the absent hash could not.
+ * wrong, and over an unverified one it supplies the verdict the absent hash could not.
  */
 function describeRebuildStatus(status: RebuildStatus | undefined, hashesConfirmed: boolean): string | undefined {
   if (status === undefined) return undefined;


### PR DESCRIPTION
## What

Revises comments, descriptions, test titles, and documentation in `readyup` for clarity.

## Why

Comments and docs across `readyup` said something "answers" where plain English already had the verb: a value is returned, a listing is produced, a check reaches a verdict. The construction spread by imitation rather than by choice, and each use cost a reader a moment deciding whether an unusual verb signalled unusual behavior. An earlier pass removed the subset where the word stood in for `returns` and kept the rest on the theory that a genuine metaphor earns its place.

## Details

### 🧪 Tests

- Three test titles now name what their assertion checks: `the rebuild did not answer for` reads `the rebuild reached no verdict on`. No assertion changed.

### 📚 Documentation

- Replacements follow each subsystem's existing vocabulary rather than one uniform substitute: `verify/` reaches a verdict, `list/` produces a listing, and the rest return a result, resolve alike, or cover a case.
- Twelve uses survive, each in a sentence naming its question, among them `exitCodes.ts`'s `The code answers "can I retry this invocation?"`.
- The shared sentence now reads `` `detail` explains why this status `` in `README.md`, `src/init/templates.ts`, and `.readyup/kits/internal/default.ts`, and the README line quoting it matches. `explains` avoids `states` and `says`, which the same sentence already assigns to `name` and `fix`.
- `packages/readyup/CHANGELOG.md` is generated from released commit bodies and is left alone, so the word survives there.

Closes #353
