### PR TITLE
#271 Name the remedy for each failing verdict in rdy verify

### DIFF
--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1224,10 +1224,13 @@ rdy verify --rebuild           Also recompile each kit and compare it to the com
 ── Verifying kits against .readyup/manifest.json
 🔴 deploy
    drift (expected 6f58905a, got eb104f57)
+   💊 Move the edits into the source, then run `rdy compile --force`.
 🟢 smoke
 
 1 of 2 kits failed verification.
 ```
+
+A failing kit closes with what to do about it, behind the token `rdy run` puts on a check's `fix`. The remedies follow every verdict rather than sitting beside the one that produced each, and a remedy several of a kit's verdicts share is named once.
 
 Each kit has three independent verdicts. The compiled output is `ok`, `drift`, `missing`, or `unverified`; the source is `ok`, `stale`, `missing`, or `unverified`; the [recorded inputs](#what-a-manifest-entry-records) are `ok`, `stale`, or `unverified`. `drift` means someone edited the bundle by hand; a stale source means the TypeScript moved on and nobody recompiled; stale inputs mean the same of a module the bundle inlined or a JSON projection it substituted. A kit can be all three at once.
 
@@ -1237,11 +1240,15 @@ The inputs verdict names every input that failed rather than the first, each on 
 🔴 deploy
    input stale: checks/shared.ts (module, expected 6f58905a, got eb104f57)
    input unprojectable: ../../package.json (Path not found in JSON: version)
+   💊 Run `rdy compile` to rebuild it.
+   💊 Restore the picked fields in ../../package.json, or repoint the kit's `pickJson` call.
 ```
+
+A changed input is recompiled away; an unprojectable one is not, because the file is present and it is the kit that names fields no longer there.
 
 Anything other than `ok` or `unverified` on any axis fails the run. `unverified` does not, since an entry with no recorded hash -- or one compiled before readyup recorded the input closure -- says nothing about whether the kit changed.
 
-Under `--json`, each kit reports `status`, `sourceStatus`, and `inputsStatus`. A `drift` verdict reports `expected` and `actual`; a stale source reports `sourceExpected` and `sourceActual`; stale inputs report `inputFailures`, one entry per input naming its `kind`, `path`, and `reason`, plus whichever of `expected`, `actual`, and `detail` that reason has.
+Under `--json`, each kit reports `status`, `sourceStatus`, and `inputsStatus`. A `drift` verdict reports `expected` and `actual`; a stale source reports `sourceExpected` and `sourceActual`; stale inputs report `inputFailures`, one entry per input naming its `kind`, `path`, and `reason`, plus whichever of `expected`, `actual`, and `detail` that reason has. The remedies are human output alone: a consumer reads the verdict and words its own.
 
 In CI:
 
@@ -1262,6 +1269,7 @@ The three verdicts cover what the compile read and recorded as hashes. A bundle 
 
 🔴 deploy
    rebuild mismatch (rebuilt 8c31f0a2, on disk 6f58905a; esbuild 0.28.1 -> 0.29.0; zod 3.24.1 -> 4.0.0)
+   💊 Run `rdy compile` to rebuild it.
 🟢 smoke
 ```
 
@@ -1273,7 +1281,10 @@ The comparison is against the bundle on disk, never the recorded hash, so the ve
 🔴 deploy
    drift (expected 6f58905a, got eb104f57)
    rebuild ok
+   💊 The bundle reproduces, so its recorded hash is what is stale. Run `rdy compile --force` to re-record it.
 ```
+
+The remedy changes with it. A drifted bundle is otherwise sent back through the source, since only a hand edit explains it; here there is nothing to move, and `--force` rewrites the record rather than the kit. Either way the command carries `--force`, because `rdy compile` gates on drift and skips the kit rather than overwriting it.
 
 The verdict is `ok`, `mismatch`, `failed` (the source no longer compiles), or `missing` (nothing to recompile, or nothing to compare against). Only `ok` passes. There is no `unverified` here: an exactness check that waived the kits it could not reach would establish less than it appears to.
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1230,7 +1230,7 @@ rdy verify --rebuild           Also recompile each kit and compare it to the com
 1 of 2 kits failed verification.
 ```
 
-A failing kit closes with what to do about it, behind the token `rdy run` puts on a check's `fix`. The remedies follow every verdict rather than sitting beside the one that produced each, and a remedy several of a kit's verdicts share is named once. A file more than one axis names is remedied once too, by the axis holding the more exact account of it, and a drifted bundle's `--force` remedy stands alone, since `rdy compile` refuses a drifted kit and the force recompile settles whatever a bare one would have.
+A failing kit closes with what to do about it, behind the token `rdy run` puts on a check's `fix`. The remedies follow every verdict rather than sitting beside the one that produced each, and a remedy several of a kit's verdicts share is named once. A file more than one axis names is remedied once too, by the axis holding the more exact account of it, and a remedy whose whole action is a bare `rdy compile` is dropped once the bundle has drifted, since the drift gate refuses that command and the `--force` remedy recompiles from the same source. Remedies the force recompile does not settle still print.
 
 Each kit has three independent verdicts. The compiled output is `ok`, `drift`, `missing`, or `unverified`; the source is `ok`, `stale`, `missing`, or `unverified`; the [recorded inputs](#what-a-manifest-entry-records) are `ok`, `stale`, or `unverified`. `drift` means someone edited the bundle by hand; a stale source means the TypeScript moved on and nobody recompiled; stale inputs mean the same of a module the bundle inlined or a JSON projection it substituted. A kit can be all three at once.
 

--- a/packages/readyup/README.md
+++ b/packages/readyup/README.md
@@ -1230,7 +1230,7 @@ rdy verify --rebuild           Also recompile each kit and compare it to the com
 1 of 2 kits failed verification.
 ```
 
