### PR TITLE
#431 Lint and typecheck the kit sources under .readyup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 # Written by `rdy compile`, whose own formatting Prettier would fight over on every build.
+.readyup/kits/*.js
 .readyup/manifest.json
 # Written by compositor's sample generator, and pinned byte for byte by a drift test.
 packages/compositor/samples/

--- a/.readyup/kits/demo.js
+++ b/.readyup/kits/demo.js
@@ -4,7 +4,7 @@ export const __readyupVersion = "0.34.0";
 
 
 // .readyup/kits/demo.ts
-import { defineRdyKit } from "readyup";
+import { defineRdyChecklist, defineRdyKit, defineRdyStagedChecklist } from "readyup";
 import {
   commandExists,
   fileContains,
@@ -13,7 +13,7 @@ import {
   hasDevDependency,
   readJsonValue
 } from "readyup/check-utils";
-var projectFoundations = {
+var projectFoundations = defineRdyChecklist({
   name: "project-foundations",
   preconditions: [
     {
@@ -53,8 +53,8 @@ var projectFoundations = {
       ]
     }
   ]
-};
-var optionalIntegrations = {
+});
+var optionalIntegrations = defineRdyChecklist({
   name: "optional-integrations",
   checks: [
     {
@@ -92,8 +92,8 @@ var optionalIntegrations = {
       ]
     }
   ]
-};
-var codeQuality = {
+});
+var codeQuality = defineRdyChecklist({
   name: "code-quality",
   checks: [
     {
@@ -131,8 +131,8 @@ var codeQuality = {
       fix: "brew install jq \u2014 useful for JSON processing in shell scripts"
     }
   ]
-};
-var publishingPipeline = {
+});
+var publishingPipeline = defineRdyStagedChecklist({
   name: "publishing-pipeline",
   groups: [
     // Stage 1: Build infrastructure
@@ -170,7 +170,7 @@ var publishingPipeline = {
     ]
   ],
   fixLocation: "inline"
-};
+});
 var demo_default = defineRdyKit({
   checklists: [projectFoundations, optionalIntegrations, codeQuality, publishingPipeline]
 });

--- a/.readyup/kits/demo.ts
+++ b/.readyup/kits/demo.ts
@@ -62,7 +62,7 @@ const projectFoundations = {
       ],
     },
   ],
-} as const;
+};
 
 // -- Flat checklist with skip conditions --
 // Demonstrates: N/A suppression. Docker and Renovate sections vanish entirely
@@ -106,7 +106,7 @@ const optionalIntegrations = {
       ],
     },
   ],
-} as const;
+};
 
 // -- Flat checklist with mixed severities --
 // Demonstrates: error, warn, and recommend severity levels. Also shows a
@@ -150,7 +150,7 @@ const codeQuality = {
       fix: 'brew install jq — useful for JSON processing in shell scripts',
     },
   ],
-} as const;
+};
 
 // -- Staged checklist with halt-on-failure --
 // Demonstrates: sequential group execution. If compliance fails, release
@@ -195,7 +195,7 @@ const publishingPipeline = {
     ],
   ],
   fixLocation: 'inline' as const,
-} as const;
+};
 
 export default defineRdyKit({
   checklists: [projectFoundations, optionalIntegrations, codeQuality, publishingPipeline],

--- a/.readyup/kits/demo.ts
+++ b/.readyup/kits/demo.ts
@@ -8,7 +8,7 @@
  *
  *   rdy run demo
  */