-A failing kit closes with what to do about it, behind the token `rdy run` puts on a check's `fix`. The remedies follow every verdict rather than sitting beside the one that produced each, and a remedy several of a kit's verdicts share is named once.
+A failing kit closes with what to do about it, behind the token `rdy run` puts on a check's `fix`. The remedies follow every verdict rather than sitting beside the one that produced each, and a remedy several of a kit's verdicts share is named once. A file more than one axis names is remedied once too, by the axis holding the more exact account of it, and a drifted bundle's `--force` remedy stands alone, since `rdy compile` refuses a drifted kit and the force recompile settles whatever a bare one would have.
 
 Each kit has three independent verdicts. The compiled output is `ok`, `drift`, `missing`, or `unverified`; the source is `ok`, `stale`, `missing`, or `unverified`; the [recorded inputs](#what-a-manifest-entry-records) are `ok`, `stale`, or `unverified`. `drift` means someone edited the bundle by hand; a stale source means the TypeScript moved on and nobody recompiled; stale inputs mean the same of a module the bundle inlined or a JSON projection it substituted. A kit can be all three at once.
 

--- a/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
+++ b/packages/readyup/src/layout/__tests__/layoutEngine.unit.test.ts
@@ -506,6 +506,10 @@ describe('token and glyph', () => {
     expect(engine.token('passed')).toBe(`${PASSED} `);
   });
 
+  it('renders fix text behind the fix token', () => {
+    expect(engine.formatFix('Run `rdy compile`.')).toBe(`${engine.token('fix')}Run \`rdy compile\`.`);
+  });
+
   it('returns a glyph and one space for mid-line placement', () => {
     expect(engine.inlineGlyph('kit')).toBe(`${richFormatter.tokens.kit.glyph} `);
     expect(engine.inlineGlyph('skippedOptional')).toBe(`${SKIPPED} `);

--- a/packages/readyup/src/layout/layoutEngine.ts
+++ b/packages/readyup/src/layout/layoutEngine.ts
@@ -101,6 +101,7 @@ export interface LayoutEngine {
   formatCheckLine(input: CheckLineInput): string;
   formatCountLine(counts: SummaryCounts, durationMs: number): string;
   formatCounts(counts: SummaryCounts): string;
+  formatFix(fix: string): string;
   formatHeading(name: string, level: HeadingLevel, detail?: string): string;
   formatHint(hint: string): string;
   formatReasonBlock(reasons: string[], depth?: number): string[];
@@ -146,6 +147,11 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
    */
   function formatCountLine(counts: SummaryCounts, durationMs: number): string {
     return token(resolveWorstToken(counts.worstSeverity)) + buildCountBody(counts, durationMs);
+  }
+
+  /** Returns fix text behind the token marking it, as one line. */
+  function formatFix(fix: string): string {
+    return `${token('fix')}${fix}`;
   }
 
   /**
@@ -252,6 +258,7 @@ export function createLayoutEngine(formatter: Formatter): LayoutEngine {
     formatCheckLine,
     formatCountLine,
     formatCounts,
+    formatFix,
     formatHeading,
     formatHint,
     formatReasonBlock,

--- a/packages/readyup/src/reporting/remedies.ts
+++ b/packages/readyup/src/reporting/remedies.ts
@@ -1,9 +1,7 @@
 /**
  * Remedy text shared by the commands that report a kit's staleness.
  *
- * `rdy verify` enforces where `rdy run` advises, so the two reach the same verdicts and have to give
- * the same advice about them. Stating each string once is what keeps a reworded remedy from reaching
- * one command and not the other.
+ * `rdy verify` enforces, whereas `rdy run` advises; the two must reach the same verdicts and give the same advice.
  */
 
 /** The remedy for a bundle whose recorded hash no longer describes it, which only `--force` recompiles. */

--- a/packages/readyup/src/reporting/remedies.ts
+++ b/packages/readyup/src/reporting/remedies.ts
@@ -1,0 +1,13 @@
+/**
+ * Remedy text shared by the commands that report a kit's staleness.
+ *
+ * `rdy verify` enforces where `rdy run` advises, so the two reach the same verdicts and have to give
+ * the same advice about them. Stating each string once is what keeps a reworded remedy from reaching
+ * one command and not the other.
+ */
+
+/** The remedy for a bundle whose recorded hash no longer describes it, which only `--force` recompiles. */
+export const MOVE_EDITS_REMEDY = 'Move the edits into the source, then run `rdy compile --force`.';
+
+/** The remedy every axis reaches where a plain recompile settles what it found. */
+export const RECOMPILE_REMEDY = 'Run `rdy compile` to rebuild it.';

--- a/packages/readyup/src/reporting/reportRdy.ts
+++ b/packages/readyup/src/reporting/reportRdy.ts
@@ -172,7 +172,7 @@ function collectReasons(result: FailedResult, includeFix: boolean): string[] {
   const reasons: string[] = [];
   if (result.detail !== null) reasons.push(result.detail);
   if (result.error !== null) reasons.push(`Error: ${result.error.message}`);
-  if (includeFix && result.fix !== null) reasons.push(formatFixReason(result.fix));
+  if (includeFix && result.fix !== null) reasons.push(getLayout().formatFix(result.fix));
   return reasons;
 }
 
@@ -185,11 +185,6 @@ function collectFixes(results: RdyResult[]): AttributedFix[] {
   );
 }
 
-/** Returns a fix as one reason line, behind the token marking fix text wherever a kit places it. */
-function formatFixReason(fix: string): string {
-  return `${getLayout().token('fix')}${fix}`;
-}
-
 /**
  * Returns each fix as its failed check re-rendered, the fix standing where the reason would.
  *
@@ -199,7 +194,7 @@ function formatFixReason(fix: string): string {
 function renderFixRecap(fixes: AttributedFix[]): string[] {
   return fixes.flatMap((entry) => [
     getLayout().formatCheckLine({ token: resolveWorstToken(entry.severity), name: entry.name }),
-    ...getLayout().formatReasonBlock([formatFixReason(entry.fix)]),
+    ...getLayout().formatReasonBlock([getLayout().formatFix(entry.fix)]),
   ]);
 }
 

--- a/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/kit-staleness.unit.test.ts
@@ -127,7 +127,7 @@ describe(warnOnKitStaleness, () => {
         {
           code: 'target-drift',
           message: 'compiled kit "default" does not match the hash the manifest recorded for it.',
-          remedy: 'Run `rdy compile --force` to rebuild it from source.',
+          remedy: 'Move the edits into the source, then run `rdy compile --force`.',
         },
       ]);
     });
@@ -199,7 +199,7 @@ describe(warnOnKitStaleness, () => {
 
       expect(stderr).toBe(
         'Warning: compiled kit "default" does not match the hash the manifest recorded for it. ' +
-          'Run `rdy compile --force` to rebuild it from source.\n',
+          'Move the edits into the source, then run `rdy compile --force`.\n',
       );
     });
 

--- a/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runHumanMode.unit.test.ts
@@ -520,7 +520,7 @@ describe(runHumanMode, () => {
     const TARGET_DRIFT = {
       code: 'target-drift',
       message: 'compiled kit "alpha" does not match the hash the manifest recorded for it.',
-      remedy: 'Run `rdy compile --force` to rebuild it from source.',
+      remedy: 'Move the edits into the source, then run `rdy compile --force`.',
     };
 
     /** Builds two entries whose names and compiled paths differ, so a kit paired with the wrong source shows. */

--- a/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
+++ b/packages/readyup/src/run/__tests__/runJsonMode.unit.test.ts
@@ -266,7 +266,7 @@ describe(runJsonMode, () => {
     const TARGET_DRIFT = {
       code: 'target-drift',
       message: 'compiled kit "alpha" does not match the hash the manifest recorded for it.',
-      remedy: 'Run `rdy compile --force` to rebuild it from source.',
+      remedy: 'Move the edits into the source, then run `rdy compile --force`.',
     };
 
     /** Builds two entries whose names and compiled paths differ, so a kit paired with the wrong source shows. */

--- a/packages/readyup/src/run/kit-staleness.ts
+++ b/packages/readyup/src/run/kit-staleness.ts
@@ -83,7 +83,7 @@ export function warnOnKitStaleness(
     warnings.push({
       code: 'target-drift',
       message: `compiled kit "${kitName}" does not match the hash the manifest recorded for it.`,
-      remedy: 'Run `rdy compile --force` to rebuild it from source.',
+      remedy: 'Move the edits into the source, then run `rdy compile --force`.',
     });
   }
   if (readVerdict(() => checkSourceDrift(entry, tracking.manifestDir))?.kind === 'stale') {

--- a/packages/readyup/src/run/kit-staleness.ts
+++ b/packages/readyup/src/run/kit-staleness.ts
@@ -7,6 +7,7 @@ import { DEFAULT_MANIFEST_PATH } from '../manifest/manifestPath.ts';
 import type { RdyManifest } from '../manifest/manifestSchema.ts';
 import { ManifestNotFoundError, readManifest } from '../manifest/readManifest.ts';
 import { toDisplayPath } from '../portable/toDisplayPath.ts';
+import { MOVE_EDITS_REMEDY, RECOMPILE_REMEDY } from '../reporting/remedies.ts';
 import type { RaisedWarning } from '../schemas/common.ts';
 import { checkDrift } from '../verify/checkDrift.ts';
 import type { InputsStatus } from '../verify/checkInputDrift.ts';
@@ -83,21 +84,21 @@ export function warnOnKitStaleness(
     warnings.push({
       code: 'target-drift',
       message: `compiled kit "${kitName}" does not match the hash the manifest recorded for it.`,
-      remedy: 'Move the edits into the source, then run `rdy compile --force`.',
+      remedy: MOVE_EDITS_REMEDY,
     });
   }
   if (readVerdict(() => checkSourceDrift(entry, tracking.manifestDir))?.kind === 'stale') {
     warnings.push({
       code: 'source-stale',
       message: `kit "${kitName}" was compiled from an older source than the one on disk.`,
-      remedy: 'Run `rdy compile` to rebuild it.',
+      remedy: RECOMPILE_REMEDY,
     });
   }
   if (hasChangedInput(readVerdict(() => checkInputDrift(entry, tracking.manifestDir)))) {
     warnings.push({
       code: 'input-stale',
       message: `kit "${kitName}" inlined files that no longer match the ones on disk.`,
-      remedy: 'Run `rdy compile` to rebuild it.',
+      remedy: RECOMPILE_REMEDY,
     });
   }
 

--- a/packages/readyup/src/verify/__tests__/remedies.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/remedies.unit.test.ts
@@ -37,7 +37,7 @@ describe(resolveRemedies, () => {
       expect(resolveRemedies(KIT, verdicts)).toStrictEqual([RE_RECORD]);
     });
 
-    it('names only the source remedy where the rebuild also fails, whose recompile the drift gate refuses', () => {
+    it('names only the move-edits remedy where the rebuild also fails, whose recompile the drift gate refuses', () => {
       const rebuild = { kind: 'mismatch', expected: 'aaa', actual: 'bbb' } as const;
 
       expect(resolveRemedies(KIT, buildVerdicts({ drift: buildDrift(), rebuild }))).toStrictEqual([MOVE_EDITS]);
@@ -152,11 +152,67 @@ describe(resolveRemedies, () => {
     const verdicts = buildVerdicts({
       drift: buildDrift(),
       inputs: buildStaleInputs([
-        { kind: 'module', path: 'checks/shared.ts', reason: 'changed', expected: 'aaa', actual: 'bbb' },
+        { kind: 'inline', path: '../../package.json', reason: 'unprojectable', detail: 'Path not found: version' },
       ]),
     });
 
-    expect(resolveRemedies(KIT, verdicts)).toStrictEqual([MOVE_EDITS, RECOMPILE]);
+    expect(resolveRemedies(KIT, verdicts)).toStrictEqual([
+      MOVE_EDITS,
+      "Restore the picked fields in ../../package.json, or repoint the kit's `pickJson` call.",
+    ]);
+  });
+
+  describe('collapsing remedies a reader cannot act on', () => {
+    it("names one remedy for a source recorded among the kit's own inputs, where both axes report it gone", () => {
+      const verdicts = buildVerdicts({
+        inputs: buildStaleInputs([{ kind: 'module', path: 'kits/deploy.ts', reason: 'missing' }]),
+        source: buildMissingSource(),
+      });
+
+      expect(resolveRemedies(KIT, verdicts)).toStrictEqual([
+        'Restore kits/deploy.ts, or run `rdy compile` to drop the kit from the manifest.',
+      ]);
+    });
+
+    it('drops a bare recompile where the target has drifted, which the drift gate refuses to run', () => {
+      const verdicts = buildVerdicts({
+        drift: buildDrift(),
+        inputs: buildStaleInputs([
+          { kind: 'module', path: 'checks/shared.ts', reason: 'changed', expected: 'aaa', actual: 'bbb' },
+        ]),
+        source: { kind: 'stale', expected: 'eee', actual: 'fff', resolvedPath: '/repo/kits/deploy.ts' },
+      });
+
+      expect(resolveRemedies(KIT, verdicts)).toStrictEqual([MOVE_EDITS]);
+    });
+
+    it('drops a bare recompile beside the re-record remedy, which recompiles from the same source', () => {
+      const verdicts = buildVerdicts({
+        drift: buildDrift(),
+        rebuild: { kind: 'ok' },
+        source: { kind: 'stale', expected: 'eee', actual: 'fff', resolvedPath: '/repo/kits/deploy.ts' },
+      });
+
+      expect(resolveRemedies(KIT, verdicts)).toStrictEqual([RE_RECORD]);
+    });
+
+    it('keeps the bare recompile for a bundle that is merely gone, which hits no drift gate', () => {
+      const verdicts = buildVerdicts({
+        drift: { kind: 'missing', resolvedPath: '/repo/kits/deploy.js' },
+        source: { kind: 'stale', expected: 'eee', actual: 'fff', resolvedPath: '/repo/kits/deploy.ts' },
+      });
+
+      expect(resolveRemedies(KIT, verdicts)).toStrictEqual([RECOMPILE]);
+    });
+
+    it('keeps a remedy the force recompile does not settle, such as a repointed pickJson call', () => {
+      const verdicts = buildVerdicts({
+        drift: buildDrift(),
+        rebuild: { kind: 'failed', message: 'Unexpected token' },
+      });
+
+      expect(resolveRemedies(KIT, verdicts)).toStrictEqual([MOVE_EDITS, 'Fix the kit source so it compiles.']);
+    });
   });
 });
 

--- a/packages/readyup/src/verify/__tests__/remedies.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/remedies.unit.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RdyManifestKit } from '../../manifest/manifestSchema.ts';
+import { resolveRemedies } from '../remedies.ts';
+import type { KitVerdicts } from '../verdicts.ts';
+
+const KIT: RdyManifestKit = { name: 'deploy', path: 'kits/deploy.js', source: 'kits/deploy.ts' };
+
+const RECOMPILE = 'Run `rdy compile` to rebuild it.';
+const MOVE_EDITS = 'Move the edits into the source, then run `rdy compile --force`.';
+const RE_RECORD =
+  'The bundle reproduces, so its recorded hash is what is stale. Run `rdy compile --force` to re-record it.';
+
+describe(resolveRemedies, () => {
+  it('names no remedy for a kit whose every verdict is ok', () => {
+    const verdicts = buildVerdicts({
+      drift: { kind: 'ok', targetHash: 'abc' },
+      inputs: { kind: 'ok' },
+      source: { kind: 'ok', sourceHash: 'def' },
+    });
+
+    expect(resolveRemedies(KIT, verdicts)).toStrictEqual([]);
+  });
+
+  it('names no remedy for a kit whose only non-ok verdicts are unverified', () => {
+    expect(resolveRemedies(KIT, buildVerdicts())).toStrictEqual([]);
+  });
+
+  describe('compiled-output verdict', () => {
+    it('sends a drifted bundle back through the source, because compile skips a drifted kit', () => {
+      expect(resolveRemedies(KIT, buildVerdicts({ drift: buildDrift() }))).toStrictEqual([MOVE_EDITS]);
+    });
+
+    it('names re-recording instead where the rebuild reproduces the drifted bundle', () => {
+      const verdicts = buildVerdicts({ drift: buildDrift(), rebuild: { kind: 'ok' } });
+
+      expect(resolveRemedies(KIT, verdicts)).toStrictEqual([RE_RECORD]);
+    });
+
+    it('names only the source remedy where the rebuild also fails, whose recompile the drift gate refuses', () => {
+      const rebuild = { kind: 'mismatch', expected: 'aaa', actual: 'bbb' } as const;
+
+      expect(resolveRemedies(KIT, buildVerdicts({ drift: buildDrift(), rebuild }))).toStrictEqual([MOVE_EDITS]);
+    });
+
+    it('recompiles a bundle that is gone, which no drift gate stands in the way of', () => {
+      const drift = { kind: 'missing', resolvedPath: '/repo/kits/deploy.js' } as const;
+
+      expect(resolveRemedies(KIT, buildVerdicts({ drift }))).toStrictEqual([RECOMPILE]);
+    });
+  });
+
+  describe('source verdict', () => {
+    it('recompiles a source that has moved on', () => {
+      const source = { kind: 'stale', expected: 'aaa', actual: 'bbb', resolvedPath: '/repo/kits/deploy.ts' } as const;
+
+      expect(resolveRemedies(KIT, buildVerdicts({ source }))).toStrictEqual([RECOMPILE]);
+    });
+
+    it('names the vanished source, offering a recompile as the way to drop the kit', () => {
+      expect(resolveRemedies(KIT, buildVerdicts({ source: buildMissingSource() }))).toStrictEqual([
+        'Restore kits/deploy.ts, or run `rdy compile` to drop the kit from the manifest.',
+      ]);
+    });
+
+    it('falls back to a recompile where the entry records no source to name', () => {
+      const kit: RdyManifestKit = { name: 'deploy', path: 'kits/deploy.js' };
+
+      expect(resolveRemedies(kit, buildVerdicts({ source: buildMissingSource() }))).toStrictEqual([RECOMPILE]);
+    });
+  });
+
+  describe('inputs verdict', () => {
+    it('recompiles a kit whose recorded input has changed', () => {
+      const inputs = buildStaleInputs([
+        { kind: 'module', path: 'checks/shared.ts', reason: 'changed', expected: 'aaa', actual: 'bbb' },
+      ]);
+
+      expect(resolveRemedies(KIT, buildVerdicts({ inputs }))).toStrictEqual([RECOMPILE]);
+    });
+
+    it('names an input that is gone, offering a recompile where the kit no longer reads it', () => {
+      const inputs = buildStaleInputs([{ kind: 'module', path: 'checks/shared.ts', reason: 'missing' }]);
+
+      expect(resolveRemedies(KIT, buildVerdicts({ inputs }))).toStrictEqual([
+        'Restore checks/shared.ts, or run `rdy compile` if the kit no longer reads it.',
+      ]);
+    });
+
+    it('sends an unprojectable input to the picked fields rather than to a recompile', () => {
+      const inputs = buildStaleInputs([
+        { kind: 'inline', path: '../../package.json', reason: 'unprojectable', detail: 'Path not found: version' },
+      ]);
+
+      expect(resolveRemedies(KIT, buildVerdicts({ inputs }))).toStrictEqual([
+        "Restore the picked fields in ../../package.json, or repoint the kit's `pickJson` call.",
+      ]);
+    });
+
+    it('names one remedy for several inputs that failed the same way', () => {
+      const inputs = buildStaleInputs([
+        { kind: 'module', path: 'checks/one.ts', reason: 'changed', expected: 'aaa', actual: 'bbb' },
+        { kind: 'module', path: 'checks/two.ts', reason: 'changed', expected: 'ccc', actual: 'ddd' },
+      ]);
+
+      expect(resolveRemedies(KIT, buildVerdicts({ inputs }))).toStrictEqual([RECOMPILE]);
+    });
+  });
+
+  describe('rebuild verdict', () => {
+    it('recompiles a bundle the rebuild does not reproduce', () => {
+      const rebuild = { kind: 'mismatch', expected: 'aaa', actual: 'bbb' } as const;
+
+      expect(resolveRemedies(KIT, buildVerdicts({ rebuild }))).toStrictEqual([RECOMPILE]);
+    });
+
+    it('sends a source that no longer compiles back to the kit rather than to a recompile', () => {
+      const rebuild = { kind: 'failed', message: 'Unexpected token' } as const;
+
+      expect(resolveRemedies(KIT, buildVerdicts({ rebuild }))).toStrictEqual(['Fix the kit source so it compiles.']);
+    });
+
+    it('recompiles to fill in a manifest entry the rebuild found nothing recorded in', () => {
+      const rebuild = { kind: 'missing', reason: 'no source recorded in manifest' } as const;
+
+      expect(resolveRemedies(KIT, buildVerdicts({ rebuild }))).toStrictEqual([RECOMPILE]);
+    });
+
+    it('stays silent where the hash axis owning the absent file has already named it', () => {
+      const rebuild = { kind: 'missing', reason: 'source file kits/deploy.ts is gone' } as const;
+      const verdicts = buildVerdicts({ rebuild, source: buildMissingSource() });
+
+      expect(resolveRemedies(KIT, verdicts)).toStrictEqual([
+        'Restore kits/deploy.ts, or run `rdy compile` to drop the kit from the manifest.',
+      ]);
+    });
+  });
+
+  it('names a shared remedy once for a kit that reaches it on three axes', () => {
+    const verdicts = buildVerdicts({
+      inputs: buildStaleInputs([
+        { kind: 'module', path: 'checks/shared.ts', reason: 'changed', expected: 'aaa', actual: 'bbb' },
+      ]),
+      rebuild: { kind: 'mismatch', expected: 'ccc', actual: 'ddd' },
+      source: { kind: 'stale', expected: 'eee', actual: 'fff', resolvedPath: '/repo/kits/deploy.ts' },
+    });
+
+    expect(resolveRemedies(KIT, verdicts)).toStrictEqual([RECOMPILE]);
+  });
+
+  it('orders remedies by axis, the compiled output before the inputs', () => {
+    const verdicts = buildVerdicts({
+      drift: buildDrift(),
+      inputs: buildStaleInputs([
+        { kind: 'module', path: 'checks/shared.ts', reason: 'changed', expected: 'aaa', actual: 'bbb' },
+      ]),
+    });
+
+    expect(resolveRemedies(KIT, verdicts)).toStrictEqual([MOVE_EDITS, RECOMPILE]);
+  });
+});
+
+// region | Helpers
+
+/** Returns a drifted compiled-output verdict. */
+function buildDrift(): KitVerdicts['drift'] {
+  return { kind: 'drift', expected: 'aaa', actual: 'bbb', resolvedPath: '/repo/kits/deploy.js' };
+}
+
+/** Returns a source verdict reporting the recorded file as gone. */
+function buildMissingSource(): KitVerdicts['source'] {
+  return { kind: 'missing', resolvedPath: '/repo/kits/deploy.ts' };
+}
+
+/** Returns an inputs verdict carrying the given failures. */
+function buildStaleInputs(
+  failures: Extract<KitVerdicts['inputs'], { kind: 'stale' }>['failures'],
+): KitVerdicts['inputs'] {
+  return { kind: 'stale', failures };
+}
+
+/** Returns a verdict set that fails nothing, with `overrides` replacing whichever axes a test drives. */
+function buildVerdicts(overrides: Partial<KitVerdicts> = {}): KitVerdicts {
+  return {
+    drift: { kind: 'unverified' },
+    inputs: { kind: 'unverified' },
+    rebuild: undefined,
+    source: { kind: 'unverified' },
+    ...overrides,
+  };
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/verify/__tests__/remedies.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/remedies.unit.test.ts
@@ -205,13 +205,25 @@ describe(resolveRemedies, () => {
       expect(resolveRemedies(KIT, verdicts)).toStrictEqual([RECOMPILE]);
     });
 
-    it('keeps a remedy the force recompile does not settle, such as a repointed pickJson call', () => {
+    it('keeps a remedy the force recompile does not settle, such as a source that no longer compiles', () => {
       const verdicts = buildVerdicts({
         drift: buildDrift(),
         rebuild: { kind: 'failed', message: 'Unexpected token' },
       });
 
       expect(resolveRemedies(KIT, verdicts)).toStrictEqual([MOVE_EDITS, 'Fix the kit source so it compiles.']);
+    });
+
+    it('keeps a remedy that only offers a recompile as its second branch, whose first branch drift does not block', () => {
+      const verdicts = buildVerdicts({
+        drift: buildDrift(),
+        inputs: buildStaleInputs([{ kind: 'module', path: 'checks/shared.ts', reason: 'missing' }]),
+      });
+
+      expect(resolveRemedies(KIT, verdicts)).toStrictEqual([
+        MOVE_EDITS,
+        'Restore checks/shared.ts, or run `rdy compile` if the kit no longer reads it.',
+      ]);
     });
   });
 });

--- a/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.rebuild.tool.test.ts
@@ -186,34 +186,40 @@ describe('verifyCommand --rebuild', () => {
   it('fails a hand-edited bundle', async () => {
     writeFileSync(path.join(tempDir, 'kit.js'), 'export default { checklists: [] };\n');
 
-    const { exitCode, stdout } = await runVerify();
+    const { exitCode, stderr, stdout } = await runVerify();
 
     expect(exitCode).toBe(1);
     expect(readPayload(stdout)).toMatchObject({
       kits: [{ status: 'drift', rebuildStatus: 'mismatch' }],
     });
+    expect(stderr).toContain('Move the edits into the source, then run `rdy compile --force`.');
   });
 
   it('reports a passing rebuild beside a recorded hash that has gone wrong', async () => {
     patchKits(path.join(tempDir, 'manifest.json'), { targetHash: 'deadbeef' });
 
-    const { exitCode, stdout } = await runVerify();
+    const { exitCode, stderr, stdout } = await runVerify();
 
     expect(exitCode).toBe(1);
     expect(readPayload(stdout)).toMatchObject({
       kits: [{ status: 'drift', rebuildStatus: 'ok' }],
     });
+    expect(stderr).toContain(
+      'The bundle reproduces, so its recorded hash is what is stale. Run `rdy compile --force` to re-record it.',
+    );
+    expect(stderr).not.toContain('Move the edits into the source');
   });
 
   it('fails a kit whose source no longer compiles', async () => {
     writeFileSync(path.join(tempDir, 'kit.ts'), 'export default { checklists: [ ;\n');
 
-    const { exitCode, stdout } = await runVerify();
+    const { exitCode, stderr, stdout } = await runVerify();
 
     expect(exitCode).toBe(1);
     expect(readPayload(stdout)).toMatchObject({
       kits: [{ rebuildStatus: 'failed' }],
     });
+    expect(stderr).toContain('Fix the kit source so it compiles.');
   });
 
   it('leaves every rebuild field out of the payload without the flag', async () => {
@@ -267,6 +273,9 @@ function restampBundle(tempDir: string, version: string): void {
 /**
  * Runs `verify` over the tempdir's manifest with JSON output on and the rebuild check on unless waived,
  * returning its exit code alongside what it wrote.
+ *
+ * `--json` sends the payload to stdout and every human-readable line to stderr, so a test reading the
+ * remedies reads stderr.
  */
 async function runVerify({ rebuild = true, manifestPath = 'manifest.json' } = {}) {
   using io = captureStdio();
@@ -274,7 +283,7 @@ async function runVerify({ rebuild = true, manifestPath = 'manifest.json' } = {}
   const rebuildFlag = rebuild ? ['--rebuild'] : [];
   const exitCode = await verifyCommand(['--manifest', manifestPath, ...rebuildFlag, '--json']);
 
-  return { exitCode, stdout: io.stdout };
+  return { exitCode, stderr: io.stderr, stdout: io.stdout };
 }
 
 // endregion | Helpers

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -44,6 +44,7 @@ import { verifyCommand } from '../verifyCommand.ts';
 const OK = richFormatter.tokens.passed.glyph;
 const FAILED = richFormatter.tokens.failedError.glyph;
 const UNVERIFIED = richFormatter.tokens.skippedOptional.glyph;
+const FIX = richFormatter.tokens.fix.glyph;
 
 describe(verifyCommand, () => {
   beforeEach(() => {
@@ -341,6 +342,126 @@ describe(verifyCommand, () => {
       const { stdout } = await verify(['--rebuild']);
 
       expect(stdout).toContain('rebuild ok');
+    });
+  });
+
+  describe('remedies', () => {
+    /** Arranges a manifest naming one kit, leaving each test to drive whichever axes it is about. */
+    function arrangeSingleKit(): void {
+      mockReadManifest.mockReturnValue({
+        version: 1,
+        kits: [{ name: 'alpha', path: 'alpha.js', source: 'alpha.ts', targetHash: 'aaaa1111' }],
+      });
+    }
+
+    it("closes a failing kit's block with what to do about its verdict", async () => {
+      arrangeSingleKit();
+      mockCheckDrift.mockReturnValue({
+        kind: 'drift',
+        expected: 'aaaa1111',
+        actual: 'aaaa9999',
+        resolvedPath: '/abs/alpha.js',
+      });
+
+      const { exitCode, stdout } = await verify([]);
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain(
+        `${FAILED} alpha\n   drift (expected aaaa1111, got aaaa9999)` +
+          `\n   ${FIX} Move the edits into the source, then run \`rdy compile --force\`.`,
+      );
+    });
+
+    it('states every verdict before the first remedy, so the diagnosis reads whole', async () => {
+      arrangeSingleKit();
+      mockCheckDrift.mockReturnValue({
+        kind: 'drift',
+        expected: 'aaaa1111',
+        actual: 'aaaa9999',
+        resolvedPath: '/abs/alpha.js',
+      });
+      mockCheckSourceDrift.mockReturnValue({
+        kind: 'stale',
+        expected: '5555aaaa',
+        actual: '6666bbbb',
+        resolvedPath: '/abs/alpha.ts',
+      });
+
+      const { stdout } = await verify([]);
+
+      expect(stdout).toContain(
+        `${FAILED} alpha\n   drift (expected aaaa1111, got aaaa9999)` +
+          `\n   source stale (expected 5555aaaa, got 6666bbbb)` +
+          `\n   ${FIX} Move the edits into the source, then run \`rdy compile --force\`.` +
+          `\n   ${FIX} Run \`rdy compile\` to rebuild it.`,
+      );
+    });
+
+    it('names a remedy once for a kit that reaches it on two axes', async () => {
+      arrangeSingleKit();
+      mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
+      mockCheckSourceDrift.mockReturnValue({
+        kind: 'stale',
+        expected: '5555aaaa',
+        actual: '6666bbbb',
+        resolvedPath: '/abs/alpha.ts',
+      });
+      mockCheckInputDrift.mockReturnValue({
+        kind: 'stale',
+        failures: [{ kind: 'module', path: 'shared.ts', reason: 'changed', expected: '7777', actual: '8888' }],
+      });
+
+      const { stdout } = await verify([]);
+
+      expect(stdout.match(/Run `rdy compile` to rebuild it\./g)).toHaveLength(1);
+    });
+
+    it('leaves a passing kit its bare line, having nothing for it to fix', async () => {
+      arrangeSingleKit();
+      mockCheckDrift.mockReturnValue({ kind: 'ok', targetHash: 'aaaa1111' });
+
+      const { exitCode, stdout } = await verify([]);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain(`${OK} alpha\n`);
+      expect(stdout).not.toContain(FIX);
+    });
+
+    it('leaves an unverified kit its bare line, having reached no failing verdict', async () => {
+      arrangeSingleKit();
+      mockCheckDrift.mockReturnValue({ kind: 'unverified' });
+
+      const { exitCode, stdout } = await verify([]);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).not.toContain(FIX);
+    });
+
+    it('keeps every remedy out of the JSON payload', async () => {
+      arrangeSingleKit();
+      mockCheckDrift.mockReturnValue({
+        kind: 'drift',
+        expected: 'aaaa1111',
+        actual: 'aaaa9999',
+        resolvedPath: '/abs/alpha.js',
+      });
+
+      const { stdout } = await verify(['--json']);
+
+      expect(JSON.parse(stdout)).toStrictEqual({
+        schemaVersion: 1,
+        passed: false,
+        kits: [
+          {
+            name: 'alpha',
+            status: 'drift',
+            expected: 'aaaa1111',
+            actual: 'aaaa9999',
+            sourceStatus: 'unverified',
+            inputsStatus: 'unverified',
+          },
+        ],
+      });
     });
   });
 

--- a/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
+++ b/packages/readyup/src/verify/__tests__/verifyCommand.unit.test.ts
@@ -380,20 +380,18 @@ describe(verifyCommand, () => {
         actual: 'aaaa9999',
         resolvedPath: '/abs/alpha.js',
       });
-      mockCheckSourceDrift.mockReturnValue({
+      mockCheckInputDrift.mockReturnValue({
         kind: 'stale',
-        expected: '5555aaaa',
-        actual: '6666bbbb',
-        resolvedPath: '/abs/alpha.ts',
+        failures: [{ kind: 'inline', path: 'pkg.json', reason: 'unprojectable', detail: 'Path not found: version' }],
       });
 
       const { stdout } = await verify([]);
 
       expect(stdout).toContain(
         `${FAILED} alpha\n   drift (expected aaaa1111, got aaaa9999)` +
-          `\n   source stale (expected 5555aaaa, got 6666bbbb)` +
+          `\n   input unprojectable: pkg.json (Path not found: version)` +
           `\n   ${FIX} Move the edits into the source, then run \`rdy compile --force\`.` +
-          `\n   ${FIX} Run \`rdy compile\` to rebuild it.`,
+          `\n   ${FIX} Restore the picked fields in pkg.json, or repoint the kit's \`pickJson\` call.`,
       );
     });
 

--- a/packages/readyup/src/verify/remedies.ts
+++ b/packages/readyup/src/verify/remedies.ts
@@ -48,11 +48,6 @@ export function resolveRemedies(kit: RdyManifestKit, verdicts: KitVerdicts): str
  * refuses a drifted kit and exits non-zero. The `--force` remedy the drift verdict raised is then the only command
  * that runs, and it recompiles from the same source, so it settles whatever the dropped remedy was raised for.
  * Drift alone gates this: A bundle that is merely gone recompiles normally, and its own remedy is the bare recompile.
- *
- * A remedy that only offers a recompile as its second branch survives, and is not reworded to name `--force` instead.
- * It leads with an action the drift does not block, its recompile branch becomes available once the drift remedy above
- * it is carried out, and `--force` is the wrong command to put in a reader's hands before then: It overwrites the
- * bundle whose edits the drift remedy is telling them to move into the source first.
  */
 function collapseRemedies(raised: Remedy[], targetDrifted: boolean): string[] {
   const spokenFor = new Set<string>();
@@ -92,7 +87,7 @@ function resolveDriftRemedy(status: DriftStatus, rebuild: RebuildStatus | undefi
   }
 }
 
-/** Returns the remedy for one input the compile read that no longer matches what it read. */
+/** Returns the remedy for one recorded input that no longer matches what the compile read. */
 function resolveInputFailureRemedy(failure: InputFailure): Remedy {
   switch (failure.reason) {
     case 'changed':
@@ -110,11 +105,7 @@ function resolveInputFailureRemedy(failure: InputFailure): Remedy {
   }
 }
 
-/**
- * Returns one remedy per failing input, and none where the verdict is `ok` or `unverified`.
- *
- * Ten inputs failing for one reason collapse to one remedy, since the caller deduplicates.
- */
+/** Returns one remedy per failing input, and none where the verdict is `ok` or `unverified`. */
 function resolveInputRemedies(status: InputsStatus): Remedy[] {
   return status.kind === 'stale' ? status.failures.map(resolveInputFailureRemedy) : [];
 }
@@ -123,9 +114,7 @@ function resolveInputRemedies(status: InputsStatus): Remedy[] {
  * Returns the remedy for the rebuild verdict, or `undefined` where there is nothing to add.
  *
  * Defers to a source the hash axis reports as gone. The verdict names the file only inside a free-text reason,
- * so the caller's path rule cannot see the collision and the deferral is made here. A drifted or missing target needs
- * no such guard: this verdict's recompile is bare, so the caller drops it under drift and deduplicates it against
- * the target's own identical text.
+ * so the caller's path rule cannot see the collision and the deferral is made here.
  *
  * `failed` always speaks. It is about the source rather than the bundle, and a kit that no longer compiles has to
  * be fixed before any remedy naming a recompile can be carried out.

--- a/packages/readyup/src/verify/remedies.ts
+++ b/packages/readyup/src/verify/remedies.ts
@@ -1,4 +1,5 @@
 import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
+import { MOVE_EDITS_REMEDY, RECOMPILE_REMEDY } from '../reporting/remedies.ts';
 import type { DriftStatus } from './checkDrift.ts';
 import type { InputFailure, InputsStatus } from './checkInputDrift.ts';
 import type { RebuildStatus } from './checkRebuild.ts';
@@ -6,14 +7,11 @@ import type { SourceStatus } from './checkSourceDrift.ts';
 import type { KitVerdicts } from './verdicts.ts';
 import { hasSourceFailed, hasTargetFailed } from './verdicts.ts';
 
-/**
- * The remedy for everything a plain recompile settles.
- *
- * Shared by four verdicts, so a kit failing several of them names the command once rather than
- * repeating it per axis. Worded as `rdy run` words the same advice, which it gives on three of
- * these verdicts where this command enforces.
- */
-const RECOMPILE = 'Run `rdy compile` to rebuild it.';
+/** One thing to do about a kit, and the file it speaks for where it speaks for one. */
+interface Remedy {
+  path?: string;
+  text: string;
+}
 
 /**
  * Returns what to do about a kit's failing verdicts, in axis order and without repetition.
@@ -27,17 +25,45 @@ const RECOMPILE = 'Run `rdy compile` to rebuild it.';
  */
 export function resolveRemedies(kit: RdyManifestKit, verdicts: KitVerdicts): string[] {
   const { drift, inputs, rebuild, source } = verdicts;
-  const remedies = [
+  const raised = [
     resolveDriftRemedy(drift, rebuild),
     resolveSourceRemedy(kit, source),
     ...resolveInputRemedies(inputs),
     resolveRebuildRemedy(rebuild, drift, source),
-  ].filter((remedy): remedy is string => remedy !== undefined);
+  ].filter((remedy): remedy is Remedy => remedy !== undefined);
 
-  return [...new Set(remedies)];
+  return collapseRemedies(raised, drift.kind === 'drift');
 }
 
 // region | Helpers
+
+/**
+ * Returns the remedies a reader can act on, in the order the axes raised them.
+ *
+ * Two rules, each collapsing a pair the axes reach independently and neither able to see. A file
+ * more than one axis names is remedied once, by the axis that spoke first, which is the one holding
+ * the more exact account of it: a kit's own source is recorded among its inputs, so deleting it
+ * fails both axes on one path and only the source axis knows the file is the kit's entry.
+ *
+ * A bare recompile is dropped wherever the target has drifted, because `rdy compile` refuses a
+ * drifted kit and exits non-zero. The `--force` remedy the drift verdict raised is then the only
+ * command that runs, and it recompiles from the same source, so it settles whatever the dropped
+ * remedy was raised for. Drift alone gates this: a bundle that is merely gone recompiles normally,
+ * and its own remedy is the bare recompile.
+ */
+function collapseRemedies(raised: Remedy[], targetDrifted: boolean): string[] {
+  const spokenFor = new Set<string>();
+  const texts: string[] = [];
+
+  for (const { path, text } of raised) {
+    if (path !== undefined && spokenFor.has(path)) continue;
+    if (targetDrifted && text === RECOMPILE_REMEDY) continue;
+    if (path !== undefined) spokenFor.add(path);
+    texts.push(text);
+  }
+
+  return [...new Set(texts)];
+}
 
 /**
  * Returns the remedy for the compiled-output verdict, or `undefined` where there is nothing to fix.
@@ -47,29 +73,38 @@ export function resolveRemedies(kit: RdyManifestKit, verdicts: KitVerdicts): str
  * question `--rebuild` answers. A missing bundle does not hit that gate, so a plain recompile
  * regenerates it.
  */
-function resolveDriftRemedy(status: DriftStatus, rebuild: RebuildStatus | undefined): string | undefined {
+function resolveDriftRemedy(status: DriftStatus, rebuild: RebuildStatus | undefined): Remedy | undefined {
   switch (status.kind) {
     case 'ok':
     case 'unverified':
       return undefined;
     case 'drift':
-      return rebuild?.kind === 'ok'
-        ? 'The bundle reproduces, so its recorded hash is what is stale. Run `rdy compile --force` to re-record it.'
-        : 'Move the edits into the source, then run `rdy compile --force`.';
+      return {
+        text:
+          rebuild?.kind === 'ok'
+            ? 'The bundle reproduces, so its recorded hash is what is stale. Run `rdy compile --force` to re-record it.'
+            : MOVE_EDITS_REMEDY,
+      };
     case 'missing':
-      return RECOMPILE;
+      return { text: RECOMPILE_REMEDY };
   }
 }
 
 /** Returns the remedy for one input the compile read that no longer matches what it read. */
-function resolveInputFailureRemedy(failure: InputFailure): string {
+function resolveInputFailureRemedy(failure: InputFailure): Remedy {
   switch (failure.reason) {
     case 'changed':
-      return RECOMPILE;
+      return { path: failure.path, text: RECOMPILE_REMEDY };
     case 'missing':
-      return `Restore ${failure.path}, or run \`rdy compile\` if the kit no longer reads it.`;
+      return {
+        path: failure.path,
+        text: `Restore ${failure.path}, or run \`rdy compile\` if the kit no longer reads it.`,
+      };
     case 'unprojectable':
-      return `Restore the picked fields in ${failure.path}, or repoint the kit's \`pickJson\` call.`;
+      return {
+        path: failure.path,
+        text: `Restore the picked fields in ${failure.path}, or repoint the kit's \`pickJson\` call.`,
+      };
   }
 }
 
@@ -78,18 +113,17 @@ function resolveInputFailureRemedy(failure: InputFailure): string {
  *
  * Ten inputs failing for one reason collapse to one remedy, since the caller deduplicates.
  */
-function resolveInputRemedies(status: InputsStatus): string[] {
+function resolveInputRemedies(status: InputsStatus): Remedy[] {
   return status.kind === 'stale' ? status.failures.map(resolveInputFailureRemedy) : [];
 }
 
 /**
  * Returns the remedy for the rebuild verdict, or `undefined` where there is nothing to add.
  *
- * `mismatch` and `missing` both speak about a file another axis may own, and stay silent where it
- * does. A drifted target is the case that matters: the bundle was edited by hand, and the plain
- * recompile a mismatch would prescribe is the one command the drift gate refuses to run. `missing`
- * additionally defers to a vanished source, leaving a recompile to fill in a manifest entry that
- * records no source or no compiled path, which is the only reason no other axis reports.
+ * Defers to a source the hash axis reports as gone. The verdict names the file only inside a
+ * free-text reason, so the caller's path rule cannot see the collision and the deferral is made
+ * here. A drifted target needs no such guard: this verdict's recompile is bare, and the caller drops
+ * a bare recompile for every axis at once.
  *
  * `failed` always speaks. It is about the source rather than the bundle, and a kit that no longer
  * compiles has to be fixed before any remedy naming a recompile can be carried out.
@@ -98,18 +132,18 @@ function resolveRebuildRemedy(
   status: RebuildStatus | undefined,
   drift: DriftStatus,
   source: SourceStatus,
-): string | undefined {
+): Remedy | undefined {
   if (status === undefined) return undefined;
 
   switch (status.kind) {
     case 'ok':
       return undefined;
     case 'mismatch':
-      return hasTargetFailed(drift) ? undefined : RECOMPILE;
+      return { text: RECOMPILE_REMEDY };
     case 'failed':
-      return 'Fix the kit source so it compiles.';
+      return { text: 'Fix the kit source so it compiles.' };
     case 'missing':
-      return hasTargetFailed(drift) || hasSourceFailed(source) ? undefined : RECOMPILE;
+      return hasTargetFailed(drift) || hasSourceFailed(source) ? undefined : { text: RECOMPILE_REMEDY };
   }
 }
 
@@ -119,17 +153,20 @@ function resolveRebuildRemedy(
  * A recompile is what drops a vanished kit from the manifest, because the sweep rewrites the whole
  * file from the sources it finds; nobody edits the entry out by hand.
  */
-function resolveSourceRemedy(kit: RdyManifestKit, status: SourceStatus): string | undefined {
+function resolveSourceRemedy(kit: RdyManifestKit, status: SourceStatus): Remedy | undefined {
   switch (status.kind) {
     case 'ok':
     case 'unverified':
       return undefined;
     case 'stale':
-      return RECOMPILE;
+      return { ...(kit.source !== undefined && { path: kit.source }), text: RECOMPILE_REMEDY };
     case 'missing':
       return kit.source === undefined
-        ? RECOMPILE
-        : `Restore ${kit.source}, or run \`rdy compile\` to drop the kit from the manifest.`;
+        ? { text: RECOMPILE_REMEDY }
+        : {
+            path: kit.source,
+            text: `Restore ${kit.source}, or run \`rdy compile\` to drop the kit from the manifest.`,
+          };
   }
 }
 

--- a/packages/readyup/src/verify/remedies.ts
+++ b/packages/readyup/src/verify/remedies.ts
@@ -1,0 +1,136 @@
+import type { RdyManifestKit } from '../manifest/manifestSchema.ts';
+import type { DriftStatus } from './checkDrift.ts';
+import type { InputFailure, InputsStatus } from './checkInputDrift.ts';
+import type { RebuildStatus } from './checkRebuild.ts';
+import type { SourceStatus } from './checkSourceDrift.ts';
+import type { KitVerdicts } from './verdicts.ts';
+import { hasSourceFailed, hasTargetFailed } from './verdicts.ts';
+
+/**
+ * The remedy for everything a plain recompile settles.
+ *
+ * Shared by four verdicts, so a kit failing several of them names the command once rather than
+ * repeating it per axis. Worded as `rdy run` words the same advice, which it gives on three of
+ * these verdicts where this command enforces.
+ */
+const RECOMPILE = 'Run `rdy compile` to rebuild it.';
+
+/**
+ * Returns what to do about a kit's failing verdicts, in axis order and without repetition.
+ *
+ * Keyed on the whole verdict set rather than one verdict at a time, because a drifted target's
+ * remedy depends on what the rebuild found: a bundle that reproduces byte for byte has nothing to
+ * move into the source, and it is the recorded hash that needs rewriting.
+ *
+ * A passing or `unverified` verdict contributes nothing, so a kit that fails no axis gets an empty
+ * list.
+ */
+export function resolveRemedies(kit: RdyManifestKit, verdicts: KitVerdicts): string[] {
+  const { drift, inputs, rebuild, source } = verdicts;
+  const remedies = [
+    resolveDriftRemedy(drift, rebuild),
+    resolveSourceRemedy(kit, source),
+    ...resolveInputRemedies(inputs),
+    resolveRebuildRemedy(rebuild, drift, source),
+  ].filter((remedy): remedy is string => remedy !== undefined);
+
+  return [...new Set(remedies)];
+}
+
+// region | Helpers
+
+/**
+ * Returns the remedy for the compiled-output verdict, or `undefined` where there is nothing to fix.
+ *
+ * Both `drift` branches name `--force`, because `rdy compile` gates on drift and skips the kit
+ * rather than overwriting it. They differ in whether there are edits to move first, which is the
+ * question `--rebuild` answers. A missing bundle does not hit that gate, so a plain recompile
+ * regenerates it.
+ */
+function resolveDriftRemedy(status: DriftStatus, rebuild: RebuildStatus | undefined): string | undefined {
+  switch (status.kind) {
+    case 'ok':
+    case 'unverified':
+      return undefined;
+    case 'drift':
+      return rebuild?.kind === 'ok'
+        ? 'The bundle reproduces, so its recorded hash is what is stale. Run `rdy compile --force` to re-record it.'
+        : 'Move the edits into the source, then run `rdy compile --force`.';
+    case 'missing':
+      return RECOMPILE;
+  }
+}
+
+/** Returns the remedy for one input the compile read that no longer matches what it read. */
+function resolveInputFailureRemedy(failure: InputFailure): string {
+  switch (failure.reason) {
+    case 'changed':
+      return RECOMPILE;
+    case 'missing':
+      return `Restore ${failure.path}, or run \`rdy compile\` if the kit no longer reads it.`;
+    case 'unprojectable':
+      return `Restore the picked fields in ${failure.path}, or repoint the kit's \`pickJson\` call.`;
+  }
+}
+
+/**
+ * Returns one remedy per failing input, and none where the verdict is `ok` or `unverified`.
+ *
+ * Ten inputs failing for one reason collapse to one remedy, since the caller deduplicates.
+ */
+function resolveInputRemedies(status: InputsStatus): string[] {
+  return status.kind === 'stale' ? status.failures.map(resolveInputFailureRemedy) : [];
+}
+
+/**
+ * Returns the remedy for the rebuild verdict, or `undefined` where there is nothing to add.
+ *
+ * `mismatch` and `missing` both speak about a file another axis may own, and stay silent where it
+ * does. A drifted target is the case that matters: the bundle was edited by hand, and the plain
+ * recompile a mismatch would prescribe is the one command the drift gate refuses to run. `missing`
+ * additionally defers to a vanished source, leaving a recompile to fill in a manifest entry that
+ * records no source or no compiled path, which is the only reason no other axis reports.
+ *
+ * `failed` always speaks. It is about the source rather than the bundle, and a kit that no longer
+ * compiles has to be fixed before any remedy naming a recompile can be carried out.
+ */
+function resolveRebuildRemedy(
+  status: RebuildStatus | undefined,
+  drift: DriftStatus,
+  source: SourceStatus,
+): string | undefined {
+  if (status === undefined) return undefined;
+
+  switch (status.kind) {
+    case 'ok':
+      return undefined;
+    case 'mismatch':
+      return hasTargetFailed(drift) ? undefined : RECOMPILE;
+    case 'failed':
+      return 'Fix the kit source so it compiles.';
+    case 'missing':
+      return hasTargetFailed(drift) || hasSourceFailed(source) ? undefined : RECOMPILE;
+  }
+}
+
+/**
+ * Returns the remedy for the source verdict, or `undefined` where there is nothing to fix.
+ *
+ * A recompile is what drops a vanished kit from the manifest, because the sweep rewrites the whole
+ * file from the sources it finds; nobody edits the entry out by hand.
+ */
+function resolveSourceRemedy(kit: RdyManifestKit, status: SourceStatus): string | undefined {
+  switch (status.kind) {
+    case 'ok':
+    case 'unverified':
+      return undefined;
+    case 'stale':
+      return RECOMPILE;
+    case 'missing':
+      return kit.source === undefined
+        ? RECOMPILE
+        : `Restore ${kit.source}, or run \`rdy compile\` to drop the kit from the manifest.`;
+  }
+}
+
+// endregion | Helpers

--- a/packages/readyup/src/verify/remedies.ts
+++ b/packages/readyup/src/verify/remedies.ts
@@ -5,7 +5,7 @@ import type { InputFailure, InputsStatus } from './checkInputDrift.ts';
 import type { RebuildStatus } from './checkRebuild.ts';
 import type { SourceStatus } from './checkSourceDrift.ts';
 import type { KitVerdicts } from './verdicts.ts';
-import { hasSourceFailed, hasTargetFailed } from './verdicts.ts';
+import { hasSourceFailed } from './verdicts.ts';
 
 /** One thing to do about a kit, and the file it speaks for where it speaks for one. */
 interface Remedy {
@@ -29,7 +29,7 @@ export function resolveRemedies(kit: RdyManifestKit, verdicts: KitVerdicts): str
     resolveDriftRemedy(drift, rebuild),
     resolveSourceRemedy(kit, source),
     ...resolveInputRemedies(inputs),
-    resolveRebuildRemedy(rebuild, drift, source),
+    resolveRebuildRemedy(rebuild, source),
   ].filter((remedy): remedy is Remedy => remedy !== undefined);
 
   return collapseRemedies(raised, drift.kind === 'drift');
@@ -45,11 +45,17 @@ export function resolveRemedies(kit: RdyManifestKit, verdicts: KitVerdicts): str
  * the more exact account of it: a kit's own source is recorded among its inputs, so deleting it
  * fails both axes on one path and only the source axis knows the file is the kit's entry.
  *
- * A bare recompile is dropped wherever the target has drifted, because `rdy compile` refuses a
- * drifted kit and exits non-zero. The `--force` remedy the drift verdict raised is then the only
- * command that runs, and it recompiles from the same source, so it settles whatever the dropped
- * remedy was raised for. Drift alone gates this: a bundle that is merely gone recompiles normally,
- * and its own remedy is the bare recompile.
+ * A remedy whose whole action is a bare recompile is dropped wherever the target has drifted,
+ * because `rdy compile` refuses a drifted kit and exits non-zero. The `--force` remedy the drift
+ * verdict raised is then the only command that runs, and it recompiles from the same source, so it
+ * settles whatever the dropped remedy was raised for. Drift alone gates this: a bundle that is
+ * merely gone recompiles normally, and its own remedy is the bare recompile.
+ *
+ * A remedy that only offers a recompile as its second branch survives, and is not reworded to name
+ * `--force` instead. It leads with an action the drift does not block, its recompile branch becomes
+ * available once the drift remedy above it is carried out, and `--force` is the wrong command to put
+ * in a reader's hands before then: it overwrites the bundle whose edits the drift remedy is telling
+ * them to move into the source first.
  */
 function collapseRemedies(raised: Remedy[], targetDrifted: boolean): string[] {
   const spokenFor = new Set<string>();
@@ -122,17 +128,13 @@ function resolveInputRemedies(status: InputsStatus): Remedy[] {
  *
  * Defers to a source the hash axis reports as gone. The verdict names the file only inside a
  * free-text reason, so the caller's path rule cannot see the collision and the deferral is made
- * here. A drifted target needs no such guard: this verdict's recompile is bare, and the caller drops
- * a bare recompile for every axis at once.
+ * here. A drifted or missing target needs no such guard: this verdict's recompile is bare, so the
+ * caller drops it under drift and deduplicates it against the target's own identical text.
  *
  * `failed` always speaks. It is about the source rather than the bundle, and a kit that no longer
  * compiles has to be fixed before any remedy naming a recompile can be carried out.
  */
-function resolveRebuildRemedy(
-  status: RebuildStatus | undefined,
-  drift: DriftStatus,
-  source: SourceStatus,
-): Remedy | undefined {
+function resolveRebuildRemedy(status: RebuildStatus | undefined, source: SourceStatus): Remedy | undefined {
   if (status === undefined) return undefined;
 
   switch (status.kind) {
@@ -143,7 +145,7 @@ function resolveRebuildRemedy(
     case 'failed':
       return { text: 'Fix the kit source so it compiles.' };
     case 'missing':
-      return hasTargetFailed(drift) || hasSourceFailed(source) ? undefined : { text: RECOMPILE_REMEDY };
+      return hasSourceFailed(source) ? undefined : { text: RECOMPILE_REMEDY };
   }
 }
 

--- a/packages/readyup/src/verify/remedies.ts
+++ b/packages/readyup/src/verify/remedies.ts
@@ -16,12 +16,11 @@ interface Remedy {
 /**
  * Returns what to do about a kit's failing verdicts, in axis order and without repetition.
  *
- * Keyed on the whole verdict set rather than one verdict at a time, because a drifted target's
- * remedy depends on what the rebuild found: a bundle that reproduces byte for byte has nothing to
- * move into the source, and it is the recorded hash that needs rewriting.
+ * Keyed on the whole verdict set rather than one verdict at a time, because a drifted target's remedy depends on what
+ * the rebuild found: A bundle that reproduces byte for byte has nothing to move into the source, and it is the
+ * recorded hash that needs rewriting.
  *
- * A passing or `unverified` verdict contributes nothing, so a kit that fails no axis gets an empty
- * list.
+ * A passing or `unverified` verdict contributes nothing, so a kit that fails no axis gets an empty list.
  */
 export function resolveRemedies(kit: RdyManifestKit, verdicts: KitVerdicts): string[] {
   const { drift, inputs, rebuild, source } = verdicts;
@@ -40,22 +39,20 @@ export function resolveRemedies(kit: RdyManifestKit, verdicts: KitVerdicts): str
 /**
  * Returns the remedies a reader can act on, in the order the axes raised them.
  *
- * Two rules, each collapsing a pair the axes reach independently and neither able to see. A file
- * more than one axis names is remedied once, by the axis that spoke first, which is the one holding
- * the more exact account of it: a kit's own source is recorded among its inputs, so deleting it
- * fails both axes on one path and only the source axis knows the file is the kit's entry.
+ * Two rules, each collapsing a pair the axes reach independently and neither able to see. A file more than one axis
+ * names is remedied once, by the axis that spoke first, which is the one holding the more exact account of it:
+ * A kit's own source is recorded among its inputs, so deleting it fails both axes on one path and only the source
+ * axis knows the file is the kit's entry.
  *
- * A remedy whose whole action is a bare recompile is dropped wherever the target has drifted,
- * because `rdy compile` refuses a drifted kit and exits non-zero. The `--force` remedy the drift
- * verdict raised is then the only command that runs, and it recompiles from the same source, so it
- * settles whatever the dropped remedy was raised for. Drift alone gates this: a bundle that is
- * merely gone recompiles normally, and its own remedy is the bare recompile.
+ * A remedy whose whole action is a bare recompile is dropped wherever the target has drifted, because `rdy compile`
+ * refuses a drifted kit and exits non-zero. The `--force` remedy the drift verdict raised is then the only command
+ * that runs, and it recompiles from the same source, so it settles whatever the dropped remedy was raised for.
+ * Drift alone gates this: A bundle that is merely gone recompiles normally, and its own remedy is the bare recompile.
  *
- * A remedy that only offers a recompile as its second branch survives, and is not reworded to name
- * `--force` instead. It leads with an action the drift does not block, its recompile branch becomes
- * available once the drift remedy above it is carried out, and `--force` is the wrong command to put
- * in a reader's hands before then: it overwrites the bundle whose edits the drift remedy is telling
- * them to move into the source first.
+ * A remedy that only offers a recompile as its second branch survives, and is not reworded to name `--force` instead.
+ * It leads with an action the drift does not block, its recompile branch becomes available once the drift remedy above
+ * it is carried out, and `--force` is the wrong command to put in a reader's hands before then: It overwrites the
+ * bundle whose edits the drift remedy is telling them to move into the source first.
  */
 function collapseRemedies(raised: Remedy[], targetDrifted: boolean): string[] {
   const spokenFor = new Set<string>();
@@ -74,10 +71,9 @@ function collapseRemedies(raised: Remedy[], targetDrifted: boolean): string[] {
 /**
  * Returns the remedy for the compiled-output verdict, or `undefined` where there is nothing to fix.
  *
- * Both `drift` branches name `--force`, because `rdy compile` gates on drift and skips the kit
- * rather than overwriting it. They differ in whether there are edits to move first, which is the
- * question `--rebuild` answers. A missing bundle does not hit that gate, so a plain recompile
- * regenerates it.
+ * Both `drift` branches name `--force`, because `rdy compile` gates on drift and skips the kit rather than
+ * overwriting it. They differ in whether there are edits to move first, which is the question `--rebuild` answers.
+ * A missing bundle does not hit that gate, so a plain recompile regenerates it.
  */
 function resolveDriftRemedy(status: DriftStatus, rebuild: RebuildStatus | undefined): Remedy | undefined {
   switch (status.kind) {
@@ -126,13 +122,13 @@ function resolveInputRemedies(status: InputsStatus): Remedy[] {
 /**
  * Returns the remedy for the rebuild verdict, or `undefined` where there is nothing to add.
  *
- * Defers to a source the hash axis reports as gone. The verdict names the file only inside a
- * free-text reason, so the caller's path rule cannot see the collision and the deferral is made
- * here. A drifted or missing target needs no such guard: this verdict's recompile is bare, so the
- * caller drops it under drift and deduplicates it against the target's own identical text.
+ * Defers to a source the hash axis reports as gone. The verdict names the file only inside a free-text reason,
+ * so the caller's path rule cannot see the collision and the deferral is made here. A drifted or missing target needs
+ * no such guard: this verdict's recompile is bare, so the caller drops it under drift and deduplicates it against
+ * the target's own identical text.
  *
- * `failed` always speaks. It is about the source rather than the bundle, and a kit that no longer
- * compiles has to be fixed before any remedy naming a recompile can be carried out.
+ * `failed` always speaks. It is about the source rather than the bundle, and a kit that no longer compiles has to
+ * be fixed before any remedy naming a recompile can be carried out.
  */
 function resolveRebuildRemedy(status: RebuildStatus | undefined, source: SourceStatus): Remedy | undefined {
   if (status === undefined) return undefined;
@@ -152,8 +148,8 @@ function resolveRebuildRemedy(status: RebuildStatus | undefined, source: SourceS
 /**
  * Returns the remedy for the source verdict, or `undefined` where there is nothing to fix.
  *
- * A recompile is what drops a vanished kit from the manifest, because the sweep rewrites the whole
- * file from the sources it finds; nobody edits the entry out by hand.
+ * A recompile is what drops a vanished kit from the manifest, because the sweep rewrites the whole file from the
+ * sources it finds; nobody edits the entry out by hand.
  */
 function resolveSourceRemedy(kit: RdyManifestKit, status: SourceStatus): Remedy | undefined {
   switch (status.kind) {

--- a/packages/readyup/src/verify/verdicts.ts
+++ b/packages/readyup/src/verify/verdicts.ts
@@ -1,0 +1,22 @@
+import type { DriftStatus } from './checkDrift.ts';
+import type { InputsStatus } from './checkInputDrift.ts';
+import type { RebuildStatus } from './checkRebuild.ts';
+import type { SourceStatus } from './checkSourceDrift.ts';
+
+/** Every verdict one kit reached, gathered so each pass over a kit reads the same set. */
+export interface KitVerdicts {
+  drift: DriftStatus;
+  inputs: InputsStatus;
+  rebuild: RebuildStatus | undefined;
+  source: SourceStatus;
+}
+
+/** Returns `true` when the source verdict reports a mismatch or a missing file. */
+export function hasSourceFailed(status: SourceStatus): boolean {
+  return status.kind === 'missing' || status.kind === 'stale';
+}
+
+/** Returns `true` when the compiled-output verdict reports a mismatch or a missing file. */
+export function hasTargetFailed(status: DriftStatus): boolean {
+  return status.kind === 'drift' || status.kind === 'missing';
+}

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -206,22 +206,12 @@ function formatStatusLine(kit: RdyManifestKit, verdicts: KitVerdicts): string {
 
   if (token === 'failedError') {
     const claim = getLayout().formatCheckLine({ token, name: kit.name });
-    const remedies = resolveRemedies(kit, verdicts).map(formatRemedy);
+    const remedies = resolveRemedies(kit, verdicts).map((remedy) => getLayout().formatFix(remedy));
     return [claim, ...getLayout().formatReasonBlock([...clauses, ...remedies])].join('\n') + '\n';
   }
 
   const detail = clauses.join('; ');
   return getLayout().formatCheckLine({ token, name: kit.name, ...(detail !== '' && { detail }) }) + '\n';
-}
-
-/**
- * Returns a remedy as one reason line, behind the token marking fix text.
- *
- * The same token `rdy run` puts on a check's `fix`, so the two commands mark an action to take
- * alike.
- */
-function formatRemedy(remedy: string): string {
-  return `${getLayout().token('fix')}${remedy}`;
 }
 
 /**

--- a/packages/readyup/src/verify/verifyCommand.ts
+++ b/packages/readyup/src/verify/verifyCommand.ts
@@ -25,14 +25,9 @@ import type { DependencyChange, RebuildStatus } from './checkRebuild.ts';
 import { checkRebuild } from './checkRebuild.ts';
 import type { SourceStatus } from './checkSourceDrift.ts';
 import { checkSourceDrift } from './checkSourceDrift.ts';
-
-/** Every verdict one kit reached, gathered so each pass over a kit reads the same set. */
-interface KitVerdicts {
-  drift: DriftStatus;
-  inputs: InputsStatus;
-  rebuild: RebuildStatus | undefined;
-  source: SourceStatus;
-}
+import { resolveRemedies } from './remedies.ts';
+import type { KitVerdicts } from './verdicts.ts';
+import { hasSourceFailed, hasTargetFailed } from './verdicts.ts';
 
 const verifyOptions = {
   json: { type: 'boolean' },
@@ -193,8 +188,9 @@ function buildVerifyEntry(name: string, { drift, inputs, rebuild, source }: KitV
 /**
  * Returns a kit's line, showing whichever of its verdicts has something to report.
  *
- * A failing kit gets each verdict on its own line beneath its name; any other kit gets them inline.
- * A kit that passes every verdict shows none, leaving its token to report the outcome.
+ * A failing kit gets each verdict on its own line beneath its name, then what to do about them, one
+ * line per distinct remedy; any other kit gets its verdicts inline and no remedy, having nothing to
+ * fix. A kit that passes every verdict shows none, leaving its token to report the outcome.
  */
 function formatStatusLine(kit: RdyManifestKit, verdicts: KitVerdicts): string {
   const { drift, inputs, rebuild, source } = verdicts;
@@ -210,11 +206,22 @@ function formatStatusLine(kit: RdyManifestKit, verdicts: KitVerdicts): string {
 
   if (token === 'failedError') {
     const claim = getLayout().formatCheckLine({ token, name: kit.name });
-    return [claim, ...getLayout().formatReasonBlock(clauses)].join('\n') + '\n';
+    const remedies = resolveRemedies(kit, verdicts).map(formatRemedy);
+    return [claim, ...getLayout().formatReasonBlock([...clauses, ...remedies])].join('\n') + '\n';
   }
 
   const detail = clauses.join('; ');
   return getLayout().formatCheckLine({ token, name: kit.name, ...(detail !== '' && { detail }) }) + '\n';
+}
+
+/**
+ * Returns a remedy as one reason line, behind the token marking fix text.
+ *
+ * The same token `rdy run` puts on a check's `fix`, so the two commands mark an action to take
+ * alike.
+ */
+function formatRemedy(remedy: string): string {
+  return `${getLayout().token('fix')}${remedy}`;
 }
 
 /**
@@ -230,16 +237,6 @@ function resolveToken({ drift, inputs, rebuild, source }: KitVerdicts): TokenNam
   if (anyFailed) return 'failedError';
   if (drift.kind === 'unverified' && rebuild?.kind !== 'ok') return 'skippedOptional';
   return 'passed';
-}
-
-/** Returns `true` when the compiled-output verdict reports a mismatch or a missing file. */
-function hasTargetFailed(status: DriftStatus): boolean {
-  return status.kind === 'missing' || status.kind === 'drift';
-}
-
-/** Returns `true` when the source verdict reports a mismatch or a missing file. */
-function hasSourceFailed(status: SourceStatus): boolean {
-  return status.kind === 'missing' || status.kind === 'stale';
 }
 
 /** Returns a clause describing the compiled-output verdict, or `undefined` when the verdict is `ok`. */


### PR DESCRIPTION
## What

Adds a remedy to `rdy verify`'s human-readable output, describing how to fix a failing kit.

## Why

`rdy verify` named what was wrong with a kit but not what to do about it, leaving a reader who hit a drift or a stale input to work out which compile invocation gets past it. The one remedy readyup did offer for a drifted bundle, `rdy compile --force`, discarded the hand edits that caused the drift without warning.

## Details

### 🎉 Features

- A failing kit's block closes with one line per distinct remedy, behind the same `fix` token `rdy run` puts on a check's fix. Every verdict prints before the first remedy, so the diagnosis reads whole.
- The remedy follows the verdict: a stale source or a changed input is sent to `rdy compile`; a drifted bundle to the source its hand edits belong in; a missing source or input to a restore line naming the file, with a recompile as the second branch; an input whose picked fields are gone to the kit's `pickJson` call rather than to a recompile.
- Under `--rebuild`, a drifted bundle that recompiles byte for byte is told that its recorded hash is what is stale and to re-record it, since there are no edits to move. A source that no longer compiles is sent back to the kit.
- A kit that passes every verdict, or reaches only `unverified` ones, keeps its bare line.

### 🐛 Bug fixes

- `rdy run`'s `target-drift` warning now gives the wording `rdy verify` gives for the same condition, so the advisory and the enforcing gate no longer disagree about what to do. The previous remedy sent the reader straight to a flag that overwrites the drifted bundle.
- A file more than one axis names is remedied once, by the axis holding the more exact account of it. A kit's own source is recorded among its inputs, so deleting it failed both axes on one path and printed two contradictory accounts of what a recompile would do.
- A remedy whose whole action is a bare `rdy compile` is dropped wherever the target has drifted, since `rdy compile` skips a drifted kit and counts it against the run. Remedies the force recompile does not settle still print, as does one that offers a recompile only as its second branch.

### ♻️ Refactoring

- `rdy run` and `rdy verify` take the two remedies they share from `reporting/remedies.ts` instead of stating them twice.
- `KitVerdicts`, `hasSourceFailed`, and `hasTargetFailed` move out of `verifyCommand.ts` into `verify/verdicts.ts`, so remedy resolution reads the same verdict set the reporter does.
- Fix-text rendering moves onto the layout engine as `formatFix`, which `reportRdy.ts` and `verifyCommand.ts` both call.

### 🧪 Tests

- `remedies.unit.test.ts` covers remedy resolution on each axis, the deduplication, and both collapse rules, including the cases the rules deliberately leave alone.
- `verifyCommand.unit.test.ts` pins the rendered block: verdicts before remedies, one line per distinct remedy, a bare line for a passing or unverified kit, and no remedy in the JSON payload.
- `verifyCommand.rebuild.tool.test.ts` reads the remedies off stderr for the drifted, reproducing, and non-compiling cases.

### 📚 Documentation

- The README's four failing `rdy verify` samples carry their remedy lines, with the rules that govern which remedies print and why a reproducing bundle is told to re-record its hash.
- Comments across the touched files are revised to house discipline, and `verifyCommand.ts`'s private fix-text helper is collapsed into the layout engine's.

Closes #271