-import { defineRdyKit } from 'readyup';
+import { defineRdyChecklist, defineRdyKit, defineRdyStagedChecklist } from 'readyup';
 import {
   commandExists,
   fileContains,
@@ -21,7 +21,7 @@ import {
 // -- Flat checklist with preconditions and nested checks --
 // Demonstrates: precondition gating, nested check hierarchy, fix messages.
 
-const projectFoundations = {
+const projectFoundations = defineRdyChecklist({
   name: 'project-foundations',
   preconditions: [
     {
@@ -62,13 +62,13 @@ const projectFoundations = {
       ],
     },
   ],
-};
+});
 
 // -- Flat checklist with skip conditions --
 // Demonstrates: N/A suppression. Docker and Renovate sections vanish entirely
 // when their config files are absent. Only integrations that are present appear.
 
-const optionalIntegrations = {
+const optionalIntegrations = defineRdyChecklist({
   name: 'optional-integrations',
   checks: [
     {
@@ -106,13 +106,13 @@ const optionalIntegrations = {
       ],
     },
   ],
-};
+});
 
 // -- Flat checklist with mixed severities --
 // Demonstrates: error, warn, and recommend severity levels. Also shows a
 // failed parent with a skipped child (bitbucket-pipelines.yml).
 
-const codeQuality = {
+const codeQuality = defineRdyChecklist({
   name: 'code-quality',
   checks: [
     {
@@ -139,25 +139,25 @@ const codeQuality = {
     },
     {
       name: 'actionlint is installed',
-      severity: 'warn' as const,
+      severity: 'warn',
       check: () => commandExists('actionlint'),
       fix: 'brew install actionlint — catches workflow syntax errors before they hit CI',
     },
     {
       name: 'jq is installed',
-      severity: 'recommend' as const,
+      severity: 'recommend',
       check: () => commandExists('jq'),
       fix: 'brew install jq — useful for JSON processing in shell scripts',
     },
   ],
-};
+});
 
 // -- Staged checklist with halt-on-failure --
 // Demonstrates: sequential group execution. If compliance fails, release
 // automation checks are skipped — no point verifying workflows for an
 // unpublishable package.
 
-const publishingPipeline = {
+const publishingPipeline = defineRdyStagedChecklist({
   name: 'publishing-pipeline',
   groups: [
     // Stage 1: Build infrastructure
@@ -194,8 +194,8 @@ const publishingPipeline = {
       },
     ],
   ],
-  fixLocation: 'inline' as const,
-};
+  fixLocation: 'inline',
+});
 
 export default defineRdyKit({
   checklists: [projectFoundations, optionalIntegrations, codeQuality, publishingPipeline],

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -11,7 +11,7 @@
       "esbuildVersion": "0.28.2",
       "inputs": [
         {
-          "hash": "33b6ea59",
+          "hash": "36715211",
           "kind": "module",
           "path": "kits/demo.ts"
         }
@@ -20,7 +20,7 @@
       "path": "kits/demo.js",
       "readyupVersion": "0.34.0",
       "source": "kits/demo.ts",
-      "sourceHash": "33b6ea59",
+      "sourceHash": "36715211",
       "targetHash": "52481a2f"
     }
   ]

--- a/.readyup/manifest.json
+++ b/.readyup/manifest.json
@@ -11,7 +11,7 @@
       "esbuildVersion": "0.28.2",
       "inputs": [
         {
-          "hash": "36715211",
+          "hash": "d4f3407c",
           "kind": "module",
           "path": "kits/demo.ts"
         }
@@ -20,8 +20,8 @@
       "path": "kits/demo.js",
       "readyupVersion": "0.34.0",
       "source": "kits/demo.ts",
-      "sourceHash": "36715211",
-      "targetHash": "52481a2f"
+      "sourceHash": "d4f3407c",
+      "targetHash": "d619942c"
     }
   ]
 }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -37,8 +37,18 @@ const RESTRICTED_SYNTAX = [
 const config = defineConfig([
   ...baseConfig,
   {
-    // Completely ignore these files
-    ignores: ['**/*.sh', '**/.claude/**', '**/.readyup/**', '**/coverage/**', '**/dist/**', '**/local/**'],
+    // Nothing here is source this repo authors: a `.sh` file holds no JavaScript to lint, `.claude/` is harness
+    // configuration and the skills CodeAssembly generates into it, the two `.readyup/` entries are what `rdy compile`
+    // writes, and `coverage/`, `dist/`, and `local/` hold generated or machine-local output.
+    ignores: [
+      '**/*.sh',
+      '**/.claude/**',
+      '**/.readyup/**/*.js',
+      '**/.readyup/manifest.json',
+      '**/coverage/**',
+      '**/dist/**',
+      '**/local/**',
+    ],
   },
   {
     // `strict-lint` promotes rule severities and not this report, so the default `warn` would leave a directive

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,5 +2,5 @@
 pre-commit:
   commands:
     format:
-      run: pnpm exec prettier --write --log-level warn --ignore-unknown {staged_files}
+      run: pnpm exec nmr fmt {staged_files}
       stage_fixed: true

--- a/packages/readyup/.readyup/kits/__tests__/bundledKits.tool.test.ts
+++ b/packages/readyup/.readyup/kits/__tests__/bundledKits.tool.test.ts
@@ -10,11 +10,11 @@ import { compileConfig } from '../../../src/compile/compileConfig.ts';
 import { validateCompiledOutput } from '../../../src/compile/validateCompiledOutput.ts';
 import { listCommand } from '../../../src/list/listCommand.ts';
 import type { RdyManifestKit } from '../../../src/manifest/manifestSchema.ts';
+import { resolveKitSources } from '../../../src/run/resolveKitSources.ts';
+import { runCommand } from '../../../src/run/runCommand.ts';
 import { ListOutputSchema } from '../../../src/schemas/listOutputSchema.ts';
 import type { JsonKitResultEntry, JsonReport } from '../../../src/schemas/reportSchema.ts';
 import { ReportSchema } from '../../../src/schemas/reportSchema.ts';
-import { resolveKitSources } from '../../../src/run/resolveKitSources.ts';
-import { runCommand } from '../../../src/run/runCommand.ts';
 import { hashFile } from '../../../src/verify/targetHash.ts';
 
 const PACKAGE_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');

--- a/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildFreshnessChecks.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_MANIFEST_PATH } from 'readyup';
 import type { CheckOutcome, FractionProgress, RdyCheck } from 'readyup';
+import { DEFAULT_MANIFEST_PATH } from 'readyup';
 import {
   describeJsonProjectionFailure,
   fileExists,

--- a/packages/readyup/.readyup/kits/checks/buildSelfContainmentChecks.ts
+++ b/packages/readyup/.readyup/kits/checks/buildSelfContainmentChecks.ts
@@ -11,7 +11,7 @@ import { listCompiledBundlePaths, NO_BUNDLES_REASON } from './kit-layout.ts';
  * have to supply, which is what makes a bundle no longer self-contained.
  */
 const ALLOWED_PREFIXES = ['node:', 'readyup/'];
-const ALLOWED_SPECIFIERS = ['readyup'];
+const ALLOWED_SPECIFIERS = new Set(['readyup']);
 
 /**
  * Patterns capturing the module specifier from each import form esbuild emits.
@@ -77,7 +77,7 @@ function describeSelfContainment(bundlePath: string): CheckOutcome {
 
 /** Returns true when a specifier is one esbuild was told to leave external. */
 function isAllowedSpecifier(specifier: string): boolean {
-  return ALLOWED_SPECIFIERS.includes(specifier) || ALLOWED_PREFIXES.some((prefix) => specifier.startsWith(prefix));
+  return ALLOWED_SPECIFIERS.has(specifier) || ALLOWED_PREFIXES.some((prefix) => specifier.startsWith(prefix));
 }
 
 /** Every distinct module specifier the bundle text imports. */

--- a/packages/readyup/.readyup/kits/checks/kit-layout.ts
+++ b/packages/readyup/.readyup/kits/checks/kit-layout.ts
@@ -2,8 +2,8 @@ import { readdirSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-import { DEFAULT_MANIFEST_PATH } from 'readyup';
 import type { SkipResult } from 'readyup';
+import { DEFAULT_MANIFEST_PATH } from 'readyup';
 import type { JsonPathSpec } from 'readyup/check-utils';
 import { fileExists, isRecord, readJsonFile } from 'readyup/check-utils';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
   },
   "include": [
     ".config/**/*.ts",
+    // Kit sources so that they are typechecked and the ESLint project service can resolve them.
+    ".readyup/kits/**/*.ts",
     "__tests__/",
     "config/",
     // Root-level TS files so that the ESLint project service can resolve them.


### PR DESCRIPTION
## What

Modifies ESLint and TypeScript configs so that kit sources and tests under `.readyup/` are linted and type-checked.

Also modifies the pre-commit hook to format files using `nmr fmt` (instead of directly calling `prettier`) to align with fleet conventions and benefit from gitignore exclusions.

## Why

The blanket `**/.readyup/**` entry exempted 17 tracked, authored TypeScript files from every rule, five of them test suites. No finding in that tree could reach a gate, so a convention violation there was caught only where a human happened to read the file, which is how an import-order defect reached review on #320 rather than a pre-commit hook.

## Details

### ♻️ Refactoring

- `ALLOWED_SPECIFIERS` in `buildSelfContainmentChecks.ts` becomes a `Set` read through `has()`, and `simple-import-sort/imports` orders the imports in `buildFreshnessChecks.ts`, `kit-layout.ts`, and `bundledKits.tool.test.ts`. `ALLOWED_PREFIXES` stays an array, since it is read through `some(startsWith)`.
- The checklist helpers are runtime identity functions imported from `readyup`, so the recompiled `demo.js` gains four calls and a widened import. Every specifier it names is still external, and `rdy verify --rebuild` passes against the new `targetHash`.

### ⚙️ Tooling

- The replacement ignore entries are `**/.readyup/**/*.js` and `**/.readyup/manifest.json`. The leading `**/` matches zero segments, so one pattern covers both the repo root and the package tree, and the trailing `**/` covers a bundle emitted into a subdirectory such as the root's `kits/internal/`. The block's comment gives each remaining entry a reason, in place of `// Completely ignore these files`.
- The `include` addition is `.readyup/kits/**/*.ts`. `packages/readyup/tsconfig.json` already declared the same pattern, so the root now typechecks its kits on the terms the package already used.
- 17 files came under the linter: 2 at the repo root and 15 under `packages/readyup/`.
- `nmr-fmt` passes `--ignore-path` for every `.prettierignore` git reports anywhere in the repo, where bare Prettier reads only the file resolved against the working directory; it also batches its file list within a fixed argument budget. The package tree's generated files need no entry of their own, since `packages/readyup/.gitignore` already excludes them and `nmr-fmt` selects through `git ls-files`.

Closes #431

